### PR TITLE
proposal: seekable blocked-gzip (BGZF/mgzip) reading + block-split writing

### DIFF
--- a/ASYNC.md
+++ b/ASYNC.md
@@ -1,0 +1,232 @@
+# Async API — Exploration
+
+> **Status: exploration, not a decision.** v1 currently lists "Async API" as a
+> **decided deferral** (`openspec/project.md` "Deferred / out of scope (v1)",
+> `SPEC.md` Appendix A, `ARCHITECTURE.md` §5.3). This document analyses how hard
+> async would actually be, whether it must be "baked in from the start," and what
+> the cheap-now / expensive-later seams are. It ends with a recommendation and a
+> short list of decisions that are the maintainer's to make. Nothing here changes
+> a shipped spec; promoting any of it means a real `openspec/changes/` proposal.
+
+## 1. The question
+
+> "It may be better to bake [async] in from the start instead of trying to add it
+> later."
+
+The instinct behind this is sound and worth taking seriously: async is the classic
+**"function colour"** problem. `async def` can only be awaited from `async def`, so
+if the core is written sync and async is bolted on later, you risk a parallel
+universe of duplicated code (`read` / `aread`, `open` / `aopen`, `__iter__` /
+`__aiter__`) threaded through every backend. If that were the real cost of "later,"
+baking in now would clearly win.
+
+The conclusion of this analysis is that **it is not the real cost** — because a hard
+constraint (below) caps how async an archive library can ever be in Python, and that
+cap happens to fall exactly where the current architecture already has a clean seam.
+So the recommendation is **not** "rewrite the core async," nor "stay sync and shrug,"
+but a narrow middle: **keep the core sync, and spend ~1–2 days now on a handful of
+seams that make a leaf-level async facade cheap to add later.**
+
+## 2. What "async" means for an archive library
+
+There are three independent surfaces a caller might want to be async. They are *not*
+the same feature and have very different value:
+
+| Surface | What the caller writes | Who benefits |
+|---|---|---|
+| **(S) Async source** | open an archive whose *compressed bytes* arrive over the network without blocking the event loop (`s3://…/a.zip`, an `http` body, an fsspec async file) | servers reading archives off object storage / remote FS |
+| **(M) Async member streams** | `await stream.read(n)` / `async for chunk in stream` on a member, with backpressure into an async consumer | streaming a member out to an async HTTP response |
+| **(I) Async iteration / extraction** | `async for member in reader`, `await reader.extract_all(dest)` so a long extraction doesn't block the loop | any asyncio app that doesn't want a multi-second blocking call |
+
+Surface **(I)** is satisfiable *today* with zero core changes via
+`asyncio.to_thread(archivey.extract_all, ...)` — the whole operation runs in a worker
+thread and the event loop stays responsive. That is the current plan (§5.3) and it is
+genuinely adequate for "don't block my loop while extracting." Surfaces **(S)** and
+**(M)** are where a thread wrapper is unsatisfying, and they are what "bake it in"
+is really about.
+
+## 3. The hard constraint: the decoders *pull* bytes synchronously
+
+Every decode path the library relies on is **synchronous C code that pulls its input
+through a blocking `read()` callback we do not control**:
+
+- `zipfile` calls `self.fp.read(n)` synchronously deep inside `ZipExtFile`.
+- `tarfile` reads from `fileobj` synchronously while walking headers.
+- stdlib `lzma` / `bz2` / `zlib` decompressors are pull-driven C extensions.
+- the native 7z / RAR header parsers read from a sync stream; `unrar` is a subprocess
+  whose pipe we read synchronously.
+
+There is no hook to make `lzma.decompress` *await* its next input chunk. You cannot
+suspend a C stack frame on an `await`. This has a decisive consequence:
+
+> **There is no "async all the way down" available in Python without rewriting the
+> decoders.** The most async an archive library can be is: an async *source* surface
+> and an async *consumer* surface, with the sync decode core **running in a worker
+> thread** and **bridged** to the event loop.
+
+Two corollaries:
+
+1. Async buys **no CPU concurrency** — decode is CPU-bound under the GIL. The only win
+   is **I/O overlap**: not blocking the loop while waiting on a slow (network) source,
+   and applying backpressure to an async consumer.
+2. Because decode must run in a thread *anyway*, the bridge is the same regardless of
+   whether the core is "written async." A native-async core would still call
+   `lzma.decompress` on a worker thread. The async-ness only ever lives at the
+   **edges** (source in, bytes out), never in the middle.
+
+This is why "bake the whole core async" is the wrong target: the middle *cannot* be
+async, and the edges are exactly where the current design already injects/returns
+plain objects.
+
+## 4. The realistic ceiling, drawn on our architecture
+
+Given §3, the maximal async design is:
+
+```
+   async caller
+        │   await reader.read(member)        ← async edge (M / I)
+        ▼
+ ┌──────────────────────────┐
+ │  archivey.asyncio facade │  runs the sync reader on a worker thread,
+ │  (anyio BlockingPortal)  │  bridges chunks back via from_thread
+ └──────────────────────────┘
+        │   sync BinaryIO.read(n)            ← the sync core, unchanged
+        ▼
+ ┌──────────────────────────┐
+ │  sync ArchiveReader +     │  zipfile / tarfile / lzma / 7z / unrar
+ │  DecompressorStream stack │  — pulls bytes synchronously
+ └──────────────────────────┘
+        │   source.read(n)                   ← async edge (S)
+        ▼
+ ┌──────────────────────────┐
+ │  sync-facade over an      │  a thin shim that turns the core's blocking
+ │  async source             │  read(n) into `portal.call(async_source.read, n)`
+ └──────────────────────────┘
+```
+
+Both async edges are bridged with the **same** primitive: a worker thread running the
+sync core, plus `anyio` / `asyncio` `run_in_executor` + a portal to call back into the
+loop for the async source. The sync core in the middle **does not change shape**.
+
+## 5. Options
+
+### Option A — Sync-only + `asyncio.to_thread` (status quo)
+
+`asyncio.to_thread(archivey.extract_all, src, dest)`. Whole op in one thread.
+
+- **Cost now:** zero (already the plan). **Cost later:** zero.
+- **Gets you:** surface (I) — loop stays responsive during a whole-archive operation.
+- **Doesn't get you:** (S) genuine async source I/O; (M) per-chunk backpressure into an
+  async consumer. Concurrency is bounded by the thread pool; a streaming read from S3
+  blocks a whole thread for the archive's lifetime.
+
+### Option B — Sync core + thin async facade leaf (`archivey.asyncio`), added later
+
+A separate module that *wraps* the sync core. `async for member in areader`,
+`await astream.read(n)` where each call hops to the worker thread; an async source is
+adapted by a sync-facade shim (§4). The core never imports it; the facade is a **leaf,
+not a root**, so it adds no colour to the core.
+
+- **Cost now:** zero (it's deferred). **Cost later:** moderate, **isolated** — one new
+  module + tests, *if* the core honours the §6 seams. Without the seams it's still
+  doable but uglier (e.g. an async source can only be supported by buffering it whole
+  first).
+- **Gets you:** (I) fully; (M) with real backpressure; (S) for any async source that
+  can be driven from a worker thread via a portal.
+- This is exactly the "future `archivey.asyncio` module … is a clean add-on" already
+  promised in ARCHITECTURE.md §5.3 — this document's contribution is to confirm it
+  *stays* a clean add-on, and to pin down the seams that keep it clean.
+
+### Option C — Native async core ("bake it in")
+
+Re-express the source protocol, the `DecompressorStream` stack, the backends, and the
+reader surface in `async def`. Decode still runs sync on a thread (§3), so the async
+keywords stop at the decoder boundary regardless.
+
+- **Cost now:** very high — weeks. It colours every layer, doubles the stream stack,
+  and forces an `anyio`/event-loop dependency into the core (against the zero-dep-core
+  rule). It must *still* bridge to sync decoders, so it carries Option B's complexity
+  **plus** the colour tax.
+- **Gets you:** nothing Option B doesn't, because the win is capped at the edges (§3).
+- **Verdict:** net negative. It pays the full colour cost to reach a ceiling that
+  Option B reaches from a leaf.
+
+## 6. What "baking in now" *should* mean — the cheap seams
+
+The valuable kernel of "bake it in from the start" is **not** writing async code now;
+it is making sure the sync core never makes an assumption that *blocks* Option B later.
+These are small, sync-only, and worth doing during the stream/reader work regardless:
+
+1. **Inject the source as a narrow Protocol, not concrete `BinaryIO`.** Define an
+   internal `ReadableSource` (`read`, `readable`, `close`) / `SeekableSource`
+   (`+ seek`, `tell`, `seekable`) Protocol and type backend/stream inputs against it.
+   The runtime objects stay ordinary sync file objects; the point is that the core
+   already accepts *"anything that reads like a file,"* so a later sync-facade-over-
+   async-source drops in without touching call sites. (The binaryio layer in the
+   stream PR already normalises arbitrary streams — this is formalising that boundary
+   as the single injection point.)
+
+2. **Keep every reader instance thread-confinable.** No module-global mutable I/O
+   state; all per-open state lives on the reader/stream instance; nothing assumes it
+   runs on the thread that constructed it. Then the facade can own a reader on a
+   dedicated worker thread with no surprises. (Largely true today — worth stating as a
+   contract so it isn't broken accidentally.)
+
+3. **Keep the byte interface pull-based and chunked end-to-end.** The whole stack is
+   already `read(n) -> bytes` with bounded buffers (the `stream_members` backpressure
+   model). A portal bridges a pull-based sync stream to an async consumer cleanly; a
+   push/callback design would not. Don't introduce eager whole-member materialisation
+   on any hot path.
+
+4. **Don't leak the event loop into error/context plumbing.** The per-library
+   translators + central context stamping (error-handling spec) are already
+   loop-agnostic; keep it that way so the facade needs no special error handling.
+
+5. **Write the plan down (this doc) and link it** from the deferral note, so "later"
+   starts from a design rather than a blank page.
+
+None of these is async code. All are sync hygiene that a careful library wants anyway.
+Their combined cost is ~1–2 days folded into the existing stream/reader phases, versus
+the weeks Option C would cost — and they make Option B a localised, low-risk add.
+
+## 7. Recommendation
+
+1. **Do not bake a native async core in (reject Option C).** The Python decoder
+   constraint (§3) caps the payoff at the edges, where the architecture already has a
+   seam; paying the colour tax buys nothing extra.
+2. **Keep v1 sync, document `asyncio.to_thread` for surface (I)** (Option A) as the
+   supported answer today.
+3. **Adopt the §6 seams now** as explicit, sync-only contracts in the relevant specs
+   (`archive-reading`, `compressed-streams`/stream layer, `backend-registry`) so the
+   future facade is guaranteed cheap. This is the honest, low-cost way to honour "bake
+   it in from the start."
+4. **Spec the `archivey.asyncio` facade (Option B) as a named, scheduled follow-on**
+   (not just "speculative"), built on `anyio` so it serves both asyncio and trio, and
+   landing after the sync core is stable.
+
+In one line: **bake in the *seams*, not the *colour*.**
+
+## 8. Effort estimate
+
+| Item | When | Effort | Risk |
+|---|---|---|---|
+| A: document `to_thread` recipe | now | ~0.5 day | none |
+| §6 seams (source Protocol, thread-confinement contract, pull-model guarantee, doc) | now, folded into stream/reader phases | ~1–2 days | low |
+| B: `archivey.asyncio` facade via `anyio` (loop bridge, async source shim, `async for`/`await read`, tests) | scheduled follow-on | ~3–5 days | low–moderate, **isolated** to one module |
+| C: native async core | — | weeks | high; rejected |
+
+## 9. Decisions for the maintainer
+
+This document deliberately does **not** edit the shipped deferral. The following are
+the maintainer's calls; once made, they become real `openspec/changes/` proposals:
+
+1. **Flip the framing** of the deferral from "decided deferral" to "sync v1 + a
+   *scheduled* `archivey.asyncio` follow-on built on the §6 seams"? (Touches
+   `openspec/project.md` line ~112, `SPEC.md` Appendix A, `ARCHITECTURE.md` §5.3.)
+2. **Adopt the §6 seams as v1 contracts** now (the only thing with a cost in the
+   current phases), or leave them implicit?
+3. **`anyio` vs `asyncio`-only** for the eventual facade (anyio ⇒ trio support, one
+   extra dep behind an `[async]` extra; asyncio-only ⇒ zero deps, asyncio-bound)?
+4. **Is async source I/O (surface S) in scope at all**, or is "async consumer of a
+   local-file archive" (surfaces I + M) enough? S only earns its keep alongside the
+   deferred fsspec/remote-source work in `IDEAS.md`.

--- a/openspec/changes/seekable-gzip-and-block-writing/proposal.md
+++ b/openspec/changes/seekable-gzip-and-block-writing/proposal.md
@@ -1,0 +1,186 @@
+# Seekable blocked-gzip reading + block-split writing
+
+## Why
+
+Random access inside a single gzip stream currently requires an accelerator: the
+`[seekable]` extra ships `rapidgzip` (gzip) and `indexed_bzip2` (bzip2), and without one
+gzip is forward-only — a backward seek re-decompresses from the start, which the stream
+layer now *warns* about (`seekable-decompressor-streams`). That is the right default for
+**arbitrary** gzip, where block boundaries can only be discovered by decoding.
+
+But two widely used gzip **variants** are *self-describing* and need no decoding to index:
+
+- **BGZF** (the bgzip format; ubiquitous in bioinformatics — BAM/VCF/tabix). The file is a
+  sequence of independent ≤64 KiB gzip members; each member's gzip extra field carries a
+  `BC` subfield holding the compressed block size (`BSIZE`). A 28-byte empty member marks
+  EOF. A BGZF file is a **valid gzip file** — standard tools decompress it unchanged.
+- **mgzip** (a multi-threaded gzip writer). Same idea: each block is a standalone gzip
+  member whose extra field (`MZ` subfield, 4-byte body) stores that member's compressed
+  size; no 64 KiB cap. Also a valid gzip file.
+
+Both store the per-block compressed size in the header, so a block index can be built by
+**walking members without decompressing** — exactly the shape we already parse natively
+for XZ (stream/block index) and lzip (trailer scan). That means Archivey can give BGZF and
+mgzip **random access with zero dependencies** (stdlib `zlib` only), matching the
+native-first philosophy and **without** requiring `rapidgzip`.
+
+Separately, `indexed_gzip` (a Cython wrapper over zlib's `zran.c`) is a lighter, more
+portable accelerator than `rapidgzip` for *arbitrary* gzip, and it can **persist** its
+index (`.gzidx` export/import). It is worth offering as an opt-in alternative gzip backend.
+
+Finally, the **write** side is the mirror of all of this: compressing in independent blocks
+of size *X* makes the output randomly seekable later (and parallel-compressible). For gzip
+that means emitting **BGZF** — a standard, interoperable format, not a bespoke one — which
+round-trips with the native reader above. For xz it means setting the `lzma` `block_size`
+(already readable by our XZ index reader); for zstd, the **zstd seekable format**.
+
+This change is **specs only**: it records the intended capability so the read/write
+symmetry is designed in. No code lands here; implementation is sequenced under Impact.
+
+## What Changes
+
+- **`seekable-decompressor-streams`** — two added requirements:
+  - **Native blocked-gzip random access (BGZF / mgzip):** recognize the blocked structure
+    from the first member's extra field, build a `SeekPoint` index by walking members via
+    the per-block compressed size (no decompression), and serve random reads by decoding
+    only the needed member(s). Zero-dependency (stdlib `zlib`). Arbitrary (non-blocked)
+    gzip is unaffected and still relies on the sequential/accelerator path.
+  - **`indexed_gzip` as an alternative gzip accelerator:** an optional backend for
+    *arbitrary* gzip random access, selected like the existing accelerators, with clean
+    absence behavior; it may build and (optionally) import/export a persistent index.
+- **`packaging-and-extras`** — note that `[seekable]` MAY include `indexed_gzip` as an
+  alternative gzip accelerator alongside `rapidgzip` / `indexed_bzip2`.
+- **`format-single-file-compressors`** — an added requirement for **block-split writing**:
+  an optional `block_size` that produces independently-decompressible output — gzip→BGZF,
+  xz→`lzma` block size, zstd→zstd seekable format — defaulting off (one solid stream), with
+  output that remains readable by standard tools and by Archivey's native seekable readers.
+
+Not changing **`format-detection`**: BGZF and mgzip are detected as `gzip` by magic
+(`1f 8b`) exactly as today; the blocked structure is discovered by the seekable reader, not
+by detection. No new magic, no new format enum.
+
+## Specs
+
+Proposed deltas (kept here, not applied to `openspec/specs/*` until accepted, per the
+"propose in `changes/`, don't edit shipped specs ad hoc" rule). Requirement text is written
+sync-ready.
+
+### seekable-decompressor-streams — ADDED Requirement: Native random access for blocked gzip (BGZF / mgzip)
+
+The system SHALL provide zero-dependency random access within **blocked gzip** streams —
+BGZF and mgzip — by reading the per-block size recorded in each gzip member's extra field,
+without decompressing to find block boundaries. Blocked gzip is a sequence of independent
+standalone gzip members; the system SHALL build a seek-point index by walking the members
+(each member's compressed size comes from its extra subfield; its uncompressed size from
+its gzip `ISIZE` trailer) and SHALL serve a seek by decoding only the member(s) containing
+the target offset. Recognition is by the member's extra subfield: BGZF's `BC` subfield
+(`BSIZE`, ≤64 KiB blocks) or mgzip's `MZ` subfield (4-byte compressed-member-size body).
+A gzip stream with **no** recognized blocked-gzip subfield is not treated as blocked; it
+falls back to the sequential path (or an accelerator, if enabled). Because blocked gzip is
+valid gzip, the same bytes remain decompressible by any gzip tool.
+
+When the blocked-gzip index is available, the reader SHALL report random-access capability
+in its cost (non-SOLID `access_cost` and a `seekable` flag), per
+`format-single-file-compressors`.
+
+#### Scenario: seeking within a BGZF file via the BC subfields
+
+- **WHEN** a seekable source whose first gzip member carries a `BC` extra subfield is opened
+- **THEN** the system walks the members using each block's `BSIZE` to build a block index without decompressing
+- **AND** a subsequent seek to an arbitrary uncompressed offset decodes only the block(s) containing that offset
+
+#### Scenario: seeking within an mgzip file via the MZ subfield
+
+- **WHEN** a seekable source whose gzip members carry the mgzip `MZ` extra subfield is opened
+- **THEN** the system builds the block index from the per-member compressed sizes and serves seeks by decoding only the needed member(s)
+
+#### Scenario: a plain gzip stream is not treated as blocked
+
+- **WHEN** a gzip stream has no recognized blocked-gzip extra subfield
+- **THEN** the native blocked-gzip path does not engage; the stream is served sequentially (or by an accelerator, if enabled), exactly as today
+
+### seekable-decompressor-streams — ADDED Requirement: indexed_gzip as an alternative gzip accelerator
+
+The system MAY use `indexed_gzip` (a zlib `zran`-based backend) as an alternative to
+`rapidgzip` for random access within **arbitrary** gzip streams, resolved by the same
+access-mode-aware configuration as the other accelerators and gated by the `[seekable]`
+extra. When enabled and installed it builds an index of seek points on demand; it MAY
+support importing/exporting that index to a persistent file. When it is absent or disabled,
+behavior is unchanged (sequential, with the rewind warning). `indexed_gzip` requires a
+seekable source.
+
+#### Scenario: gzip random access via indexed_gzip
+
+- **WHEN** the `indexed_gzip` backend is enabled and installed and a seekable gzip source is opened
+- **THEN** a seek to an arbitrary uncompressed offset is served without decompressing from the start
+
+#### Scenario: indexed_gzip backend absent
+
+- **WHEN** `indexed_gzip` is not installed or is disabled
+- **THEN** gzip random access falls back to any other enabled accelerator, else to the sequential path (which warns once on a rewind)
+
+### packaging-and-extras — MODIFIED Requirement: the `[seekable]` extra
+
+The `[seekable]` extra MAY include `indexed_gzip` as an alternative gzip accelerator
+alongside `rapidgzip` (gzip) and `indexed_bzip2` (bzip2). All remain optional: the core
+reads these formats sequentially without them. (No change to the zero-dependency core: the
+native blocked-gzip reader above adds **no** dependency — it uses stdlib `zlib`.)
+
+#### Scenario: seekable extra provides the gzip accelerators
+
+- **WHEN** `[seekable]` is installed
+- **THEN** `rapidgzip` and/or `indexed_gzip` are available as gzip random-access backends, and `indexed_bzip2` as the bzip2 backend
+
+### format-single-file-compressors — ADDED Requirement: block-split writing for seekable output
+
+When writing a single-file compressed stream, the system MAY accept a `block_size` option
+that produces **independently-decompressible blocks**, so the result supports later random
+access (and parallel compression). The mechanism is per codec and SHALL use the format's
+standard, interoperable blocking — never a bespoke container:
+
+- **gzip → BGZF**: independent ≤64 KiB gzip members with the `BC` extra subfield (and the
+  28-byte EOF marker). Output is valid gzip and is randomly seekable by the native
+  blocked-gzip reader.
+- **xz → multi-block**: set the `lzma` stream `block_size`; output is ordinary `.xz`,
+  randomly seekable via the XZ block index the reader already parses.
+- **zstd → zstd seekable format**: the skippable-frame seek table; output is ordinary
+  `.zst`.
+
+`block_size` SHALL default to off (a single solid stream — today's behavior). A codec with
+no block mechanism SHALL ignore the option (or reject it) rather than silently writing a
+non-seekable stream that claims to be blocked.
+
+#### Scenario: writing gzip with a block size yields seekable BGZF
+
+- **WHEN** a gzip single-file stream is written with `block_size` set
+- **THEN** the output is a valid BGZF gzip file (standard tools decompress it) that the native blocked-gzip reader can randomly seek
+
+#### Scenario: writing xz with a block size yields a seekable multi-block stream
+
+- **WHEN** an xz single-file stream is written with `block_size` set
+- **THEN** the output is an ordinary `.xz` whose block index lets the reader seek to an arbitrary offset by decoding only the relevant block(s)
+
+#### Scenario: default writing stays solid
+
+- **WHEN** no `block_size` is given
+- **THEN** a single solid stream is written, exactly as today
+
+## Impact
+
+- **Depends on:** Phase 2 stream layer — the `DecompressorStream` / `SeekPoint` index
+  machinery (reused by the blocked-gzip reader), the codec registry, and the `[seekable]`
+  extra. The write side depends on the archive/single-file **writing** path (later phase).
+- **Affected capabilities:** `seekable-decompressor-streams` (two new requirements),
+  `packaging-and-extras` (optional `indexed_gzip`), `format-single-file-compressors`
+  (`block_size` write option). No change to `format-detection` or the format enum.
+- **Sequencing (implementation, not in this proposal):**
+  - *Native blocked-gzip reading* fits alongside the other native seekable readers and can
+    land with single-file compressors (Phase 3) or shortly after — it is pure-stdlib.
+  - *`indexed_gzip`* is a small optional-backend addition; lowest priority, non-breaking.
+  - *`block_size` writing* belongs to the writing phase (Phase 5+), designed to round-trip
+    with the native readers.
+- **Out of scope:** arbitrary (non-blocked) gzip random access without an accelerator
+  remains unsupported by design; standalone mgzip support beyond recognizing its `MZ`
+  subfield in the shared blocked-gzip reader is not pursued (too niche to warrant its own
+  path); the bespoke `indexed_gzip` `.gzidx` on-disk index format is referenced as an
+  optional capability, not mandated.

--- a/openspec/changes/seekable-gzip-and-block-writing/tasks.md
+++ b/openspec/changes/seekable-gzip-and-block-writing/tasks.md
@@ -1,0 +1,69 @@
+# Tasks — Seekable blocked-gzip reading + block-split writing
+
+> Specs-only proposal. These tasks describe the implementation when the change is
+> accepted and scheduled; nothing is implemented here. Run tools through `uv`
+> (`uv run pytest`, `uv run pyrefly check`, `uv run ty check`, `uv run ruff`).
+> Depends on the Phase-2 stream layer (`DecompressorStream`/`SeekPoint`, codec registry).
+
+## 1. Native blocked-gzip random access (BGZF / mgzip) — zero-dep
+
+- [ ] 1.1 Add a `BgzfDecompressorStream` (a `DecompressorStream` subclass) that, on a
+      seekable source, recognizes blocked gzip from the first member's extra field:
+      the BGZF `BC` subfield (`BSIZE`, ≤64 KiB) or the mgzip `MZ` subfield (4-byte
+      compressed-member-size body).
+- [ ] 1.2 Build the `SeekPoint` index by walking members without decompressing: per-member
+      compressed size from the extra subfield; per-member uncompressed size from the gzip
+      `ISIZE` trailer. Decode a seek by resetting to the member containing the target.
+- [ ] 1.3 Wire it into the gzip codec path: when the source is seekable and blocked-gzip is
+      recognized, use this backend; otherwise fall back to the existing sequential/
+      accelerator path (no rewind warning needed when the index is present).
+- [ ] 1.4 Report random-access capability in the cost model (non-SOLID `access_cost`,
+      `seekable` flag) when the index is available.
+- [ ] 1.5 Leave non-blocked gzip untouched (still sequential, still warns on rewind).
+
+## 2. `indexed_gzip` alternative accelerator (optional)
+
+- [ ] 2.1 Add an `indexed_gzip` backend for arbitrary gzip random access, resolved by the
+      same access-mode-aware config as `rapidgzip`, gated by `[seekable]`.
+- [ ] 2.2 Translate `indexed_gzip` exceptions into the v2 hierarchy; clean absence/disabled
+      behavior (fall back to another accelerator, else sequential).
+- [ ] 2.3 (Optional) expose import/export of its persistent index (`.gzidx`).
+- [ ] 2.4 Add `indexed_gzip` to the `[seekable]` extra in `pyproject.toml`.
+
+## 3. Block-split writing (`block_size`)
+
+- [ ] 3.1 Add a `block_size` write option to single-file compressor writing.
+- [ ] 3.2 gzip → emit BGZF (independent ≤64 KiB members + `BC` subfield + 28-byte EOF
+      marker); verify standard `gzip` decompresses it and the native reader (task 1) seeks it.
+- [ ] 3.3 xz → set the `lzma` stream `block_size`; verify the XZ index reader seeks it.
+- [ ] 3.4 zstd → write the zstd seekable format (skippable-frame seek table).
+- [ ] 3.5 A codec with no block mechanism ignores/rejects `block_size` rather than writing a
+      non-seekable stream that claims to be blocked. Default off (one solid stream).
+
+## 4. Tests
+
+- [ ] 4.1 BGZF read: index built without full decode; backward/forward seeks decode only the
+      needed block(s); cross-validate against a `bgzip`/pysam-produced fixture when available
+      (skip cleanly otherwise).
+- [ ] 4.2 mgzip read: `MZ`-subfield index; seek correctness; cross-validate against an
+      `mgzip`-produced fixture when available.
+- [ ] 4.3 Plain gzip is not misdetected as blocked (no `BC`/`MZ` → sequential path).
+- [ ] 4.4 `indexed_gzip` present/absent (skip when not installed); generic-gzip seek works.
+- [ ] 4.5 Round-trip: write gzip with `block_size` → read back via the native BGZF reader and
+      via stdlib `gzip`; write xz with `block_size` → seek via the XZ index.
+
+## 5. Verify — acceptance
+
+- [ ] 5.1 All added `seekable-decompressor-streams` scenarios covered (BGZF, mgzip, plain-gzip
+      fallback, indexed_gzip present/absent).
+- [ ] 5.2 All added `format-single-file-compressors` write scenarios covered.
+- [ ] 5.3 Zero-dependency core unchanged: the native blocked-gzip reader uses only stdlib
+      `zlib` (assert no new core dependency). `indexed_gzip` stays optional under `[seekable]`.
+- [ ] 5.4 `uv run pyrefly check`, `uv run ty check`, `uv run ruff check` clean; new tests green.
+
+## 6. Sync specs
+
+- [ ] 6.1 On acceptance, sync the `## Specs` deltas into `openspec/specs/` (the
+      `seekable-decompressor-streams`, `packaging-and-extras`, and
+      `format-single-file-compressors` requirements) and register nothing new in the
+      capability map (no new capability — these extend existing ones).


### PR DESCRIPTION
A **specs-only** OpenSpec change proposal capturing the investigation of BGZF, indexed_gzip, mgzip, and block-split writing. No code, and **no shipped `openspec/specs/*` are edited** — the proposed requirement deltas live in `openspec/changes/seekable-gzip-and-block-writing/` (per the repo's "propose in `changes/`, don't edit shipped specs ad hoc" rule). Kept entirely separate from the Phase-2 PR #7.

## Summary of what's proposed

**`seekable-decompressor-streams`** (two added requirements)
- **Native, zero-dependency random access for blocked gzip (BGZF + mgzip).** Both store the per-block compressed size in each gzip member's extra field — BGZF's `BC` subfield, mgzip's `MZ` subfield — so a block index can be built by *walking members without decompressing*, exactly like our existing XZ block-index and lzip trailer-scan readers. This gives BGZF/mgzip random access with stdlib `zlib` only — **no `rapidgzip` needed**. Arbitrary (non-blocked) gzip is unaffected.
- **`indexed_gzip` as an optional alternative gzip accelerator** (lighter/more portable than `rapidgzip`, with a persistable index), behind the same `[seekable]` gating.

**`packaging-and-extras`** — `[seekable]` may include `indexed_gzip` alongside `rapidgzip`/`indexed_bzip2`. The native blocked-gzip reader adds **no** dependency.

**`format-single-file-compressors`** — a `block_size` write option that emits seekable, *interoperable* output (gzip→**BGZF**, xz→`lzma` block size, zstd→zstd seekable format), defaulting to a single solid stream. This is the write-side mirror of the native readers.

No `format-detection` change: BGZF/mgzip are detected as `gzip` by magic; the blocked structure is discovered by the reader, not detection.

## Disposition of the four questions
- **BGZF** → support reading natively (high value, zero-dep, reuses existing machinery).
- **indexed_gzip** → worth offering as an optional alternative accelerator; low priority, non-breaking.
- **mgzip** → recognize its `MZ` subfield inside the shared blocked-gzip reader (a few lines on top of BGZF); not worth a standalone path.
- **block-split writing** → yes, designed to round-trip with the native readers; belongs to the writing phase.

Implementation is sequenced in the proposal (`tasks.md`), not done here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0183r6yxzNcJfo9QZXaXELBY)_