### PR TITLE
openspec: codec-descriptor refactor + compression-library evaluation proposals

### DIFF
--- a/openspec/changes/codec-descriptor-refactor/proposal.md
+++ b/openspec/changes/codec-descriptor-refactor/proposal.md
@@ -72,45 +72,15 @@ backs each codec — that is the separate `compression-library-evaluation` chang
 
 ## Specs
 
-Proposed deltas (kept here until accepted, per the "propose in `changes/`, don't edit
-shipped specs ad hoc" rule). Authoritative specs touched:
+The full delta requirements (with scenarios) live in this change's `specs/` directory and
+are what `openspec validate` checks:
 
-### compressed-streams — ADDED Requirement: A codec is described by one StreamCodec descriptor
+- `specs/compressed-streams/spec.md` — **ADDED** "A codec is described by one StreamCodec descriptor".
+- `specs/format-detection/spec.md` — **MODIFIED** magic/extension/probe tables aggregated from backends *and* codec descriptors.
+- `specs/backend-registry/spec.md` — **MODIFIED** codec availability + install hints come from the descriptor (drop `_CODEC_REQUIREMENT`).
+- `specs/format-single-file-compressors/spec.md` — **MODIFIED** per-codec metadata comes from the descriptor.
 
-The system SHALL represent each single-stream codec as a single descriptor object that
-carries its open function, exception translator, magic signatures (including the `weak`
-flag), whether it is recognized by a content probe, its standalone file extensions, an
-optional metadata extractor that fills `ArchiveMember` fields, and its optional-dependency
-requirement (package / extra / external tool + install hint + unlocked capability). A new
-standalone codec SHALL become fully readable and detectable by registering one descriptor,
-without edits to the detector, the single-file reader, or the registry's availability code.
-
-#### Scenario: adding a standalone codec is a one-descriptor change
-
-- **WHEN** a new single-stream codec descriptor is registered (open fn, translator, magic/probe, extension, requirement)
-- **THEN** `detect_format()` recognizes it, `SingleFileBackend` reads it as a one-member archive, and `format_availability()` reports its support — with no other code changes
-
-### format-detection — MODIFIED Requirement: Magic/extension/probe tables are aggregated from backends *and* codec descriptors
-
-The detector SHALL build its magic, extension, and content-probe tables from two data
-sources — the container format backends (`ReadBackend.MAGIC`/`EXTENSIONS`) and the
-stream-codec descriptors — with no per-format `detect()` logic in either. Stream-codec
-magic/probe rows that were previously declared on `SingleFileBackend` SHALL come from the
-descriptors instead, with identical results.
-
-### backend-registry — MODIFIED Requirement: Codec availability + install hints come from the descriptor
-
-A format's compositional support and its missing-component install hints SHALL be derived
-from the codec descriptors' `requirement` fields, replacing the separate
-`_CODEC_REQUIREMENT` table, so a codec's package/extra/hint is declared in exactly one
-place.
-
-### format-single-file-compressors — MODIFIED Requirement: Per-codec metadata comes from the descriptor
-
-The single multi-format `SingleFileBackend` SHALL obtain each format's metadata extraction
-from its codec descriptor's `extract_metadata` hook rather than a reader-local dispatch
-table, keeping the reader codec-agnostic (the "one backend, per-codec hooks" structure is
-preserved; only the hooks' home moves).
+All four are behavior-preserving rewordings of *where the per-codec data lives*.
 
 ## Impact
 

--- a/openspec/changes/codec-descriptor-refactor/proposal.md
+++ b/openspec/changes/codec-descriptor-refactor/proposal.md
@@ -1,0 +1,131 @@
+# Unify per-codec logic behind a single StreamCodec descriptor
+
+## Why
+
+The knowledge about a single-stream codec (gzip, bzip2, xz, zstd, lz4, lzip, zlib,
+brotli, unix-compress) is currently **scattered across four modules**, so adding or
+changing one codec means editing all of them:
+
+- `internal/streams/codecs.py` — the open function + the exception translator +
+  the optional-package sentinel (`is_codec_available`).
+- the format backends (`formats/single_file_reader.py`, and later `tar_reader.py`) —
+  the `MAGIC` signatures, `EXTENSIONS`, and `CONTENT_PROBE_FORMATS` declared as data.
+- `formats/single_file_reader.py` — the per-codec **metadata hooks**
+  (`_gzip_metadata`, `_sized_stream_metadata`, …).
+- `internal/registry.py` — the `_CODEC_REQUIREMENT` table mapping a codec to its
+  package / extra / install hint / unlocked capability.
+
+`detect_format()` and `SingleFileReader` are *almost* format-agnostic (the Stage-2
+review moved weakness into `MagicSignature` and probes into `CONTENT_PROBE_FORMATS`),
+but the last per-format pieces — which codec a magic implies, what metadata to extract,
+which library unlocks it — still live in three different places. A reviewer asked for a
+single descriptor that encapsulates all of it (PR #13 review), so that detection and the
+single-file reader become **fully data-driven** and a new standalone codec is "add one
+descriptor", not "touch four files".
+
+## What Changes
+
+Introduce a single **`StreamCodec` descriptor** (working name) in the
+`compressed-streams` layer — one per single-stream codec — bundling everything the
+rest of the library needs to know about it:
+
+| Field | Replaces | Used by |
+|-------|----------|---------|
+| `codec` / `stream_format` | `Codec`, `_STREAM_FORMAT_CODECS` | everywhere |
+| `open(source, params, config)` | `_CodecSpec.open` | `open_codec_stream` |
+| `translate(exc)` | `_CodecSpec.translate` | `ArchiveStream` |
+| `magic: tuple[MagicSignature, ...]` (incl. `weak`) | backend `MAGIC` entries for stream codecs | detection |
+| `content_probe: bool` (or a probe fn) | `CONTENT_PROBE_FORMATS` | detection |
+| `extensions: tuple[str, ...]` | backend `EXTENSIONS` for stream codecs | detection / naming |
+| `extract_metadata(reader_ctx, member)` | `SingleFileReader._METADATA_HOOKS` | single-file reader |
+| `requirement: MissingComponent \| None` | `registry._CODEC_REQUIREMENT` + `is_codec_available` sentinel | registry availability |
+
+A single descriptor registry (keyed by `Codec` / `StreamFormat`) is the source of
+truth. Then:
+
+- **`detect_format()`** aggregates stream-codec magic + content probes **from the
+  descriptors**, alongside the *container* magics the format backends still declare
+  (ZIP's `PK..`, TAR's `ustar`, ISO's `CD001`). Container vs. stream-codec detection
+  stays one combined table; only the source of the stream-codec rows moves.
+- **`SingleFileBackend` / `SingleFileReader`** derive `FORMATS` / `EXTENSIONS` /
+  `MAGIC` / `CONTENT_PROBE_FORMATS` and the metadata extraction from the descriptors
+  instead of hand-listing them. The reader becomes codec-agnostic: infer the member
+  shell, then call `descriptor.extract_metadata(...)`.
+- **`backend-registry`** computes a single-file format's tri-state support and install
+  hint from the descriptor's `requirement`, dropping the parallel `_CODEC_REQUIREMENT`
+  table. The compositional ZIP/7z/TAR-over-codec rules are unchanged — they already
+  read codec availability through the same descriptors.
+
+This is a **behavior-preserving refactor**: same detection results, same availability,
+same metadata, same errors. It is explicitly *not* a place to change which library
+backs each codec — that is the separate `compression-library-evaluation` change.
+
+### Scope boundaries
+
+- **Container formats stay separate.** ZIP/TAR/ISO/7z/RAR are *container* backends
+  (`ReadBackend`), not stream codecs; they keep their own `MAGIC`/`EXTENSIONS` and are
+  unaffected except that the detector now merges two well-defined sources (container
+  backends + codec descriptors).
+- **The filter-only codecs** (Delta, the BCJ family) are not standalone streams and get
+  no detector/metadata fields — they remain coder-chain components (Phase 7).
+- **No new codecs** and **no library swaps** here.
+
+## Specs
+
+Proposed deltas (kept here until accepted, per the "propose in `changes/`, don't edit
+shipped specs ad hoc" rule). Authoritative specs touched:
+
+### compressed-streams — ADDED Requirement: A codec is described by one StreamCodec descriptor
+
+The system SHALL represent each single-stream codec as a single descriptor object that
+carries its open function, exception translator, magic signatures (including the `weak`
+flag), whether it is recognized by a content probe, its standalone file extensions, an
+optional metadata extractor that fills `ArchiveMember` fields, and its optional-dependency
+requirement (package / extra / external tool + install hint + unlocked capability). A new
+standalone codec SHALL become fully readable and detectable by registering one descriptor,
+without edits to the detector, the single-file reader, or the registry's availability code.
+
+#### Scenario: adding a standalone codec is a one-descriptor change
+
+- **WHEN** a new single-stream codec descriptor is registered (open fn, translator, magic/probe, extension, requirement)
+- **THEN** `detect_format()` recognizes it, `SingleFileBackend` reads it as a one-member archive, and `format_availability()` reports its support — with no other code changes
+
+### format-detection — MODIFIED Requirement: Magic/extension/probe tables are aggregated from backends *and* codec descriptors
+
+The detector SHALL build its magic, extension, and content-probe tables from two data
+sources — the container format backends (`ReadBackend.MAGIC`/`EXTENSIONS`) and the
+stream-codec descriptors — with no per-format `detect()` logic in either. Stream-codec
+magic/probe rows that were previously declared on `SingleFileBackend` SHALL come from the
+descriptors instead, with identical results.
+
+### backend-registry — MODIFIED Requirement: Codec availability + install hints come from the descriptor
+
+A format's compositional support and its missing-component install hints SHALL be derived
+from the codec descriptors' `requirement` fields, replacing the separate
+`_CODEC_REQUIREMENT` table, so a codec's package/extra/hint is declared in exactly one
+place.
+
+### format-single-file-compressors — MODIFIED Requirement: Per-codec metadata comes from the descriptor
+
+The single multi-format `SingleFileBackend` SHALL obtain each format's metadata extraction
+from its codec descriptor's `extract_metadata` hook rather than a reader-local dispatch
+table, keeping the reader codec-agnostic (the "one backend, per-codec hooks" structure is
+preserved; only the hooks' home moves).
+
+## Impact
+
+- **Affected code:** `internal/streams/codecs.py` (the descriptor + registry),
+  `internal/detection.py` (aggregate from descriptors), `formats/single_file_reader.py`
+  (derive tables + metadata from descriptors), `internal/registry.py` (availability via
+  descriptors; drop `_CODEC_REQUIREMENT`).
+- **Spec deltas:** `compressed-streams`, `format-detection`, `backend-registry`,
+  `format-single-file-compressors` (all behavior-preserving rewordings of "where the data
+  lives").
+- **Tests:** existing detection / single-file / registry suites must stay green
+  unchanged (the refactor asserts no behavior change); add a small test that a synthetic
+  descriptor becomes detectable + readable + availability-reported with no other edits.
+- **Depends on / coordinates with:** `compression-library-evaluation` — that change may
+  change which library a descriptor's `open`/`translate` point at, but the descriptor
+  shape defined here is where those choices live.
+- **Risk:** breadth of the touch. Mitigated by keeping it strictly behavior-preserving
+  and leaning on the existing green suites as the regression net.

--- a/openspec/changes/codec-descriptor-refactor/specs/backend-registry/spec.md
+++ b/openspec/changes/codec-descriptor-refactor/specs/backend-registry/spec.md
@@ -1,0 +1,21 @@
+# Backend Registry — delta (codec-descriptor refactor)
+
+## MODIFIED Requirements
+
+### Requirement: Codec availability and install hints come from the descriptor
+
+A format's compositional support and its missing-component install hints SHALL be derived
+from the codec descriptors' `requirement` fields, so a codec's package / extra / install
+hint / unlocked capability is declared in exactly one place. The separate
+`_CODEC_REQUIREMENT` table SHALL be removed, and the tri-state FULL / PARTIAL / NONE results
+for every format MUST be unchanged from before the refactor.
+
+#### Scenario: a codec's install hint is declared once
+
+- **WHEN** a single-codec format's sole codec backend is missing
+- **THEN** `format_availability()` reports `NONE` with the install hint taken from that codec's descriptor `requirement`, not from a duplicate registry table
+
+#### Scenario: multi-codec container support is unchanged
+
+- **WHEN** `format_availability()` is queried for ZIP / 7z / a `tar.<codec>` on a system missing some optional member codecs
+- **THEN** the support level and missing-component list are identical to before, computed from the same codec descriptors

--- a/openspec/changes/codec-descriptor-refactor/specs/compressed-streams/spec.md
+++ b/openspec/changes/codec-descriptor-refactor/specs/compressed-streams/spec.md
@@ -1,0 +1,25 @@
+# Compressed Streams — delta (codec-descriptor refactor)
+
+## ADDED Requirements
+
+### Requirement: A codec is described by one StreamCodec descriptor
+
+The system SHALL represent each single-stream codec as a single descriptor object that
+carries its open function, exception translator, magic signatures (including the `weak`
+flag), whether it is recognized by a content probe, its standalone file extensions, an
+optional metadata extractor that fills `ArchiveMember` fields, and its optional-dependency
+requirement (package / extra / external tool + install hint + unlocked capability). A new
+standalone codec SHALL become fully readable and detectable by registering one descriptor,
+without edits to the detector, the single-file reader, or the registry's availability code.
+The descriptor registry MUST NOT eagerly import optional codec libraries, so the zero-dep
+core stays importable with no third-party packages.
+
+#### Scenario: adding a standalone codec is a one-descriptor change
+
+- **WHEN** a new single-stream codec descriptor is registered (open fn, translator, magic/probe, extension, requirement)
+- **THEN** `detect_format()` recognizes it, `SingleFileBackend` reads it as a one-member archive, and `format_availability()` reports its support — with no other code changes
+
+#### Scenario: descriptors do not pull in optional libraries at import
+
+- **WHEN** `archivey` is imported in a core-only environment (no optional codec packages)
+- **THEN** building the descriptor registry raises no `ImportError` and imports no third-party codec package

--- a/openspec/changes/codec-descriptor-refactor/specs/format-detection/spec.md
+++ b/openspec/changes/codec-descriptor-refactor/specs/format-detection/spec.md
@@ -1,0 +1,23 @@
+# Format Detection — delta (codec-descriptor refactor)
+
+## MODIFIED Requirements
+
+### Requirement: Magic/extension/probe tables are aggregated from backends and codec descriptors
+
+The detector SHALL build its magic, extension, and content-probe tables from two data
+sources — the container format backends (`ReadBackend.MAGIC` / `EXTENSIONS`) and the
+stream-codec descriptors — with no per-format `detect()` logic in either. The stream-codec
+magic, weak-flag, extension, and content-probe rows that were previously declared on
+`SingleFileBackend` SHALL be sourced from the descriptors instead, and detection results
+(strong-vs-weak magic ordering, the zlib weak+probe path, the Brotli magic-less probe, and
+the magic/extension conflict warning) MUST be unchanged.
+
+#### Scenario: stream-codec magic comes from the descriptors
+
+- **WHEN** `detect_format()` runs after the refactor on a `.gz` / `.zst` / zlib / Brotli source
+- **THEN** the format, confidence, and `detected_by` are identical to before, with the magic/probe rows now drawn from the codec descriptors rather than hand-listed on `SingleFileBackend`
+
+#### Scenario: container magic still comes from the format backends
+
+- **WHEN** a ZIP / TAR / ISO source is detected
+- **THEN** the match is driven by the container backend's `MAGIC` (unchanged), merged into the same aggregated table as the codec-descriptor rows

--- a/openspec/changes/codec-descriptor-refactor/specs/format-single-file-compressors/spec.md
+++ b/openspec/changes/codec-descriptor-refactor/specs/format-single-file-compressors/spec.md
@@ -1,0 +1,22 @@
+# Single-File Compressor Format Behavior — delta (codec-descriptor refactor)
+
+## MODIFIED Requirements
+
+### Requirement: Per-codec metadata comes from the codec descriptor
+
+The single multi-format `SingleFileBackend` SHALL obtain each format's metadata extraction
+from its codec descriptor's metadata hook rather than a reader-local dispatch table, keeping
+the reader codec-agnostic. The "one backend, per-codec hooks" structure SHALL be preserved —
+only the hooks' home moves onto the descriptor — and the surfaced metadata (gzip `FNAME` →
+`extra["gzip.original_filename"]` + `raw_name`, gzip mtime, xz/lzip decompressed size, and
+the per-format size-availability rules) MUST be unchanged.
+
+#### Scenario: gzip metadata extraction lives on the codec descriptor
+
+- **WHEN** a `.gz` source with a stored `FNAME` and mtime is opened
+- **THEN** `extra["gzip.original_filename"]` (Latin-1 decoded), `raw_name`, and `modified` are populated exactly as before, via the gzip descriptor's metadata hook rather than a reader method
+
+#### Scenario: a codec with no extra metadata needs no hook
+
+- **WHEN** a `.bz2` source (no header metadata) is opened
+- **THEN** the member carries the default shell with `size` `None`, because its descriptor registers no metadata hook

--- a/openspec/changes/codec-descriptor-refactor/tasks.md
+++ b/openspec/changes/codec-descriptor-refactor/tasks.md
@@ -1,0 +1,53 @@
+# Tasks — Unify per-codec logic behind a single StreamCodec descriptor
+
+> Behavior-preserving refactor. Run tools through `uv` (`uv run pytest`,
+> `uv run pyrefly check`, `uv run ty check`, `uv run ruff`). The existing
+> detection / single-file / registry suites are the regression net — they must stay
+> green **unchanged** (any required test edit is a signal the refactor changed behavior).
+
+## 1. Define the descriptor
+
+- [ ] 1.1 Add a `StreamCodec` descriptor in `internal/streams/codecs.py` with: `codec` /
+      `stream_format`, `open`, `translate`, `magic: tuple[MagicSignature, ...]`,
+      `content_probe` (flag or probe fn), `extensions`, `extract_metadata` (optional),
+      and `requirement: MissingComponent | None`.
+- [ ] 1.2 Build the descriptor registry from the current `_REGISTRY` + `_STREAM_FORMAT_CODECS`
+      + the magic/probe/extension data currently on `SingleFileBackend` + the
+      `_CODEC_REQUIREMENT` table. Keep `MissingComponent` where it lives (or move it to a
+      neutral module to avoid a registry↔codecs import cycle).
+- [ ] 1.3 Keep `Codec` / `resolve_codec` / `open_codec_stream` / `codec_for_stream_format`
+      working as thin accessors over the descriptors (no caller churn outside the four files).
+
+## 2. Route detection through the descriptors
+
+- [ ] 2.1 `detect_format()` aggregates stream-codec magic + content probes from the
+      descriptor registry, merged with the container backends' `MAGIC`/`EXTENSIONS`.
+- [ ] 2.2 Confirm identical results: strong/weak magic ordering, the zlib weak+probe path,
+      the Brotli magic-less probe, conflict warnings — all unchanged.
+
+## 3. Route the single-file reader through the descriptors
+
+- [ ] 3.1 `SingleFileBackend.FORMATS`/`EXTENSIONS`/`MAGIC`/`CONTENT_PROBE_FORMATS` derive
+      from the descriptors (no hand-listed tables).
+- [ ] 3.2 `SingleFileReader` calls `descriptor.extract_metadata(...)` instead of the local
+      `_METADATA_HOOKS`; the gzip FNAME/mtime and xz/lzip size hooks move onto their
+      descriptors. Member name inference + the one-member shape are unchanged.
+
+## 4. Route registry availability through the descriptors
+
+- [ ] 4.1 `format_availability()` reads a single-codec format's `requirement` from its
+      descriptor; delete `_CODEC_REQUIREMENT`. The multi-codec container rules (ZIP/7z/TAR)
+      read codec availability through the same descriptors.
+
+## 5. Verify
+
+- [ ] 5.1 `uv run pytest` green with **no changes** to the existing detection / single-file /
+      registry / zip tests.
+- [ ] 5.2 Add `tests/test_codec_descriptor.py`: register a synthetic descriptor and assert it
+      is detectable, readable as a one-member archive, and availability-reported — with no
+      edits elsewhere.
+- [ ] 5.3 `uv run pyrefly check` + `uv run ty check` clean; `uv run ruff check` clean.
+- [ ] 5.4 Zero-dep core still importable with no third-party packages (the descriptor
+      registry must not eagerly import optional codec libs).
+- [ ] 5.5 Sync the four spec deltas (compressed-streams, format-detection, backend-registry,
+      format-single-file-compressors).

--- a/openspec/changes/compression-library-evaluation/proposal.md
+++ b/openspec/changes/compression-library-evaluation/proposal.md
@@ -83,11 +83,18 @@ xz/lzma (stdlib `lzma`, our `xz.py`, `python-xz`), lzip (our `lzip.py`), zstd (`
 
 ### 3. Dependency cleanup
 
-- Remove `python-xz` and `pyzstd` from the `[all]` extra **if** confirmed unused (they are,
-  in `src/`), or wire them up if the evaluation says to keep them. Whatever the outcome,
-  `[all]` should contain no dependency the library never imports.
+User-facing extras must not pin a library only `src/` *doesn't* use, and **test-only**
+libraries (decode oracles `rarfile`/`py7zr`; fixture generators `ncompress`, and `pyzstd`
+while it only *writes* fixtures) belong in the `dev` dependency group, not in an extra.
+Concretely:
+
+- `python-xz` — imported nowhere (not `src/`, not the tests): **remove** from `[all]`.
+- `pyzstd` — used only by the dev test oracle to generate zstd fixtures: **move** from
+  `[all]` to the `dev` group (or, if the evaluation promotes it to the runtime zstd backend,
+  to the `[zstd]` extra).
 - Ensure the `[zstd]` extra points at whatever the evaluation selects (and add an extra for
   a seekable-zstd backend if one is adopted).
+- Add a guard so a user-facing extra can never again pin a package no `src/` code imports.
 
 ## Specs
 

--- a/openspec/changes/compression-library-evaluation/proposal.md
+++ b/openspec/changes/compression-library-evaluation/proposal.md
@@ -19,12 +19,18 @@ not written down anywhere**, and a couple of the choices are now in doubt:
     format** (not arbitrary `.zst`), and pyzstd's own docs nudge toward the stdlib /
     `backports.zstd`; it is unclear whether those support efficient seeking at all.
 - **xz uses our own parser** (`internal/streams/xz.py`) rather than
-  [`python-xz`](https://github.com/rogdham/python-xz), which appears to do the same
-  thing (block-index random access). We *think* an own-vs-`python-xz` exploration happened,
-  but it is **not recorded**, and `python-xz` is still pinned in the `[all]` extra while
-  being **entirely unused** (no `src/` import, not even referenced by the dev test oracle).
-  `pyzstd` is likewise pinned in `[all]` but unused in `src/` (only the dev test oracle uses
-  it, to *generate* zstd fixtures).
+  [`python-xz`](https://github.com/rogdham/python-xz). This decision **was** made and is
+  recorded — in the DEV repo, [`davitf/archivey-dev#214`](https://github.com/davitf/archivey-dev/pull/214)
+  ("Implement XzDecompressorStream with block-level seeking"): the native parser (on stdlib
+  `lzma`) gives block-level random access via the XZ stream index, an efficient `SEEK_END`
+  via a backwards index scan, correct **multi-stream** handling (a case the prior path got
+  wrong), per-stream fallback scanning for truncated/index-less files, and architectural
+  uniformity with `LzipDecompressorStream`. DEV kept `python-xz` only as a *disabled-by-default
+  comparison/benchmark* backend. v2 carried over the native parser **but not** that
+  comparison backend, so the `python-xz` pin in `[all]` is now **entirely unused** (no `src/`
+  import, not even referenced by the dev test oracle). The decision just needs to be carried
+  into *this* repo's spec/docs (and the dead pin resolved). `pyzstd` is likewise pinned in
+  `[all]` but unused in `src/` (only the dev test oracle uses it, to *generate* zstd fixtures).
 
 So we have undocumented decisions, at least one intended migration, an unexplored
 seekable-zstd option, and dead dependencies. This change does the systematic comparison,
@@ -65,8 +71,11 @@ xz/lzma (stdlib `lzma`, our `xz.py`, `python-xz`), lzip (our `lzip.py`), zstd (`
   `SeekableZstdFile` vs. none), noting the trade-off that `SeekableZstdFile` only reads the
   Seekable Zstd container, not arbitrary `.zst`. Capture how the choice interacts with the
   3.14 stdlib so we can prefer the stdlib when available.
-- **xz:** record *why* we maintain our own `xz.py` instead of `python-xz` (or decide to
-  switch). Either way, resolve the dangling `python-xz` dependency.
+- **xz:** carry the already-made decision (DEV [`#214`](https://github.com/davitf/archivey-dev/pull/214))
+  into this repo's docs/spec — own `xz.py` for block-index random access, efficient
+  `SEEK_END`, correct multi-stream handling, and `DecompressorStream` uniformity — and
+  resolve the dangling `python-xz` `[all]` pin (v2 doesn't keep it even as a comparison
+  backend, so it should be removed).
 - **everything else:** record the chosen library + the rejected alternatives + the reason,
   so future contributors don't re-litigate (e.g. why `uncompresspy` for `.Z`, why
   `rapidgzip` for both gzip and bzip2 random access — the macOS single-accelerator
@@ -82,32 +91,16 @@ xz/lzma (stdlib `lzma`, our `xz.py`, `python-xz`), lzip (our `lzip.py`), zstd (`
 
 ## Specs
 
-Proposed deltas (kept here until accepted). This change is primarily a doc + packaging
-decision; the spec touchpoints are light.
+The full delta requirements (with scenarios) live in this change's `specs/` directory:
 
-### packaging-and-extras — MODIFIED Requirement: Optional extras map to exactly the libraries the code uses
+- `specs/packaging-and-extras/spec.md` — **MODIFIED** optional extras map to exactly the libraries the code uses (drop the dead `python-xz` / `pyzstd` pins).
+- `specs/documentation/spec.md` — **ADDED** per-format compression-library choices are documented in `docs/library-analysis.md`, citing already-recorded decisions (e.g. [`davitf/archivey-dev#214`](https://github.com/davitf/archivey-dev/pull/214) for XZ).
 
-The extras→capability mapping SHALL list only libraries the library actually imports; an
-extra MUST NOT pin a dependency that no code path uses. The per-codec library choice and
-its rationale SHALL be recorded in `docs/library-analysis.md`, which is the source of truth
-for why each library is used or rejected.
-
-#### Scenario: no dead optional dependency
-
-- **WHEN** the `[all]` extra (or any extra) is audited against `src/` imports
-- **THEN** every pinned package is reachable from some code path, or it is removed
-
-### documentation — ADDED Requirement: Library choices are documented
-
-The documentation SHALL include a per-format compression-library analysis that, for each
-codec, names the chosen library, the alternatives considered, and the criteria
-(non-seekable support, efficient seeking, corruption/truncation detection, error reporting,
-install/availability, maintenance) behind the decision.
-
-> The concrete backend-selection requirements in `compressed-streams` /
-> `seekable-decompressor-streams` are updated by the **follow-up** changes that implement
-> any chosen swap (e.g. zstd backend migration, seekable-zstd support); this change records
-> the decisions and criteria, not the swaps.
+This change is primarily a doc + packaging decision; the spec touchpoints are light. The
+concrete backend-selection requirements in `compressed-streams` /
+`seekable-decompressor-streams` are updated by the **follow-up** changes that implement any
+chosen swap (zstd migration, seekable-zstd support) — this change records the decisions and
+criteria, not the swaps.
 
 ## Impact
 

--- a/openspec/changes/compression-library-evaluation/proposal.md
+++ b/openspec/changes/compression-library-evaluation/proposal.md
@@ -1,0 +1,126 @@
+# Per-format compression-library evaluation + a recorded decision doc
+
+## Why
+
+We picked a concrete library (or rolled our own) for each codec, but **the rationale is
+not written down anywhere**, and a couple of the choices are now in doubt:
+
+- **zstd uses `zstandard`.** It is the one codec with a known wart — it cannot seek
+  backwards, so we wrap it in `_ZstdReopenStream` (reopen-from-start), and it is loose
+  about surfacing some error conditions. The maintainer intends to **migrate to
+  `pyzstd`**, which wraps libzstd more directly and is the spirit of Python 3.14's stdlib
+  `compression.zstd`. There are several candidates to weigh:
+  - `zstandard` (current), `pyzstd`, the **stdlib `compression.zstd`** (3.14+),
+    `backports.zstd` ([Rogdham](https://github.com/Rogdham/backports.zstd)) for older
+    Pythons, and **`indexed_zstd`** ([martinellimarco](https://github.com/martinellimarco/indexed_zstd),
+    used by ratarmount, same author lineage as rapidgzip/indexed_bzip2) for *efficient
+    seeking*.
+  - `pyzstd` ships a `SeekableZstdFile` class, but it only handles the **Seekable Zstd
+    format** (not arbitrary `.zst`), and pyzstd's own docs nudge toward the stdlib /
+    `backports.zstd`; it is unclear whether those support efficient seeking at all.
+- **xz uses our own parser** (`internal/streams/xz.py`) rather than
+  [`python-xz`](https://github.com/rogdham/python-xz), which appears to do the same
+  thing (block-index random access). We *think* an own-vs-`python-xz` exploration happened,
+  but it is **not recorded**, and `python-xz` is still pinned in the `[all]` extra while
+  being **entirely unused** (no `src/` import, not even referenced by the dev test oracle).
+  `pyzstd` is likewise pinned in `[all]` but unused in `src/` (only the dev test oracle uses
+  it, to *generate* zstd fixtures).
+
+So we have undocumented decisions, at least one intended migration, an unexplored
+seekable-zstd option, and dead dependencies. This change does the systematic comparison,
+**records it in a doc**, decides per codec, and cleans up the dependency list.
+
+## What Changes
+
+This is **investigation + a decision doc + dependency cleanup**. Actual library swaps
+(e.g. `zstandard` → `pyzstd`, or adding `indexed_zstd` for seekable zstd) land in their
+own follow-up changes once decided — but the decisions and their rationale are fixed here.
+
+### 1. A per-format library analysis doc
+
+Add **`docs/library-analysis.md`** (rendered in the MkDocs site) — the single source of
+truth for "which library backs each codec and why". For every codec the library reads, a
+row per candidate library scored on:
+
+| Criterion | What it captures |
+|-----------|------------------|
+| Non-seekable source | Works on a pipe/socket (forward-only) without a fileno? |
+| Efficient seeking | Indexed/random access without re-decompressing from the start? |
+| Corruption detection | Raises on bad data (vs. silently returning garbage)? |
+| Truncation detection | Raises on a short/cut stream (vs. silent short read)? |
+| Error reporting fidelity | Are errors distinguishable + translatable to our `CorruptionError`/`TruncatedError`? |
+| Install / availability | Pure-Python vs. native wheels; platform/arch coverage; build deps |
+| Maintenance | Activity, releases, Python-version support |
+| Notes | Quirks (e.g. zstandard's no-backward-seek; rapidgzip/indexed_bzip2 macOS dual-load) |
+
+Codecs to cover: gzip (stdlib, `rapidgzip`), bzip2 (stdlib, `rapidgzip.IndexedBzip2File`),
+xz/lzma (stdlib `lzma`, our `xz.py`, `python-xz`), lzip (our `lzip.py`), zstd (`zstandard`,
+`pyzstd`, stdlib `compression.zstd`, `backports.zstd`, `indexed_zstd`), lz4 (`lz4`), brotli
+(`brotli`), unix-compress (`uncompresspy`), deflate64 (`inflate64`), ppmd (`pyppmd`).
+
+### 2. Decisions to reach (and record)
+
+- **zstd:** choose the primary decode backend (validate or revise the `zstandard` →
+  `pyzstd` intent) and decide the seekable-zstd story (`indexed_zstd` vs. pyzstd's
+  `SeekableZstdFile` vs. none), noting the trade-off that `SeekableZstdFile` only reads the
+  Seekable Zstd container, not arbitrary `.zst`. Capture how the choice interacts with the
+  3.14 stdlib so we can prefer the stdlib when available.
+- **xz:** record *why* we maintain our own `xz.py` instead of `python-xz` (or decide to
+  switch). Either way, resolve the dangling `python-xz` dependency.
+- **everything else:** record the chosen library + the rejected alternatives + the reason,
+  so future contributors don't re-litigate (e.g. why `uncompresspy` for `.Z`, why
+  `rapidgzip` for both gzip and bzip2 random access — the macOS single-accelerator
+  constraint is already in `docs/known-issues.md` and should be cross-linked).
+
+### 3. Dependency cleanup
+
+- Remove `python-xz` and `pyzstd` from the `[all]` extra **if** confirmed unused (they are,
+  in `src/`), or wire them up if the evaluation says to keep them. Whatever the outcome,
+  `[all]` should contain no dependency the library never imports.
+- Ensure the `[zstd]` extra points at whatever the evaluation selects (and add an extra for
+  a seekable-zstd backend if one is adopted).
+
+## Specs
+
+Proposed deltas (kept here until accepted). This change is primarily a doc + packaging
+decision; the spec touchpoints are light.
+
+### packaging-and-extras — MODIFIED Requirement: Optional extras map to exactly the libraries the code uses
+
+The extras→capability mapping SHALL list only libraries the library actually imports; an
+extra MUST NOT pin a dependency that no code path uses. The per-codec library choice and
+its rationale SHALL be recorded in `docs/library-analysis.md`, which is the source of truth
+for why each library is used or rejected.
+
+#### Scenario: no dead optional dependency
+
+- **WHEN** the `[all]` extra (or any extra) is audited against `src/` imports
+- **THEN** every pinned package is reachable from some code path, or it is removed
+
+### documentation — ADDED Requirement: Library choices are documented
+
+The documentation SHALL include a per-format compression-library analysis that, for each
+codec, names the chosen library, the alternatives considered, and the criteria
+(non-seekable support, efficient seeking, corruption/truncation detection, error reporting,
+install/availability, maintenance) behind the decision.
+
+> The concrete backend-selection requirements in `compressed-streams` /
+> `seekable-decompressor-streams` are updated by the **follow-up** changes that implement
+> any chosen swap (e.g. zstd backend migration, seekable-zstd support); this change records
+> the decisions and criteria, not the swaps.
+
+## Impact
+
+- **New doc:** `docs/library-analysis.md` (+ a nav entry in `mkdocs.yml`); cross-links from
+  `docs/known-issues.md` and `COMPARISON.md` (which already mentions the seekable-stream
+  subsystem).
+- **Packaging:** `pyproject.toml` `[all]` / `[zstd]` extras adjusted per the findings
+  (drop dead `python-xz` / `pyzstd`, or justify keeping).
+- **Follow-up changes (not built here):** a zstd backend migration (`zstandard` → chosen
+  primary), optional seekable-zstd support (`indexed_zstd` / `SeekableZstdFile`), and any
+  xz backend change — each its own proposal once this evaluation lands.
+- **Coordinates with:** `codec-descriptor-refactor` — the descriptor's `open`/`translate`/
+  `requirement` are where a chosen swap is ultimately wired.
+- **Risk:** low — this records decisions and removes dead deps; behavior changes are
+  deferred to the follow-up swap changes, each independently testable against the existing
+  codec/seekable-stream suites.

--- a/openspec/changes/compression-library-evaluation/specs/documentation/spec.md
+++ b/openspec/changes/compression-library-evaluation/specs/documentation/spec.md
@@ -1,0 +1,23 @@
+# Documentation — delta (compression-library evaluation)
+
+## ADDED Requirements
+
+### Requirement: Per-format compression-library choices are documented
+
+The documentation SHALL include a per-format compression-library analysis
+(`docs/library-analysis.md`) that, for each codec the library reads, names the chosen
+library, the alternatives considered, and the criteria behind the decision (non-seekable
+support, efficient seeking, corruption detection, truncation detection, error-reporting
+fidelity, install/availability, maintenance). Where a decision was already made and recorded
+elsewhere, the analysis SHALL cite it — e.g. the native XZ parser choice in
+`davitf/archivey-dev#214`.
+
+#### Scenario: every read codec has a recorded rationale
+
+- **WHEN** a contributor reads `docs/library-analysis.md`
+- **THEN** for each codec (gzip, bzip2, xz/lzma, lzip, zstd, lz4, brotli, unix-compress, deflate64, ppmd) they find the chosen library, the rejected alternatives, and the reason
+
+#### Scenario: an already-recorded decision is cited, not re-derived
+
+- **WHEN** the analysis covers XZ
+- **THEN** it states the native-parser decision and links `davitf/archivey-dev#214` rather than re-litigating it

--- a/openspec/changes/compression-library-evaluation/specs/packaging-and-extras/spec.md
+++ b/openspec/changes/compression-library-evaluation/specs/packaging-and-extras/spec.md
@@ -1,0 +1,22 @@
+# Packaging and Extras — delta (compression-library evaluation)
+
+## MODIFIED Requirements
+
+### Requirement: Optional extras map to exactly the libraries the code uses
+
+The extras → capability mapping SHALL list only libraries the library actually imports; an
+extra MUST NOT pin a dependency that no code path in `src/` uses. The per-codec library
+choice and its rationale SHALL be recorded in `docs/library-analysis.md`, which is the
+source of truth for why each library is used or rejected. The currently-dead `python-xz`
+and `pyzstd` pins in the `[all]` extra SHALL be removed (or wired up if the evaluation
+decides to use them).
+
+#### Scenario: no dead optional dependency
+
+- **WHEN** the `[all]` extra (or any extra) is audited against `src/` imports
+- **THEN** every pinned package is reachable from some code path, or it is removed
+
+#### Scenario: the zstd extra matches the chosen backend
+
+- **WHEN** the evaluation selects the zstd decode backend
+- **THEN** the `[zstd]` extra pins exactly that package (plus any adopted seekable-zstd backend), and `docs/library-analysis.md` records the choice

--- a/openspec/changes/compression-library-evaluation/specs/packaging-and-extras/spec.md
+++ b/openspec/changes/compression-library-evaluation/specs/packaging-and-extras/spec.md
@@ -4,19 +4,31 @@
 
 ### Requirement: Optional extras map to exactly the libraries the code uses
 
-The extras → capability mapping SHALL list only libraries the library actually imports; an
-extra MUST NOT pin a dependency that no code path in `src/` uses. The per-codec library
-choice and its rationale SHALL be recorded in `docs/library-analysis.md`, which is the
-source of truth for why each library is used or rejected. The currently-dead `python-xz`
-and `pyzstd` pins in the `[all]` extra SHALL be removed (or wired up if the evaluation
-decides to use them).
+User-facing optional **extras** (`[7z]`, `[zstd]`, `[all]`, …) SHALL list only libraries
+that `src/` imports at runtime for that capability; an extra MUST NOT pin a dependency that
+no `src/` code path uses. Libraries needed **only by the test suite** — decode oracles
+(`rarfile`, `py7zr`) and fixture generators (`ncompress`, and `pyzstd` while it is only used
+to *write* zstd fixtures) — SHALL live in the `dev` dependency group, never in a user-facing
+extra. The per-codec library choice and its rationale SHALL be recorded in
+`docs/library-analysis.md`, the source of truth for why each library is used or rejected.
 
-#### Scenario: no dead optional dependency
+Applying this now: `python-xz` (imported nowhere — not `src/`, not the tests) SHALL be
+removed from `[all]`; `pyzstd` (used only by the dev test oracle to generate fixtures) SHALL
+move from `[all]` to the `dev` group — unless the zstd evaluation promotes it to the runtime
+`[zstd]` backend, in which case it belongs in that extra.
 
-- **WHEN** the `[all]` extra (or any extra) is audited against `src/` imports
-- **THEN** every pinned package is reachable from some code path, or it is removed
+#### Scenario: no dead optional dependency in a user-facing extra
+
+- **WHEN** the `[all]` extra (or any user-facing extra) is audited against `src/` imports
+- **THEN** every pinned package is reachable from some `src/` code path, or it is removed
+
+#### Scenario: a test-only library lives in the dev group, not an extra
+
+- **WHEN** a library is imported only by the test suite (an oracle or a fixture generator), e.g. `rarfile`, `py7zr`, `ncompress`, or fixture-only `pyzstd`
+- **THEN** it is declared in the `dev` dependency group and is absent from every user-facing extra
 
 #### Scenario: the zstd extra matches the chosen backend
 
 - **WHEN** the evaluation selects the zstd decode backend
 - **THEN** the `[zstd]` extra pins exactly that package (plus any adopted seekable-zstd backend), and `docs/library-analysis.md` records the choice
+

--- a/openspec/changes/compression-library-evaluation/tasks.md
+++ b/openspec/changes/compression-library-evaluation/tasks.md
@@ -45,11 +45,14 @@
 
 - [ ] 5.1 Add `docs/library-analysis.md` with the filled matrix + per-codec decisions; add a
       nav entry in `mkdocs.yml`; cross-link from `docs/known-issues.md` / `COMPARISON.md`.
-- [ ] 5.2 Audit `pyproject.toml` extras against `src/` imports; remove `python-xz` and
-      `pyzstd` from `[all]` (confirmed unused in `src/`) or justify keeping each; ensure
-      `[zstd]` matches the decision.
-- [ ] 5.3 Add a `tests/check_zero_dep_core.py`-style or unit guard that every package pinned
-      in an extra is importable-and-reachable (no dead optional deps), so this can't regress.
+- [ ] 5.2 Audit `pyproject.toml` against `src/` imports and sort each dep into the right
+      bucket: **remove** `python-xz` from `[all]` (imported nowhere); **move** `pyzstd` from
+      `[all]` to the `dev` group (test-only fixture generator) unless the evaluation promotes
+      it to the runtime `[zstd]` backend; confirm the existing test-only oracles
+      (`rarfile`, `py7zr`, `ncompress`) stay in `dev`; ensure `[zstd]` matches the decision.
+- [ ] 5.3 Add a guard (a `check_zero_dep_core.py`-style script or unit test) that every
+      package pinned in a **user-facing extra** is imported by some `src/` code path, so a
+      dead/test-only dep can't slip back into an extra.
 
 ## 6. Verify + hand off
 

--- a/openspec/changes/compression-library-evaluation/tasks.md
+++ b/openspec/changes/compression-library-evaluation/tasks.md
@@ -26,13 +26,14 @@
 - [ ] 2.5 Decide: primary decode backend (validate/revise the `zstandard`→`pyzstd` intent) +
       the seekable-zstd story (indexed_zstd / SeekableZstdFile / none). Record the rationale.
 
-## 3. Investigate xz (own parser vs python-xz)
+## 3. xz (own parser vs python-xz) — decision already made, just carry it over
 
-- [ ] 3.1 Compare our `internal/streams/xz.py` (block-index random access, lzip-style trailer
-      handling) against `python-xz` (rogdham): feature parity, seeking, error reporting,
-      multi-stream/multi-block coverage, maintenance.
-- [ ] 3.2 Record why we keep our own parser (or decide to switch); either way resolve the
-      dangling `python-xz` `[all]` pin.
+- [ ] 3.1 Summarize the recorded DEV decision (`davitf/archivey-dev#214`) in the analysis
+      doc: native `xz.py` on stdlib `lzma` for block-index random access, efficient
+      `SEEK_END` (backwards index scan), correct multi-stream handling, per-stream fallback
+      for index-less/truncated files, and `DecompressorStream` uniformity with lzip. Link the PR.
+- [ ] 3.2 Note that v2 did **not** carry over DEV's disabled-by-default `python-xz`
+      comparison backend, so the `python-xz` `[all]` pin is dead — remove it (§5.2).
 
 ## 4. Record the rest
 

--- a/openspec/changes/compression-library-evaluation/tasks.md
+++ b/openspec/changes/compression-library-evaluation/tasks.md
@@ -1,0 +1,59 @@
+# Tasks — Per-format compression-library evaluation + decision doc
+
+> Investigation + a decision doc + dependency cleanup. Library *swaps* are deferred to
+> follow-up changes; this change fixes the decisions and their rationale. Run tools through
+> `uv` (`uv run pytest`, `uv run pyrefly check`, `uv run ty check`, `uv run ruff`).
+
+## 1. Build the comparison matrix
+
+- [ ] 1.1 For each codec the library reads (gzip, bzip2, xz/lzma, lzip, zstd, lz4, brotli,
+      unix-compress, deflate64, ppmd), list the candidate libraries and the chosen one today.
+- [ ] 1.2 Define the scoring columns: non-seekable support, efficient seeking,
+      corruption detection, truncation detection, error-reporting fidelity (translatable?),
+      install/availability (pure-Python vs. native wheels, platform/arch), maintenance, notes.
+
+## 2. Investigate zstd (the open question)
+
+- [ ] 2.1 `zstandard` (current): document the no-backward-seek behavior we wrap in
+      `_ZstdReopenStream`, and which corruption/truncation cases it does and does not raise.
+- [ ] 2.2 `pyzstd`: decode behavior, seeking (incl. `SeekableZstdFile` — confirm it only
+      reads the **Seekable Zstd** format, not arbitrary `.zst`), error reporting, availability.
+- [ ] 2.3 stdlib `compression.zstd` (3.14+) and `backports.zstd` (older Pythons): seeking
+      support (likely none/limited), error reporting, the "prefer stdlib when present" angle.
+- [ ] 2.4 `indexed_zstd` (martinellimarco; used by ratarmount): efficient seeking, non-seekable
+      behavior, availability, and the same-process-as-rapidgzip concern (does it bundle a C++
+      core that could collide like indexed_bzip2 — see `docs/known-issues.md`?).
+- [ ] 2.5 Decide: primary decode backend (validate/revise the `zstandard`→`pyzstd` intent) +
+      the seekable-zstd story (indexed_zstd / SeekableZstdFile / none). Record the rationale.
+
+## 3. Investigate xz (own parser vs python-xz)
+
+- [ ] 3.1 Compare our `internal/streams/xz.py` (block-index random access, lzip-style trailer
+      handling) against `python-xz` (rogdham): feature parity, seeking, error reporting,
+      multi-stream/multi-block coverage, maintenance.
+- [ ] 3.2 Record why we keep our own parser (or decide to switch); either way resolve the
+      dangling `python-xz` `[all]` pin.
+
+## 4. Record the rest
+
+- [ ] 4.1 Document the chosen library + rejected alternatives + reason for gzip, bzip2, lzip,
+      lz4, brotli, unix-compress, deflate64, ppmd. Cross-link the rapidgzip/indexed_bzip2
+      single-accelerator macOS constraint already in `docs/known-issues.md`.
+
+## 5. Write the doc + clean up deps
+
+- [ ] 5.1 Add `docs/library-analysis.md` with the filled matrix + per-codec decisions; add a
+      nav entry in `mkdocs.yml`; cross-link from `docs/known-issues.md` / `COMPARISON.md`.
+- [ ] 5.2 Audit `pyproject.toml` extras against `src/` imports; remove `python-xz` and
+      `pyzstd` from `[all]` (confirmed unused in `src/`) or justify keeping each; ensure
+      `[zstd]` matches the decision.
+- [ ] 5.3 Add a `tests/check_zero_dep_core.py`-style or unit guard that every package pinned
+      in an extra is importable-and-reachable (no dead optional deps), so this can't regress.
+
+## 6. Verify + hand off
+
+- [ ] 6.1 `uv run pytest` / `pyrefly` / `ty` / `ruff` green (doc + packaging only — no
+      runtime behavior change in this change).
+- [ ] 6.2 Sync the spec deltas (`packaging-and-extras`, `documentation`).
+- [ ] 6.3 File the follow-up swap changes the decisions call for (zstd backend migration,
+      optional seekable-zstd support, any xz change) — each its own proposal.


### PR DESCRIPTION
Two OpenSpec change proposals coming out of the PR #13 review discussion. **Proposals only** — `proposal.md` + `tasks.md` with inline spec deltas, mirroring the `rapidgzip-truncation-investigation` layout. No code changes; the existing suite stays green.

## 1. `codec-descriptor-refactor`

Your "should we have a `StreamBackend` class?" idea. Today the per-codec logic is split across four modules:

- `codecs.py` — open fn + exception translator + availability sentinel
- the format backends — `MAGIC` / `EXTENSIONS` / `CONTENT_PROBE_FORMATS` data
- `single_file_reader.py` — the per-codec metadata hooks
- `registry.py` — `_CODEC_REQUIREMENT` (package / extra / install hint)

The proposal consolidates all of it into one **`StreamCodec` descriptor** per codec, so `detect_format()`, `SingleFileBackend`, and the registry availability all become data-driven (a new standalone codec = one descriptor, not four edits). Explicitly **behavior-preserving** — the existing detection/single-file/registry suites are the regression net and must stay green unchanged. Container formats (ZIP/TAR/ISO/7z) stay separate.

## 2. `compression-library-evaluation`

Your zstd/xz library question, generalized. Investigates the candidate libraries per codec and records the decision in a new **`docs/library-analysis.md`** (per-codec matrix: non-seekable support · efficient seeking · corruption detection · truncation detection · error-reporting fidelity · install/availability · maintenance).

Open questions it resolves:
- **zstd** — `zstandard` (current, with the no-backward-seek workaround) vs `pyzstd` (the intended migration target) vs stdlib `compression.zstd` (3.14+) vs `backports.zstd` vs `indexed_zstd` (seekable, ratarmount's choice). Notes that pyzstd's `SeekableZstdFile` only reads the Seekable Zstd format, not arbitrary `.zst`.
- **xz** — our own `xz.py` parser vs `python-xz`; record *why* (the exploration isn't written down anywhere), and resolve the dangling dep.
- Records the chosen + rejected library for every other codec too.

It also cleans up the **dead `python-xz` / `pyzstd` pins** in the `[all]` extra (both confirmed unused in `src/`). Actual library swaps are deferred to their own follow-up changes once the decisions land here.

The two changes coordinate: the descriptor's `open` / `translate` / `requirement` fields are where any library swap chosen by the evaluation ultimately gets wired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QVdJG1mJyrPRfYVbU6PT59)_