### PR TITLE
Phase 3 Stage 1: foundation + ZIP backend (detect→select→open→read→cost)

### DIFF
--- a/openspec/changes/phase-3-indexed-leaf-formats/proposal.md
+++ b/openspec/changes/phase-3-indexed-leaf-formats/proposal.md
@@ -59,9 +59,11 @@ the work is plannable as concrete tasks:
   `ExtractionCoordinator` / safe-extraction. This is the *only* container that composes
   with stream compressors (see the seek-heavy-container note under ISO).
 - **Single-file compressors** (`formats/single_file_reader.py`): **one**
-  `SingleFileBackend` whose `FORMATS` is the standalone-codec set
-  (gz/bz2/xz/lzip/zlib/brotli + unix-compress this phase; **zst/lz4 deferred to
-  Phase 8**; needs `StreamFormat`/`ArchiveFormat` enum extensions — see Specs). One
+  `SingleFileBackend` whose `FORMATS` is the full standalone-codec set
+  (gz/bz2/xz/zst/lz4/lzip/zlib/brotli + unix-compress; needs `StreamFormat`/
+  `ArchiveFormat` enum extensions — see Specs). zst/lz4 are included now (their codecs
+  already exist from Phase 2 and there was no concrete blocker); Phase 8 is left for their
+  *seekable-decompressor* refinements only. One
   `FILE` member, name inferred from the source filename (strip known ext / append
   `.uncompressed` / default `"data"`), per-codec metadata hooks (gzip `FNAME` →
   `extra["gzip.original_filename"]` decoded + `raw_name` undecoded; xz/zst header size;
@@ -211,7 +213,8 @@ is realized in Phase 7, not here.
   frozen-oracle coverage as it transfers.
 - **Deferred (recorded, not built here):** TAR forward-only `stream_members()` +
   `ExtractionCoordinator` / safe-extraction (Phase 4), SFX detection (Phase 7), ZST/LZ4
-  single-file (Phase 8), ISO raw-`.bin` sector stripping (optional/MAY-drop), mounting
+  *seekable-decompressor* refinements (Phase 8 — basic ZST/LZ4 single-file reading is
+  included here), ISO raw-`.bin` sector stripping (optional/MAY-drop), mounting
   compressed seek-heavy containers (`.iso.xz`/`.zip.xz` — single-file-wrapped instead),
   multiple *format* backends per format, explicit ZIP `spool_max_size` opt-in.
 - **Risk:** `PeekableStream` is the one fresh primitive (not a port) — get the

--- a/openspec/changes/phase-3-indexed-leaf-formats/specs/archive-data-model/spec.md
+++ b/openspec/changes/phase-3-indexed-leaf-formats/specs/archive-data-model/spec.md
@@ -38,7 +38,7 @@ class StreamFormat(StrEnum):
 ```
 
 Named standalone `ArchiveFormat` constants SHALL exist for the bare single-stream
-formats — `GZ`, `BZ2`, `XZ`, `ZST`, `LZIP`, `ZLIB`, `BROTLI`, `Z` (each
+formats — `GZ`, `BZ2`, `XZ`, `ZST`, `LZ4`, `LZIP`, `ZLIB`, `BROTLI`, `Z` (each
 `RAW_STREAM × <codec>`) — alongside the container constants (`ZIP`, `TAR`, `TAR_GZ`, …).
 Container × codec combinations that are **not in common practice** (e.g. `tar.lz`,
 `tar.br`) SHALL NOT get a predefined constant; they are constructed on demand as

--- a/openspec/changes/phase-3-indexed-leaf-formats/specs/backend-registry/spec.md
+++ b/openspec/changes/phase-3-indexed-leaf-formats/specs/backend-registry/spec.md
@@ -37,7 +37,7 @@ class IsoReadBackend(ReadBackend):
     EXTENSIONS = {".iso": ArchiveFormat.ISO}        # extension -> format
     MAGIC = ((32769, b"CD001", ArchiveFormat.ISO),) # (offset, bytes, format)
     OPTIONAL_DEPENDENCY = "pycdlib"       # data; the registry derives availability from it
-    def open_read(self, source, streaming, password, encoding, archive_name) -> ArchiveReader:
+    def open_read(self, source, format, streaming, password, encoding, archive_name) -> ArchiveReader:
         assert pycdlib is not None        # open_read is only reached for an available backend
         ...
 
@@ -118,7 +118,11 @@ class ReadBackend(ABC):
     OPTIONAL_DEPENDENCY: str | None = None               # e.g. "pycdlib"
 
     @abstractmethod
-    def open_read(self, source, streaming, password, encoding, archive_name) -> ArchiveReader: ...
+    def open_read(self, source, format, streaming, password, encoding, archive_name) -> ArchiveReader: ...
+    # `format` is the resolved ArchiveFormat the registry selected this backend for —
+    # detected by open_archive() or passed explicitly by the caller. A multi-format
+    # backend (SingleFileBackend, TAR) uses it to pick its concrete codec/variant instead
+    # of re-inspecting the source; single-format backends ignore it.
 
 class WriteBackend(ABC):
     FORMATS: tuple[ArchiveFormat, ...]

--- a/openspec/changes/phase-3-indexed-leaf-formats/specs/backend-registry/spec.md
+++ b/openspec/changes/phase-3-indexed-leaf-formats/specs/backend-registry/spec.md
@@ -110,10 +110,19 @@ backends into one table; backends carry no `detect(peek)` method (matching is
 centralized — see the detection/selection requirement).
 
 ```python
+class MagicSignature(NamedTuple):
+    offset: int
+    magic: bytes
+    format: ArchiveFormat
+    weak: bool = False   # a too-short/unspecific signal (zlib's 2-byte header): the
+                         # detector confirms it with a content probe before accepting it
+
 class ReadBackend(ABC):
     FORMATS: tuple[ArchiveFormat, ...]                   # formats this backend reads
     EXTENSIONS: Mapping[str, ArchiveFormat] = {}         # ".gz" -> ArchiveFormat.GZ
-    MAGIC: tuple[tuple[int, bytes, ArchiveFormat], ...] = ()  # (offset, bytes, format)
+    MAGIC: tuple[MagicSignature, ...] = ()               # magic signals declared as data
+    CONTENT_PROBE_FORMATS: tuple[ArchiveFormat, ...] = ()  # magic-less formats (Brotli)
+                         # the detector confirms by decoding a bounded prefix through the codec
     REQUIRES_SEEK: bool = False                          # if True, non-seekable sources rejected
     OPTIONAL_DEPENDENCY: str | None = None               # e.g. "pycdlib"
 

--- a/openspec/changes/phase-3-indexed-leaf-formats/tasks.md
+++ b/openspec/changes/phase-3-indexed-leaf-formats/tasks.md
@@ -27,11 +27,20 @@
 - [ ] 0.5 **Seek-heavy containers are not mounted over a compressor**: only TAR
       composes with stream compressors; `.iso.xz`/`.iso.gz`/`.zip.xz` are single-file
       compressors wrapping the inner image.
-- [ ] 0.6 Scope: unix-compress single-file lands here; **ZST/LZ4 → Phase 8**;
-      **SFX detection → Phase 7**; ISO raw-`.bin` stripping deferred (MAY-drop).
+- [x] 0.6 Scope: unix-compress single-file lands here; **ZST/LZ4 single-file also land
+      here** (revised — the codecs already exist from Phase 2, the magic bytes are known,
+      and `ZST` was already a named constant; only `ArchiveFormat.LZ4` + the detection
+      entries were missing, so there was no concrete blocker). **SFX detection → Phase 7**;
+      ISO raw-`.bin` stripping deferred (MAY-drop). (Phase 8 remains for ZST/LZ4 *seekable*
+      decompressor refinements, not basic single-file reading.)
 - [x] 0.7 No `config` param on `open_read` this phase: a backend opening a codec builds
       `StreamConfig(streaming=self._streaming)` itself so the accelerator `AUTO`
       resolves correctly. A public config surface arrives in Phase 5.
+- [x] 0.8 `open_read` **receives the resolved `format`** (detected by `open_archive` or
+      passed by the caller) rather than re-inspecting the source. A multi-format backend
+      (`SingleFileBackend`, TAR) uses it to pick its concrete codec/variant; this also
+      lets the caller's explicit `format=` truly bypass detection. (Spec delta:
+      `backend-registry` `open_read` signature.)
 
 ## Stage map (implementation order — one PR per stage)
 
@@ -146,14 +155,16 @@ incrementally — each as its format's stage lands.
 - [x] 4.0 **Extend the data model** (prerequisite): add `StreamFormat.LZIP` (`"lz"`),
       `ZLIB` (`"zz"`), `BROTLI` (`"br"`), `UNIX_COMPRESS` (`"Z"`); extend
       `_STREAM_FORMAT_CODECS` to map them to their `Codec`; add named standalone
-      `ArchiveFormat` constants (`LZIP`, `ZLIB`, `BROTLI`, `Z`). Uncommon **combos**
-      (e.g. `tar.lz`) get **no** predefined constant — they are built on demand as
-      `ArchiveFormat(container, stream)`. (Spec delta: `archive-data-model`.)
+      `ArchiveFormat` constants (`LZIP`, `ZLIB`, `BROTLI`, `Z`, and `LZ4` — `ZST`
+      already existed). Uncommon **combos** (e.g. `tar.lz`) get **no** predefined
+      constant — they are built on demand as `ArchiveFormat(container, stream)`.
+      (Spec delta: `archive-data-model`.)
 - [x] 4.1 `formats/single_file_reader.py` — one `SingleFileBackend`,
-      `FORMATS` = standalone-codec set available this phase
-      (gz/bz2/xz/lzip/zlib/brotli/unix-compress); decompression via
+      `FORMATS` = the full standalone-codec set
+      (gz/bz2/xz/zst/lz4/lzip/zlib/brotli/unix-compress); decompression via
       `open_codec_stream(codec_for_stream_format(fmt.stream), source,
-      config=StreamConfig(streaming=streaming))` (see 0.7).
+      config=StreamConfig(streaming=streaming))` (see 0.7). A missing optional codec
+      (zstandard/lz4) makes its single-file format NONE-support via the registry.
 - [x] 4.2 One `FILE` member; name inference (strip known compression ext / append
       `.uncompressed` / default `"data"`); no synthesized directories; exactly one
       member yielded.
@@ -236,7 +247,8 @@ incrementally — each as its format's stage lands.
 - [x] 8.2 **(S2)** `format-single-file-compressors` scenarios for this-phase codecs
       (name inference, one member, gzip stored name → `extra` + `raw_name`, per-format
       size rules, `DIRECT` cost, non-seekable `.Z` raises, password raises). ZST/LZ4
-      scenarios deferred to Phase 8.
+      single-file scenarios included here (skipped when their codec is absent); their
+      *seekable-decompressor* refinements remain Phase 8.
 - [ ] 8.3 **(S4)** `format-iso` scenarios (namespace auto-select + fidelity, write
       rejected, non-seekable rejected) — skip when `pycdlib` absent.
 - [ ] 8.4 `format-detection` scenarios, by stage: **(S1)** magic, extension, conflict

--- a/openspec/changes/phase-3-indexed-leaf-formats/tasks.md
+++ b/openspec/changes/phase-3-indexed-leaf-formats/tasks.md
@@ -262,6 +262,19 @@ incrementally — each as its format's stage lands.
       `streaming=False`): **(S1)** ZIP + non-seekable ZIP fail-fast; **(S3)** TAR.
 - [ ] 8.7 Retire the matching `tests/_dev_oracle/` coverage as each format transfers
       (per stage).
+- [~] 8.8 **Per-format corrupt/truncated handling** — opening or reading a corrupt /
+      truncated archive raises `CorruptionError` / `TruncatedError` (with the original
+      exception as `__cause__`), exercised **per backend as it lands** rather than
+      deferred wholesale to Phase 10. This pulls testing-contract's "Corrupt archive"
+      adversarial case forward so each backend's `_translate_exception` hook is locked
+      down when written. Done: **(S1)** ZIP (truncated archive; corrupt member CRC),
+      **(S2)** single-file (truncated/corrupt gzip, via a non-seekable source so the
+      stdlib path is deterministic). Pending: **(S3)** TAR, **(S4)** ISO. The full
+      adversarial corpus (traversal, bombs, every format) still consolidates in
+      Phase 10. **Follow-up (codec layer, pre-existing):** the `rapidgzip` accelerator
+      leaks a raw `RuntimeError` on a corrupt header and does not raise on truncation —
+      `_translate_rapidgzip` needs the corrupt-header pattern, and truncation detection
+      needs a decision (see review notes).
 
 ## 9. Verify — acceptance criteria
 

--- a/openspec/changes/phase-3-indexed-leaf-formats/tasks.md
+++ b/openspec/changes/phase-3-indexed-leaf-formats/tasks.md
@@ -18,9 +18,9 @@
 ## 0. Decisions locked in this change (no code, just honored below)
 
 - [ ] 0.1 Single-file = **one** multi-format `SingleFileBackend` + per-codec hooks.
-- [ ] 0.2 Registry: **always register**; support is tri-state (FULL/PARTIAL/NONE),
+- [x] 0.2 Registry: **always register**; support is tri-state (FULL/PARTIAL/NONE),
       compositional over format backend + codec backends. Format backends stay 1:1.
-- [ ] 0.3 Non-seekable ZIP **fails fast** (no implicit spool).
+- [x] 0.3 Non-seekable ZIP **fails fast** (no implicit spool).
 - [ ] 0.4 **TAR read** (random-access) + compressed-tar detection land here; TAR
       `stream_members`/forward-only + `ExtractionCoordinator`/safe-extraction stay
       **Phase 4**.
@@ -29,7 +29,7 @@
       compressors wrapping the inner image.
 - [ ] 0.6 Scope: unix-compress single-file lands here; **ZST/LZ4 → Phase 8**;
       **SFX detection → Phase 7**; ISO raw-`.bin` stripping deferred (MAY-drop).
-- [ ] 0.7 No `config` param on `open_read` this phase: a backend opening a codec builds
+- [x] 0.7 No `config` param on `open_read` this phase: a backend opening a codec builds
       `StreamConfig(streaming=self._streaming)` itself so the accelerator `AUTO`
       resolves correctly. A public config surface arrives in Phase 5.
 
@@ -54,11 +54,11 @@ incrementally — each as its format's stage lands.
 
 > **Stage 1.**
 
-- [ ] 1.1 `internal/streams/peekable.py` — buffer first `DETECTION_LIMIT` bytes
+- [x] 1.1 `internal/streams/peekable.py` — buffer first `DETECTION_LIMIT` bytes
       (4 096 default; 32 774 when ISO detection is triggered), `.peek(n)` returns
       buffered bytes without consuming, reads drain buffer-then-underlying. Presents
       as `BinaryIO`. Constructed by the opener for **non-seekable** sources.
-- [ ] 1.2 Tests: peek without consume; read replays buffer then passes through;
+- [x] 1.2 Tests: peek without consume; read replays buffer then passes through;
       peek beyond buffered limit; non-seekable underlying; ISO-sized window.
 
 ## 2. Format detection
@@ -66,12 +66,13 @@ incrementally — each as its format's stage lands.
 > **Spans stages** — core in Stage 1; each probe lands with the backend it feeds
 > (Brotli → S2, inner-TAR → S3, ISO window → S4). Stage tags are inline below.
 
-- [ ] 2.1 **(S1)** `detect_format(source) -> FormatInfo` + the `FormatInfo` /
+- [x] 2.1 **(S1)** `detect_format(source) -> FormatInfo` + the `FormatInfo` /
       `DetectionConfidence` dataclasses per `format-detection`.
-- [ ] 2.2 **(S1)** Magic table aggregated from each backend's `MAGIC`/`EXTENSIONS`
+- [x] 2.2 **(S1)** Magic table aggregated from each backend's `MAGIC`/`EXTENSIONS`
       **data** (no per-backend `detect()` logic); magic-first (`CERTAIN`) → extension
-      (`GUESS`); zlib 2-byte header treated as a weak/low-confidence match.
-- [ ] 2.3 **(S1)** Magic/extension **conflict** → `logging.WARNING` on
+      (`GUESS`); zlib 2-byte header treated as a weak/low-confidence match. (zlib weak
+      match arrives with the zlib magic entry in S2 — no zlib backend is registered yet.)
+- [x] 2.3 **(S1)** Magic/extension **conflict** → `logging.WARNING` on
       `archivey.detection`; magic wins.
 - [ ] 2.4 **(S3)** Inner-TAR probe over a single-file compressor →
       `TAR_GZ`/`TAR_BZ2`/`TAR_XZ`/`TAR_LZIP`/… (decompress ≥ 512 bytes; skip + defer
@@ -86,7 +87,7 @@ incrementally — each as its format's stage lands.
       32 KiB is cheap and the rule is cleaner). Peek to 32 774 bytes (`PeekableStream`
       grows its buffer to this cap on demand); too-short stream → "not ISO", fall
       through (never reject solely for being shorter than the ISO window).
-- [ ] 2.7 **(S1)** Non-consumption: seekable/path sources `seek(0)` after detection;
+- [x] 2.7 **(S1)** Non-consumption: seekable/path sources `seek(0)` after detection;
       non-seekable wrapped once in `PeekableStream` by the opener and shared with the
       backend.
 - [ ] 2.8 (Deferred — Phase 7) SFX EXE-stub scan + `payload_offset`. Not built here.
@@ -95,16 +96,16 @@ incrementally — each as its format's stage lands.
 
 > **Stage 1.**
 
-- [ ] 3.1 `formats/zip_reader.py` on the ABC (stdlib `zipfile`); `MAGIC`/`EXTENSIONS`
+- [x] 3.1 `formats/zip_reader.py` on the ABC (stdlib `zipfile`); `MAGIC`/`EXTENSIONS`
       declared as data; `REQUIRES_SEEK = True`; `_MEMBER_LIST_UPFRONT`,
       `_SUPPORTS_RANDOM_ACCESS`.
-- [ ] 3.2 `ZipInfo` → `ArchiveMember` mapping: `mode` from `external_attr>>16`
+- [x] 3.2 `ZipInfo` → `ArchiveMember` mapping: `mode` from `external_attr>>16`
       (None when 0 / non-Unix), NT-timestamp precedence over DOS `date_time`,
       type from mode/`is_dir()`/symlink extra fields, `compression` map,
       `is_encrypted` from `flag_bits & 0x1`.
-- [ ] 3.3 Central-directory lookup is O(1) via `NameToInfo` (no extra I/O).
-- [ ] 3.4 Non-seekable source → `StreamNotSeekableError` at open (fail fast).
-- [ ] 3.5 Multi-volume (split/spanned) ZIP → **best-effort** `UnsupportedFeatureError`
+- [x] 3.3 Central-directory lookup is O(1) via `NameToInfo` (no extra I/O).
+- [x] 3.4 Non-seekable source → `StreamNotSeekableError` at open (fail fast).
+- [x] 3.5 Multi-volume (split/spanned) ZIP → **best-effort** `UnsupportedFeatureError`
       with the "rejoin first" hint: detect the obvious signals we can cheaply see
       (a `.z01`/`.zNN` segment by name; a non-zero disk field if `zipfile` surfaces it)
       and raise; otherwise let `zipfile` try, and translate a resulting `BadZipFile`
@@ -193,20 +194,20 @@ incrementally — each as its format's stage lands.
 > **Stage 1** (the tri-state machinery; **NONE** end-to-end is verified in Stage 4
 > with ISO, and full **PARTIAL**-at-read completes in Phase 7 with 7z).
 
-- [ ] 6.1 Register **all** known backends at import; optional ones derive availability
+- [x] 6.1 Register **all** known backends at import; optional ones derive availability
       from the `_optional(OPTIONAL_DEPENDENCY)` sentinel (no per-backend boolean);
       retain `OPTIONAL_DEPENDENCY` + install hint.
-- [ ] 6.2 `FormatSupport` enum (FULL/PARTIAL/NONE); `format_availability(fmt)`
+- [x] 6.2 `FormatSupport` enum (FULL/PARTIAL/NONE); `format_availability(fmt)`
       computed compositionally over the format backend + the codec backends a format
       can use; returns missing components (package/extra/tool + hint + unlocked
       codecs).
-- [ ] 6.3 `list_supported_formats()` → FULL ∪ PARTIAL; `list_known_formats()` → all
+- [x] 6.3 `list_supported_formats()` → FULL ∪ PARTIAL; `list_known_formats()` → all
       known.
-- [ ] 6.4 Selection: `reader_for_format()` maps detected format → backend; a NONE
+- [x] 6.4 Selection: `reader_for_format()` maps detected format → backend; a NONE
       format raises `UnsupportedFormatError` with the install hint; missing-dep gaps
       kept distinct from by-design rejections (BCJ2/unknown method IDs →
       `UnsupportedFeatureError`).
-- [ ] 6.5 Public-API exposure of `detect_format`, `list_supported_formats`,
+- [x] 6.5 Public-API exposure of `detect_format`, `list_supported_formats`,
       `list_known_formats`, `format_availability`.
 
 ## 7. Wire `open_archive()` + cost
@@ -214,19 +215,19 @@ incrementally — each as its format's stage lands.
 > **Stage 1** for the wiring (7.1); **7.2** per-format cost is verified as each
 > format's stage lands (ZIP S1, single-file S2, TAR S3, ISO S4).
 
-- [ ] 7.1 `open_archive()` detects (wrapping non-seekable in `PeekableStream`),
+- [x] 7.1 `open_archive()` detects (wrapping non-seekable in `PeekableStream`),
       selects the backend, enforces `REQUIRES_SEEK` fail-fast, hands over the shared
       stream.
 - [ ] 7.2 `CostReceipt` values verified per format (ZIP `INDEXED`/`DIRECT`/`SEEKABLE`;
       TAR `REQUIRES_SCANNING`|`REQUIRES_DECOMPRESSION`/`DIRECT`; single-file
       `INDEXED`/`DIRECT`; ISO `INDEXED`/`DIRECT`/`SEEKABLE`).
-- [ ] 7.3 Thread the encoding: `open_read` receives the caller's explicit `encoding`
+- [x] 7.3 Thread the encoding: `open_read` receives the caller's explicit `encoding`
       if given, else the detector's `encoding_hint`, else `None` (backend
       auto-detects). The existing `encoding` parameter carries it — no new argument.
 
 ## 8. Tests added (new suite)
 
-- [ ] 8.1 **(S1)** `format-zip` scenarios (CostReceipt, O(1) lookup, member mapping,
+- [x] 8.1 **(S1)** `format-zip` scenarios (CostReceipt, O(1) lookup, member mapping,
       non-seekable fail-fast, multi-volume rejection).
 - [ ] 8.1b **(S3)** `format-tar` random-access read scenarios (PAX/GNU/ustar mapping,
       compressed-tar `tar.gz`/`tar.xz`/…, cost). Streaming/`stream_members` scenarios

--- a/openspec/changes/phase-3-indexed-leaf-formats/tasks.md
+++ b/openspec/changes/phase-3-indexed-leaf-formats/tasks.md
@@ -17,7 +17,7 @@
 
 ## 0. Decisions locked in this change (no code, just honored below)
 
-- [ ] 0.1 Single-file = **one** multi-format `SingleFileBackend` + per-codec hooks.
+- [x] 0.1 Single-file = **one** multi-format `SingleFileBackend` + per-codec hooks.
 - [x] 0.2 Registry: **always register**; support is tri-state (FULL/PARTIAL/NONE),
       compositional over format backend + codec backends. Format backends stay 1:1.
 - [x] 0.3 Non-seekable ZIP **fails fast** (no implicit spool).
@@ -79,7 +79,7 @@ incrementally — each as its format's stage lands.
       when codec backend absent). These are **openable** once the TAR reader (§3b)
       lands. No inner-ISO / inner-ZIP probe — seek-heavy containers stay
       single-file-wrapped (0.5).
-- [ ] 2.5 **(S2)** Brotli **content probe** (`PROBABLE`); skipped when the Brotli
+- [x] 2.5 **(S2)** Brotli **content probe** (`PROBABLE`); skipped when the Brotli
       backend is missing (fall through to `.br` extension `GUESS`); each probe restores
       position.
 - [ ] 2.6 **(S4)** ISO probe: always attempt it as a **fallback** when the 4 KiB magic
@@ -143,35 +143,36 @@ incrementally — each as its format's stage lands.
 
 > **Stage 2.**
 
-- [ ] 4.0 **Extend the data model** (prerequisite): add `StreamFormat.LZIP` (`"lz"`),
+- [x] 4.0 **Extend the data model** (prerequisite): add `StreamFormat.LZIP` (`"lz"`),
       `ZLIB` (`"zz"`), `BROTLI` (`"br"`), `UNIX_COMPRESS` (`"Z"`); extend
       `_STREAM_FORMAT_CODECS` to map them to their `Codec`; add named standalone
       `ArchiveFormat` constants (`LZIP`, `ZLIB`, `BROTLI`, `Z`). Uncommon **combos**
       (e.g. `tar.lz`) get **no** predefined constant — they are built on demand as
       `ArchiveFormat(container, stream)`. (Spec delta: `archive-data-model`.)
-- [ ] 4.1 `formats/single_file_reader.py` — one `SingleFileBackend`,
+- [x] 4.1 `formats/single_file_reader.py` — one `SingleFileBackend`,
       `FORMATS` = standalone-codec set available this phase
       (gz/bz2/xz/lzip/zlib/brotli/unix-compress); decompression via
       `open_codec_stream(codec_for_stream_format(fmt.stream), source,
       config=StreamConfig(streaming=streaming))` (see 0.7).
-- [ ] 4.2 One `FILE` member; name inference (strip known compression ext / append
+- [x] 4.2 One `FILE` member; name inference (strip known compression ext / append
       `.uncompressed` / default `"data"`); no synthesized directories; exactly one
       member yielded.
-- [ ] 4.3 Per-codec metadata hooks (dispatch table, not `if`-chains): gzip `FNAME` →
+- [x] 4.3 Per-codec metadata hooks (dispatch table, not `if`-chains): gzip `FNAME` →
       `extra["gzip.original_filename"]` (decoded) **and** `raw_name` (undecoded bytes);
       `name` still derived from the source filename unless configured otherwise (+
       gzip mtime). Other size hooks: xz/zst header size; lz4 frame size; lzip trailer
       size; gz size always `None`; bz2/zlib/br/Z size `None` until full read (then may
-      update).
-- [ ] 4.4 Cost: `INDEXED` listing (always one member); `DIRECT` access (one member —
+      update). (xz/lzip size implemented via the seekable index/trailer; zst/lz4 are
+      Phase 8.)
+- [x] 4.4 Cost: `INDEXED` listing (always one member); `DIRECT` access (one member —
       no inter-member dependency, so `SOLID` does not apply). Whether the opened member
       *stream* can seek (xz block index, etc.) is a stream-level property
       (`seekable-decompressor-streams`), not the archive-level `CostReceipt`.
-- [ ] 4.5 unix-compress quirks honored: **requires a seekable source** — a non-seekable
+- [x] 4.5 unix-compress quirks honored: **requires a seekable source** — a non-seekable
       `.Z` raises `StreamNotSeekableError` at open (the unix-compress codec already
       raises this; other single-file formats stay readable on a non-seekable source).
       No truncation signal → a short stream yields fewer bytes with no error.
-- [ ] 4.6 A non-`None` `password` on a single-file open raises
+- [x] 4.6 A non-`None` `password` on a single-file open raises
       `UnsupportedOperationError` (single-file compressors have no encryption).
 
 ## 5. ISO backend
@@ -232,7 +233,7 @@ incrementally — each as its format's stage lands.
 - [ ] 8.1b **(S3)** `format-tar` random-access read scenarios (PAX/GNU/ustar mapping,
       compressed-tar `tar.gz`/`tar.xz`/…, cost). Streaming/`stream_members` scenarios
       deferred to Phase 4.
-- [ ] 8.2 **(S2)** `format-single-file-compressors` scenarios for this-phase codecs
+- [x] 8.2 **(S2)** `format-single-file-compressors` scenarios for this-phase codecs
       (name inference, one member, gzip stored name → `extra` + `raw_name`, per-format
       size rules, `DIRECT` cost, non-seekable `.Z` raises, password raises). ZST/LZ4
       scenarios deferred to Phase 8.

--- a/src/archivey/__init__.py
+++ b/src/archivey/__init__.py
@@ -13,6 +13,11 @@ from archivey.internal.cost import (
     ListingCost,
     StreamCapability,
 )
+from archivey.internal.detection import (
+    DetectionConfidence,
+    FormatInfo,
+    detect_format,
+)
 from archivey.internal.errors import (
     ArchiveyError,
     CorruptionError,
@@ -36,6 +41,14 @@ from archivey.internal.errors import (
 )
 from archivey.internal.open_archive import open_archive
 from archivey.internal.reader import ArchiveReader
+from archivey.internal.registry import (
+    FormatAvailability,
+    FormatSupport,
+    MissingComponent,
+    format_availability,
+    list_known_formats,
+    list_supported_formats,
+)
 from archivey.internal.types import (
     ArchiveFormat,
     ArchiveInfo,
@@ -51,6 +64,15 @@ from archivey.internal.types import (
 __all__ = [
     "__version__",
     "open_archive",
+    "detect_format",
+    "FormatInfo",
+    "DetectionConfidence",
+    "format_availability",
+    "list_supported_formats",
+    "list_known_formats",
+    "FormatSupport",
+    "FormatAvailability",
+    "MissingComponent",
     "ArchiveReader",
     "ArchiveFormat",
     "ContainerFormat",
@@ -85,6 +107,11 @@ __all__ = [
     "PackageNotInstalledError",
     "UnsupportedOperationError",
 ]
+
+# Register the bundled backends eagerly (each module self-registers on import), so the
+# availability queries (list_supported_formats / format_availability) work immediately
+# after `import archivey`, without first calling open_archive().
+import archivey.formats  # noqa: E402,F401
 
 # Keep the importlib.metadata helpers out of the public `archivey` namespace
 # (so `__all__` stays the single, hand-curated description of the public API).

--- a/src/archivey/formats/__init__.py
+++ b/src/archivey/formats/__init__.py
@@ -4,3 +4,4 @@
 # bundled backends available for selection. Do not remove these imports — without
 # them the registry would be empty and `open_archive()` would find no backend.
 from archivey.formats import directory_reader as _directory_reader  # noqa: F401
+from archivey.formats import zip_reader as _zip_reader  # noqa: F401

--- a/src/archivey/formats/__init__.py
+++ b/src/archivey/formats/__init__.py
@@ -4,4 +4,5 @@
 # bundled backends available for selection. Do not remove these imports — without
 # them the registry would be empty and `open_archive()` would find no backend.
 from archivey.formats import directory_reader as _directory_reader  # noqa: F401
+from archivey.formats import single_file_reader as _single_file_reader  # noqa: F401
 from archivey.formats import zip_reader as _zip_reader  # noqa: F401

--- a/src/archivey/formats/directory_reader.py
+++ b/src/archivey/formats/directory_reader.py
@@ -6,7 +6,7 @@ import os
 import stat
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import BinaryIO, Iterator
+from typing import BinaryIO, Iterator, Mapping
 
 from archivey.internal.cost import (
     AccessCost,
@@ -206,8 +206,8 @@ class DirectoryReadBackend(ReadBackend):
     """Backend factory for directory pseudo-archives."""
 
     FORMATS: tuple[ArchiveFormat, ...] = (ArchiveFormat.DIRECTORY,)
-    EXTENSIONS: tuple[str, ...] = ()
-    MAGIC: tuple[tuple[int, bytes], ...] = ()
+    EXTENSIONS: Mapping[str, ArchiveFormat] = {}
+    MAGIC: tuple[tuple[int, bytes, ArchiveFormat], ...] = ()
     REQUIRES_SEEK = False
 
     def open_read(

--- a/src/archivey/formats/directory_reader.py
+++ b/src/archivey/formats/directory_reader.py
@@ -21,6 +21,7 @@ from archivey.internal.types import (
     ArchiveFormat,
     ArchiveInfo,
     ArchiveMember,
+    MagicSignature,
     MemberType,
 )
 
@@ -207,7 +208,7 @@ class DirectoryReadBackend(ReadBackend):
 
     FORMATS: tuple[ArchiveFormat, ...] = (ArchiveFormat.DIRECTORY,)
     EXTENSIONS: Mapping[str, ArchiveFormat] = {}
-    MAGIC: tuple[tuple[int, bytes, ArchiveFormat], ...] = ()
+    MAGIC: tuple[MagicSignature, ...] = ()
     REQUIRES_SEEK = False
 
     def open_read(

--- a/src/archivey/formats/directory_reader.py
+++ b/src/archivey/formats/directory_reader.py
@@ -213,11 +213,14 @@ class DirectoryReadBackend(ReadBackend):
     def open_read(
         self,
         source: Path | BinaryIO,
+        format: ArchiveFormat,
         streaming: bool,
         password: bytes | None,
         encoding: str | None,
         archive_name: str | None,
     ) -> DirectoryReader:
+        # `format` is always DIRECTORY here (single-format backend); accepted for the
+        # uniform ReadBackend signature.
         if not isinstance(source, Path):
             raise TypeError("Directory backend requires a Path source")
         return DirectoryReader(source, streaming, archive_name or str(source))

--- a/src/archivey/formats/single_file_reader.py
+++ b/src/archivey/formats/single_file_reader.py
@@ -8,7 +8,8 @@ logic lives in a small **dispatch table of metadata hooks** (gzip's stored filen
 xz/lzip decompressed size), so a new standalone codec becomes readable by adding the codec
 + enum + detection entry — no new backend class (see ``format-single-file-compressors``).
 
-ZST/LZ4 standalone reading is deferred to Phase 8 and intentionally not in ``FORMATS``.
+ZST and LZ4 are first-class standalone formats here (their codecs already exist from
+Phase 2); only their *seekable-decompressor* refinements remain for Phase 8.
 """
 
 from __future__ import annotations
@@ -125,6 +126,13 @@ class SingleFileReader(BaseArchiveReader):
                 archive_name=archive_name,
             )
 
+        # A non-seekable source cannot be randomly accessed, so a random-access accelerator
+        # (rapidgzip/indexed_bzip2) would only fail trying to seek it — keep the codec in
+        # sequential mode for such a source regardless of the archive's streaming flag.
+        self._codec_config = StreamConfig(
+            streaming=self._streaming or not self._seekable
+        )
+
         self._member = self._build_member(archive_name)
 
     def _build_member(self, archive_name: str | None) -> ArchiveMember:
@@ -173,7 +181,7 @@ class SingleFileReader(BaseArchiveReader):
         if not isinstance(self._source, Path):
             return None
         try:
-            backend = resolve_codec(self._codec, StreamConfig(streaming=self._streaming))
+            backend = resolve_codec(self._codec, self._codec_config)
             stream = backend.open(str(self._source))
         except (ArchiveyError, OSError, ValueError):
             return None
@@ -198,7 +206,7 @@ class SingleFileReader(BaseArchiveReader):
         return open_codec_stream(
             self._codec,
             codec_source,
-            config=StreamConfig(streaming=self._streaming),
+            config=self._codec_config,
             stamp=lambda exc: self._stamp_error_context(exc, member.name),
         )
 

--- a/src/archivey/formats/single_file_reader.py
+++ b/src/archivey/formats/single_file_reader.py
@@ -43,7 +43,6 @@ from archivey.internal.types import (
     ArchiveFormat,
     ArchiveInfo,
     ArchiveMember,
-    ContainerFormat,
     MemberType,
     StreamFormat,
 )
@@ -54,6 +53,8 @@ _EXTENSIONS: dict[str, ArchiveFormat] = {
     ".gz": ArchiveFormat.GZ,
     ".bz2": ArchiveFormat.BZ2,
     ".xz": ArchiveFormat.XZ,
+    ".zst": ArchiveFormat.ZST,
+    ".lz4": ArchiveFormat.LZ4,
     ".lz": ArchiveFormat.LZIP,
     ".zz": ArchiveFormat.ZLIB,
     ".br": ArchiveFormat.BROTLI,
@@ -67,6 +68,8 @@ _FORMATS: tuple[ArchiveFormat, ...] = (
     ArchiveFormat.GZ,
     ArchiveFormat.BZ2,
     ArchiveFormat.XZ,
+    ArchiveFormat.ZST,
+    ArchiveFormat.LZ4,
     ArchiveFormat.LZIP,
     ArchiveFormat.ZLIB,
     ArchiveFormat.BROTLI,
@@ -275,6 +278,8 @@ class SingleFileBackend(ReadBackend):
         (0, b"\x1f\x8b", ArchiveFormat.GZ),
         (0, b"BZh", ArchiveFormat.BZ2),
         (0, b"\xfd7zXZ\x00", ArchiveFormat.XZ),
+        (0, b"\x28\xb5\x2f\xfd", ArchiveFormat.ZST),
+        (0, b"\x04\x22\x4d\x18", ArchiveFormat.LZ4),
         (0, b"LZIP", ArchiveFormat.LZIP),
         (0, b"\x1f\x9d", ArchiveFormat.Z),
         # zlib's 2-byte CMF/FLG header — a weak signal (see detection's _WEAK_MAGIC_FORMATS).
@@ -288,33 +293,17 @@ class SingleFileBackend(ReadBackend):
     def open_read(
         self,
         source: Path | BinaryIO,
+        format: ArchiveFormat,
         streaming: bool,
         password: bytes | None,
         encoding: str | None,
         archive_name: str | None,
     ) -> SingleFileReader:
-        format = _detect_member_format(source, archive_name)
+        # `format` is the resolved single-file format (from detection or the caller); its
+        # stream codec is exactly what to decompress with — no re-inspection needed.
         return SingleFileReader(
             source, format, streaming, password, encoding, archive_name
         )
-
-
-def _detect_member_format(source: Path | BinaryIO, archive_name: str | None) -> ArchiveFormat:
-    """Resolve which standalone codec this source is, for the reader's format.
-
-    ``open_archive`` selects this backend from a detected single-file format, but the
-    backend is also reachable directly; re-run detection to learn the concrete codec.
-    """
-    from archivey.internal.detection import detect_format
-
-    info = detect_format(source)
-    if info.format.container == ContainerFormat.RAW_STREAM:
-        return info.format
-    # Detection landed on something this backend does not serve (e.g. a bare container);
-    # fall back to the extension, else a generic error surfaces at decode time.
-    raise UnsupportedOperationError(
-        f"Source {archive_name!r} is not a single-file compressor (detected {info.format!r})."
-    )
 
 
 register_reader(SingleFileBackend)

--- a/src/archivey/formats/single_file_reader.py
+++ b/src/archivey/formats/single_file_reader.py
@@ -118,9 +118,11 @@ class SingleFileReader(BaseArchiveReader):
         self._codec = codec_for_stream_format(format.stream)
         self._seekable = not is_stream(source) or is_seekable(source)
 
-        # A non-seekable source cannot be randomly accessed, so a random-access accelerator
-        # (rapidgzip/indexed_bzip2) would only fail trying to seek it — keep the codec in
-        # sequential mode for such a source regardless of the archive's streaming flag.
+        # A non-seekable source cannot be randomly accessed, so engaging a random-access
+        # accelerator (rapidgzip) is pointless — and would in fact fail at *open*: rapidgzip
+        # needs either a seekable stream or a real OS fileno, and archivey wraps a non-seekable
+        # source in a PeekableStream that has neither (so it raises StreamNotSeekableError).
+        # Keep the codec sequential for such a source regardless of the archive's streaming flag.
         self._codec_config = StreamConfig(streaming=self._streaming or not self._seekable)
 
         self._member = self._build_member(archive_name)

--- a/src/archivey/formats/single_file_reader.py
+++ b/src/archivey/formats/single_file_reader.py
@@ -1,12 +1,13 @@
 """Single-file compressor backend — one multi-format reader for every standalone codec.
 
-A bare ``.gz`` / ``.bz2`` / ``.xz`` / ``.lz`` (lzip) / ``.zz`` (zlib) / ``.br`` (brotli) /
-``.Z`` (unix-compress) stream is presented as a one-member pseudo-archive: a single
-``FILE`` member whose name is inferred from the source filename, decompressed through the
-``compressed-streams`` codec layer. The backend is codec-agnostic; the only per-format
-logic lives in a small **dispatch table of metadata hooks** (gzip's stored filename/mtime,
-xz/lzip decompressed size), so a new standalone codec becomes readable by adding the codec
-+ enum + detection entry — no new backend class (see ``format-single-file-compressors``).
+A bare ``.gz`` / ``.bz2`` / ``.xz`` / ``.zst`` / ``.lz4`` / ``.lz`` (lzip) / ``.zz`` (zlib)
+/ ``.br`` (brotli) / ``.Z`` (unix-compress) stream is presented as a one-member
+pseudo-archive: a single ``FILE`` member whose name is inferred from the source filename,
+decompressed through the ``compressed-streams`` codec layer. The backend is codec-agnostic;
+the only per-format logic lives in small **per-codec metadata hooks** (gzip's stored
+filename/mtime, xz/lzip decompressed size), so a new standalone codec becomes readable by
+adding the codec + enum + detection entry — no new backend class (see
+``format-single-file-compressors``).
 
 ZST and LZ4 are first-class standalone formats here (their codecs already exist from
 Phase 2); only their *seekable-decompressor* refinements remain for Phase 8.
@@ -17,7 +18,7 @@ from __future__ import annotations
 import os
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import BinaryIO, Callable, Iterator, Mapping
+from typing import BinaryIO, Callable, ClassVar, Iterator, Mapping
 
 from archivey.internal.config import StreamConfig
 from archivey.internal.cost import (
@@ -28,7 +29,6 @@ from archivey.internal.cost import (
 )
 from archivey.internal.errors import (
     ArchiveyError,
-    StreamNotSeekableError,
     UnsupportedOperationError,
 )
 from archivey.internal.reader import BaseArchiveReader, ReadBackend
@@ -44,6 +44,7 @@ from archivey.internal.types import (
     ArchiveFormat,
     ArchiveInfo,
     ArchiveMember,
+    MagicSignature,
     MemberType,
     StreamFormat,
 )
@@ -117,23 +118,17 @@ class SingleFileReader(BaseArchiveReader):
         self._codec = codec_for_stream_format(format.stream)
         self._seekable = not is_stream(source) or is_seekable(source)
 
-        # unix-compress (.Z) decodes via random access, so it needs a seekable source; the
-        # other single-file formats read fine from a non-seekable source.
-        if format.stream == StreamFormat.UNIX_COMPRESS and not self._seekable:
-            raise StreamNotSeekableError(
-                "unix-compress (.Z) archives require a seekable source.",
-                source_format=format,
-                archive_name=archive_name,
-            )
-
         # A non-seekable source cannot be randomly accessed, so a random-access accelerator
         # (rapidgzip/indexed_bzip2) would only fail trying to seek it — keep the codec in
         # sequential mode for such a source regardless of the archive's streaming flag.
-        self._codec_config = StreamConfig(
-            streaming=self._streaming or not self._seekable
-        )
+        self._codec_config = StreamConfig(streaming=self._streaming or not self._seekable)
 
         self._member = self._build_member(archive_name)
+        # Open the decompression stream eagerly so format/seekability errors (e.g. a
+        # non-seekable unix-compress source, which the codec rejects via the translator)
+        # surface here at open time rather than on a later read. The opened stream is cached
+        # and served by the first _open_member(); subsequent opens build fresh streams.
+        self._first_stream: BinaryIO | None = self._open_codec_stream()
 
     def _build_member(self, archive_name: str | None) -> ArchiveMember:
         compressed_size = (
@@ -149,12 +144,54 @@ class SingleFileReader(BaseArchiveReader):
             compressed_size=compressed_size,
             modified=None,
         )
-        hook = _METADATA_HOOKS.get(self._format.stream)
+        hook = self._METADATA_HOOKS.get(self._format.stream)
         if hook is not None:
             hook(self, member)
         return member
 
-    # --- per-codec metadata helpers ------------------------------------------------------
+    # --- per-codec metadata hooks (dispatch table, not an if/elif chain) ------------------
+
+    def _gzip_metadata(self, member: ArchiveMember) -> None:
+        """Surface gzip's stored filename (FNAME) and mtime from the fixed/optional header.
+
+        RFC 1952 specifies the FNAME field as ISO-8859-1 (Latin-1), so the decoded value in
+        ``extra`` uses that encoding; ``raw_name`` keeps the verbatim stored bytes.
+        """
+        header = self._peek_header()
+        if len(header) < 10 or header[:2] != b"\x1f\x8b":
+            return
+        flg = header[3]
+        mtime = int.from_bytes(header[4:8], "little")
+        if mtime != 0:
+            member.modified = datetime.fromtimestamp(mtime, tz=timezone.utc)
+
+        pos = 10
+        if flg & 0x04:  # FEXTRA: 2-byte length + data
+            if pos + 2 > len(header):
+                return
+            xlen = int.from_bytes(header[pos : pos + 2], "little")
+            pos += 2 + xlen
+        if flg & 0x08:  # FNAME: null-terminated stored filename (Latin-1 per RFC 1952)
+            end = header.find(b"\x00", pos)
+            if end != -1:
+                name_bytes = header[pos:end]
+                member.raw_name = name_bytes
+                member.extra["gzip.original_filename"] = name_bytes.decode("latin-1")
+
+    def _sized_stream_metadata(self, member: ArchiveMember) -> None:
+        """Fill the decompressed size for formats whose index/trailer records it (xz, lzip)."""
+        member.size = self._probe_decompressed_size()
+
+    # StreamFormat -> metadata hook. A codec with no extra metadata registers no hook.
+    _METADATA_HOOKS: ClassVar[
+        dict[StreamFormat, Callable[["SingleFileReader", ArchiveMember], None]]
+    ] = {
+        StreamFormat.GZIP: _gzip_metadata,
+        StreamFormat.XZ: _sized_stream_metadata,
+        StreamFormat.LZIP: _sized_stream_metadata,
+    }
+
+    # --- metadata helpers ----------------------------------------------------------------
 
     def _peek_header(self) -> bytes:
         """The first bytes of the compressed stream, without consuming the source."""
@@ -197,9 +234,9 @@ class SingleFileReader(BaseArchiveReader):
     def _iter_members(self) -> Iterator[ArchiveMember]:
         yield self._member
 
-    def _open_member(self, member: ArchiveMember) -> BinaryIO:
+    def _open_codec_stream(self) -> BinaryIO:
+        """Open a fresh decompression stream over the source (rewinding a seekable one)."""
         src = self._source
-        # Rewind a seekable stream so repeated opens each start from the beginning.
         if is_stream(src) and is_seekable(src):
             src.seek(0)
         codec_source = str(src) if isinstance(src, Path) else src
@@ -207,8 +244,16 @@ class SingleFileReader(BaseArchiveReader):
             self._codec,
             codec_source,
             config=self._codec_config,
-            stamp=lambda exc: self._stamp_error_context(exc, member.name),
+            stamp=lambda exc: self._stamp_error_context(exc, self._member.name),
         )
+
+    def _open_member(self, member: ArchiveMember) -> BinaryIO:
+        # Serve the stream opened eagerly at init on the first call; build fresh ones after.
+        if self._first_stream is not None:
+            stream = self._first_stream
+            self._first_stream = None
+            return stream
+        return self._open_codec_stream()
 
     def _get_archive_info(self) -> ArchiveInfo:
         cost = CostReceipt(
@@ -231,50 +276,11 @@ class SingleFileReader(BaseArchiveReader):
         )
 
     def _close_archive(self) -> None:
-        pass  # the source is the caller's; member streams are closed by the caller
-
-
-# --- per-codec metadata hooks (dispatch table, not an if/elif chain) ---------------------
-
-
-def _gzip_metadata(reader: SingleFileReader, member: ArchiveMember) -> None:
-    """Surface gzip's stored filename (FNAME) and mtime from the fixed/optional header."""
-    header = reader._peek_header()
-    if len(header) < 10 or header[:2] != b"\x1f\x8b":
-        return
-    flg = header[3]
-    mtime = int.from_bytes(header[4:8], "little")
-    if mtime != 0:
-        member.modified = datetime.fromtimestamp(mtime, tz=timezone.utc)
-
-    pos = 10
-    if flg & 0x04:  # FEXTRA: 2-byte length + data
-        if pos + 2 > len(header):
-            return
-        xlen = int.from_bytes(header[pos : pos + 2], "little")
-        pos += 2 + xlen
-    if flg & 0x08:  # FNAME: null-terminated stored filename
-        end = header.find(b"\x00", pos)
-        if end != -1:
-            name_bytes = header[pos:end]
-            member.raw_name = name_bytes
-            member.extra["gzip.original_filename"] = name_bytes.decode(
-                "utf-8", errors="replace"
-            )
-
-
-def _sized_stream_metadata(reader: SingleFileReader, member: ArchiveMember) -> None:
-    """Fill the decompressed size for formats whose index/trailer records it (xz, lzip)."""
-    member.size = reader._probe_decompressed_size()
-
-
-_METADATA_HOOKS: dict[
-    StreamFormat, Callable[[SingleFileReader, ArchiveMember], None]
-] = {
-    StreamFormat.GZIP: _gzip_metadata,
-    StreamFormat.XZ: _sized_stream_metadata,
-    StreamFormat.LZIP: _sized_stream_metadata,
-}
+        # Close the eagerly-opened stream if it was never served; opened member streams are
+        # the caller's to close, and the source itself is the caller's.
+        if self._first_stream is not None:
+            self._first_stream.close()
+            self._first_stream = None
 
 
 class SingleFileBackend(ReadBackend):
@@ -282,21 +288,23 @@ class SingleFileBackend(ReadBackend):
 
     FORMATS: tuple[ArchiveFormat, ...] = _FORMATS
     EXTENSIONS: Mapping[str, ArchiveFormat] = _EXTENSIONS
-    MAGIC: tuple[tuple[int, bytes, ArchiveFormat], ...] = (
-        (0, b"\x1f\x8b", ArchiveFormat.GZ),
-        (0, b"BZh", ArchiveFormat.BZ2),
-        (0, b"\xfd7zXZ\x00", ArchiveFormat.XZ),
-        (0, b"\x28\xb5\x2f\xfd", ArchiveFormat.ZST),
-        (0, b"\x04\x22\x4d\x18", ArchiveFormat.LZ4),
-        (0, b"LZIP", ArchiveFormat.LZIP),
-        (0, b"\x1f\x9d", ArchiveFormat.Z),
-        # zlib's 2-byte CMF/FLG header — a weak signal (see detection's _WEAK_MAGIC_FORMATS).
-        (0, b"\x78\x01", ArchiveFormat.ZLIB),
-        (0, b"\x78\x5e", ArchiveFormat.ZLIB),
-        (0, b"\x78\x9c", ArchiveFormat.ZLIB),
-        (0, b"\x78\xda", ArchiveFormat.ZLIB),
+    MAGIC: tuple[MagicSignature, ...] = (
+        MagicSignature(0, b"\x1f\x8b", ArchiveFormat.GZ),
+        MagicSignature(0, b"BZh", ArchiveFormat.BZ2),
+        MagicSignature(0, b"\xfd7zXZ\x00", ArchiveFormat.XZ),
+        MagicSignature(0, b"\x28\xb5\x2f\xfd", ArchiveFormat.ZST),
+        MagicSignature(0, b"\x04\x22\x4d\x18", ArchiveFormat.LZ4),
+        MagicSignature(0, b"LZIP", ArchiveFormat.LZIP),
+        MagicSignature(0, b"\x1f\x9d", ArchiveFormat.Z),
+        # zlib's 2-byte CMF/FLG header: weak — the detector confirms it with a content probe.
+        MagicSignature(0, b"\x78\x01", ArchiveFormat.ZLIB, weak=True),
+        MagicSignature(0, b"\x78\x5e", ArchiveFormat.ZLIB, weak=True),
+        MagicSignature(0, b"\x78\x9c", ArchiveFormat.ZLIB, weak=True),
+        MagicSignature(0, b"\x78\xda", ArchiveFormat.ZLIB, weak=True),
     )
-    REQUIRES_SEEK = False  # only unix-compress needs seek; enforced per-format at open
+    # Brotli has no signature; the detector confirms it by decoding a bounded prefix.
+    CONTENT_PROBE_FORMATS: tuple[ArchiveFormat, ...] = (ArchiveFormat.BROTLI,)
+    REQUIRES_SEEK = False  # only unix-compress needs seek; the codec rejects a bad source
 
     def open_read(
         self,

--- a/src/archivey/formats/single_file_reader.py
+++ b/src/archivey/formats/single_file_reader.py
@@ -1,0 +1,320 @@
+"""Single-file compressor backend — one multi-format reader for every standalone codec.
+
+A bare ``.gz`` / ``.bz2`` / ``.xz`` / ``.lz`` (lzip) / ``.zz`` (zlib) / ``.br`` (brotli) /
+``.Z`` (unix-compress) stream is presented as a one-member pseudo-archive: a single
+``FILE`` member whose name is inferred from the source filename, decompressed through the
+``compressed-streams`` codec layer. The backend is codec-agnostic; the only per-format
+logic lives in a small **dispatch table of metadata hooks** (gzip's stored filename/mtime,
+xz/lzip decompressed size), so a new standalone codec becomes readable by adding the codec
++ enum + detection entry — no new backend class (see ``format-single-file-compressors``).
+
+ZST/LZ4 standalone reading is deferred to Phase 8 and intentionally not in ``FORMATS``.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import BinaryIO, Callable, Iterator, Mapping
+
+from archivey.internal.config import StreamConfig
+from archivey.internal.cost import (
+    AccessCost,
+    CostReceipt,
+    ListingCost,
+    StreamCapability,
+)
+from archivey.internal.errors import (
+    ArchiveyError,
+    StreamNotSeekableError,
+    UnsupportedOperationError,
+)
+from archivey.internal.reader import BaseArchiveReader, ReadBackend
+from archivey.internal.registry import register_reader
+from archivey.internal.streams.codecs import (
+    codec_for_stream_format,
+    open_codec_stream,
+    resolve_codec,
+)
+from archivey.internal.streams.decompressor_stream import DecompressorStream
+from archivey.internal.streams.streamtools import is_seekable, is_stream
+from archivey.internal.types import (
+    ArchiveFormat,
+    ArchiveInfo,
+    ArchiveMember,
+    ContainerFormat,
+    MemberType,
+    StreamFormat,
+)
+
+# Standalone-stream extensions recognized for member-name inference + extension detection.
+# (The combined `tar.gz`/`.tgz` names are a format-detection concern, not single-file naming.)
+_EXTENSIONS: dict[str, ArchiveFormat] = {
+    ".gz": ArchiveFormat.GZ,
+    ".bz2": ArchiveFormat.BZ2,
+    ".xz": ArchiveFormat.XZ,
+    ".lz": ArchiveFormat.LZIP,
+    ".zz": ArchiveFormat.ZLIB,
+    ".br": ArchiveFormat.BROTLI,
+    ".Z": ArchiveFormat.Z,
+}
+
+# Lowercased recognized compression extensions, for the "strip vs append .uncompressed" rule.
+_COMPRESSION_EXTS: frozenset[str] = frozenset(ext.lower() for ext in _EXTENSIONS)
+
+_FORMATS: tuple[ArchiveFormat, ...] = (
+    ArchiveFormat.GZ,
+    ArchiveFormat.BZ2,
+    ArchiveFormat.XZ,
+    ArchiveFormat.LZIP,
+    ArchiveFormat.ZLIB,
+    ArchiveFormat.BROTLI,
+    ArchiveFormat.Z,
+)
+
+# How many header bytes to peek for cheap metadata (gzip FNAME/mtime). Long stored names
+# beyond this are simply not surfaced.
+_HEADER_PEEK = 512
+
+
+def _infer_member_name(archive_name: str | None) -> str:
+    """Infer the single member's name from the source filename (see the spec)."""
+    if archive_name is None:
+        return "data"
+    base = os.path.basename(archive_name)
+    root, ext = os.path.splitext(base)
+    if ext.lower() in _COMPRESSION_EXTS and root:
+        return root
+    return base + ".uncompressed"
+
+
+class SingleFileReader(BaseArchiveReader):
+    """Presents one standalone compressed stream as a one-member archive."""
+
+    _SUPPORTS_RANDOM_ACCESS = True
+    _MEMBER_LIST_UPFRONT = True
+
+    def __init__(
+        self,
+        source: Path | BinaryIO,
+        format: ArchiveFormat,
+        streaming: bool,
+        password: bytes | None,
+        encoding: str | None,
+        archive_name: str | None,
+    ) -> None:
+        if password is not None:
+            raise UnsupportedOperationError(
+                "Single-file compressors do not support passwords (they carry no encryption)."
+            )
+        super().__init__(format, streaming, archive_name)
+        self._source = source
+        self._codec = codec_for_stream_format(format.stream)
+        self._seekable = not is_stream(source) or is_seekable(source)
+
+        # unix-compress (.Z) decodes via random access, so it needs a seekable source; the
+        # other single-file formats read fine from a non-seekable source.
+        if format.stream == StreamFormat.UNIX_COMPRESS and not self._seekable:
+            raise StreamNotSeekableError(
+                "unix-compress (.Z) archives require a seekable source.",
+                source_format=format,
+                archive_name=archive_name,
+            )
+
+        self._member = self._build_member(archive_name)
+
+    def _build_member(self, archive_name: str | None) -> ArchiveMember:
+        compressed_size = (
+            os.path.getsize(self._source)
+            if isinstance(self._source, Path) and self._source.exists()
+            else None
+        )
+        member = ArchiveMember(
+            type=MemberType.FILE,
+            name=_infer_member_name(archive_name),
+            raw_name=None,
+            size=None,  # filled per-codec below where cheaply known
+            compressed_size=compressed_size,
+            modified=None,
+        )
+        hook = _METADATA_HOOKS.get(self._format.stream)
+        if hook is not None:
+            hook(self, member)
+        return member
+
+    # --- per-codec metadata helpers ------------------------------------------------------
+
+    def _peek_header(self) -> bytes:
+        """The first bytes of the compressed stream, without consuming the source."""
+        from archivey.internal.streams.peekable import PeekableStream
+
+        src = self._source
+        if isinstance(src, Path):
+            with open(src, "rb") as f:
+                return f.read(_HEADER_PEEK)
+        if isinstance(src, PeekableStream):
+            return src.peek(_HEADER_PEEK)
+        if is_seekable(src):
+            data = src.read(_HEADER_PEEK)
+            src.seek(0)
+            return data
+        return b""
+
+    def _probe_decompressed_size(self) -> int | None:
+        """Decompressed size from the stream index/trailer, when cheaply available.
+
+        Only attempted for a path source (a fresh handle the probe fully owns), so it never
+        disturbs a caller-provided stream's position or lifetime.
+        """
+        if not isinstance(self._source, Path):
+            return None
+        try:
+            backend = resolve_codec(self._codec, StreamConfig(streaming=self._streaming))
+            stream = backend.open(str(self._source))
+        except (ArchiveyError, OSError, ValueError):
+            return None
+        try:
+            if isinstance(stream, DecompressorStream):
+                return stream.try_get_size()
+            return None
+        finally:
+            stream.close()
+
+    # --- reader hooks --------------------------------------------------------------------
+
+    def _iter_members(self) -> Iterator[ArchiveMember]:
+        yield self._member
+
+    def _open_member(self, member: ArchiveMember) -> BinaryIO:
+        src = self._source
+        # Rewind a seekable stream so repeated opens each start from the beginning.
+        if is_stream(src) and is_seekable(src):
+            src.seek(0)
+        codec_source = str(src) if isinstance(src, Path) else src
+        return open_codec_stream(
+            self._codec,
+            codec_source,
+            config=StreamConfig(streaming=self._streaming),
+            stamp=lambda exc: self._stamp_error_context(exc, member.name),
+        )
+
+    def _get_archive_info(self) -> ArchiveInfo:
+        cost = CostReceipt(
+            listing_cost=ListingCost.INDEXED,  # exactly one member, always
+            access_cost=AccessCost.DIRECT,  # one member -> no solid-block dependency
+            stream_capability=(
+                StreamCapability.SEEKABLE if self._seekable else StreamCapability.FORWARD_ONLY
+            ),
+            solid_block_count=None,
+        )
+        return ArchiveInfo(
+            format=self._format,
+            format_version=None,
+            is_solid=False,
+            member_count=1,
+            comment=None,
+            is_encrypted=False,
+            is_multivolume=False,
+            cost=cost,
+        )
+
+    def _close_archive(self) -> None:
+        pass  # the source is the caller's; member streams are closed by the caller
+
+
+# --- per-codec metadata hooks (dispatch table, not an if/elif chain) ---------------------
+
+
+def _gzip_metadata(reader: SingleFileReader, member: ArchiveMember) -> None:
+    """Surface gzip's stored filename (FNAME) and mtime from the fixed/optional header."""
+    header = reader._peek_header()
+    if len(header) < 10 or header[:2] != b"\x1f\x8b":
+        return
+    flg = header[3]
+    mtime = int.from_bytes(header[4:8], "little")
+    if mtime != 0:
+        member.modified = datetime.fromtimestamp(mtime, tz=timezone.utc)
+
+    pos = 10
+    if flg & 0x04:  # FEXTRA: 2-byte length + data
+        if pos + 2 > len(header):
+            return
+        xlen = int.from_bytes(header[pos : pos + 2], "little")
+        pos += 2 + xlen
+    if flg & 0x08:  # FNAME: null-terminated stored filename
+        end = header.find(b"\x00", pos)
+        if end != -1:
+            name_bytes = header[pos:end]
+            member.raw_name = name_bytes
+            member.extra["gzip.original_filename"] = name_bytes.decode(
+                "utf-8", errors="replace"
+            )
+
+
+def _sized_stream_metadata(reader: SingleFileReader, member: ArchiveMember) -> None:
+    """Fill the decompressed size for formats whose index/trailer records it (xz, lzip)."""
+    member.size = reader._probe_decompressed_size()
+
+
+_METADATA_HOOKS: dict[
+    StreamFormat, Callable[[SingleFileReader, ArchiveMember], None]
+] = {
+    StreamFormat.GZIP: _gzip_metadata,
+    StreamFormat.XZ: _sized_stream_metadata,
+    StreamFormat.LZIP: _sized_stream_metadata,
+}
+
+
+class SingleFileBackend(ReadBackend):
+    """One backend serving every standalone single-file compressor."""
+
+    FORMATS: tuple[ArchiveFormat, ...] = _FORMATS
+    EXTENSIONS: Mapping[str, ArchiveFormat] = _EXTENSIONS
+    MAGIC: tuple[tuple[int, bytes, ArchiveFormat], ...] = (
+        (0, b"\x1f\x8b", ArchiveFormat.GZ),
+        (0, b"BZh", ArchiveFormat.BZ2),
+        (0, b"\xfd7zXZ\x00", ArchiveFormat.XZ),
+        (0, b"LZIP", ArchiveFormat.LZIP),
+        (0, b"\x1f\x9d", ArchiveFormat.Z),
+        # zlib's 2-byte CMF/FLG header — a weak signal (see detection's _WEAK_MAGIC_FORMATS).
+        (0, b"\x78\x01", ArchiveFormat.ZLIB),
+        (0, b"\x78\x5e", ArchiveFormat.ZLIB),
+        (0, b"\x78\x9c", ArchiveFormat.ZLIB),
+        (0, b"\x78\xda", ArchiveFormat.ZLIB),
+    )
+    REQUIRES_SEEK = False  # only unix-compress needs seek; enforced per-format at open
+
+    def open_read(
+        self,
+        source: Path | BinaryIO,
+        streaming: bool,
+        password: bytes | None,
+        encoding: str | None,
+        archive_name: str | None,
+    ) -> SingleFileReader:
+        format = _detect_member_format(source, archive_name)
+        return SingleFileReader(
+            source, format, streaming, password, encoding, archive_name
+        )
+
+
+def _detect_member_format(source: Path | BinaryIO, archive_name: str | None) -> ArchiveFormat:
+    """Resolve which standalone codec this source is, for the reader's format.
+
+    ``open_archive`` selects this backend from a detected single-file format, but the
+    backend is also reachable directly; re-run detection to learn the concrete codec.
+    """
+    from archivey.internal.detection import detect_format
+
+    info = detect_format(source)
+    if info.format.container == ContainerFormat.RAW_STREAM:
+        return info.format
+    # Detection landed on something this backend does not serve (e.g. a bare container);
+    # fall back to the extension, else a generic error surfaces at decode time.
+    raise UnsupportedOperationError(
+        f"Source {archive_name!r} is not a single-file compressor (detected {info.format!r})."
+    )
+
+
+register_reader(SingleFileBackend)

--- a/src/archivey/formats/zip_reader.py
+++ b/src/archivey/formats/zip_reader.py
@@ -42,6 +42,7 @@ from archivey.internal.types import (
     CompressionAlgorithm,
     CompressionMethod,
     CreateSystem,
+    MagicSignature,
     MemberType,
 )
 
@@ -73,36 +74,52 @@ def _decode_with_fallback(data: bytes) -> str:
     return data.decode("latin-1")
 
 
-def _zip_modified(info: zipfile.ZipInfo) -> datetime | None:
-    """Return the member's modification time.
+def _zip_timestamps(
+    info: zipfile.ZipInfo,
+) -> tuple[datetime | None, datetime | None, datetime | None]:
+    """Return ``(modified, accessed, created)`` for a member.
 
-    An Extended Timestamp extra field (0x5455) records a real Unix timestamp and takes
-    precedence over the 2-second-granularity DOS ``date_time``; when present, the result is
-    a timezone-aware UTC ``datetime``. Otherwise a naive ``datetime`` from ``date_time`` is
-    returned (``None`` for the "no timestamp" sentinel year 1980-00-00).
+    The DOS ``date_time`` gives a 2-second-granularity modification time (``None`` for the
+    "no timestamp" sentinel year 1980). An Extended Timestamp extra field (0x5455) records
+    real Unix timestamps and takes precedence: its flags byte signals which of
+    modification/access/creation times follow (in that order), each a signed 32-bit Unix
+    time interpreted as UTC. The central directory typically carries only the modification
+    time even when the flags advertise more, so access/creation are often ``None``.
     """
     if info.date_time == (1980, 0, 0, 0, 0, 0):
-        dos_modtime = None
+        modified: datetime | None = None
     else:
         try:
-            dos_modtime = datetime(*info.date_time)
+            modified = datetime(*info.date_time)
         except ValueError:
             logger.warning("Invalid ZIP date_time for %r: %r", info.filename, info.date_time)
-            dos_modtime = None
+            modified = None
+    accessed: datetime | None = None
+    created: datetime | None = None
 
-    pos = 0
     extra = info.extra or b""
+    pos = 0
     while pos + 4 <= len(extra):
         tag, length = struct.unpack("<HH", extra[pos : pos + 4])
-        if tag == 0x5455 and length >= 5:  # Extended Timestamp, with flags + at least mtime
-            flags = extra[pos + 4]
-            if flags & 0x01:  # modification time present
-                mod_time = int.from_bytes(extra[pos + 5 : pos + 9], "little")
-                if mod_time > 0:
-                    return datetime.fromtimestamp(mod_time, tz=timezone.utc)
+        field = extra[pos + 4 : pos + 4 + length]
+        if tag == 0x5455 and field:  # Extended Timestamp: flags byte + present times
+            flags = field[0]
+            cursor = 1
+            for bit in (0x01, 0x02, 0x04):  # mtime, atime, ctime, in order
+                if flags & bit and cursor + 4 <= len(field):
+                    ts = int.from_bytes(field[cursor : cursor + 4], "little", signed=True)
+                    when = datetime.fromtimestamp(ts, tz=timezone.utc)
+                    if bit == 0x01:
+                        modified = when
+                    elif bit == 0x02:
+                        accessed = when
+                    else:
+                        created = when
+                    cursor += 4
+            break
         pos += 4 + length
 
-    return dos_modtime
+    return modified, accessed, created
 
 
 class ZipReader(BaseArchiveReader):
@@ -122,23 +139,18 @@ class ZipReader(BaseArchiveReader):
         super().__init__(ArchiveFormat.ZIP, streaming, archive_name)
         self._password = password
         self._encoding = encoding
-        # Normalized member name -> ZipInfo, for O(1) data access without re-deriving the
-        # stored filename. Populated as members are materialized in _iter_members().
-        self._info_by_name: dict[str, zipfile.ZipInfo] = {}
 
         if is_stream(source) and not is_seekable(source):
             raise StreamNotSeekableError(
-                "ZIP archives cannot be read from a non-seekable source (the central "
-                "directory lives at the end of the file). Buffer the source to disk or a "
-                "BytesIO and reopen.",
+                "ZIP archives cannot be read from a non-seekable source: the central "
+                "directory lives at the end of the file.",
                 archive_name=archive_name,
             )
 
         # A split-set segment (name.z01, name.z42, …) cannot be read by stdlib zipfile.
         if archive_name and _SPLIT_SEGMENT_RE.search(archive_name):
             raise UnsupportedFeatureError(
-                "Multi-volume (split/spanned) ZIP archives are not supported. Rejoin the "
-                "volumes first (e.g. `zip -s 0 split.zip --out whole.zip`) and reopen.",
+                "Multi-volume (split/spanned) ZIP archives are not supported.",
                 archive_name=archive_name,
                 source_format=ArchiveFormat.ZIP,
             )
@@ -149,8 +161,7 @@ class ZipReader(BaseArchiveReader):
         except zipfile.BadZipFile as exc:
             if _looks_like_multivolume(exc):
                 raise UnsupportedFeatureError(
-                    "This ZIP appears to span multiple disks/volumes, which is not "
-                    "supported. Rejoin the volumes first and reopen.",
+                    "This ZIP spans multiple disks/volumes, which is not supported.",
                     archive_name=archive_name,
                     source_format=ArchiveFormat.ZIP,
                 ) from exc
@@ -194,7 +205,6 @@ class ZipReader(BaseArchiveReader):
 
         decoded = info.filename
         name = normalize_member_name(decoded.replace("\\", "/"), member_type)
-        self._info_by_name[name] = info
         raw_name = info.orig_filename.encode(
             "utf-8" if info.flag_bits & 0x800 else "cp437", errors="surrogateescape"
         )
@@ -211,13 +221,16 @@ class ZipReader(BaseArchiveReader):
             with self._archive.open(info, pwd=self._password) as f:
                 link_target = f.read().decode("utf-8", errors="surrogateescape")
 
+        modified, accessed, created = _zip_timestamps(info)
         return ArchiveMember(
             type=member_type,
             name=name,
             raw_name=raw_name,
             size=info.file_size,
             compressed_size=info.compress_size,
-            modified=_zip_modified(info),
+            modified=modified,
+            accessed=accessed,
+            created=created,
             mode=mode,
             compression=(CompressionMethod(algo=algo),),
             is_encrypted=bool(info.flag_bits & 0x1),
@@ -225,19 +238,14 @@ class ZipReader(BaseArchiveReader):
             create_system=create_system,
             link_target=link_target,
             extra={"zip.compress_type": info.compress_type},
+            _raw=info,  # carry the ZipInfo so _open_member needs no name/id lookup table
         )
 
     def _open_member(self, member: ArchiveMember) -> BinaryIO:
-        if not self._info_by_name:
-            # Materialize the member list so the name->ZipInfo map is populated (e.g. when
-            # opening a member object without a prior listing pass).
-            self._get_members_registered()
-        try:
-            info = self._info_by_name[member.name]
-        except KeyError:
-            raise KeyError(
-                f"Member {member.name!r} not found in this ZIP archive"
-            ) from None
+        # The member carries its own ZipInfo (`_raw`), so data access needs no name/id map
+        # — and a duplicate member name can't resolve to the wrong entry.
+        info = member._raw
+        assert isinstance(info, zipfile.ZipInfo), "ZIP member is missing its ZipInfo handle"
         raw = cast(
             "BinaryIO",
             self._archive.open(info, pwd=self._password),
@@ -277,10 +285,10 @@ class ZipReadBackend(ReadBackend):
 
     FORMATS: tuple[ArchiveFormat, ...] = (ArchiveFormat.ZIP,)
     EXTENSIONS: Mapping[str, ArchiveFormat] = {".zip": ArchiveFormat.ZIP}
-    MAGIC: tuple[tuple[int, bytes, ArchiveFormat], ...] = (
-        (0, b"\x50\x4b\x03\x04", ArchiveFormat.ZIP),  # standard local file header
-        (0, b"\x50\x4b\x05\x06", ArchiveFormat.ZIP),  # empty archive (EOCD)
-        (0, b"\x50\x4b\x07\x08", ArchiveFormat.ZIP),  # spanned / data-descriptor marker
+    MAGIC: tuple[MagicSignature, ...] = (
+        MagicSignature(0, b"\x50\x4b\x03\x04", ArchiveFormat.ZIP),  # standard local header
+        MagicSignature(0, b"\x50\x4b\x05\x06", ArchiveFormat.ZIP),  # empty archive (EOCD)
+        MagicSignature(0, b"\x50\x4b\x07\x08", ArchiveFormat.ZIP),  # spanned marker
     )
     REQUIRES_SEEK = True
 

--- a/src/archivey/formats/zip_reader.py
+++ b/src/archivey/formats/zip_reader.py
@@ -287,11 +287,14 @@ class ZipReadBackend(ReadBackend):
     def open_read(
         self,
         source: Path | BinaryIO,
+        format: ArchiveFormat,
         streaming: bool,
         password: bytes | None,
         encoding: str | None,
         archive_name: str | None,
     ) -> ZipReader:
+        # `format` is always ZIP here (single-format backend); accepted for the uniform
+        # ReadBackend signature.
         return ZipReader(source, streaming, password, encoding, archive_name)
 
 

--- a/src/archivey/formats/zip_reader.py
+++ b/src/archivey/formats/zip_reader.py
@@ -1,0 +1,293 @@
+"""ZIP backend on the v2 ABC, backed by the stdlib ``zipfile`` module.
+
+The central directory is read on open, giving O(1) member listing (``INDEXED``) and
+direct random access (``DIRECT``) to any member. A non-seekable source fails fast (the
+central directory lives at EOF), and split/spanned multi-volume sets are rejected with a
+clear "rejoin first" error (see ``format-zip``).
+"""
+
+from __future__ import annotations
+
+import io
+import re
+import stat
+import struct
+import zipfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import BinaryIO, Iterator, Mapping, cast
+
+from archivey.internal.cost import (
+    AccessCost,
+    CostReceipt,
+    ListingCost,
+    StreamCapability,
+)
+from archivey.internal.errors import (
+    ArchiveyError,
+    CorruptionError,
+    EncryptionError,
+    StreamNotSeekableError,
+    UnsupportedFeatureError,
+)
+from archivey.internal.logs import backends as logger
+from archivey.internal.naming import normalize_member_name
+from archivey.internal.reader import BaseArchiveReader, ReadBackend
+from archivey.internal.registry import register_reader
+from archivey.internal.streams.streamtools import is_seekable, is_stream
+from archivey.internal.types import (
+    ArchiveFormat,
+    ArchiveInfo,
+    ArchiveMember,
+    CompressionAlgorithm,
+    CompressionMethod,
+    CreateSystem,
+    MemberType,
+)
+
+# Encoding fallbacks for ZIP metadata stored without the UTF-8 flag.
+_ZIP_ENCODINGS = ("utf-8", "cp437", "cp1252", "latin-1")
+
+# A ".z01"/".z42"/… segment name — the obvious signal of a split (multi-volume) ZIP set.
+_SPLIT_SEGMENT_RE = re.compile(r"\.z\d{2}$", re.IGNORECASE)
+
+# ZIP compression-method id -> our codec algorithm. Unknown ids map to UNKNOWN rather than
+# raising, matching the open-ended CompressionAlgorithm contract.
+_ZIP_COMPRESSION_ALGOS: dict[int, CompressionAlgorithm] = {
+    0: CompressionAlgorithm.STORED,
+    8: CompressionAlgorithm.DEFLATE,
+    9: CompressionAlgorithm.DEFLATE64,
+    12: CompressionAlgorithm.BZIP2,
+    14: CompressionAlgorithm.LZMA,
+    93: CompressionAlgorithm.ZSTD,
+    98: CompressionAlgorithm.PPMD,
+}
+
+
+def _decode_with_fallback(data: bytes) -> str:
+    for encoding in _ZIP_ENCODINGS:
+        try:
+            return data.decode(encoding)
+        except UnicodeDecodeError:
+            continue
+    return data.decode("latin-1")
+
+
+def _zip_modified(info: zipfile.ZipInfo) -> datetime | None:
+    """Return the member's modification time.
+
+    An Extended Timestamp extra field (0x5455) records a real Unix timestamp and takes
+    precedence over the 2-second-granularity DOS ``date_time``; when present, the result is
+    a timezone-aware UTC ``datetime``. Otherwise a naive ``datetime`` from ``date_time`` is
+    returned (``None`` for the "no timestamp" sentinel year 1980-00-00).
+    """
+    if info.date_time == (1980, 0, 0, 0, 0, 0):
+        dos_modtime = None
+    else:
+        try:
+            dos_modtime = datetime(*info.date_time)
+        except ValueError:
+            logger.warning("Invalid ZIP date_time for %r: %r", info.filename, info.date_time)
+            dos_modtime = None
+
+    pos = 0
+    extra = info.extra or b""
+    while pos + 4 <= len(extra):
+        tag, length = struct.unpack("<HH", extra[pos : pos + 4])
+        if tag == 0x5455 and length >= 5:  # Extended Timestamp, with flags + at least mtime
+            flags = extra[pos + 4]
+            if flags & 0x01:  # modification time present
+                mod_time = int.from_bytes(extra[pos + 5 : pos + 9], "little")
+                if mod_time > 0:
+                    return datetime.fromtimestamp(mod_time, tz=timezone.utc)
+        pos += 4 + length
+
+    return dos_modtime
+
+
+class ZipReader(BaseArchiveReader):
+    """Reads a ZIP archive via stdlib ``zipfile``."""
+
+    _SUPPORTS_RANDOM_ACCESS = True
+    _MEMBER_LIST_UPFRONT = True
+
+    def __init__(
+        self,
+        source: Path | BinaryIO,
+        streaming: bool,
+        password: bytes | None,
+        encoding: str | None,
+        archive_name: str | None,
+    ) -> None:
+        super().__init__(ArchiveFormat.ZIP, streaming, archive_name)
+        self._password = password
+        self._encoding = encoding
+        # Normalized member name -> ZipInfo, for O(1) data access without re-deriving the
+        # stored filename. Populated as members are materialized in _iter_members().
+        self._info_by_name: dict[str, zipfile.ZipInfo] = {}
+
+        if is_stream(source) and not is_seekable(source):
+            raise StreamNotSeekableError(
+                "ZIP archives cannot be read from a non-seekable source (the central "
+                "directory lives at the end of the file). Buffer the source to disk or a "
+                "BytesIO and reopen.",
+                archive_name=archive_name,
+            )
+
+        # A split-set segment (name.z01, name.z42, …) cannot be read by stdlib zipfile.
+        if archive_name and _SPLIT_SEGMENT_RE.search(archive_name):
+            raise UnsupportedFeatureError(
+                "Multi-volume (split/spanned) ZIP archives are not supported. Rejoin the "
+                "volumes first (e.g. `zip -s 0 split.zip --out whole.zip`) and reopen.",
+                archive_name=archive_name,
+                source_format=ArchiveFormat.ZIP,
+            )
+
+        try:
+            # typeshed types ZipFile too narrowly; a binary stream is valid here.
+            self._archive: zipfile.ZipFile = zipfile.ZipFile(source, "r")  # type: ignore[arg-type]
+        except zipfile.BadZipFile as exc:
+            if _looks_like_multivolume(exc):
+                raise UnsupportedFeatureError(
+                    "This ZIP appears to span multiple disks/volumes, which is not "
+                    "supported. Rejoin the volumes first and reopen.",
+                    archive_name=archive_name,
+                    source_format=ArchiveFormat.ZIP,
+                ) from exc
+            raise CorruptionError(
+                f"Could not open ZIP archive: {exc!r}",
+                archive_name=archive_name,
+                source_format=ArchiveFormat.ZIP,
+            ) from exc
+
+    def _translate_exception(self, exc: Exception) -> ArchiveyError | None:
+        if isinstance(exc, zipfile.BadZipFile):
+            return CorruptionError(f"Error reading ZIP archive: {exc!r}")
+        if isinstance(exc, RuntimeError):
+            text = str(exc).lower()
+            if "password required" in text:
+                return EncryptionError("Password required to read this ZIP member")
+            if "bad password" in text:
+                return EncryptionError("Wrong password for this ZIP member")
+        if isinstance(exc, io.UnsupportedOperation) and "seek" in str(exc):
+            return StreamNotSeekableError("ZIP archives require a seekable source")
+        if isinstance(exc, NotImplementedError) and "compression method" in str(exc).lower():
+            return UnsupportedFeatureError(f"Unsupported ZIP compression method: {exc!r}")
+        return None
+
+    def _iter_members(self) -> Iterator[ArchiveMember]:
+        for info in self._archive.infolist():
+            yield self._to_member(info)
+
+    def _to_member(self, info: zipfile.ZipInfo) -> ArchiveMember:
+        full_mode = info.external_attr >> 16
+        is_unix = info.create_system == 3
+        # Permission bits only; None when no usable Unix mode was stored.
+        mode = stat.S_IMODE(full_mode) if (info.external_attr != 0 and is_unix) else None
+
+        if info.is_dir():
+            member_type = MemberType.DIRECTORY
+        elif is_unix and stat.S_ISLNK(full_mode):
+            member_type = MemberType.SYMLINK
+        else:
+            member_type = MemberType.FILE
+
+        decoded = info.filename
+        name = normalize_member_name(decoded.replace("\\", "/"), member_type)
+        self._info_by_name[name] = info
+        raw_name = info.orig_filename.encode(
+            "utf-8" if info.flag_bits & 0x800 else "cp437", errors="surrogateescape"
+        )
+
+        algo = _ZIP_COMPRESSION_ALGOS.get(info.compress_type, CompressionAlgorithm.UNKNOWN)
+
+        try:
+            create_system = CreateSystem(info.create_system)
+        except ValueError:
+            create_system = CreateSystem.UNKNOWN
+
+        link_target = None
+        if member_type == MemberType.SYMLINK:
+            with self._archive.open(info) as f:
+                link_target = f.read().decode("utf-8", errors="surrogateescape")
+
+        return ArchiveMember(
+            type=member_type,
+            name=name,
+            raw_name=raw_name,
+            size=info.file_size,
+            compressed_size=info.compress_size,
+            modified=_zip_modified(info),
+            mode=mode,
+            compression=(CompressionMethod(algo=algo),),
+            is_encrypted=bool(info.flag_bits & 0x1),
+            comment=_decode_with_fallback(info.comment) if info.comment else None,
+            create_system=create_system,
+            link_target=link_target,
+            extra={"zip.compress_type": info.compress_type},
+        )
+
+    def _open_member(self, member: ArchiveMember) -> BinaryIO:
+        if not self._info_by_name:
+            # Materialize the member list so the name->ZipInfo map is populated (e.g. when
+            # opening a member object without a prior listing pass).
+            self._get_members_registered()
+        info = self._info_by_name[member.name]
+        raw = cast(
+            "BinaryIO",
+            self._archive.open(info, pwd=self._password),
+        )
+        return self._wrap_member_stream(raw, member.name)
+
+    def _get_archive_info(self) -> ArchiveInfo:
+        comment = self._archive.comment
+        cost = CostReceipt(
+            listing_cost=ListingCost.INDEXED,
+            access_cost=AccessCost.DIRECT,
+            stream_capability=StreamCapability.SEEKABLE,
+            solid_block_count=None,
+        )
+        return ArchiveInfo(
+            format=ArchiveFormat.ZIP,
+            format_version=None,
+            is_solid=False,  # ZIP is never solid: each member has an independent offset
+            member_count=len(self._archive.infolist()),
+            comment=_decode_with_fallback(comment) if comment else None,
+            is_encrypted=False,  # ZIP has per-member encryption, not header-level
+            is_multivolume=False,
+            cost=cost,
+        )
+
+    def _close_archive(self) -> None:
+        self._archive.close()
+
+
+def _looks_like_multivolume(exc: zipfile.BadZipFile) -> bool:
+    text = str(exc).lower()
+    return "multi" in text or "disk" in text or "spanned" in text or "split" in text
+
+
+class ZipReadBackend(ReadBackend):
+    """Backend factory for ZIP archives."""
+
+    FORMATS: tuple[ArchiveFormat, ...] = (ArchiveFormat.ZIP,)
+    EXTENSIONS: Mapping[str, ArchiveFormat] = {".zip": ArchiveFormat.ZIP}
+    MAGIC: tuple[tuple[int, bytes, ArchiveFormat], ...] = (
+        (0, b"\x50\x4b\x03\x04", ArchiveFormat.ZIP),  # standard local file header
+        (0, b"\x50\x4b\x05\x06", ArchiveFormat.ZIP),  # empty archive (EOCD)
+        (0, b"\x50\x4b\x07\x08", ArchiveFormat.ZIP),  # spanned / data-descriptor marker
+    )
+    REQUIRES_SEEK = True
+
+    def open_read(
+        self,
+        source: Path | BinaryIO,
+        streaming: bool,
+        password: bytes | None,
+        encoding: str | None,
+        archive_name: str | None,
+    ) -> ZipReader:
+        return ZipReader(source, streaming, password, encoding, archive_name)
+
+
+register_reader(ZipReadBackend)

--- a/src/archivey/formats/zip_reader.py
+++ b/src/archivey/formats/zip_reader.py
@@ -208,7 +208,7 @@ class ZipReader(BaseArchiveReader):
 
         link_target = None
         if member_type == MemberType.SYMLINK:
-            with self._archive.open(info) as f:
+            with self._archive.open(info, pwd=self._password) as f:
                 link_target = f.read().decode("utf-8", errors="surrogateescape")
 
         return ArchiveMember(
@@ -232,7 +232,12 @@ class ZipReader(BaseArchiveReader):
             # Materialize the member list so the name->ZipInfo map is populated (e.g. when
             # opening a member object without a prior listing pass).
             self._get_members_registered()
-        info = self._info_by_name[member.name]
+        try:
+            info = self._info_by_name[member.name]
+        except KeyError:
+            raise KeyError(
+                f"Member {member.name!r} not found in this ZIP archive"
+            ) from None
         raw = cast(
             "BinaryIO",
             self._archive.open(info, pwd=self._password),

--- a/src/archivey/internal/detection.py
+++ b/src/archivey/internal/detection.py
@@ -11,34 +11,35 @@ streams are read and rewound to position 0; a non-seekable stream must be wrappe
 :class:`~archivey.internal.streams.peekable.PeekableStream` first (the opener does this),
 which detection inspects via ``peek``.
 
-Content probes (Brotli), the inner-TAR probe, the ISO extended window, and SFX scanning
-arrive with the backends they feed in later Phase-3 stages / Phase 7; this module is the
-Stage-1 core.
+Magic-less / weak-magic formats are confirmed by a **content probe** (decoding a bounded
+prefix through the codec): Brotli (no signature) and zlib (a 2-byte header too unspecific
+to trust). Both the weak-magic flag and the magic-less probe formats are declared by the
+backends as data, so the detector stays format-agnostic. The inner-TAR probe, the ISO
+extended window, and SFX scanning arrive with the backends they feed in later stages.
 """
 
 from __future__ import annotations
 
+import io
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
 from typing import BinaryIO
 
-from archivey.internal.errors import FormatDetectionError
+from archivey.internal.errors import ArchiveyError, FormatDetectionError, TruncatedError
 from archivey.internal.logs import detection as logger
 from archivey.internal.registry import get_registry
-from archivey.internal.streams.codecs import Codec, is_codec_available
+from archivey.internal.streams.codecs import (
+    codec_for_stream_format,
+    is_codec_available,
+    open_codec_stream,
+)
 from archivey.internal.streams.peekable import DETECTION_LIMIT, PeekableStream
 from archivey.internal.streams.streamtools import is_seekable, read_exact
-from archivey.internal.types import ArchiveFormat
+from archivey.internal.types import ArchiveFormat, MagicSignature
 
-# The zlib 2-byte header (CMF/FLG) is not a true magic number — the same prefix begins
-# many raw-deflate streams and can occur in arbitrary data — so a zlib magic match is the
-# weakest entry in the table: it is consulted only after the stronger magics and the
-# content probe, and a conflicting extension overrides it (see ``format-detection``).
-_WEAK_MAGIC_FORMATS: frozenset[ArchiveFormat] = frozenset({ArchiveFormat.ZLIB})
-
-# Bytes fed to a content probe (e.g. Brotli) — enough to trip a malformed-stream error
-# without decompressing the whole payload.
+# Bytes fed to a content probe — enough to trip a malformed-stream error without
+# decompressing the whole payload.
 _PROBE_PREFIX = 256
 
 
@@ -91,36 +92,38 @@ def _peek_prefix(source: str | Path | BinaryIO, length: int) -> bytes:
 
 def _match_magic(
     data: bytes,
-    magic_entries: list[tuple[int, bytes, ArchiveFormat]],
+    magic_entries: list[MagicSignature],
     *,
     weak: bool,
 ) -> ArchiveFormat | None:
     """Return the first matching magic, considering only weak or only strong entries."""
-    for offset, magic, fmt in magic_entries:
-        is_weak = fmt in _WEAK_MAGIC_FORMATS
-        if is_weak != weak:
+    for entry in magic_entries:
+        if entry.weak != weak:
             continue
-        if data[offset : offset + len(magic)] == magic:
-            return fmt
+        if data[entry.offset : entry.offset + len(entry.magic)] == entry.magic:
+            return entry.format
     return None
 
 
-def _brotli_content_probe(data: bytes) -> bool:
-    """Whether a bounded prefix of ``data`` decompresses cleanly through Brotli.
+def _content_probe(fmt: ArchiveFormat, data: bytes) -> bool:
+    """Whether a bounded prefix of ``data`` decodes cleanly through ``fmt``'s codec.
 
-    Brotli has no magic bytes, so it is recognized structurally. Skipped (returns
-    ``False``, i.e. "no match") when the Brotli backend is not installed, so detection
-    falls through to the ``.br`` extension guess. Operates on the already-peeked bytes, so
-    it consumes nothing from the source.
+    Used both for magic-less formats (Brotli) and to confirm a weak magic match (zlib): a
+    valid stream decodes some output (or runs out of the prefix → ``TruncatedError``),
+    while a non-matching one raises a corruption error. Skipped (returns ``False``) when the
+    codec backend is absent, so detection falls through to the extension guess. Operates on
+    the already-peeked bytes, so it consumes nothing from the source.
     """
-    if not is_codec_available(Codec.BROTLI):
+    codec = codec_for_stream_format(fmt.stream)
+    if not is_codec_available(codec):
         return False
-    import brotli  # optional dep; guarded by is_codec_available above
-
     try:
-        brotli.Decompressor().process(data[:_PROBE_PREFIX])
+        with open_codec_stream(codec, io.BytesIO(data[:_PROBE_PREFIX])) as stream:
+            stream.read(_PROBE_PREFIX)
         return True
-    except brotli.error:
+    except TruncatedError:
+        return True  # decoded fine, just ran out of the bounded prefix
+    except ArchiveyError:
         return False
 
 
@@ -151,7 +154,7 @@ def detect_format(source: str | Path | BinaryIO) -> FormatInfo:
     # at 32 769), but at least the default detection window.
     needed = max(
         DETECTION_LIMIT,
-        max((offset + len(magic) for offset, magic, _ in magic_entries), default=0),
+        max((e.offset + len(e.magic) for e in magic_entries), default=0),
     )
     data = _peek_prefix(source, needed)
     name = _source_extension_name(source)
@@ -170,18 +173,18 @@ def detect_format(source: str | Path | BinaryIO) -> FormatInfo:
             )
         return FormatInfo(strong_fmt, DetectionConfidence.CERTAIN, "magic")
 
-    # 2. Weak magic (zlib's 2-byte header): a real but low-confidence signal. A conflicting
-    #    extension overrides it (no warning — the weakness is by design); otherwise report
-    #    it as PROBABLE rather than CERTAIN.
+    # 2. Weak magic (zlib's 2-byte header): accepted only when a content probe confirms the
+    #    stream actually decodes through that codec — otherwise the 2-byte prefix is too
+    #    unspecific to trust.
     weak_fmt = _match_magic(data, magic_entries, weak=True)
-    if weak_fmt is not None:
-        if ext_fmt is not None and ext_fmt != weak_fmt:
-            return FormatInfo(ext_fmt, DetectionConfidence.GUESS, "extension")
-        return FormatInfo(weak_fmt, DetectionConfidence.PROBABLE, "magic")
+    if weak_fmt is not None and _content_probe(weak_fmt, data):
+        return FormatInfo(weak_fmt, DetectionConfidence.PROBABLE, "content_probe")
 
-    # 3. Content probes for magic-less formats (Brotli). Skipped when the backend is absent.
-    if _brotli_content_probe(data):
-        return FormatInfo(ArchiveFormat.BROTLI, DetectionConfidence.PROBABLE, "content_probe")
+    # 3. Magic-less formats confirmed by a content probe (Brotli). Skipped when the codec
+    #    backend is absent, so detection falls through to the extension guess.
+    for probe_fmt in registry.content_probe_formats():
+        if _content_probe(probe_fmt, data):
+            return FormatInfo(probe_fmt, DetectionConfidence.PROBABLE, "content_probe")
 
     # 4. Extension-only guess.
     if ext_fmt is not None:

--- a/src/archivey/internal/detection.py
+++ b/src/archivey/internal/detection.py
@@ -26,9 +26,20 @@ from typing import BinaryIO
 from archivey.internal.errors import FormatDetectionError
 from archivey.internal.logs import detection as logger
 from archivey.internal.registry import get_registry
+from archivey.internal.streams.codecs import Codec, is_codec_available
 from archivey.internal.streams.peekable import DETECTION_LIMIT, PeekableStream
 from archivey.internal.streams.streamtools import is_seekable, read_exact
 from archivey.internal.types import ArchiveFormat
+
+# The zlib 2-byte header (CMF/FLG) is not a true magic number — the same prefix begins
+# many raw-deflate streams and can occur in arbitrary data — so a zlib magic match is the
+# weakest entry in the table: it is consulted only after the stronger magics and the
+# content probe, and a conflicting extension overrides it (see ``format-detection``).
+_WEAK_MAGIC_FORMATS: frozenset[ArchiveFormat] = frozenset({ArchiveFormat.ZLIB})
+
+# Bytes fed to a content probe (e.g. Brotli) — enough to trip a malformed-stream error
+# without decompressing the whole payload.
+_PROBE_PREFIX = 256
 
 
 class DetectionConfidence(Enum):
@@ -79,12 +90,38 @@ def _peek_prefix(source: str | Path | BinaryIO, length: int) -> bytes:
 
 
 def _match_magic(
-    data: bytes, magic_entries: list[tuple[int, bytes, ArchiveFormat]]
+    data: bytes,
+    magic_entries: list[tuple[int, bytes, ArchiveFormat]],
+    *,
+    weak: bool,
 ) -> ArchiveFormat | None:
+    """Return the first matching magic, considering only weak or only strong entries."""
     for offset, magic, fmt in magic_entries:
+        is_weak = fmt in _WEAK_MAGIC_FORMATS
+        if is_weak != weak:
+            continue
         if data[offset : offset + len(magic)] == magic:
             return fmt
     return None
+
+
+def _brotli_content_probe(data: bytes) -> bool:
+    """Whether a bounded prefix of ``data`` decompresses cleanly through Brotli.
+
+    Brotli has no magic bytes, so it is recognized structurally. Skipped (returns
+    ``False``, i.e. "no match") when the Brotli backend is not installed, so detection
+    falls through to the ``.br`` extension guess. Operates on the already-peeked bytes, so
+    it consumes nothing from the source.
+    """
+    if not is_codec_available(Codec.BROTLI):
+        return False
+    import brotli  # optional dep; guarded by is_codec_available above
+
+    try:
+        brotli.Decompressor().process(data[:_PROBE_PREFIX])
+        return True
+    except brotli.error:
+        return False
 
 
 def _match_extension(
@@ -118,21 +155,35 @@ def detect_format(source: str | Path | BinaryIO) -> FormatInfo:
     )
     data = _peek_prefix(source, needed)
     name = _source_extension_name(source)
-
-    magic_fmt = _match_magic(data, magic_entries)
     ext_fmt = _match_extension(name, extension_map)
 
-    if magic_fmt is not None:
-        if ext_fmt is not None and ext_fmt != magic_fmt:
+    # 1. Strong (exact, multi-byte) magic wins, with a conflict warning vs the extension.
+    strong_fmt = _match_magic(data, magic_entries, weak=False)
+    if strong_fmt is not None:
+        if ext_fmt is not None and ext_fmt != strong_fmt:
             logger.warning(
                 "Format conflict for %r: extension suggests %r but magic bytes indicate "
                 "%r; using the magic-byte result.",
                 name,
                 ext_fmt,
-                magic_fmt,
+                strong_fmt,
             )
-        return FormatInfo(magic_fmt, DetectionConfidence.CERTAIN, "magic")
+        return FormatInfo(strong_fmt, DetectionConfidence.CERTAIN, "magic")
 
+    # 2. Weak magic (zlib's 2-byte header): a real but low-confidence signal. A conflicting
+    #    extension overrides it (no warning — the weakness is by design); otherwise report
+    #    it as PROBABLE rather than CERTAIN.
+    weak_fmt = _match_magic(data, magic_entries, weak=True)
+    if weak_fmt is not None:
+        if ext_fmt is not None and ext_fmt != weak_fmt:
+            return FormatInfo(ext_fmt, DetectionConfidence.GUESS, "extension")
+        return FormatInfo(weak_fmt, DetectionConfidence.PROBABLE, "magic")
+
+    # 3. Content probes for magic-less formats (Brotli). Skipped when the backend is absent.
+    if _brotli_content_probe(data):
+        return FormatInfo(ArchiveFormat.BROTLI, DetectionConfidence.PROBABLE, "content_probe")
+
+    # 4. Extension-only guess.
     if ext_fmt is not None:
         return FormatInfo(ext_fmt, DetectionConfidence.GUESS, "extension")
 

--- a/src/archivey/internal/detection.py
+++ b/src/archivey/internal/detection.py
@@ -1,0 +1,142 @@
+"""Format detection: ``detect_format()`` and the ``FormatInfo`` it returns.
+
+Detection is **magic-first** (an exact magic-byte match at the expected offset →
+``CERTAIN``) with an extension fallback (``GUESS``). The magic and extension tables are
+not hand-maintained here: each registered backend declares its ``MAGIC`` / ``EXTENSIONS``
+as data and the detector aggregates them, so a new format becomes detectable by
+registering its backend (see ``format-detection`` and ``backend-registry``).
+
+Detection never consumes bytes from the source: paths are opened and closed; seekable
+streams are read and rewound to position 0; a non-seekable stream must be wrapped in a
+:class:`~archivey.internal.streams.peekable.PeekableStream` first (the opener does this),
+which detection inspects via ``peek``.
+
+Content probes (Brotli), the inner-TAR probe, the ISO extended window, and SFX scanning
+arrive with the backends they feed in later Phase-3 stages / Phase 7; this module is the
+Stage-1 core.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import BinaryIO
+
+from archivey.internal.errors import FormatDetectionError
+from archivey.internal.logs import detection as logger
+from archivey.internal.registry import get_registry
+from archivey.internal.streams.peekable import DETECTION_LIMIT, PeekableStream
+from archivey.internal.streams.streamtools import is_seekable, read_exact
+from archivey.internal.types import ArchiveFormat
+
+
+class DetectionConfidence(Enum):
+    CERTAIN = "certain"  # exact magic-byte match at the expected offset
+    PROBABLE = "probable"  # structural/content probe (inner-tar probe, SFX scan)
+    GUESS = "guess"  # file extension only, no content confirmation
+
+
+@dataclass(frozen=True)
+class FormatInfo:
+    """The result of :func:`detect_format` — the detected format plus how sure we are."""
+
+    format: ArchiveFormat
+    confidence: DetectionConfidence
+    detected_by: str  # "magic", "extension", "content_probe", "sfx_scan"
+    encoding_hint: str | None = None
+    payload_offset: int = 0  # nonzero only for SFX archives (is-SFX == payload_offset > 0)
+
+
+def _source_extension_name(source: object) -> str | None:
+    """The filename to match an extension against, or ``None`` when the source is anonymous."""
+    if isinstance(source, (str, Path)):
+        return str(source)
+    name = getattr(source, "name", None)
+    return name if isinstance(name, str) else None
+
+
+def _peek_prefix(source: str | Path | BinaryIO, length: int) -> bytes:
+    """Return the source's first ``length`` bytes without consuming them.
+
+    Paths are opened and closed; a :class:`PeekableStream` is peeked; a seekable stream is
+    read and rewound to position 0. A raw non-seekable stream would lose the prefix, so the
+    caller (the opener) must wrap it in a ``PeekableStream`` first.
+    """
+    if isinstance(source, (str, Path)):
+        with open(source, "rb") as f:
+            return read_exact(f, length)
+    if isinstance(source, PeekableStream):
+        return source.peek(length)
+    if is_seekable(source):
+        data = read_exact(source, length)
+        source.seek(0)
+        return data
+    # Raw non-seekable stream used standalone: reading consumes bytes the caller can no
+    # longer reach. Detection still works, but the prefix is gone — the opener avoids this
+    # by wrapping non-seekable sources in a PeekableStream.
+    return read_exact(source, length)
+
+
+def _match_magic(
+    data: bytes, magic_entries: list[tuple[int, bytes, ArchiveFormat]]
+) -> ArchiveFormat | None:
+    for offset, magic, fmt in magic_entries:
+        if data[offset : offset + len(magic)] == magic:
+            return fmt
+    return None
+
+
+def _match_extension(
+    name: str | None, extension_map: dict[str, ArchiveFormat]
+) -> ArchiveFormat | None:
+    if name is None:
+        return None
+    lowered = name.lower()
+    # Longest extension wins so ".tar.gz" beats ".gz".
+    for ext in sorted(extension_map, key=len, reverse=True):
+        if lowered.endswith(ext.lower()):
+            return extension_map[ext]
+    return None
+
+
+def detect_format(source: str | Path | BinaryIO) -> FormatInfo:
+    """Identify the archive format of ``source`` without fully opening it.
+
+    Returns a :class:`FormatInfo`. Raises :class:`FormatDetectionError` when no magic
+    pattern matches and no extension guess is available.
+    """
+    registry = get_registry()
+    magic_entries = registry.magic_entries()
+    extension_map = registry.extension_map()
+
+    # Read enough to cover the deepest magic offset (e.g. TAR's ustar at 257, ISO's CD001
+    # at 32 769), but at least the default detection window.
+    needed = max(
+        DETECTION_LIMIT,
+        max((offset + len(magic) for offset, magic, _ in magic_entries), default=0),
+    )
+    data = _peek_prefix(source, needed)
+    name = _source_extension_name(source)
+
+    magic_fmt = _match_magic(data, magic_entries)
+    ext_fmt = _match_extension(name, extension_map)
+
+    if magic_fmt is not None:
+        if ext_fmt is not None and ext_fmt != magic_fmt:
+            logger.warning(
+                "Format conflict for %r: extension suggests %r but magic bytes indicate "
+                "%r; using the magic-byte result.",
+                name,
+                ext_fmt,
+                magic_fmt,
+            )
+        return FormatInfo(magic_fmt, DetectionConfidence.CERTAIN, "magic")
+
+    if ext_fmt is not None:
+        return FormatInfo(ext_fmt, DetectionConfidence.GUESS, "extension")
+
+    raise FormatDetectionError(
+        "Could not detect archive format: no magic-byte match and no usable file extension.",
+        archive_name=name,
+    )

--- a/src/archivey/internal/open_archive.py
+++ b/src/archivey/internal/open_archive.py
@@ -99,6 +99,7 @@ def open_archive(
     backend = backend_cls()
     return backend.open_read(
         open_source,
+        format=format,
         streaming=streaming,
         password=password,
         encoding=effective_encoding,

--- a/src/archivey/internal/open_archive.py
+++ b/src/archivey/internal/open_archive.py
@@ -5,9 +5,12 @@ from __future__ import annotations
 from pathlib import Path
 from typing import BinaryIO
 
-from archivey.internal.errors import FormatDetectionError
+from archivey.internal.detection import FormatInfo, detect_format
+from archivey.internal.errors import StreamNotSeekableError
 from archivey.internal.reader import ArchiveReader
 from archivey.internal.registry import get_registry
+from archivey.internal.streams.peekable import PeekableStream
+from archivey.internal.streams.streamtools import is_seekable, is_stream
 from archivey.internal.types import ArchiveFormat
 
 
@@ -38,8 +41,10 @@ def open_archive(
     time on a non-seekable source. ``streaming=True`` promises forward-only, single-pass
     access (works on any source, but disables random-access methods).
 
-    If source is a directory path, opens it as a directory pseudo-archive.
-    Format detection (Phase 3) is not yet wired; only DIRECTORY is auto-detected here.
+    The format is auto-detected from the source's magic bytes (then its extension) unless
+    ``format=`` is passed explicitly. A directory path opens as a directory pseudo-archive.
+    A non-seekable stream is wrapped in a :class:`PeekableStream` so detection never
+    consumes bytes the backend still needs.
     """
     # Import formats package to ensure backends are registered
     import archivey.formats  # noqa: F401
@@ -49,23 +54,53 @@ def open_archive(
 
     archive_name = source_name(source)
 
-    if isinstance(source, (str, Path)) and Path(source).is_dir():
-        format = ArchiveFormat.DIRECTORY
+    # A path source: normalize str -> Path; a directory short-circuits detection.
+    open_source: Path | BinaryIO
+    if isinstance(source, (str, Path)):
+        path = Path(source)
+        if path.is_dir():
+            format = ArchiveFormat.DIRECTORY
+        open_source = path
+    else:
+        open_source = source
 
+    detected: FormatInfo | None = None
     if format is None:
-        raise FormatDetectionError(
-            "Format detection not yet implemented (Phase 3). "
-            "Pass format= explicitly, or open a directory.",
-            archive_name=archive_name,
-        )
+        # Non-seekable streams must be wrapped before detection so the peeked prefix is
+        # replayed to the backend; the same wrapper is then handed over.
+        if is_stream(open_source) and not is_seekable(open_source):
+            open_source = PeekableStream(open_source)
+        detected = detect_format(open_source)
+        format = detected.format
 
     registry = get_registry()
     backend_cls = registry.reader_for_format(format)
+
+    # Fail fast for a seek-requiring backend on a non-seekable source (the access-mode
+    # contract: streaming=False does not implicitly buffer).
+    if (
+        backend_cls.REQUIRES_SEEK
+        and is_stream(open_source)
+        and not is_seekable(open_source)
+    ):
+        raise StreamNotSeekableError(
+            f"Format {format!r} requires a seekable source, but the given stream is not "
+            f"seekable. Buffer it to disk or a BytesIO and reopen.",
+            source_format=format,
+            archive_name=archive_name,
+        )
+
+    # Thread the encoding: an explicit caller encoding wins, else the detector's hint, else
+    # None (the backend auto-detects).
+    effective_encoding = encoding
+    if effective_encoding is None and detected is not None:
+        effective_encoding = detected.encoding_hint
+
     backend = backend_cls()
     return backend.open_read(
-        Path(source) if isinstance(source, str) else source,
+        open_source,
         streaming=streaming,
         password=password,
-        encoding=encoding,
+        encoding=effective_encoding,
         archive_name=archive_name,
     )

--- a/src/archivey/internal/reader.py
+++ b/src/archivey/internal/reader.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import BinaryIO, Callable, Iterator
+from typing import BinaryIO, Callable, Iterator, Mapping
 
 from archivey.internal.cost import CostReceipt
 from archivey.internal.errors import (
@@ -26,13 +26,27 @@ MemberSelector = Callable[[ArchiveMember], bool] | None
 
 
 class ReadBackend(ABC):
-    """Stateless factory for creating ArchiveReader instances."""
+    """Stateless factory for creating ArchiveReader instances.
+
+    Each backend declares its magic and extensions **as data**, and every entry names
+    the :class:`ArchiveFormat` it implies, so a *multi-format* backend (the single
+    ``SingleFileBackend``, the TAR backend over ``TAR`` + its compressed combos) can map
+    each signal to the right format. The detector aggregates these across all registered
+    backends; backends carry no ``detect()`` method.
+    """
 
     FORMATS: tuple[ArchiveFormat, ...]
-    EXTENSIONS: tuple[str, ...]
-    MAGIC: tuple[tuple[int, bytes], ...]
+    # ".gz" -> ArchiveFormat.GZ
+    EXTENSIONS: Mapping[str, ArchiveFormat] = {}
+    # (offset, magic bytes, format)
+    MAGIC: tuple[tuple[int, bytes, ArchiveFormat], ...] = ()
     REQUIRES_SEEK: bool = False
+    # Name of the optional dependency this backend needs (e.g. "pycdlib"); the registry
+    # derives availability centrally from whether it imports. ``None`` for core backends.
     OPTIONAL_DEPENDENCY: str | None = None
+    # Human-readable install hint surfaced when the dependency is absent
+    # (e.g. "pip install archivey[iso]").
+    INSTALL_HINT: str | None = None
 
     @abstractmethod
     def open_read(

--- a/src/archivey/internal/reader.py
+++ b/src/archivey/internal/reader.py
@@ -18,6 +18,7 @@ from archivey.internal.types import (
     ArchiveFormat,
     ArchiveInfo,
     ArchiveMember,
+    MagicSignature,
     MemberType,
 )
 
@@ -38,8 +39,12 @@ class ReadBackend(ABC):
     FORMATS: tuple[ArchiveFormat, ...]
     # ".gz" -> ArchiveFormat.GZ
     EXTENSIONS: Mapping[str, ArchiveFormat] = {}
-    # (offset, magic bytes, format)
-    MAGIC: tuple[tuple[int, bytes, ArchiveFormat], ...] = ()
+    # Magic-byte signals as data (offset, bytes, format, weak); a ``weak`` entry (zlib's
+    # 2-byte header) is confirmed by a content probe before acceptance.
+    MAGIC: tuple[MagicSignature, ...] = ()
+    # Magic-less formats this backend reads that the detector confirms by a content probe
+    # (feeding a bounded prefix to the codec) — e.g. Brotli, which has no signature.
+    CONTENT_PROBE_FORMATS: tuple[ArchiveFormat, ...] = ()
     REQUIRES_SEEK: bool = False
     # Name of the optional dependency this backend needs (e.g. "pycdlib"); the registry
     # derives availability centrally from whether it imports. ``None`` for core backends.

--- a/src/archivey/internal/reader.py
+++ b/src/archivey/internal/reader.py
@@ -52,11 +52,17 @@ class ReadBackend(ABC):
     def open_read(
         self,
         source: Path | BinaryIO,
+        format: ArchiveFormat,
         streaming: bool,
         password: bytes | None,
         encoding: str | None,
         archive_name: str | None,
-    ) -> "BaseArchiveReader": ...
+    ) -> "BaseArchiveReader":
+        """Open ``source`` as ``format`` (the resolved format the registry selected this
+        backend for — either detected by ``open_archive`` or supplied by the caller). A
+        multi-format backend uses it to pick its concrete codec/variant rather than
+        re-inspecting the source."""
+        ...
 
 
 class WriteBackend(ABC):

--- a/src/archivey/internal/registry.py
+++ b/src/archivey/internal/registry.py
@@ -62,7 +62,7 @@ class FormatAvailability:
 # multi-codec container still opens and lists). Single-codec RAW_STREAM formats are handled
 # separately (their sole codec missing makes them NONE, not PARTIAL).
 _CONTAINER_OPTIONAL_CODECS: dict[ContainerFormat, tuple[Codec, ...]] = {
-    ContainerFormat.ZIP: (Codec.DEFLATE64, Codec.ZSTD),
+    ContainerFormat.ZIP: (Codec.DEFLATE64, Codec.ZSTD, Codec.PPMD),
 }
 
 # How each optional codec is obtained, for the install hint surfaced to the caller.

--- a/src/archivey/internal/registry.py
+++ b/src/archivey/internal/registry.py
@@ -28,7 +28,12 @@ from archivey.internal.streams.codecs import (
     codec_for_stream_format,
     is_codec_available,
 )
-from archivey.internal.types import ArchiveFormat, ContainerFormat, StreamFormat
+from archivey.internal.types import (
+    ArchiveFormat,
+    ContainerFormat,
+    MagicSignature,
+    StreamFormat,
+)
 
 
 class FormatSupport(Enum):
@@ -107,12 +112,19 @@ class BackendRegistry:
 
     # --- detection tables (aggregated from backend data) ---------------------------------
 
-    def magic_entries(self) -> list[tuple[int, bytes, ArchiveFormat]]:
-        """All ``(offset, magic, format)`` magic signals across registered read backends."""
-        entries: list[tuple[int, bytes, ArchiveFormat]] = []
+    def magic_entries(self) -> list[MagicSignature]:
+        """All magic signals (``MagicSignature``) across registered read backends."""
+        entries: list[MagicSignature] = []
         for cls in self._reader_classes:
             entries.extend(cls.MAGIC)
         return entries
+
+    def content_probe_formats(self) -> list[ArchiveFormat]:
+        """Magic-less formats reachable by a content probe, across registered backends."""
+        formats: list[ArchiveFormat] = []
+        for cls in self._reader_classes:
+            formats.extend(cls.CONTENT_PROBE_FORMATS)
+        return formats
 
     def extension_map(self) -> dict[str, ArchiveFormat]:
         """The merged ``extension -> format`` map across registered read backends."""

--- a/src/archivey/internal/registry.py
+++ b/src/archivey/internal/registry.py
@@ -1,17 +1,89 @@
-"""Backend registry: maps ArchiveFormat to ReadBackend/WriteBackend classes."""
+"""Backend registry: maps ArchiveFormat to ReadBackend/WriteBackend classes.
+
+Registration is **unconditional**: every known backend — core and optional alike —
+registers when its module is imported. Availability is then derived centrally from the
+optional dependency's module-or-``None`` sentinel, so the registry can report a tri-state,
+compositional :class:`FormatSupport` (FULL / PARTIAL / NONE) and produce install-hint
+errors, rather than silently dropping a format whose dependency is absent (see
+``backend-registry``).
+"""
 
 from __future__ import annotations
 
+import importlib
+from dataclasses import dataclass
+from enum import Enum
+from types import ModuleType
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from archivey.internal.reader import ReadBackend, WriteBackend
-    from archivey.internal.types import ArchiveFormat
 
 from archivey.internal.errors import (
     UnsupportedFormatError,
     UnsupportedOperationError,
 )
+from archivey.internal.streams.codecs import (
+    Codec,
+    codec_for_stream_format,
+    is_codec_available,
+)
+from archivey.internal.types import ArchiveFormat, ContainerFormat, StreamFormat
+
+
+class FormatSupport(Enum):
+    """Tri-state readability of a known format (see ``backend-registry``)."""
+
+    FULL = "full"  # backend usable AND every optional codec/tool it can use is present
+    PARTIAL = "partial"  # opens & lists; common members decode; some optional codec missing
+    NONE = "none"  # backend (or a single-codec format's sole codec) is unavailable
+
+
+@dataclass(frozen=True)
+class MissingComponent:
+    """A package / extra / external tool a format is missing, and what it unlocks."""
+
+    name: str  # e.g. "pycdlib", "[7z]", "unrar"
+    install_hint: str  # e.g. "pip install archivey[iso]"
+    unlocks: tuple[str, ...] = ()  # member-codecs/capabilities it enables, e.g. ("ppmd",)
+
+
+@dataclass(frozen=True)
+class FormatAvailability:
+    """The support level of a format plus the components needed to raise it."""
+
+    format: ArchiveFormat
+    support: FormatSupport
+    missing: tuple[MissingComponent, ...] = ()  # empty when FULL
+
+
+# Optional member-codecs each container can use, beyond the always-present stdlib codecs.
+# A format is FULL when all of these are available, PARTIAL when some are missing (a
+# multi-codec container still opens and lists). Single-codec RAW_STREAM formats are handled
+# separately (their sole codec missing makes them NONE, not PARTIAL).
+_CONTAINER_OPTIONAL_CODECS: dict[ContainerFormat, tuple[Codec, ...]] = {
+    ContainerFormat.ZIP: (Codec.DEFLATE64, Codec.ZSTD),
+}
+
+# How each optional codec is obtained, for the install hint surfaced to the caller.
+_CODEC_REQUIREMENT: dict[Codec, MissingComponent] = {
+    Codec.ZSTD: MissingComponent("zstandard", "pip install archivey[zstd]", ("zstd",)),
+    Codec.LZ4: MissingComponent("lz4", "pip install archivey[lz4]", ("lz4",)),
+    Codec.BROTLI: MissingComponent("brotli", "pip install archivey[7z]", ("brotli",)),
+    Codec.UNIX_COMPRESS: MissingComponent(
+        "uncompresspy", "pip install archivey[unix-compress]", ("unix_compress",)
+    ),
+    Codec.PPMD: MissingComponent("pyppmd", "pip install archivey[7z]", ("ppmd",)),
+    Codec.DEFLATE64: MissingComponent("inflate64", "pip install archivey[7z]", ("deflate64",)),
+}
+
+
+def _optional(name: str) -> ModuleType | None:
+    """Return the named module, or ``None`` when it (the optional extra) is not installed."""
+    try:
+        return importlib.import_module(name)
+    except ImportError:
+        return None
 
 
 class BackendRegistry:
@@ -20,8 +92,12 @@ class BackendRegistry:
     def __init__(self) -> None:
         self._readers: dict[ArchiveFormat, type[ReadBackend]] = {}
         self._writers: dict[ArchiveFormat, type[WriteBackend]] = {}
+        # Unique reader classes in registration order (a class may serve several formats).
+        self._reader_classes: list[type[ReadBackend]] = []
 
     def register_reader(self, backend_cls: type[ReadBackend]) -> None:
+        if backend_cls not in self._reader_classes:
+            self._reader_classes.append(backend_cls)
         for fmt in backend_cls.FORMATS:
             self._readers[fmt] = backend_cls
 
@@ -29,10 +105,86 @@ class BackendRegistry:
         for fmt in backend_cls.FORMATS:
             self._writers[fmt] = backend_cls
 
+    # --- detection tables (aggregated from backend data) ---------------------------------
+
+    def magic_entries(self) -> list[tuple[int, bytes, ArchiveFormat]]:
+        """All ``(offset, magic, format)`` magic signals across registered read backends."""
+        entries: list[tuple[int, bytes, ArchiveFormat]] = []
+        for cls in self._reader_classes:
+            entries.extend(cls.MAGIC)
+        return entries
+
+    def extension_map(self) -> dict[str, ArchiveFormat]:
+        """The merged ``extension -> format`` map across registered read backends."""
+        merged: dict[str, ArchiveFormat] = {}
+        for cls in self._reader_classes:
+            merged.update(cls.EXTENSIONS)
+        return merged
+
+    # --- availability --------------------------------------------------------------------
+
+    def _backend_available(self, backend_cls: type[ReadBackend]) -> bool:
+        dep = backend_cls.OPTIONAL_DEPENDENCY
+        return dep is None or _optional(dep) is not None
+
+    def format_availability(self, fmt: ArchiveFormat) -> FormatAvailability:
+        """Compute the tri-state support of ``fmt`` compositionally (see ``backend-registry``)."""
+        backend_cls = self._readers.get(fmt)
+        if backend_cls is None:
+            return FormatAvailability(fmt, FormatSupport.NONE, ())
+
+        if not self._backend_available(backend_cls):
+            dep = backend_cls.OPTIONAL_DEPENDENCY
+            assert dep is not None  # _backend_available only returns False when dep is set
+            hint = backend_cls.INSTALL_HINT or f"install {dep}"
+            return FormatAvailability(
+                fmt,
+                FormatSupport.NONE,
+                (MissingComponent(dep, hint),),
+            )
+
+        # Backend itself is usable; fold in the optional codecs the format can use.
+        missing: list[MissingComponent] = []
+        for codec in self._optional_codecs_for_format(fmt):
+            if not is_codec_available(codec):
+                missing.append(_CODEC_REQUIREMENT[codec])
+
+        if not missing:
+            return FormatAvailability(fmt, FormatSupport.FULL, ())
+
+        # A single-codec format (a bare RAW_STREAM single-file compressor) whose sole codec
+        # is missing is unreadable -> NONE; a multi-codec container still opens -> PARTIAL.
+        support = (
+            FormatSupport.NONE
+            if fmt.container == ContainerFormat.RAW_STREAM
+            else FormatSupport.PARTIAL
+        )
+        return FormatAvailability(fmt, support, tuple(missing))
+
+    def _optional_codecs_for_format(self, fmt: ArchiveFormat) -> tuple[Codec, ...]:
+        if fmt.container == ContainerFormat.RAW_STREAM:
+            # A single-file compressor's readability hinges on its one stream codec.
+            if fmt.stream == StreamFormat.UNCOMPRESSED:
+                return ()
+            return (codec_for_stream_format(fmt.stream),)
+        return _CONTAINER_OPTIONAL_CODECS.get(fmt.container, ())
+
+    # --- selection -----------------------------------------------------------------------
+
     def reader_for_format(self, fmt: ArchiveFormat) -> type[ReadBackend]:
-        if fmt not in self._readers:
+        availability = self.format_availability(fmt)
+        if availability.support is FormatSupport.NONE:
+            backend_cls = self._readers.get(fmt)
+            if backend_cls is None:
+                raise UnsupportedFormatError(
+                    f"No read backend registered for format {fmt!r}",
+                    source_format=fmt,
+                )
+            hints = "; ".join(
+                f"{m.name} ({m.install_hint})" for m in availability.missing
+            )
             raise UnsupportedFormatError(
-                f"No read backend registered for format {fmt!r}",
+                f"Format {fmt!r} is not available: missing {hints}",
                 source_format=fmt,
             )
         return self._readers[fmt]
@@ -45,8 +197,19 @@ class BackendRegistry:
             )
         return self._writers[fmt]
 
-    def list_formats(self) -> list[ArchiveFormat]:
+    # --- queries -------------------------------------------------------------------------
+
+    def list_known_formats(self) -> list[ArchiveFormat]:
+        """Every format the registry knows, including those with support NONE."""
         return list(self._readers.keys())
+
+    def list_supported_formats(self) -> list[ArchiveFormat]:
+        """Formats readable now — support FULL or PARTIAL (NONE excluded)."""
+        return [
+            fmt
+            for fmt in self._readers
+            if self.format_availability(fmt).support is not FormatSupport.NONE
+        ]
 
     def list_writable_formats(self) -> list[ArchiveFormat]:
         return list(self._writers.keys())
@@ -66,3 +229,18 @@ def register_writer(backend_cls: type[WriteBackend]) -> None:
 
 def get_registry() -> BackendRegistry:
     return _registry
+
+
+def format_availability(fmt: ArchiveFormat) -> FormatAvailability:
+    """Public query: the tri-state support level of ``fmt`` and its missing components."""
+    return _registry.format_availability(fmt)
+
+
+def list_supported_formats() -> list[ArchiveFormat]:
+    """Public query: formats readable now (support FULL or PARTIAL)."""
+    return _registry.list_supported_formats()
+
+
+def list_known_formats() -> list[ArchiveFormat]:
+    """Public query: every format the registry knows, including support NONE."""
+    return _registry.list_known_formats()

--- a/src/archivey/internal/streams/codecs.py
+++ b/src/archivey/internal/streams/codecs.py
@@ -203,6 +203,10 @@ _STREAM_FORMAT_CODECS: dict[StreamFormat, Codec] = {
     StreamFormat.XZ: Codec.XZ,
     StreamFormat.ZSTD: Codec.ZSTD,
     StreamFormat.LZ4: Codec.LZ4,
+    StreamFormat.LZIP: Codec.LZIP,
+    StreamFormat.ZLIB: Codec.ZLIB,
+    StreamFormat.BROTLI: Codec.BROTLI,
+    StreamFormat.UNIX_COMPRESS: Codec.UNIX_COMPRESS,
 }
 
 

--- a/src/archivey/internal/streams/codecs.py
+++ b/src/archivey/internal/streams/codecs.py
@@ -211,6 +211,27 @@ def codec_for_stream_format(stream_format: StreamFormat) -> Codec:
     return _STREAM_FORMAT_CODECS[stream_format]
 
 
+def is_codec_available(codec: Codec) -> bool:
+    """Whether ``codec``'s decompression backend is importable right now.
+
+    Codecs served by the stdlib (stored/gzip/bzip2/xz/lzip/lzma/deflate/zlib) are always
+    available; the optional codecs report on their backing package's presence. Used by the
+    registry to compute a format's tri-state support compositionally over the codecs it can
+    use. Reads the module-level sentinels live, so it reflects test monkeypatching.
+    """
+    optional_sentinels: dict[Codec, ModuleType | None] = {
+        Codec.ZSTD: _zstandard,
+        Codec.LZ4: _lz4_frame,
+        Codec.BROTLI: _brotli,
+        Codec.UNIX_COMPRESS: _uncompresspy,
+        Codec.PPMD: _pyppmd,
+        Codec.DEFLATE64: _inflate64,
+    }
+    if codec in optional_sentinels:
+        return optional_sentinels[codec] is not None
+    return True
+
+
 @dataclass(frozen=True)
 class CodecParams:
     """Per-open parameters that vary by container/coder.

--- a/src/archivey/internal/streams/peekable.py
+++ b/src/archivey/internal/streams/peekable.py
@@ -1,0 +1,109 @@
+"""``PeekableStream`` — buffer a non-seekable source's prefix so detection never
+consumes it.
+
+Format detection needs to inspect the leading bytes of a source, but a non-seekable
+stream (a socket or pipe) cannot be rewound after that inspection. The opener wraps
+such a source in a :class:`PeekableStream` **once**, runs detection through
+:meth:`PeekableStream.peek`, and hands the *same* wrapper to the backend; reads then
+replay the buffered prefix before falling through to the underlying stream, so no bytes
+are dropped (see the ``format-detection`` capability).
+
+This is the fresh v2 replacement for DEV's ``RecordableStream`` /
+``RewindableStreamWrapper``.
+"""
+
+from __future__ import annotations
+
+import io
+from typing import TYPE_CHECKING, BinaryIO
+
+if TYPE_CHECKING:
+    from _typeshed import WriteableBuffer
+
+# Default amount buffered for detection (matches ``format-detection``'s DETECTION_LIMIT).
+# The buffer grows on demand up to whatever ``peek(n)`` asks for — e.g. 32 774 bytes when
+# the ISO probe is triggered — so this is only the typical case, not a hard cap.
+DETECTION_LIMIT = 4096
+
+
+class PeekableStream(io.RawIOBase, BinaryIO):
+    """A read-only ``BinaryIO`` over a non-seekable source with a peekable prefix.
+
+    ``peek(n)`` returns the first ``n`` unconsumed bytes without advancing the read
+    position, reading ahead from the underlying stream into an internal buffer as needed.
+    ``read`` drains that buffer first, then passes through to the underlying stream.
+
+    The wrapper never closes the underlying stream: like the rest of the stream layer it
+    adapts a source the caller owns, so closing this wrapper must not take the caller's
+    stream down with it.
+    """
+
+    def __init__(self, underlying: BinaryIO) -> None:
+        super().__init__()
+        self._underlying = underlying
+        # Bytes read ahead from the underlying stream but not yet consumed by read().
+        self._buffer = bytearray()
+        # Total bytes consumed via read() (the logical position of this stream).
+        self._pos = 0
+
+    def _fill_to(self, n: int) -> None:
+        """Read ahead until the buffer holds ``n`` bytes or the underlying stream ends."""
+        while len(self._buffer) < n:
+            chunk = self._underlying.read(n - len(self._buffer))
+            if not chunk:
+                break
+            self._buffer.extend(chunk)
+
+    def peek(self, n: int) -> bytes:
+        """Return up to the first ``n`` unconsumed bytes without consuming them.
+
+        Fewer than ``n`` bytes are returned only when the underlying stream ends first.
+        """
+        if n < 0:
+            raise ValueError("peek size must be non-negative")
+        self._fill_to(n)
+        return bytes(self._buffer[:n])
+
+    def read(self, size: int | None = -1, /) -> bytes:
+        if size is None or size < 0:
+            data = bytes(self._buffer) + (self._underlying.read() or b"")
+            self._buffer.clear()
+            self._pos += len(data)
+            return data
+        self._fill_to(size)
+        data = bytes(self._buffer[:size])
+        del self._buffer[:size]
+        self._pos += len(data)
+        return data
+
+    def readinto(self, b: "WriteableBuffer", /) -> int:
+        mv = memoryview(b).cast("B")
+        data = self.read(len(mv))
+        mv[: len(data)] = data
+        return len(data)
+
+    def readable(self) -> bool:
+        return True
+
+    def writable(self) -> bool:
+        return False
+
+    def seekable(self) -> bool:
+        # A peekable stream is forward-only by construction (it wraps a non-seekable
+        # source); the peeked prefix is replayed by read(), not by seek().
+        return False
+
+    def tell(self, /) -> int:
+        return self._pos
+
+    @property
+    def name(self) -> str | None:
+        name = getattr(self._underlying, "name", None)
+        return name if isinstance(name, str) else None
+
+    def close(self) -> None:
+        # Do NOT close the underlying stream — the caller owns it.
+        super().close()
+
+    def __repr__(self) -> str:
+        return f"PeekableStream({self._underlying!r})"

--- a/src/archivey/internal/types.py
+++ b/src/archivey/internal/types.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field, replace
 from datetime import datetime
 from enum import Enum
-from typing import TYPE_CHECKING, Any, ClassVar, Mapping
+from typing import TYPE_CHECKING, Any, ClassVar, Mapping, NamedTuple
 
 if TYPE_CHECKING:
     from archivey.internal.cost import CostReceipt
@@ -120,6 +120,21 @@ _FORMAT_NAMES: dict[ArchiveFormat, str] = {
     for name, value in vars(ArchiveFormat).items()
     if isinstance(value, ArchiveFormat)
 }
+
+
+class MagicSignature(NamedTuple):
+    """One magic-byte signal a backend declares as data, with the format it implies.
+
+    ``weak`` marks a signal too short/unspecific to trust on its own (the zlib 2-byte
+    CMF/FLG header): the detector only accepts a weak match after a content probe confirms
+    the stream actually decodes (see ``format-detection``). Strong signals are accepted on
+    the byte match alone.
+    """
+
+    offset: int
+    magic: bytes
+    format: "ArchiveFormat"
+    weak: bool = False
 
 
 class MemberType(Enum):
@@ -270,6 +285,10 @@ class ArchiveMember:
     # Private internal fields (not part of the public contract)
     _member_id: int | None = field(default=None, repr=False, compare=False)
     _archive_id: str | None = field(default=None, repr=False, compare=False)
+    _raw: Any = field(default=None, repr=False, compare=False)
+    """Opaque backend handle carried on the member (e.g. the stdlib ``ZipInfo`` /
+    ``TarInfo``), so a backend can open the member's data straight from the member without
+    a separate name/id lookup table. Not part of the public contract."""
 
     # Mutable members are intentionally unhashable. Annotated `-> int` (the call
     # always raises) so the override stays compatible with object.__hash__.

--- a/src/archivey/internal/types.py
+++ b/src/archivey/internal/types.py
@@ -53,6 +53,7 @@ class ArchiveFormat:
     BZ2: ClassVar[ArchiveFormat]
     XZ: ClassVar[ArchiveFormat]
     ZST: ClassVar[ArchiveFormat]
+    LZ4: ClassVar[ArchiveFormat]
     LZIP: ClassVar[ArchiveFormat]
     ZLIB: ClassVar[ArchiveFormat]
     BROTLI: ClassVar[ArchiveFormat]
@@ -101,6 +102,7 @@ ArchiveFormat.GZ = ArchiveFormat(ContainerFormat.RAW_STREAM, StreamFormat.GZIP)
 ArchiveFormat.BZ2 = ArchiveFormat(ContainerFormat.RAW_STREAM, StreamFormat.BZIP2)
 ArchiveFormat.XZ = ArchiveFormat(ContainerFormat.RAW_STREAM, StreamFormat.XZ)
 ArchiveFormat.ZST = ArchiveFormat(ContainerFormat.RAW_STREAM, StreamFormat.ZSTD)
+ArchiveFormat.LZ4 = ArchiveFormat(ContainerFormat.RAW_STREAM, StreamFormat.LZ4)
 ArchiveFormat.LZIP = ArchiveFormat(ContainerFormat.RAW_STREAM, StreamFormat.LZIP)
 ArchiveFormat.ZLIB = ArchiveFormat(ContainerFormat.RAW_STREAM, StreamFormat.ZLIB)
 ArchiveFormat.BROTLI = ArchiveFormat(ContainerFormat.RAW_STREAM, StreamFormat.BROTLI)

--- a/src/archivey/internal/types.py
+++ b/src/archivey/internal/types.py
@@ -29,6 +29,10 @@ class StreamFormat(str, Enum):
     XZ = "xz"
     ZSTD = "zst"
     LZ4 = "lz4"
+    LZIP = "lz"
+    ZLIB = "zz"
+    BROTLI = "br"
+    UNIX_COMPRESS = "Z"
 
 
 @dataclass(frozen=True)
@@ -49,6 +53,10 @@ class ArchiveFormat:
     BZ2: ClassVar[ArchiveFormat]
     XZ: ClassVar[ArchiveFormat]
     ZST: ClassVar[ArchiveFormat]
+    LZIP: ClassVar[ArchiveFormat]
+    ZLIB: ClassVar[ArchiveFormat]
+    BROTLI: ClassVar[ArchiveFormat]
+    Z: ClassVar[ArchiveFormat]
     SEVEN_Z: ClassVar[ArchiveFormat]
     RAR: ClassVar[ArchiveFormat]
     ISO: ClassVar[ArchiveFormat]
@@ -93,6 +101,10 @@ ArchiveFormat.GZ = ArchiveFormat(ContainerFormat.RAW_STREAM, StreamFormat.GZIP)
 ArchiveFormat.BZ2 = ArchiveFormat(ContainerFormat.RAW_STREAM, StreamFormat.BZIP2)
 ArchiveFormat.XZ = ArchiveFormat(ContainerFormat.RAW_STREAM, StreamFormat.XZ)
 ArchiveFormat.ZST = ArchiveFormat(ContainerFormat.RAW_STREAM, StreamFormat.ZSTD)
+ArchiveFormat.LZIP = ArchiveFormat(ContainerFormat.RAW_STREAM, StreamFormat.LZIP)
+ArchiveFormat.ZLIB = ArchiveFormat(ContainerFormat.RAW_STREAM, StreamFormat.ZLIB)
+ArchiveFormat.BROTLI = ArchiveFormat(ContainerFormat.RAW_STREAM, StreamFormat.BROTLI)
+ArchiveFormat.Z = ArchiveFormat(ContainerFormat.RAW_STREAM, StreamFormat.UNIX_COMPRESS)
 ArchiveFormat.SEVEN_Z = ArchiveFormat(ContainerFormat.SEVEN_Z, StreamFormat.UNCOMPRESSED)
 ArchiveFormat.RAR = ArchiveFormat(ContainerFormat.RAR, StreamFormat.UNCOMPRESSED)
 ArchiveFormat.ISO = ArchiveFormat(ContainerFormat.ISO, StreamFormat.UNCOMPRESSED)

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -16,6 +16,7 @@ import pytest
 from archivey import ArchiveFormat, DetectionConfidence, FormatInfo, detect_format
 from archivey.internal.errors import FormatDetectionError
 from archivey.internal.streams import codecs as codecs_module
+from archivey.internal.types import MagicSignature
 from tests.conftest import requires
 from tests.streams_util import NonSeekableBytesIO
 
@@ -100,7 +101,7 @@ def test_magic_wins_over_conflicting_extension(
 
     class _MagicBackend(ReadBackend):
         FORMATS = (ArchiveFormat.SEVEN_Z,)
-        MAGIC = ((0, b"\x37\x7a\xbc\xaf\x27\x1c", ArchiveFormat.SEVEN_Z),)
+        MAGIC = (MagicSignature(0, b"\x37\x7a\xbc\xaf\x27\x1c", ArchiveFormat.SEVEN_Z),)
 
         def open_read(self, *a, **k):  # pragma: no cover
             raise NotImplementedError
@@ -198,19 +199,30 @@ def test_brotli_probe_skipped_when_backend_missing(
     assert info.detected_by == "extension"
 
 
-def test_zlib_weak_magic_is_probable() -> None:
+def test_zlib_weak_magic_confirmed_by_content_probe() -> None:
     data = zlib.compress(b"zlib payload")
     info = detect_format(io.BytesIO(data))
     assert info.format == ArchiveFormat.ZLIB
-    # zlib's 2-byte header is a weak signal -> PROBABLE, not CERTAIN.
+    # The weak 2-byte header is confirmed by a content probe -> PROBABLE / content_probe.
     assert info.confidence == DetectionConfidence.PROBABLE
-    assert info.detected_by == "magic"
+    assert info.detected_by == "content_probe"
 
 
-def test_zlib_weak_magic_overridden_by_conflicting_extension(tmp_path: Path) -> None:
-    # A conflicting extension overrides the weak zlib match (no warning, by design).
+def test_zlib_probe_wins_over_misleading_extension(tmp_path: Path) -> None:
+    # A genuine zlib stream named .xz: the content probe confirms zlib, so the (wrong)
+    # extension does not override it.
     path = tmp_path / "thing.xz"
     path.write_bytes(zlib.compress(b"payload"))
+    info = detect_format(path)
+    assert info.format == ArchiveFormat.ZLIB
+    assert info.detected_by == "content_probe"
+
+
+def test_weak_zlib_magic_without_valid_stream_falls_through(tmp_path: Path) -> None:
+    # A 0x78 0x9c prefix on non-zlib data: the weak magic matches but the content probe
+    # fails, so detection falls through to the extension guess instead of claiming zlib.
+    path = tmp_path / "thing.xz"
+    path.write_bytes(b"\x78\x9c" + b"\xff" * 200)  # zlib header byte, then garbage
     info = detect_format(path)
     assert info.format == ArchiveFormat.XZ
     assert info.detected_by == "extension"

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -1,6 +1,6 @@
-"""Format-detection tests — Stage 1 scope (magic, extension, conflict, never-consumes).
+"""Format-detection tests — Stage 1 + Stage 2 (Brotli content probe, weak zlib).
 
-Brotli/inner-TAR/ISO probes and SFX scanning land with their backends in later stages.
+Inner-TAR / ISO probes and SFX scanning land with their backends in later stages.
 """
 
 from __future__ import annotations
@@ -8,12 +8,15 @@ from __future__ import annotations
 import io
 import logging
 import zipfile
+import zlib
 from pathlib import Path
 
 import pytest
 
 from archivey import ArchiveFormat, DetectionConfidence, FormatInfo, detect_format
 from archivey.internal.errors import FormatDetectionError
+from archivey.internal.streams import codecs as codecs_module
+from tests.conftest import requires
 from tests.streams_util import NonSeekableBytesIO
 
 
@@ -163,3 +166,51 @@ def test_path_source_not_left_open(tmp_path: Path) -> None:
     # Detecting a path opens and closes its own handle; the file stays usable afterwards.
     detect_format(path)
     assert path.read_bytes()[:4] == b"\x50\x4b\x03\x04"
+
+
+# ---------------------------------------------------------------------------
+# Stage 2: Brotli content probe (magic-less) + weak zlib
+# ---------------------------------------------------------------------------
+
+
+@requires("brotli")
+def test_brotli_detected_by_content_probe() -> None:
+    import brotli
+
+    data = brotli.compress(b"some brotli payload to decode")
+    info = detect_format(io.BytesIO(data))
+    assert info.format == ArchiveFormat.BROTLI
+    assert info.confidence == DetectionConfidence.PROBABLE
+    assert info.detected_by == "content_probe"
+
+
+def test_brotli_probe_skipped_when_backend_missing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # With the Brotli backend absent, the probe is skipped and detection falls back to the
+    # .br extension guess rather than failing.
+    monkeypatch.setattr(codecs_module, "_brotli", None)
+    path = tmp_path / "thing.br"
+    path.write_bytes(b"not a brotli stream, just bytes")
+    info = detect_format(path)
+    assert info.format == ArchiveFormat.BROTLI
+    assert info.confidence == DetectionConfidence.GUESS
+    assert info.detected_by == "extension"
+
+
+def test_zlib_weak_magic_is_probable() -> None:
+    data = zlib.compress(b"zlib payload")
+    info = detect_format(io.BytesIO(data))
+    assert info.format == ArchiveFormat.ZLIB
+    # zlib's 2-byte header is a weak signal -> PROBABLE, not CERTAIN.
+    assert info.confidence == DetectionConfidence.PROBABLE
+    assert info.detected_by == "magic"
+
+
+def test_zlib_weak_magic_overridden_by_conflicting_extension(tmp_path: Path) -> None:
+    # A conflicting extension overrides the weak zlib match (no warning, by design).
+    path = tmp_path / "thing.xz"
+    path.write_bytes(zlib.compress(b"payload"))
+    info = detect_format(path)
+    assert info.format == ArchiveFormat.XZ
+    assert info.detected_by == "extension"

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -1,0 +1,165 @@
+"""Format-detection tests — Stage 1 scope (magic, extension, conflict, never-consumes).
+
+Brotli/inner-TAR/ISO probes and SFX scanning land with their backends in later stages.
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from archivey import ArchiveFormat, DetectionConfidence, FormatInfo, detect_format
+from archivey.internal.errors import FormatDetectionError
+from tests.streams_util import NonSeekableBytesIO
+
+
+def _zip_bytes() -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as z:
+        z.writestr("a.txt", b"hello")
+    return buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# Magic-byte detection
+# ---------------------------------------------------------------------------
+
+
+def test_magic_match_is_certain() -> None:
+    info = detect_format(io.BytesIO(_zip_bytes()))
+    assert info == FormatInfo(
+        ArchiveFormat.ZIP, DetectionConfidence.CERTAIN, "magic", None, 0
+    )
+
+
+def test_zip_empty_archive_magic() -> None:
+    # An empty ZIP is just the end-of-central-directory record (PK\x05\x06).
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w"):
+        pass
+    info = detect_format(io.BytesIO(buf.getvalue()))
+    assert info.format == ArchiveFormat.ZIP
+    assert info.detected_by == "magic"
+
+
+def test_small_archive_still_detected() -> None:
+    # A tiny ZIP (far smaller than any large probe window) is still detected by magic.
+    data = _zip_bytes()
+    assert len(data) < 4096
+    assert detect_format(io.BytesIO(data)).format == ArchiveFormat.ZIP
+
+
+# ---------------------------------------------------------------------------
+# Extension fallback
+# ---------------------------------------------------------------------------
+
+
+def test_extension_only_is_guess(tmp_path: Path) -> None:
+    # No magic match, but a .zip extension -> a GUESS by extension.
+    path = tmp_path / "mystery.zip"
+    path.write_bytes(b"not really a zip but ends in .zip")
+    info = detect_format(path)
+    assert info.format == ArchiveFormat.ZIP
+    assert info.confidence == DetectionConfidence.GUESS
+    assert info.detected_by == "extension"
+
+
+def test_unrecognized_bytes_no_name_raises() -> None:
+    with pytest.raises(FormatDetectionError):
+        detect_format(io.BytesIO(b"this is not any known archive format at all"))
+
+
+def test_unrecognized_extension_and_bytes_raises(tmp_path: Path) -> None:
+    path = tmp_path / "data.unknownext"
+    path.write_bytes(b"random bytes")
+    with pytest.raises(FormatDetectionError):
+        detect_format(path)
+
+
+# ---------------------------------------------------------------------------
+# Conflict resolution: magic wins, a warning is emitted
+# ---------------------------------------------------------------------------
+
+
+def test_magic_wins_over_conflicting_extension(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A conflict needs two formats registered (only ZIP is, in Stage 1), so drive it
+    # through a registry with two synthetic backends: magic says SEVEN_Z, the ".rar"
+    # extension says RAR. Magic must win, with a WARNING on archivey.detection.
+    from archivey.internal import detection as detection_module
+    from archivey.internal.reader import ReadBackend
+    from archivey.internal.registry import BackendRegistry
+
+    class _MagicBackend(ReadBackend):
+        FORMATS = (ArchiveFormat.SEVEN_Z,)
+        MAGIC = ((0, b"\x37\x7a\xbc\xaf\x27\x1c", ArchiveFormat.SEVEN_Z),)
+
+        def open_read(self, *a, **k):  # pragma: no cover
+            raise NotImplementedError
+
+    class _ExtBackend(ReadBackend):
+        FORMATS = (ArchiveFormat.RAR,)
+        EXTENSIONS = {".rar": ArchiveFormat.RAR}
+
+        def open_read(self, *a, **k):  # pragma: no cover
+            raise NotImplementedError
+
+    reg = BackendRegistry()
+    reg.register_reader(_MagicBackend)
+    reg.register_reader(_ExtBackend)
+    monkeypatch.setattr(detection_module, "get_registry", lambda: reg)
+
+    path = tmp_path / "thing.rar"
+    path.write_bytes(b"\x37\x7a\xbc\xaf\x27\x1c" + b"\x00" * 32)
+    with caplog.at_level(logging.WARNING, logger="archivey.detection"):
+        info = detect_format(path)
+    assert info.format == ArchiveFormat.SEVEN_Z
+    assert info.detected_by == "magic"
+    assert any("conflict" in r.getMessage().lower() for r in caplog.records), caplog.text
+
+
+def test_no_warning_when_extension_agrees(
+    tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    path = tmp_path / "archive.zip"
+    path.write_bytes(_zip_bytes())
+    with caplog.at_level(logging.WARNING, logger="archivey.detection"):
+        detect_format(path)
+    assert not caplog.records
+
+
+# ---------------------------------------------------------------------------
+# Detection never consumes bytes
+# ---------------------------------------------------------------------------
+
+
+def test_seekable_stream_rewound_to_zero() -> None:
+    stream = io.BytesIO(_zip_bytes())
+    detect_format(stream)
+    assert stream.tell() == 0
+    # The full stream is still readable from the start.
+    assert stream.read(4) == b"\x50\x4b\x03\x04"
+
+
+def test_peekable_stream_not_consumed() -> None:
+    from archivey.internal.streams.peekable import PeekableStream
+
+    data = _zip_bytes()
+    stream = PeekableStream(NonSeekableBytesIO(data))
+    info = detect_format(stream)
+    assert info.format == ArchiveFormat.ZIP
+    # Nothing consumed: the backend can still read the whole archive.
+    assert stream.read(len(data)) == data
+
+
+def test_path_source_not_left_open(tmp_path: Path) -> None:
+    path = tmp_path / "a.zip"
+    path.write_bytes(_zip_bytes())
+    # Detecting a path opens and closes its own handle; the file stays usable afterwards.
+    detect_format(path)
+    assert path.read_bytes()[:4] == b"\x50\x4b\x03\x04"

--- a/tests/test_peekable.py
+++ b/tests/test_peekable.py
@@ -1,0 +1,97 @@
+"""Tests for the ``PeekableStream`` primitive (Phase 3, §1)."""
+
+from __future__ import annotations
+
+import io
+
+from archivey.internal.streams.peekable import DETECTION_LIMIT, PeekableStream
+from tests.streams_util import NonSeekableBytesIO
+
+
+def test_peek_does_not_consume() -> None:
+    stream = PeekableStream(NonSeekableBytesIO(b"0123456789"))
+    assert stream.peek(4) == b"0123"
+    # A second peek sees the same bytes; nothing was consumed.
+    assert stream.peek(4) == b"0123"
+    assert stream.tell() == 0
+
+
+def test_read_replays_buffer_then_passes_through() -> None:
+    stream = PeekableStream(NonSeekableBytesIO(b"abcdefghij"))
+    stream.peek(4)  # buffer "abcd"
+    # First read drains the peeked buffer...
+    assert stream.read(2) == b"ab"
+    assert stream.read(2) == b"cd"
+    # ...then falls through to the underlying stream with no bytes dropped.
+    assert stream.read(6) == b"efghij"
+    assert stream.read(1) == b""
+    assert stream.tell() == 10
+
+
+def test_read_all_drains_buffer_and_underlying() -> None:
+    stream = PeekableStream(NonSeekableBytesIO(b"hello world"))
+    stream.peek(5)
+    assert stream.read() == b"hello world"
+    assert stream.read() == b""
+
+
+def test_peek_beyond_buffered_limit_grows() -> None:
+    # Peeking more than the default window grows the buffer on demand (the ISO probe needs
+    # 32 774 bytes); the same bytes are then still replayed on read.
+    data = bytes(range(256)) * 200  # 51 200 bytes, > DETECTION_LIMIT and > the ISO window
+    assert len(data) > DETECTION_LIMIT
+    stream = PeekableStream(NonSeekableBytesIO(data))
+    big = stream.peek(32774)
+    assert big == data[:32774]
+    assert stream.read(len(data)) == data
+
+
+def test_peek_past_eof_returns_short() -> None:
+    stream = PeekableStream(NonSeekableBytesIO(b"abc"))
+    assert stream.peek(100) == b"abc"
+    assert stream.read() == b"abc"
+
+
+def test_readinto_replays_buffer() -> None:
+    stream = PeekableStream(NonSeekableBytesIO(b"abcdef"))
+    stream.peek(3)
+    buf = bytearray(4)
+    n = stream.readinto(buf)
+    assert n == 4
+    assert bytes(buf) == b"abcd"
+
+
+def test_reports_non_seekable() -> None:
+    stream = PeekableStream(NonSeekableBytesIO(b"x"))
+    assert stream.seekable() is False
+    assert stream.readable() is True
+
+
+def test_close_does_not_close_underlying() -> None:
+    underlying = NonSeekableBytesIO(b"data")
+    stream = PeekableStream(underlying)
+    stream.close()
+    # The wrapper is closed, but the caller-owned underlying stream is left usable.
+    assert underlying.closed is False
+    assert underlying.read() == b"data"
+
+
+def test_name_passthrough(tmp_path) -> None:
+    path = tmp_path / "thing.bin"
+    path.write_bytes(b"abc")
+    with open(path, "rb") as f:
+        stream = PeekableStream(f)
+        assert stream.name == str(path)
+
+
+def test_name_none_for_anonymous_stream() -> None:
+    stream = PeekableStream(NonSeekableBytesIO(b"abc"))
+    assert stream.name is None
+
+
+def test_works_as_binaryio_for_buffered_reader() -> None:
+    # The backend may wrap a PeekableStream in a BufferedReader; the prefix must survive.
+    stream = PeekableStream(NonSeekableBytesIO(b"0123456789"))
+    stream.peek(4)
+    reader = io.BufferedReader(stream)
+    assert reader.read(10) == b"0123456789"

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -148,10 +148,16 @@ def test_zip_partial_when_optional_codecs_missing(
     assert ArchiveFormat.ZIP in list_supported_formats()
 
 
-def test_zip_full_when_codecs_present() -> None:
-    # The dev/[all] test environment has the optional codecs installed.
+def test_zip_full_when_codecs_present(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Force ZIP's optional member codecs present so FULL is asserted deterministically,
+    # regardless of which extras the test environment installed (the core-only CI legs
+    # have none). The PARTIAL direction is covered by
+    # test_zip_partial_when_optional_codecs_missing.
+    for sentinel in ("_inflate64", "_zstandard", "_pyppmd"):
+        monkeypatch.setattr(codecs_module, sentinel, object())
     avail = format_availability(ArchiveFormat.ZIP)
     assert avail.support is FormatSupport.FULL
+    assert avail.missing == ()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -160,6 +160,26 @@ def test_zip_full_when_codecs_present(monkeypatch: pytest.MonkeyPatch) -> None:
     assert avail.missing == ()
 
 
+def test_single_codec_format_none_when_codec_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # A bare single-file compressor whose sole codec backend is missing is NONE (not
+    # PARTIAL): there is nothing to fall back to. ZST's codec is zstandard.
+    monkeypatch.setattr(codecs_module, "_zstandard", None)
+    avail = format_availability(ArchiveFormat.ZST)
+    assert avail.support is FormatSupport.NONE
+    assert avail.missing[0].name == "zstandard"
+    assert ArchiveFormat.ZST in list_known_formats()
+    assert ArchiveFormat.ZST not in list_supported_formats()
+
+
+def test_single_codec_format_full_when_codec_present(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(codecs_module, "_zstandard", object())
+    assert format_availability(ArchiveFormat.ZST).support is FormatSupport.FULL
+
+
 # ---------------------------------------------------------------------------
 # Global registry: known includes everything; supported excludes NONE
 # ---------------------------------------------------------------------------

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -26,7 +26,7 @@ from archivey.internal.errors import UnsupportedFormatError
 from archivey.internal.reader import ReadBackend
 from archivey.internal.registry import BackendRegistry
 from archivey.internal.streams import codecs as codecs_module
-from archivey.internal.types import ContainerFormat
+from archivey.internal.types import ContainerFormat, MagicSignature
 
 # ---------------------------------------------------------------------------
 # Synthetic backends, registered into a *fresh* registry (no global pollution)
@@ -36,7 +36,7 @@ from archivey.internal.types import ContainerFormat
 class _CoreBackend(ReadBackend):
     FORMATS = (ArchiveFormat.TAR,)
     EXTENSIONS: Mapping[str, ArchiveFormat] = {".tar": ArchiveFormat.TAR}
-    MAGIC = ((257, b"ustar", ArchiveFormat.TAR),)
+    MAGIC = (MagicSignature(257, b"ustar", ArchiveFormat.TAR),)
 
     def open_read(self, source, streaming, password, encoding, archive_name):  # pragma: no cover
         raise NotImplementedError
@@ -123,7 +123,7 @@ def test_reader_for_unknown_format_raises(registry: BackendRegistry) -> None:
 
 
 def test_magic_and_extension_tables_aggregate(registry: BackendRegistry) -> None:
-    assert (257, b"ustar", ArchiveFormat.TAR) in registry.magic_entries()
+    assert MagicSignature(257, b"ustar", ArchiveFormat.TAR) in registry.magic_entries()
     assert registry.extension_map()[".tar"] == ArchiveFormat.TAR
 
 

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,205 @@
+"""Backend-registry tests — Stage 1 scope.
+
+Covers always-register-via-sentinel, tri-state FULL/PARTIAL/NONE availability,
+``list_supported_formats()`` vs ``list_known_formats()``, install-hint selection errors,
+and two simultaneous readers. The NONE-end-to-end ISO-without-pycdlib path is exercised in
+Stage 4 with the real ISO backend.
+"""
+
+from __future__ import annotations
+
+import zipfile
+from pathlib import Path
+from typing import Mapping
+
+import pytest
+
+from archivey import (
+    ArchiveFormat,
+    FormatSupport,
+    format_availability,
+    list_known_formats,
+    list_supported_formats,
+    open_archive,
+)
+from archivey.internal.errors import UnsupportedFormatError
+from archivey.internal.reader import ReadBackend
+from archivey.internal.registry import BackendRegistry
+from archivey.internal.streams import codecs as codecs_module
+from archivey.internal.types import ContainerFormat
+
+# ---------------------------------------------------------------------------
+# Synthetic backends, registered into a *fresh* registry (no global pollution)
+# ---------------------------------------------------------------------------
+
+
+class _CoreBackend(ReadBackend):
+    FORMATS = (ArchiveFormat.TAR,)
+    EXTENSIONS: Mapping[str, ArchiveFormat] = {".tar": ArchiveFormat.TAR}
+    MAGIC = ((257, b"ustar", ArchiveFormat.TAR),)
+
+    def open_read(self, source, streaming, password, encoding, archive_name):  # pragma: no cover
+        raise NotImplementedError
+
+
+class _OptionalPresentBackend(ReadBackend):
+    FORMATS = (ArchiveFormat.SEVEN_Z,)
+    OPTIONAL_DEPENDENCY = "io"  # a module that always imports
+    INSTALL_HINT = "pip install archivey[present]"
+
+    def open_read(self, source, streaming, password, encoding, archive_name):  # pragma: no cover
+        raise NotImplementedError
+
+
+class _OptionalMissingBackend(ReadBackend):
+    FORMATS = (ArchiveFormat.ISO,)
+    OPTIONAL_DEPENDENCY = "a_package_that_does_not_exist_xyz"
+    INSTALL_HINT = "pip install archivey[iso]"
+
+    def open_read(self, source, streaming, password, encoding, archive_name):  # pragma: no cover
+        raise NotImplementedError
+
+
+@pytest.fixture
+def registry() -> BackendRegistry:
+    reg = BackendRegistry()
+    reg.register_reader(_CoreBackend)
+    reg.register_reader(_OptionalPresentBackend)
+    reg.register_reader(_OptionalMissingBackend)
+    return reg
+
+
+# ---------------------------------------------------------------------------
+# Always-register; availability derived from the module-or-None sentinel
+# ---------------------------------------------------------------------------
+
+
+def test_optional_missing_backend_is_known_but_unavailable(registry: BackendRegistry) -> None:
+    # Registered regardless of its dependency: present in "known", absent from "supported".
+    assert ArchiveFormat.ISO in registry.list_known_formats()
+    assert ArchiveFormat.ISO not in registry.list_supported_formats()
+
+    avail = registry.format_availability(ArchiveFormat.ISO)
+    assert avail.support is FormatSupport.NONE
+    assert len(avail.missing) == 1
+    assert avail.missing[0].name == "a_package_that_does_not_exist_xyz"
+    assert "archivey[iso]" in avail.missing[0].install_hint
+
+
+def test_optional_present_backend_is_full(registry: BackendRegistry) -> None:
+    avail = registry.format_availability(ArchiveFormat.SEVEN_Z)
+    assert avail.support is FormatSupport.FULL
+    assert avail.missing == ()
+    assert ArchiveFormat.SEVEN_Z in registry.list_supported_formats()
+
+
+def test_core_backend_is_full(registry: BackendRegistry) -> None:
+    avail = registry.format_availability(ArchiveFormat.TAR)
+    assert avail.support is FormatSupport.FULL
+
+
+def test_unknown_format_is_none(registry: BackendRegistry) -> None:
+    avail = registry.format_availability(ArchiveFormat.RAR)
+    assert avail.support is FormatSupport.NONE
+    assert avail.missing == ()
+
+
+def test_reader_for_missing_dependency_raises_with_hint(registry: BackendRegistry) -> None:
+    with pytest.raises(UnsupportedFormatError) as excinfo:
+        registry.reader_for_format(ArchiveFormat.ISO)
+    msg = str(excinfo.value)
+    assert "a_package_that_does_not_exist_xyz" in msg
+    assert "archivey[iso]" in msg
+
+
+def test_reader_for_unknown_format_raises(registry: BackendRegistry) -> None:
+    with pytest.raises(UnsupportedFormatError):
+        registry.reader_for_format(ArchiveFormat.RAR)
+
+
+# ---------------------------------------------------------------------------
+# Detection tables aggregate backend data
+# ---------------------------------------------------------------------------
+
+
+def test_magic_and_extension_tables_aggregate(registry: BackendRegistry) -> None:
+    assert (257, b"ustar", ArchiveFormat.TAR) in registry.magic_entries()
+    assert registry.extension_map()[".tar"] == ArchiveFormat.TAR
+
+
+# ---------------------------------------------------------------------------
+# Tri-state PARTIAL: a multi-codec container missing an optional member codec
+# ---------------------------------------------------------------------------
+
+
+def test_zip_partial_when_optional_codecs_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # ZIP can store deflate64 (inflate64 / [7z]) and zstd ([zstd]); with those absent it
+    # still opens and lists common (stored/deflate) members -> PARTIAL.
+    monkeypatch.setattr(codecs_module, "_inflate64", None)
+    monkeypatch.setattr(codecs_module, "_zstandard", None)
+
+    avail = format_availability(ArchiveFormat.ZIP)
+    assert avail.support is FormatSupport.PARTIAL
+    missing_names = {m.name for m in avail.missing}
+    assert {"inflate64", "zstandard"} <= missing_names
+    # PARTIAL formats are still "supported" (readable for their common members).
+    assert ArchiveFormat.ZIP in list_supported_formats()
+
+
+def test_zip_full_when_codecs_present() -> None:
+    # The dev/[all] test environment has the optional codecs installed.
+    avail = format_availability(ArchiveFormat.ZIP)
+    assert avail.support is FormatSupport.FULL
+
+
+# ---------------------------------------------------------------------------
+# Global registry: known includes everything; supported excludes NONE
+# ---------------------------------------------------------------------------
+
+
+def test_global_known_and_supported() -> None:
+    known = list_known_formats()
+    supported = list_supported_formats()
+    assert ArchiveFormat.ZIP in known
+    assert ArchiveFormat.DIRECTORY in known
+    assert ArchiveFormat.ZIP in supported
+    # Supported is always a subset of known.
+    assert set(supported) <= set(known)
+
+
+def test_directory_is_full() -> None:
+    assert format_availability(ArchiveFormat.DIRECTORY).support is FormatSupport.FULL
+
+
+# ---------------------------------------------------------------------------
+# Two simultaneous readers
+# ---------------------------------------------------------------------------
+
+
+def _make_zip(path: Path, content: bytes) -> None:
+    with zipfile.ZipFile(path, "w") as z:
+        z.writestr("data.txt", content)
+
+
+def test_two_simultaneous_readers(tmp_path: Path) -> None:
+    a = tmp_path / "a.zip"
+    b = tmp_path / "b.zip"
+    _make_zip(a, b"alpha")
+    _make_zip(b, b"beta")
+
+    with open_archive(a) as ra, open_archive(b) as rb:
+        # Independent readers: interleaved reads do not interfere.
+        assert ra.read("data.txt") == b"alpha"
+        assert rb.read("data.txt") == b"beta"
+        assert ra.read("data.txt") == b"alpha"
+
+
+def test_partial_container_does_not_lower_for_unrelated_format(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Removing a ZIP-relevant codec must not affect a codec-less format like DIRECTORY.
+    monkeypatch.setattr(codecs_module, "_zstandard", None)
+    assert format_availability(ArchiveFormat.DIRECTORY).support is FormatSupport.FULL
+    assert ContainerFormat.DIRECTORY == ArchiveFormat.DIRECTORY.container

--- a/tests/test_single_file.py
+++ b/tests/test_single_file.py
@@ -2,7 +2,8 @@
 
 Covers name inference, the one-member shape, the gzip stored-name surface, per-format
 size rules, DIRECT/INDEXED cost, the unix-compress non-seekable rule, and the
-password-rejection rule. ZST/LZ4 standalone are deferred to Phase 8.
+password-rejection rule. ZST/LZ4 standalone are first-class here; only their
+seekable-decompressor refinements remain for Phase 8.
 """
 
 from __future__ import annotations

--- a/tests/test_single_file.py
+++ b/tests/test_single_file.py
@@ -1,0 +1,230 @@
+"""Single-file compressor backend tests — Stage 2.
+
+Covers name inference, the one-member shape, the gzip stored-name surface, per-format
+size rules, DIRECT/INDEXED cost, the unix-compress non-seekable rule, and the
+password-rejection rule. ZST/LZ4 standalone are deferred to Phase 8.
+"""
+
+from __future__ import annotations
+
+import bz2
+import gzip
+import io
+import lzma
+import zlib
+from pathlib import Path
+
+import pytest
+
+from archivey import ArchiveFormat, MemberType, open_archive
+from archivey.internal.cost import AccessCost, ListingCost
+from archivey.internal.errors import StreamNotSeekableError, UnsupportedOperationError
+from tests.conftest import requires
+from tests.streams_util import NonSeekableBytesIO, make_lzip_member, make_unix_compress
+
+
+def _gzip_bytes(payload: bytes, *, filename: str | None = None, mtime: int = 0) -> bytes:
+    buf = io.BytesIO()
+    gz = gzip.GzipFile(filename=filename or "", mode="wb", fileobj=buf, mtime=mtime)
+    gz.write(payload)
+    gz.close()
+    return buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# One backend, multiple formats; one-member shape
+# ---------------------------------------------------------------------------
+
+
+def test_one_backend_serves_multiple_formats() -> None:
+    cases = {
+        ArchiveFormat.GZ: gzip.compress(b"gzipped"),
+        ArchiveFormat.BZ2: bz2.compress(b"bzipped"),
+        ArchiveFormat.XZ: lzma.compress(b"xzipped"),
+    }
+    for expected_format, data in cases.items():
+        with open_archive(io.BytesIO(data)) as ar:
+            assert ar.format == expected_format
+            members = ar.members()
+            assert len(members) == 1
+            assert members[0].type == MemberType.FILE
+
+
+def test_exactly_one_member_no_directories() -> None:
+    with open_archive(io.BytesIO(gzip.compress(b"x"))) as ar:
+        members = list(ar)
+        assert len(members) == 1
+        assert members[0].is_file
+
+
+def test_read_roundtrip() -> None:
+    with open_archive(io.BytesIO(bz2.compress(b"hello bzip"))) as ar:
+        assert ar.read(ar.members()[0]) == b"hello bzip"
+
+
+# ---------------------------------------------------------------------------
+# Member name inference
+# ---------------------------------------------------------------------------
+
+
+def test_name_strips_known_compression_extension(tmp_path: Path) -> None:
+    path = tmp_path / "data.txt.gz"
+    with gzip.open(path, "wb") as f:
+        f.write(b"content")
+    with open_archive(path) as ar:
+        assert ar.members()[0].name == "data.txt"
+
+
+def test_name_appends_uncompressed_for_unknown_extension(tmp_path: Path) -> None:
+    # Identified by content (gzip magic), but ".bin" is not a compression extension, so the
+    # extension is preserved and ".uncompressed" appended rather than discarding info.
+    path = tmp_path / "mystery.bin"
+    path.write_bytes(gzip.compress(b"content"))
+    with open_archive(path) as ar:
+        assert ar.members()[0].name == "mystery.bin.uncompressed"
+
+
+def test_name_defaults_to_data_for_anonymous_stream() -> None:
+    with open_archive(io.BytesIO(gzip.compress(b"x"))) as ar:
+        assert ar.members()[0].name == "data"
+
+
+# ---------------------------------------------------------------------------
+# gzip stored filename + mtime
+# ---------------------------------------------------------------------------
+
+
+def test_gzip_stored_filename_surfaced(tmp_path: Path) -> None:
+    path = tmp_path / "archive.gz"
+    path.write_bytes(_gzip_bytes(b"payload", filename="report.csv"))
+    with open_archive(path) as ar:
+        member = ar.members()[0]
+        # name comes from the source filename; the stored FNAME lives in extra + raw_name.
+        assert member.name == "archive"
+        assert member.extra["gzip.original_filename"] == "report.csv"
+        assert member.raw_name == b"report.csv"
+
+
+def test_gzip_without_stored_filename() -> None:
+    # gzip.compress writes no FNAME -> no extra key, raw_name stays None.
+    with open_archive(io.BytesIO(gzip.compress(b"x"))) as ar:
+        member = ar.members()[0]
+        assert "gzip.original_filename" not in member.extra
+        assert member.raw_name is None
+
+
+def test_gzip_mtime_surfaced() -> None:
+    data = _gzip_bytes(b"payload", mtime=1_600_000_000)
+    with open_archive(io.BytesIO(data)) as ar:
+        member = ar.members()[0]
+        assert member.modified is not None
+        assert member.modified.tzinfo is not None
+        assert int(member.modified.timestamp()) == 1_600_000_000
+
+
+# ---------------------------------------------------------------------------
+# Per-format size rules
+# ---------------------------------------------------------------------------
+
+
+def test_gz_size_is_always_none() -> None:
+    with open_archive(io.BytesIO(gzip.compress(b"x" * 1000))) as ar:
+        assert ar.members()[0].size is None
+
+
+def test_bz2_size_none_before_full_read() -> None:
+    with open_archive(io.BytesIO(bz2.compress(b"x" * 1000))) as ar:
+        assert ar.members()[0].size is None
+
+
+def test_zlib_size_none() -> None:
+    with open_archive(io.BytesIO(zlib.compress(b"x" * 1000))) as ar:
+        assert ar.members()[0].size is None
+
+
+def test_xz_size_from_header(tmp_path: Path) -> None:
+    path = tmp_path / "data.xz"
+    with lzma.open(path, "wb") as f:
+        f.write(b"x" * 1234)
+    with open_archive(path) as ar:
+        assert ar.members()[0].size == 1234
+
+
+def test_lzip_size_from_trailer(tmp_path: Path) -> None:
+    path = tmp_path / "data.lz"
+    path.write_bytes(make_lzip_member(b"y" * 777))
+    with open_archive(path) as ar:
+        assert ar.members()[0].size == 777
+
+
+# ---------------------------------------------------------------------------
+# Cost
+# ---------------------------------------------------------------------------
+
+
+def test_cost_is_indexed_and_direct() -> None:
+    with open_archive(io.BytesIO(gzip.compress(b"x"))) as ar:
+        cost = ar.cost
+        assert cost.listing_cost == ListingCost.INDEXED
+        assert cost.access_cost == AccessCost.DIRECT
+
+
+def test_archive_info() -> None:
+    with open_archive(io.BytesIO(gzip.compress(b"x"))) as ar:
+        info = ar.info
+        assert info.member_count == 1
+        assert info.is_solid is False
+        assert info.is_encrypted is False
+
+
+# ---------------------------------------------------------------------------
+# Non-seekable behavior
+# ---------------------------------------------------------------------------
+
+
+def test_non_seekable_gzip_reads_fine() -> None:
+    # Single-file formats (except .Z) read from a non-seekable source.
+    data = gzip.compress(b"streamed payload")
+    with open_archive(NonSeekableBytesIO(data)) as ar:
+        assert ar.read(ar.members()[0]) == b"streamed payload"
+
+
+@requires("uncompresspy", "ncompress")
+def test_unix_compress_non_seekable_raises() -> None:
+    data = make_unix_compress(b"lzw payload")
+    with pytest.raises(StreamNotSeekableError):
+        open_archive(NonSeekableBytesIO(data), format=ArchiveFormat.Z)
+
+
+@requires("uncompresspy", "ncompress")
+def test_unix_compress_seekable_reads(tmp_path: Path) -> None:
+    path = tmp_path / "data.Z"
+    path.write_bytes(make_unix_compress(b"lzw payload"))
+    with open_archive(path) as ar:
+        assert ar.format == ArchiveFormat.Z
+        assert ar.read(ar.members()[0]) == b"lzw payload"
+
+
+# ---------------------------------------------------------------------------
+# Password rejection
+# ---------------------------------------------------------------------------
+
+
+def test_password_raises() -> None:
+    with pytest.raises(UnsupportedOperationError):
+        open_archive(io.BytesIO(gzip.compress(b"x")), password=b"secret")
+
+
+# ---------------------------------------------------------------------------
+# Brotli (magic-less, detected by content probe)
+# ---------------------------------------------------------------------------
+
+
+@requires("brotli")
+def test_brotli_roundtrip() -> None:
+    import brotli
+
+    data = brotli.compress(b"brotli payload")
+    with open_archive(io.BytesIO(data)) as ar:
+        assert ar.format == ArchiveFormat.BROTLI
+        assert ar.read(ar.members()[0]) == b"brotli payload"

--- a/tests/test_single_file.py
+++ b/tests/test_single_file.py
@@ -19,7 +19,12 @@ import pytest
 
 from archivey import ArchiveFormat, MemberType, open_archive
 from archivey.internal.cost import AccessCost, ListingCost
-from archivey.internal.errors import StreamNotSeekableError, UnsupportedOperationError
+from archivey.internal.errors import (
+    CorruptionError,
+    StreamNotSeekableError,
+    TruncatedError,
+    UnsupportedOperationError,
+)
 from tests.conftest import requires
 from tests.streams_util import NonSeekableBytesIO, make_lzip_member, make_unix_compress
 
@@ -273,3 +278,32 @@ def test_explicit_format_bypasses_detection() -> None:
     with open_archive(io.BytesIO(data), format=ArchiveFormat.GZ) as ar:
         assert ar.format == ArchiveFormat.GZ
         assert ar.read(ar.members()[0]) == b"forced gzip"
+
+
+# ---------------------------------------------------------------------------
+# Corrupt / truncated input -> CorruptionError / TruncatedError end-to-end.
+# (Per-format slice of testing-contract's adversarial-corpus requirement, pulled
+# forward so the backend wires the codec layer's translation through correctly.
+# gzip is used because it is always available: zero-dep stdlib.)
+# ---------------------------------------------------------------------------
+
+
+# A non-seekable source keeps the codec sequential (no rapidgzip/indexed_bzip2
+# accelerator), so these assert the backend's own stdlib translation deterministically,
+# independent of which optional accelerators the environment has installed.
+
+
+def test_truncated_gzip_raises_truncated() -> None:
+    full = gzip.compress(b"streamed payload" * 1000)
+    truncated = full[: len(full) // 2]  # gzip magic intact -> detection picks GZ
+    with open_archive(NonSeekableBytesIO(truncated)) as ar:
+        with pytest.raises(TruncatedError):
+            ar.read(ar.members()[0])
+
+
+def test_corrupt_gzip_raises_corruption() -> None:
+    data = bytearray(gzip.compress(b"streamed payload" * 100))
+    data[15:35] = b"\x00" * 20  # clobber the deflate body (past the 10-byte header)
+    with open_archive(NonSeekableBytesIO(bytes(data))) as ar:
+        with pytest.raises(CorruptionError):
+            ar.read(ar.members()[0])

--- a/tests/test_single_file.py
+++ b/tests/test_single_file.py
@@ -111,6 +111,20 @@ def test_gzip_stored_filename_surfaced(tmp_path: Path) -> None:
         assert member.raw_name == b"report.csv"
 
 
+def test_gzip_stored_filename_non_ascii_is_latin1(tmp_path: Path) -> None:
+    # RFC 1952 specifies FNAME as ISO-8859-1 (Latin-1). The gzip tooling stores
+    # "café.txt" as the bytes b"caf\xe9.txt"; decoding those as UTF-8 would mangle them
+    # (0xE9 is not valid UTF-8), so the decoded value must use Latin-1.
+    path = tmp_path / "archive.gz"
+    gz = gzip.GzipFile(filename="café.txt", mode="wb", fileobj=open(path, "wb"), mtime=0)
+    gz.write(b"payload")
+    gz.close()
+    with open_archive(path) as ar:
+        member = ar.members()[0]
+        assert member.raw_name == b"caf\xe9.txt"  # verbatim stored bytes
+        assert member.extra["gzip.original_filename"] == "café.txt"
+
+
 def test_gzip_without_stored_filename() -> None:
     # gzip.compress writes no FNAME -> no extra key, raw_name stays None.
     with open_archive(io.BytesIO(gzip.compress(b"x"))) as ar:

--- a/tests/test_single_file.py
+++ b/tests/test_single_file.py
@@ -228,3 +228,47 @@ def test_brotli_roundtrip() -> None:
     with open_archive(io.BytesIO(data)) as ar:
         assert ar.format == ArchiveFormat.BROTLI
         assert ar.read(ar.members()[0]) == b"brotli payload"
+
+
+# ---------------------------------------------------------------------------
+# zstd / lz4 standalone (now first-class single-file formats)
+# ---------------------------------------------------------------------------
+
+
+@requires("zstandard")
+def test_zstd_roundtrip(tmp_path: Path) -> None:
+    import zstandard
+
+    data = zstandard.ZstdCompressor().compress(b"zstd payload")
+    with open_archive(io.BytesIO(data)) as ar:
+        assert ar.format == ArchiveFormat.ZST
+        assert ar.members()[0].name == "data"
+        assert ar.read(ar.members()[0]) == b"zstd payload"
+
+    path = tmp_path / "file.bin.zst"
+    path.write_bytes(data)
+    with open_archive(path) as ar:
+        assert ar.members()[0].name == "file.bin"
+
+
+@requires("lz4")
+def test_lz4_roundtrip() -> None:
+    import lz4.frame
+
+    data = lz4.frame.compress(b"lz4 payload")
+    with open_archive(io.BytesIO(data)) as ar:
+        assert ar.format == ArchiveFormat.LZ4
+        assert ar.read(ar.members()[0]) == b"lz4 payload"
+
+
+# ---------------------------------------------------------------------------
+# The backend uses the resolved format it is given (no re-inspection)
+# ---------------------------------------------------------------------------
+
+
+def test_explicit_format_bypasses_detection() -> None:
+    # Forcing format=GZ routes straight to the gzip codec without re-detecting the source.
+    data = gzip.compress(b"forced gzip")
+    with open_archive(io.BytesIO(data), format=ArchiveFormat.GZ) as ar:
+        assert ar.format == ArchiveFormat.GZ
+        assert ar.read(ar.members()[0]) == b"forced gzip"

--- a/tests/test_zip.py
+++ b/tests/test_zip.py
@@ -238,6 +238,38 @@ def test_extended_timestamp_precedence(tmp_path: Path) -> None:
         assert member.modified == datetime.fromtimestamp(unix_time, tz=timezone.utc)
 
 
+def test_extended_timestamp_fills_mtime_atime_ctime(tmp_path: Path) -> None:
+    # An Extended Timestamp (0x5455) with flags 0x07 carries modification, access and
+    # creation times (in that order); all three should populate the member.
+    mtime, atime, ctime = 1_600_000_000, 1_600_000_100, 1_600_000_200
+    extra = struct.pack("<HHB iii", 0x5455, 13, 0x07, mtime, atime, ctime)
+    path = tmp_path / "ts3.zip"
+    info = zipfile.ZipInfo("t.txt")
+    info.extra = extra
+    with zipfile.ZipFile(path, "w") as z:
+        z.writestr(info, b"data")
+    with open_archive(path) as ar:
+        member = ar["t.txt"]
+        assert member.modified == datetime.fromtimestamp(mtime, tz=timezone.utc)
+        assert member.accessed == datetime.fromtimestamp(atime, tz=timezone.utc)
+        assert member.created == datetime.fromtimestamp(ctime, tz=timezone.utc)
+
+
+def test_duplicate_member_names_read_independently(tmp_path: Path) -> None:
+    # Two members stored under the same name: each must read its own data. The reader keys
+    # off the member's own ZipInfo handle (member._raw), not a name map, so there is no
+    # collision.
+    path = tmp_path / "dup.zip"
+    with zipfile.ZipFile(path, "w") as z:
+        z.writestr("dup.txt", b"first")
+        z.writestr("dup.txt", b"second")
+    with open_archive(path) as ar:
+        members = ar.members()
+        assert len(members) == 2
+        assert ar.read(members[0]) == b"first"
+        assert ar.read(members[1]) == b"second"
+
+
 # ---------------------------------------------------------------------------
 # Non-seekable source fails fast
 # ---------------------------------------------------------------------------
@@ -263,12 +295,12 @@ def test_non_seekable_zip_fails_fast_via_detection(simple_zip: Path) -> None:
 
 
 def test_split_segment_name_rejected(tmp_path: Path) -> None:
-    # A .z01 segment of a split set is rejected by name with a "rejoin first" hint.
+    # A .z01 segment of a split set is rejected by name as an unsupported multi-volume ZIP.
     segment = tmp_path / "archive.z01"
     segment.write_bytes(b"\x50\x4b\x03\x04" + b"\x00" * 64)
     with pytest.raises(UnsupportedFeatureError) as excinfo:
         open_archive(segment, format=ArchiveFormat.ZIP)
-    assert "rejoin" in str(excinfo.value).lower()
+    assert "multi-volume" in str(excinfo.value).lower()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_zip.py
+++ b/tests/test_zip.py
@@ -18,7 +18,11 @@ from archivey import (
     open_archive,
 )
 from archivey.internal.cost import AccessCost, ListingCost, StreamCapability
-from archivey.internal.errors import StreamNotSeekableError, UnsupportedFeatureError
+from archivey.internal.errors import (
+    CorruptionError,
+    StreamNotSeekableError,
+    UnsupportedFeatureError,
+)
 from tests.streams_util import NonSeekableBytesIO
 
 # ---------------------------------------------------------------------------
@@ -292,3 +296,39 @@ def test_read_roundtrip_from_stream_source(simple_zip: Path) -> None:
     data = simple_zip.read_bytes()
     with open_archive(io.BytesIO(data)) as ar:
         assert ar.read("hello.txt") == b"hello world"
+
+
+# ---------------------------------------------------------------------------
+# Corrupt / truncated input -> CorruptionError (with the original cause attached).
+# (Per-format slice of testing-contract's adversarial-corpus requirement, pulled
+# forward to lock down the backend's exception translation as it lands.)
+# ---------------------------------------------------------------------------
+
+
+def test_truncated_zip_raises_corruption() -> None:
+    # A ZIP whose central directory / EOCD has been cut off: the local-file-header magic
+    # still makes detection pick ZIP, but stdlib zipfile cannot parse it.
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as z:
+        z.writestr("hello.txt", b"hello world" * 100)
+    truncated = buf.getvalue()[: len(buf.getvalue()) // 2]
+
+    with pytest.raises(CorruptionError) as excinfo:
+        open_archive(io.BytesIO(truncated))
+    assert isinstance(excinfo.value.__cause__, zipfile.BadZipFile)
+
+
+def test_corrupt_member_data_raises_corruption_on_read() -> None:
+    # A structurally valid ZIP whose stored member payload has been altered: listing
+    # succeeds, but reading the member trips the CRC check -> CorruptionError.
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_STORED) as z:
+        z.writestr("data.txt", b"A" * 200)
+    raw = bytearray(buf.getvalue())
+    # STORED payload begins after the 30-byte local header + 8-byte name ("data.txt").
+    raw[50] ^= 0xFF
+
+    with open_archive(io.BytesIO(bytes(raw))) as ar:
+        assert ar.members()[0].name == "data.txt"  # listing is unaffected
+        with pytest.raises(CorruptionError):
+            ar.read("data.txt")

--- a/tests/test_zip.py
+++ b/tests/test_zip.py
@@ -1,0 +1,294 @@
+"""ZIP backend tests — Stage 1 (member mapping, cost, O(1) lookup, non-seekable
+fail-fast, multi-volume rejection) and the ZIP slice of access-mode-and-cost."""
+
+from __future__ import annotations
+
+import io
+import struct
+import zipfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from archivey import (
+    ArchiveFormat,
+    CompressionAlgorithm,
+    MemberType,
+    open_archive,
+)
+from archivey.internal.cost import AccessCost, ListingCost, StreamCapability
+from archivey.internal.errors import StreamNotSeekableError, UnsupportedFeatureError
+from tests.streams_util import NonSeekableBytesIO
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def simple_zip(tmp_path: Path) -> Path:
+    path = tmp_path / "simple.zip"
+    with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as z:
+        z.writestr("hello.txt", b"hello world")
+        z.writestr("dir/nested.txt", b"nested content")
+    return path
+
+
+def _zip_with_unix_mode(path: Path, name: str, data: bytes, mode: int) -> None:
+    info = zipfile.ZipInfo(name)
+    info.create_system = 3  # Unix
+    info.external_attr = mode << 16
+    with zipfile.ZipFile(path, "w") as z:
+        z.writestr(info, data)
+
+
+# ---------------------------------------------------------------------------
+# Cost / format properties (also covers access-mode-and-cost for ZIP)
+# ---------------------------------------------------------------------------
+
+
+def test_cost_receipt(simple_zip: Path) -> None:
+    with open_archive(simple_zip) as ar:
+        cost = ar.cost
+        assert cost.listing_cost == ListingCost.INDEXED
+        assert cost.access_cost == AccessCost.DIRECT
+        assert cost.stream_capability == StreamCapability.SEEKABLE
+
+
+def test_archive_info(simple_zip: Path) -> None:
+    with open_archive(simple_zip) as ar:
+        info = ar.info
+        assert info.format == ArchiveFormat.ZIP
+        assert info.is_solid is False
+        assert info.is_encrypted is False
+        assert info.is_multivolume is False
+        assert info.member_count == 2
+
+
+def test_format_detected_as_zip(simple_zip: Path) -> None:
+    with open_archive(simple_zip) as ar:
+        assert ar.format == ArchiveFormat.ZIP
+
+
+# ---------------------------------------------------------------------------
+# Indexed listing + random access (access-mode-and-cost, default streaming=False)
+# ---------------------------------------------------------------------------
+
+
+def test_members_listed(simple_zip: Path) -> None:
+    with open_archive(simple_zip) as ar:
+        names = {m.name for m in ar.members()}
+        assert names == {"hello.txt", "dir/nested.txt"}
+
+
+def test_member_list_available_without_scan(simple_zip: Path) -> None:
+    with open_archive(simple_zip) as ar:
+        # The central directory is an upfront index, so the list is available with no scan.
+        members = ar.get_members_if_available()
+        assert members is not None
+        assert {m.name for m in members} == {"hello.txt", "dir/nested.txt"}
+
+
+def test_random_access_read_by_name(simple_zip: Path) -> None:
+    with open_archive(simple_zip) as ar:
+        assert ar.read("hello.txt") == b"hello world"
+        assert ar.read("dir/nested.txt") == b"nested content"
+        # Re-reading an earlier member out of order still works (random access).
+        assert ar.read("hello.txt") == b"hello world"
+
+
+def test_central_directory_lookup_no_io(simple_zip: Path) -> None:
+    # reader["name"] is served from the in-memory name map with no extra archive reads.
+    with open_archive(simple_zip) as ar:
+        ar.members()  # materialize
+        archive = ar._archive  # type: ignore[attr-defined]
+        calls = {"open": 0}
+        original_open = archive.open
+
+        def counting_open(*args, **kwargs):  # type: ignore[no-untyped-def]
+            calls["open"] += 1
+            return original_open(*args, **kwargs)
+
+        archive.open = counting_open  # type: ignore[method-assign]
+        member = ar["hello.txt"]
+        assert member.name == "hello.txt"
+        assert calls["open"] == 0  # lookup touched no archive data
+
+
+# ---------------------------------------------------------------------------
+# Member metadata mapping
+# ---------------------------------------------------------------------------
+
+
+def test_unix_mode_from_external_attr(tmp_path: Path) -> None:
+    path = tmp_path / "moded.zip"
+    _zip_with_unix_mode(path, "script.sh", b"#!/bin/sh\n", 0o755)
+    with open_archive(path) as ar:
+        member = ar["script.sh"]
+        assert member.mode == 0o755
+
+
+def test_none_mode_when_external_attr_zero() -> None:
+    # zipfile.writestr always stamps a 0o600 external_attr, so zero it in the central
+    # directory (4-byte field at offset 38 of the PK\x01\x02 record) to exercise the
+    # "external_attr == 0 -> mode None" rule.
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as z:
+        z.writestr("plain.txt", b"x")
+    raw = bytearray(buf.getvalue())
+    cd = raw.index(b"PK\x01\x02")
+    raw[cd + 38 : cd + 42] = b"\x00\x00\x00\x00"
+    with open_archive(io.BytesIO(bytes(raw))) as ar:
+        assert ar["plain.txt"].mode is None
+
+
+def test_directory_member_type(simple_zip: Path) -> None:
+    with open_archive(simple_zip) as ar:
+        by_name = {m.name: m for m in ar.members()}
+        # zipfile stores explicit directory entries with a trailing slash.
+        assert by_name["hello.txt"].type == MemberType.FILE
+
+
+def test_explicit_directory_entry(tmp_path: Path) -> None:
+    path = tmp_path / "withdir.zip"
+    with zipfile.ZipFile(path, "w") as z:
+        z.writestr("adir/", b"")
+        z.writestr("adir/file.txt", b"data")
+    with open_archive(path) as ar:
+        by_name = {m.name: m for m in ar.members()}
+        assert by_name["adir/"].type == MemberType.DIRECTORY
+
+
+def test_symlink_member(tmp_path: Path) -> None:
+    import stat as stat_module
+
+    path = tmp_path / "link.zip"
+    info = zipfile.ZipInfo("link")
+    info.create_system = 3
+    info.external_attr = (stat_module.S_IFLNK | 0o777) << 16
+    with zipfile.ZipFile(path, "w") as z:
+        z.writestr(info, b"target.txt")
+    with open_archive(path) as ar:
+        member = ar["link"]
+        assert member.type == MemberType.SYMLINK
+        assert member.link_target == "target.txt"
+
+
+def test_compression_method_mapping(tmp_path: Path) -> None:
+    path = tmp_path / "methods.zip"
+    with zipfile.ZipFile(path, "w") as z:
+        z.writestr("stored.txt", b"a" * 100, compress_type=zipfile.ZIP_STORED)
+        z.writestr("deflated.txt", b"a" * 100, compress_type=zipfile.ZIP_DEFLATED)
+    with open_archive(path) as ar:
+        by_name = {m.name: m for m in ar.members()}
+        assert by_name["stored.txt"].compression[0].algo == CompressionAlgorithm.STORED
+        assert by_name["deflated.txt"].compression[0].algo == CompressionAlgorithm.DEFLATE
+
+
+def test_encrypted_flag() -> None:
+    # stdlib zipfile cannot write encrypted entries, so set the general-purpose
+    # encryption bit (0x1) directly in the central-directory record's flag field (at
+    # offset 8 of the PK\x01\x02 record) to exercise the is_encrypted mapping.
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as z:
+        z.writestr("e.txt", b"data")
+    raw = bytearray(buf.getvalue())
+    cd = raw.index(b"PK\x01\x02")
+    flags = int.from_bytes(raw[cd + 8 : cd + 10], "little") | 0x1
+    raw[cd + 8 : cd + 10] = flags.to_bytes(2, "little")
+    with open_archive(io.BytesIO(bytes(raw))) as ar:
+        assert ar["e.txt"].is_encrypted is True
+
+
+def test_size_fields(simple_zip: Path) -> None:
+    with open_archive(simple_zip) as ar:
+        member = ar["hello.txt"]
+        assert member.size == len(b"hello world")
+        assert member.compressed_size is not None
+
+
+def test_raw_name_preserved(tmp_path: Path) -> None:
+    path = tmp_path / "utf8.zip"
+    with zipfile.ZipFile(path, "w") as z:
+        z.writestr("café.txt", b"x")  # forces the UTF-8 flag
+    with open_archive(path) as ar:
+        member = ar["café.txt"]
+        assert member.raw_name == "café.txt".encode("utf-8")
+
+
+def test_extended_timestamp_precedence(tmp_path: Path) -> None:
+    # An Extended Timestamp extra field (0x5455) carries a real Unix time and overrides the
+    # 2-second-granularity DOS date_time, yielding a tz-aware UTC datetime.
+    unix_time = 1_600_000_000  # 2020-09-13T12:26:40Z
+    extra = struct.pack("<HHB I", 0x5455, 5, 0x01, unix_time)
+    path = tmp_path / "ts.zip"
+    info = zipfile.ZipInfo("t.txt", date_time=(1990, 1, 1, 0, 0, 0))
+    info.extra = extra
+    with zipfile.ZipFile(path, "w") as z:
+        z.writestr(info, b"data")
+    with open_archive(path) as ar:
+        member = ar["t.txt"]
+        assert member.modified is not None
+        assert member.modified.tzinfo is not None
+        assert member.modified == datetime.fromtimestamp(unix_time, tz=timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# Non-seekable source fails fast
+# ---------------------------------------------------------------------------
+
+
+def test_non_seekable_zip_fails_fast(simple_zip: Path) -> None:
+    data = simple_zip.read_bytes()
+    with pytest.raises(StreamNotSeekableError):
+        open_archive(NonSeekableBytesIO(data), format=ArchiveFormat.ZIP)
+
+
+def test_non_seekable_zip_fails_fast_via_detection(simple_zip: Path) -> None:
+    # Even without an explicit format, a non-seekable ZIP is rejected at open time (the
+    # opener wraps it in a PeekableStream for detection, then enforces REQUIRES_SEEK).
+    data = simple_zip.read_bytes()
+    with pytest.raises(StreamNotSeekableError):
+        open_archive(NonSeekableBytesIO(data))
+
+
+# ---------------------------------------------------------------------------
+# Multi-volume rejection
+# ---------------------------------------------------------------------------
+
+
+def test_split_segment_name_rejected(tmp_path: Path) -> None:
+    # A .z01 segment of a split set is rejected by name with a "rejoin first" hint.
+    segment = tmp_path / "archive.z01"
+    segment.write_bytes(b"\x50\x4b\x03\x04" + b"\x00" * 64)
+    with pytest.raises(UnsupportedFeatureError) as excinfo:
+        open_archive(segment, format=ArchiveFormat.ZIP)
+    assert "rejoin" in str(excinfo.value).lower()
+
+
+# ---------------------------------------------------------------------------
+# Reading via open() and stream_members()
+# ---------------------------------------------------------------------------
+
+
+def test_open_returns_stream(simple_zip: Path) -> None:
+    with open_archive(simple_zip) as ar:
+        with ar.open("hello.txt") as f:
+            assert f.read() == b"hello world"
+
+
+def test_stream_members(simple_zip: Path) -> None:
+    with open_archive(simple_zip) as ar:
+        collected = {}
+        for member, stream in ar.stream_members():
+            collected[member.name] = stream.read() if stream is not None else None
+        assert collected["hello.txt"] == b"hello world"
+        assert collected["dir/nested.txt"] == b"nested content"
+
+
+def test_read_roundtrip_from_stream_source(simple_zip: Path) -> None:
+    # Opening from an already-seekable in-memory stream (no path) works too.
+    data = simple_zip.read_bytes()
+    with open_archive(io.BytesIO(data)) as ar:
+        assert ar.read("hello.txt") == b"hello world"


### PR DESCRIPTION
Implements the first Phase-3 stage: the shared detection/registry machinery
plus the ZIP backend, end-to-end through open_archive().

- PeekableStream (internal/streams/peekable.py): buffers a non-seekable
  source's prefix so detection never consumes bytes the backend still needs;
  peek/replay/forward-only semantics, never closes the underlying stream.
- detect_format() + FormatInfo/DetectionConfidence (internal/detection.py):
  magic-first (CERTAIN) -> extension (GUESS); tables aggregated from each
  backend's MAGIC/EXTENSIONS data; magic/extension conflict warns on
  archivey.detection; non-consuming for paths/seekable/peekable sources.
- Registry rework: always-register; tri-state compositional FormatSupport
  (FULL/PARTIAL/NONE) via the module-or-None sentinel + codec availability;
  MissingComponent/FormatAvailability; format_availability /
  list_supported_formats / list_known_formats; install-hint selection errors.
- ReadBackend ABC: EXTENSIONS now Mapping[str, ArchiveFormat], MAGIC carries
  the implied format per entry, plus INSTALL_HINT.
- ZIP backend (formats/zip_reader.py): stdlib zipfile; INDEXED/DIRECT/SEEKABLE;
  ZipInfo->ArchiveMember mapping (mode, extended-timestamp precedence, type,
  compression, is_encrypted, raw_name); O(1) name lookup; non-seekable
  fail-fast; multi-volume rejection.
- open_archive(): detects, wraps non-seekable sources in PeekableStream,
  enforces REQUIRES_SEEK fail-fast, threads encoding hint.
- Public API exposure + new test suites (peekable, detection, registry, zip).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QVdJG1mJyrPRfYVbU6PT59