### PR TITLE
tests/ci: cross-format member-stream contract + minimum-version CI leg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,12 @@ jobs:
           - { os: ubuntu-latest, python-version: "3.12", install: all }
           - { os: ubuntu-latest, python-version: "3.13", install: all }
           - { os: ubuntu-latest, python-version: "3.14", install: all }
+          # Minimum supported library versions (uv --resolution lowest-direct) on the min
+          # Python: the [all] legs above run the *current* versions of every dependency, so
+          # this leg pins each declared dep to its floor (pycdlib 1.14, zstandard 0.23, …) to
+          # catch version-specific bugs that the default highest-version resolution hides —
+          # e.g. the pycdlib 1.14 readinto over-read the ISO backend works around.
+          - { os: ubuntu-latest, python-version: "3.11", install: all-lowest }
           # macOS + Windows on min/max Python (cross-platform path/symlink/junction surface).
           - { os: macos-latest, python-version: "3.11", install: all }
           - { os: macos-latest, python-version: "3.14", install: all }
@@ -108,10 +114,20 @@ jobs:
         if: matrix.install == 'all'
         run: uv sync --group dev --extra all
 
+      # ---- [all-lowest]: same extras, but every declared dependency pinned to its minimum
+      # allowed version (--resolution lowest-direct), so the suite runs against the floor of
+      # the supported range. Resolves fresh rather than from uv.lock (which pins current
+      # versions); the shared test step below uses --no-sync so this resolution stands.
+      - name: Install all extras + dev group (minimum versions)
+        if: matrix.install == 'all-lowest'
+        run: uv sync --group dev --extra all --resolution lowest-direct
+
       - name: Install unrar (Linux only, for RAR data tests)
-        if: matrix.install == 'all' && runner.os == 'Linux'
+        if: (matrix.install == 'all' || matrix.install == 'all-lowest') && runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y unrar || true
 
       - name: Run tests
-        if: matrix.install == 'all'
-        run: uv run pytest tests/ -q
+        if: matrix.install == 'all' || matrix.install == 'all-lowest'
+        # --no-sync so the all-lowest leg keeps its minimum-version resolution instead of
+        # re-syncing back to the locked (current) versions.
+        run: uv run --no-sync pytest tests/ -q

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,17 @@ with no extra path arguments.
 RAR *data* tests need the system `unrar` binary (`apt-get install -y unrar`, etc.);
 without it those tests skip cleanly.
 
+To reproduce CI's **minimum-supported-versions** leg locally — every declared dependency
+pinned to its floor (`pycdlib 1.14`, `zstandard 0.23`, …), so version-specific library bugs
+in the supported range surface — run the suite under `uv`'s lowest-version resolution:
+
+```bash
+uv run --resolution lowest-direct --extra all pytest    # min versions of every dependency
+```
+
+CI runs the `[all]` matrix legs at current versions and one `[all-lowest]` leg at the
+floors; both must stay green.
+
 ## Tooling decisions
 
 - **Type-checking is Pyrefly + ty** — the library is kept clean on **both**. We do

--- a/src/archivey/formats/iso_reader.py
+++ b/src/archivey/formats/iso_reader.py
@@ -110,9 +110,13 @@ class _PyCdlibStream(DelegatingStream):
     so this enters it in ``__init__`` and relies on ``DelegatingStream.close()`` (which calls
     ``inner.close()``, the exact equivalent of ``PyCdlibIO.__exit__``) to exit it, keeping the
     enter/exit lifecycle paired. ``readinto_passthrough=False`` routes ``readinto`` through
-    ``read``: ``PyCdlibIO.readinto`` mis-signals EOF inside a ``BufferedReader`` (it reads into
-    the ISO sector padding past the file's logical end), while ``PyCdlibIO.read`` clamps to the
-    logical length. Read/seek/tell/seekable are inherited delegation.
+    ``read``: on the supported pycdlib floor (verified on 1.14.0) ``PyCdlibIO.readinto``
+    mis-signals EOF — at the member's logical end it returns sector-padding bytes instead of
+    0, so repeated ``readinto`` (e.g. a ``BufferedReader`` over it) reads up to the 2 KiB
+    sector boundary — while ``PyCdlibIO.read`` always clamps to the logical length. (Newer
+    pycdlib, e.g. 1.16, clamps both; the workaround stays for the ``>=1.14`` range and is
+    pinned by the cross-format member-stream contract suite.) Read/seek/tell/seekable are
+    inherited delegation.
     """
 
     def __init__(self, raw: "PyCdlibIO") -> None:

--- a/tests/test_member_stream_contract.py
+++ b/tests/test_member_stream_contract.py
@@ -1,0 +1,176 @@
+"""Cross-format contract for an opened member stream (``reader.open(member)``).
+
+The per-format test files each check their backend's metadata mapping; this suite instead
+asserts the *uniform* behaviour every backend's member stream must share, exercised against
+a small **real** archive of each implemented format. It is the v2 stand-in for the kind of
+all-formats consistency the frozen DEV oracle used to provide, scoped to the member-read
+contract.
+
+The payload is deliberately small (well under a 2 KiB ISO sector and not block-aligned), so
+a backend that over-reads — e.g. an ``readinto`` that walks past the logical end into a
+container's padding — is caught rather than masked by alignment. (This is exactly the
+``PyCdlibIO`` EOF-misreport the ISO backend works around.)
+"""
+
+from __future__ import annotations
+
+import gzip
+import io
+import tarfile
+import zipfile
+from pathlib import Path
+from typing import Callable
+
+import pytest
+
+from archivey import open_archive
+from tests.conftest import requires
+
+CONTENT = b"The quick brown fox jumps over.\n"  # 32 bytes; < one ISO sector
+MEMBER = "data.txt"
+
+# A builder makes a small archive holding one ``MEMBER`` with ``CONTENT`` and returns the
+# (source, member-name) pair to open. Source may be a path or directory.
+Builder = Callable[[Path], tuple[Path, str]]
+
+
+def _directory(tmp_path: Path) -> tuple[Path, str]:
+    root = tmp_path / "dir"
+    root.mkdir()
+    (root / MEMBER).write_bytes(CONTENT)
+    return root, MEMBER
+
+
+def _zip_deflated(tmp_path: Path) -> tuple[Path, str]:
+    path = tmp_path / "a.zip"
+    with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as z:
+        z.writestr(MEMBER, CONTENT)
+    return path, MEMBER
+
+
+def _zip_stored(tmp_path: Path) -> tuple[Path, str]:
+    path = tmp_path / "stored.zip"
+    with zipfile.ZipFile(path, "w", zipfile.ZIP_STORED) as z:
+        z.writestr(MEMBER, CONTENT)
+    return path, MEMBER
+
+
+def _tar(tmp_path: Path) -> tuple[Path, str]:
+    path = tmp_path / "a.tar"
+    with tarfile.open(path, "w") as t:
+        info = tarfile.TarInfo(MEMBER)
+        info.size = len(CONTENT)
+        t.addfile(info, io.BytesIO(CONTENT))
+    return path, MEMBER
+
+
+def _tar_gz(tmp_path: Path) -> tuple[Path, str]:
+    path = tmp_path / "a.tar.gz"
+    with tarfile.open(path, "w:gz") as t:
+        info = tarfile.TarInfo(MEMBER)
+        info.size = len(CONTENT)
+        t.addfile(info, io.BytesIO(CONTENT))
+    return path, MEMBER
+
+
+def _gzip(tmp_path: Path) -> tuple[Path, str]:
+    path = tmp_path / "data.txt.gz"
+    with gzip.open(path, "wb") as f:
+        f.write(CONTENT)
+    return path, MEMBER  # single-file member name inferred from the source filename
+
+
+def _iso(tmp_path: Path) -> tuple[Path, str]:
+    import pycdlib
+
+    iso = pycdlib.PyCdlib()
+    iso.new(interchange_level=3, rock_ridge="1.09")
+    iso.add_fp(io.BytesIO(CONTENT), len(CONTENT), "/DATA.TXT;1", rr_name=MEMBER)
+    path = tmp_path / "a.iso"
+    iso.write(str(path))
+    iso.close()
+    return path, MEMBER
+
+
+@pytest.fixture(
+    params=[
+        pytest.param(_directory, id="directory"),
+        pytest.param(_zip_deflated, id="zip_deflated"),
+        pytest.param(_zip_stored, id="zip_stored"),
+        pytest.param(_tar, id="tar"),
+        pytest.param(_tar_gz, id="tar_gz"),
+        pytest.param(_gzip, id="gzip"),
+        pytest.param(_iso, id="iso", marks=requires("pycdlib")),
+    ]
+)
+def member(request: pytest.FixtureRequest, tmp_path: Path) -> tuple[Path, str]:
+    builder: Builder = request.param
+    return builder(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# Reading
+# ---------------------------------------------------------------------------
+
+
+def test_read_more_than_available_returns_all(member: tuple[Path, str]) -> None:
+    source, name = member
+    with open_archive(source) as ar, ar.open(name) as f:
+        # A read size far beyond the member length returns exactly the member's bytes.
+        assert f.read(10_000) == CONTENT
+
+
+def test_read_at_eof_returns_empty(member: tuple[Path, str]) -> None:
+    source, name = member
+    with open_archive(source) as ar, ar.open(name) as f:
+        assert f.read() == CONTENT
+        assert f.read() == b""
+        assert f.read(64) == b""
+
+
+def test_readinto_oversized_buffer_truncates_at_eof(member: tuple[Path, str]) -> None:
+    # readinto into a buffer larger than the remaining data must return the actual byte
+    # count (not the buffer size) and fill only those bytes — never reading into a
+    # container's sector/block padding past the member's logical end.
+    source, name = member
+    with open_archive(source) as ar, ar.open(name) as f:
+        buf = bytearray(10_000)
+        n = f.readinto(buf)
+        assert n == len(CONTENT)
+        assert bytes(buf[:n]) == CONTENT
+        # A second readinto at EOF fills nothing.
+        assert f.readinto(bytearray(64)) == 0
+
+
+def test_piecewise_read_then_eof(member: tuple[Path, str]) -> None:
+    source, name = member
+    with open_archive(source) as ar, ar.open(name) as f:
+        first = f.read(5)
+        assert first == CONTENT[:5]
+        assert first + f.read() == CONTENT
+        assert f.read(1) == b""
+
+
+# ---------------------------------------------------------------------------
+# Seeking (only when the member stream reports seekable)
+# ---------------------------------------------------------------------------
+
+
+def test_seek_past_end_then_read_returns_empty(member: tuple[Path, str]) -> None:
+    source, name = member
+    with open_archive(source) as ar, ar.open(name) as f:
+        if not f.seekable():
+            pytest.skip("member stream is not seekable")
+        f.seek(len(CONTENT) + 100)
+        assert f.read() == b""
+        assert f.read(64) == b""
+
+
+def test_seek_to_start_rereads(member: tuple[Path, str]) -> None:
+    source, name = member
+    with open_archive(source) as ar, ar.open(name) as f:
+        if not f.seekable():
+            pytest.skip("member stream is not seekable")
+        assert f.read(5) == CONTENT[:5]
+        f.seek(0)
+        assert f.read() == CONTENT


### PR DESCRIPTION
Follow-up to #18 (Phase 3). Two related additions that together catch version-specific library bugs — prompted by the ISO `readinto`/EOF question.

## 1. Cross-format member-stream contract suite

`tests/test_member_stream_contract.py` opens a small **real** archive of every implemented format (directory, ZIP stored/deflated, TAR, tar.gz, gzip single-file, ISO) and asserts the uniform `reader.open(member)` stream contract:

- `read(n)` past the end returns exactly the member's bytes;
- `read()` / `read(n)` at EOF return `b""`;
- `readinto()` into an oversized buffer returns the real byte count and fills **only** those bytes, and a follow-up `readinto` at EOF returns `0` — never reading into a container's sector/block padding (the behaviour the ISO backend's `_PyCdlibStream` guards);
- seek past end then read returns `b""`, and `seek(0)` re-reads (seekable members).

Small, non-block-aligned payload so an over-read is caught, not masked by alignment. 7 formats × 6 behaviours. This is the v2 stand-in for the DEV oracle's all-formats consistency checks (which `test_reader_contract.py`, using *synthetic* readers, did not provide), scoped to the member-read contract.

## 2. Minimum-supported-versions CI leg (uv `--resolution lowest-direct`)

The `[all]` matrix legs run the **current** versions of every dependency. New `[all-lowest]` leg (ubuntu / py3.11) pins each declared dep to its **floor** (`pycdlib 1.14`, `zstandard 0.23`, `rapidgzip 0.16`, …) and runs the full suite — the uv-native equivalent of DEV's tox min-version environments. Documented locally in CONTRIBUTING as `uv run --resolution lowest-direct --extra all pytest`.

## Why these go together — verified, not theoretical

The ISO `readinto` fix is **load-bearing**, not cosmetic. On the supported floor (**pycdlib 1.14.0**) `PyCdlibIO.readinto` mis-signals EOF: at the member's logical end it returns sector padding instead of `0`, so a `BufferedReader.read()` over it yields a full 2048-byte sector. With `_PyCdlibStream`'s `readinto_passthrough=False` removed, the contract suite's ISO `readinto`-at-EOF case **fails on 1.14.0**; with it, it passes. pycdlib 1.16 fixed it upstream — which is exactly why the default (highest-version) CI legs would never have caught it, and why the `[all-lowest]` leg is needed.

## Checks

577 passed / 7 skipped; pyrefly + ty + ruff clean. Verified at current versions (pycdlib 1.16) and at the floors (pycdlib 1.14) locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)