### PR TITLE
docs: record per-codec compression-library decisions + drop dead deps

### DIFF
--- a/COMPARISON.md
+++ b/COMPARISON.md
@@ -26,7 +26,7 @@ The two designs converged on most fundamentals — unified member model, magic-b
 Where they differ, **DEV is ahead on reading depth** and **CSP is ahead on scope and a few safety/ergonomics ideas**:
 
 - DEV solved the solid-archive streaming problem *properly* — true bounded-memory streaming via a background thread + queue for 7z and a single `unrar p` pipe demultiplexer for RAR. CSP's per-block `SpooledTemporaryFile` caching is strictly worse and should be discarded.
-- DEV has an entire subsystem CSP never conceived: **seekable decompressor streams** (XZ block index, lzip trailer scan, rapidgzip/indexed_bzip2 backends) giving random access *inside* compressed streams.
+- DEV has an entire subsystem CSP never conceived: **seekable decompressor streams** (XZ block index, lzip trailer scan, rapidgzip/indexed_bzip2 backends) giving random access *inside* compressed streams. (For the per-codec library choices behind this layer — including the native XZ parser and the zstd backend decision — see [`docs/library-analysis.md`](docs/library-analysis.md).)
 - DEV's test harness (declarative sample archives × format matrix × backend configs ≈ 1,000+ effective cases) is far beyond CSP's plan.
 - CSP has **writing + conversion**, which DEV lacks entirely, plus **decompression-bomb protection** (absent in DEV), and a crisper **cost/access-mode model** — which DEV's own in-progress `openspec` changes (`access-intent`, `base-reader-architecture-extensions`) independently arrived at but have not implemented.
 

--- a/IDEAS.md
+++ b/IDEAS.md
@@ -96,19 +96,57 @@
   folders in parallel (py7zr does this); members *within* one solid block stay
   sequential. No benefit for a single-block solid archive.
 
-- **Seek-index persistence** — save/load the gzip/bz2/xz seek points (the index built by
-  `seekable-decompressor-streams`; `rapidgzip`/`indexed_bzip2` already expose import/export)
-  to disk so repeated random access into the same file is cheap across runs. **Must guard
-  against staleness:** key/validate the stored index against the archive's identity
-  (mtime + size, ideally a content hash) so an index is never reused for a modified
-  archive.
+- **Efficient seekable zstd — probably a *native* frame-index reader, not `indexed_zstd`.**
+  zstd currently has *no* fast random access: a backward seek re-decompresses from the start
+  (rewind + warning), like brotli/lz4/zlib. The obvious candidate,
+  [`indexed_zstd`](https://github.com/martinellimarco/indexed_zstd) (martinellimarco; the zstd
+  backend ratarmount uses, wrapping `libzstd-seek`), is a heavy Cython/C++17 extension that
+  statically bundles a C++ core "based on `indexed_bzip2`" — so it carries the *same class* of
+  macOS dual-load symbol-collision risk that forced archivey onto a single accelerator library
+  (`docs/known-issues.md`) and would need its own coexistence canary.
 
-- **Archive repair / recovery mode** — best-effort extraction of corrupt or truncated
-  archives, returning what is readable rather than failing the whole operation.
-  Synergizes with the native streaming ZIP reader and `OnError.CONTINUE`. (We already have
-  concrete real-world ZIPs that no existing reader repairs but ours plausibly could.)
+  **But first check whether it actually buys us anything our own infrastructure can't.**
+  `libzstd-seek`'s jump table maps **frame boundaries only** — its own header says records map a
+  compressed to an uncompressed position where "both positions refer to frame boundaries", giving
+  "constant-time random access **at zstd frame granularity**". A seek into the middle of a frame
+  jumps to that frame's start and decodes forward; there is **no** intra-frame state
+  checkpointing (unlike `rapidgzip`, which snapshots the inflate window mid-stream). That is
+  *exactly* the granularity our `_SegmentedDecompressorStream` already delivers for **xz** (block
+  index) and **lzip** (member/trailer scan): seek = jump to the segment containing the offset,
+  decode forward within it. So the likely-better path is a **small native zstd reader** that
+  reuses that infrastructure — build a frame index by scanning frame headers (compressed size
+  per frame from its header; decompressed size from the frame's optional `Frame_Content_Size`
+  field or, when present, the *Seekable Zstd* skippable-frame seek table) — getting the same
+  frame-granularity seeking **for free**, with zero new heavy dependency and no macOS risk. This
+  is the zstd analogue of why we wrote `xz.py`/`lzip.py` instead of depending on `python-xz`.
 
-- **Integrity-verify mode** — verify every member against its stored checksum without
-  writing to disk. Marginal value (it's essentially `stream_members()` reading each stream
-  fully and discarding, which already triggers digest verification at EOF), but trivial to
-  add as a named convenience.
+  Things to confirm before committing to the native route:
+  - **Does `indexed_zstd` do anything a frame-index reader wouldn't?** From the docs, no — it is
+    frame-granularity only (no intra-frame seeking). If that holds, the native reader loses
+    nothing. (`rapidgzip`-style intra-member seeking would be the only reason to prefer a heavy
+    lib, and `libzstd-seek` does not do it.)
+  - **Benchmark the candidates — "same granularity" doesn't mean "same speed".** Even at equal
+    seek granularity, the C++ lib might still win on raw throughput (e.g. faster libzstd decode
+    of the forward run within a frame, cheaper jump-table construction, less Python-level
+    overhead) enough to justify adding it as an *accelerator* (the way `rapidgzip` is, behind an
+    extra) rather than rejecting it. Decide with numbers, not just the feature comparison: build a
+    representative large `.zst` (and a multi-frame / *Seekable Zstd* variant), then time several
+    access patterns — cold full sequential read, `SEEK_END` + tail read, a scattered set of random
+    seeks-then-reads, and a backward rewind — across the **stdlib `compression.zstd` reader**, the
+    **native frame-index wrapper**, and **`indexed_zstd`**, measuring wall time, peak memory, and
+    index-build cost. If the native wrapper is within a small constant of `indexed_zstd`, prefer it
+    (no heavy dep, no macOS risk); if `indexed_zstd` is dramatically faster on a real workload,
+    weigh it as an optional accelerator. A `benchmarks/`-style script (cf. DEV's `bench_xz.py`) is
+    the natural home.
+  - **The benefit only exists for multi-frame `.zst`.** A single-frame stream — the common
+    default from the `zstd` CLI and most writers — has exactly one frame, so frame-granularity
+    seeking yields a single seek point (offset 0) and helps neither approach; the win is real
+    only for *Seekable Zstd* files or anything compressed with frame splitting (e.g. `.tar.zst`
+    written that way). Worth measuring how often multi-frame `.zst` actually occurs before
+    investing in either.
+  - **Frames without `Frame_Content_Size`** can't be indexed without decoding them (this is also
+    `libzstd-seek`'s slow fallback). The native reader can simply build the index only when sizes
+    are available (header field or seek table) and otherwise fall back to the rewind path.
+
+  Note `pyzstd.SeekableZstdFile` is **not** a substitute either: it reads only the *Seekable
+  Zstd* container, not plain `.zst`. See `docs/library-analysis.md` (zstd).

--- a/docs/known-issues.md
+++ b/docs/known-issues.md
@@ -1,5 +1,9 @@
 # Known issues
 
+> See also [Compression-library analysis](library-analysis.md) for which library backs each
+> codec and why — including why `rapidgzip` is the single accelerator library (the issue below)
+> and why an `indexed_zstd` zstd accelerator would face the same constraint.
+
 ## Random-access accelerators on macOS (resolved)
 
 **Status:** resolved. archivey uses a single accelerator library — `rapidgzip` — for both gzip

--- a/docs/library-analysis.md
+++ b/docs/library-analysis.md
@@ -1,0 +1,337 @@
+# Compression-library analysis
+
+This is the single source of truth for **which library backs each codec Archivey reads, and
+why**. For every codec it records the chosen backend, the alternatives weighed, and the
+criteria behind the decision, so a future contributor does not have to re-litigate a choice
+(or rediscover a library's quirks) from scratch.
+
+Every decision is documented **in full here**, even when it was originally made elsewhere, so
+this doc stays self-contained as the predecessor repository is retired. Where a choice has an
+external origin — notably the native XZ parser, first implemented in
+[`davitf/archivey-dev#214`](https://github.com/davitf/archivey-dev/pull/214) — the link is kept
+only as provenance, not as a stand-in for the rationale.
+
+Archivey reads codecs through one uniform, pull-based stream layer
+(`compressed-streams`); format parsers compose those streams instead of calling codec
+libraries directly. Random access *inside* a compressed stream is a separate concern owned by
+`seekable-decompressor-streams`. The packaging contract (which extra pulls which library)
+lives in `packaging-and-extras`; this doc explains the *reasoning* the extras encode.
+
+## How each candidate is scored
+
+| Criterion | What it captures |
+|-----------|------------------|
+| **Non-seekable source** | Works on a forward-only pipe/socket (no `fileno`, no `seek`)? |
+| **Efficient seeking** | Indexed/random access without re-decompressing from the start? |
+| **Corruption detection** | Raises on bad data instead of silently returning garbage? |
+| **Truncation detection** | Raises on a short/cut stream instead of a silent short read? |
+| **Error-reporting fidelity** | Are errors distinguishable and translatable to our `CorruptionError` / `TruncatedError` / non-seekable error? |
+| **Install / availability** | Pure-Python vs. native wheels; platform/arch coverage; build deps |
+| **Maintenance** | Activity, releases, Python-version support |
+
+Two recurring notes:
+
+- **"Re-decode rewind" is acceptable, not failure.** A codec with no native index services a
+  backward seek by re-decompressing from the start — O(n) per rewind. Per
+  `seekable-decompressor-streams` this is permitted but never silent: the first rewinding seek
+  logs a warning. So "no efficient seeking" is a quality-of-implementation note, not a
+  disqualifier.
+- **Container CRCs are a second integrity net.** Even when a codec does not detect corruption
+  itself, the `compressed-streams` verification stage checks the container-supplied digest
+  (e.g. a ZIP/7z member CRC32) over the decompressed bytes at clean EOF. Standalone single-file
+  streams (`.gz`, `.zst`, …) without a member digest rely on the codec's own check.
+
+## Summary: chosen backend per codec
+
+| Codec | Chosen backend | Availability | Efficient seek | Corruption | Truncation |
+|-------|----------------|--------------|----------------|------------|------------|
+| gzip | stdlib `gzip` (+ `rapidgzip` for random access) | core (`[seekable]` for accel) | via `rapidgzip` | yes (CRC) | yes¹ |
+| bzip2 | stdlib `bz2` (+ `rapidgzip.IndexedBzip2File`) | core (`[seekable]` for accel) | via `rapidgzip` | yes (block CRC) | yes |
+| xz | native `xz.py` over stdlib `lzma` | core | **yes** (block index) | yes (CRC) | yes |
+| lzip | native `lzip.py` over stdlib `lzma` | core | **yes** (trailer scan) | yes (CRC) | yes |
+| LZMA1/LZMA2 (raw) | stdlib `lzma` `FORMAT_RAW` | core | n/a (container-owned) | yes | yes |
+| Delta, BCJ x86/ARM/ARMT/PPC/SPARC/IA64 | stdlib `lzma` raw filters | core | n/a (filter stage) | yes | yes |
+| raw Deflate / zlib | stdlib `zlib` | core | no (rewind) | yes | yes |
+| zstd | **stdlib `compression.zstd` (3.14+) / `backports.zstd` (<3.14)** — *migration; see below* | `[zstd]` | no (rewind) | yes (frame checksum) | **yes** |
+| lz4 | `lz4` | `[lz4]` | no (rewind) | yes | yes |
+| brotli | `brotli` | `[7z]` | no (rewind) | yes | partial² |
+| unix-compress (`.Z`) | `uncompresspy` | `[unix-compress]` | yes (random-access decoder) | yes | no³ |
+| Deflate64 | `inflate64` | `[7z]` | no | yes | yes |
+| PPMd (var.H) | `pyppmd` | `[7z]` | no | yes | yes |
+
+¹ gzip truncation: stdlib raises `EOFError`; the `rapidgzip` accelerator does **not** reliably
+report it, so Archivey adds an ISIZE backstop on a seekable path (see `docs/known-issues.md`
+and `seekable-decompressor-streams`).
+² brotli has no length/CRC trailer, so a truncated stream is detected only when the
+decompressor never reports "finished" at EOF (surfaced as `TruncatedError`), not by a stored
+size.
+³ the `.Z` format carries no length or checksum, so truncation is undetectable — a cut stream
+just yields fewer bytes.
+
+---
+
+## zstd — the open question (decision: migrate off `zstandard`)
+
+zstd is the one codec whose choice was actively in doubt. The current backend, `zstandard`,
+has two real warts; the question was which of several candidates to move to.
+
+### Candidates
+
+- **`zstandard`** (current) — Gregory Szorc's CFFI/C wrapper of libzstd. Bespoke reader API.
+- **`pyzstd`** — Ma Lin's (animalize) wrapper; its `ZstdFile` is built on the stdlib
+  `_compression` machinery (same family as `gzip`/`bz2`/`lzma`). It was the basis for CPython's
+  stdlib module (PEP 784) and, as of 0.19, **depends on `backports.zstd` for Python < 3.14**.
+  Also ships `SeekableZstdFile`.
+- **stdlib `compression.zstd`** (Python 3.14+) — the new standard-library module; same
+  `ZstdFile`/`ZstdError`/`open` surface.
+- **`backports.zstd`** (Rogdham) — a pure backport of `compression.zstd`'s API for Python
+  3.10–3.13 (no third-party deps).
+- **`indexed_zstd`** (martinellimarco) — efficient *seeking* over arbitrary `.zst`; see the
+  seekable section.
+
+### Measured behaviour
+
+Probed directly on Python 3.11 with a 200 KB incompressible (multi-block) frame:
+
+| Behaviour | `zstandard` 0.25 | `pyzstd` 0.19 | `backports.zstd` 1.6 / stdlib 3.14 |
+|-----------|------------------|---------------|------------------------------------|
+| Truncation (cut stream) | ❌ **silent short read** | ✅ `EOFError` | ✅ `EOFError` |
+| Corruption, frame checksum on | ✅ `ZstdError` | ✅ | ✅ `ZstdError` |
+| Corruption, no checksum | ❌ silent | ❌ silent | ❌ silent (inherent to zstd: the default frame has no integrity check) |
+| Backward seek | ❌ raises `OSError` → needs the `_ZstdReopenStream` reopen-from-start hack | ✅ rewinds in place | ✅ rewinds in place |
+| Non-seekable forward read | ✅ | ✅ | ✅ |
+| Reader API family | bespoke | `_compression`-based | `_compression`-based |
+
+The two `zstandard` warts are the ones called out in the proposal: it **silently** short-reads
+a truncated stream (no `TruncatedError`), and its reader **cannot seek backward**, which is why
+the current code wraps it in `_ZstdReopenStream` (close, rewind the source, reopen, re-decode
+forward).
+
+### Decision
+
+**Migrate the zstd decode backend off `zstandard` to the stdlib `compression.zstd` line.** The
+recorded target is:
+
+- **Python 3.14+:** use the stdlib `compression.zstd`.
+- **Python 3.11–3.13:** use `backports.zstd` (the same `compression.zstd` API). Because
+  `pyzstd >= 0.19` depends on `backports.zstd`, an environment that installs `pyzstd` for any
+  reason also satisfies this — so the decode path can target the **`compression.zstd` /
+  `backports.zstd` API uniformly** (`compression.zstd` if importable, else `backports.zstd`)
+  and need not import `pyzstd` directly for plain decode.
+
+Why, against the alternatives:
+
+- It **fixes both warts at once**: truncation surfaces as `EOFError` (→ our `TruncatedError`,
+  exactly as for `gzip`/`bz2`/`lzma`), and the reader rewinds in place, so `_ZstdReopenStream`
+  and its special-case can be **deleted** when the swap lands.
+- It gives **API-family parity** with the other stdlib codecs (`_compression.DecompressReader`),
+  so the error taxonomy and the rewind-warning behaviour are uniform with gzip/bz2/lzma.
+- It is **future-proof toward the standard library** — the long-term backend is `compression.zstd`,
+  and `backports.zstd` is just the same API on older Pythons.
+- `zstandard` is rejected as the primary decoder for the two warts above (its only edge,
+  bespoke streaming features, Archivey does not use).
+- `pyzstd` is **not** named as the direct dependency: it would work (identical behaviour in the
+  table, plus `SeekableZstdFile`), but targeting the `compression.zstd`/`backports.zstd` API is
+  the smaller, more future-aligned surface, and `pyzstd` pulls `backports.zstd` anyway. `pyzstd`
+  remains relevant only if/when the *Seekable Zstd* container is supported.
+
+**Status / packaging:** the actual library swap is deferred to a follow-up change (see
+`compression-library-evaluation` task 6.3); until it lands, the `[zstd]` (and the `[7z]` bundle's
+zstd) backend stays `zstandard` and the `_ZstdReopenStream` wrapper stays in place. `pyzstd` was
+previously pinned in `[all]` purely as a test-fixture generator and is now removed (the active
+test suite generates zstd fixtures with `zstandard`; only the frozen `tests/_dev_oracle`
+referenced `pyzstd`, and it guards for its absence).
+
+### Seekable zstd (efficient random access) — none for now
+
+Decision: **no efficient zstd seeking yet** — a backward seek re-decompresses from the start and
+warns, the same as brotli/lz4/zlib (`seekable-decompressor-streams`, "index-less codecs warn on a
+rewinding seek"). The candidates were:
+
+- **`indexed_zstd`** — gives O(1) seeking over arbitrary `.zst` via `libzstd-seek`, but **only at
+  frame granularity** (its jump table maps frame boundaries; a seek into a frame decodes forward
+  from the frame start — there is no intra-frame state checkpointing like `rapidgzip`).
+  **Deferred, and possibly unnecessary:** it is a Cython/C++17 extension "based on
+  `indexed_bzip2`" that statically bundles a C++ core, carrying the *same class* of macOS
+  dual-load symbol-collision risk that forced Archivey onto a single accelerator library
+  (`docs/known-issues.md`). And frame-granularity seeking is *exactly* what Archivey's own
+  `_SegmentedDecompressorStream` already provides for xz and lzip — so a small **native zstd
+  frame-index reader** reusing that infrastructure would likely give the same seeking with no
+  heavy dependency and no macOS risk. The note is no help for the common **single-frame** `.zst`
+  either way (one frame → one seek point). This is registered in `IDEAS.md` (Performance &
+  robustness), framed as "evaluate native frame-index reuse before depending on `indexed_zstd`".
+- **`pyzstd.SeekableZstdFile`** — rejected as a general answer: it reads only the *Seekable Zstd*
+  container (a seek table stored in a trailing skippable frame), **not** arbitrary `.zst`, so it
+  cannot give random access to ordinary zstd streams or `.tar.zst`.
+
+---
+
+## xz — native parser over stdlib `lzma`
+
+**Decision:** XZ is read by Archivey's **own** `internal/streams/xz.py` over stdlib `lzma`, not
+by any third-party library. (Originally implemented in
+[`davitf/archivey-dev#214`](https://github.com/davitf/archivey-dev/pull/214); the full rationale
+is recorded below so this doc stands on its own.)
+
+### Why XZ allows a native seekable reader
+
+An XZ file is a sequence of one or more independent **streams** (optionally separated by 4-byte
+null padding). Each stream ends with a 12-byte **footer** that points back to an **index**
+recording, for every **block** in the stream, its compressed (unpadded) and uncompressed sizes.
+So the per-block uncompressed offsets can be reconstructed by reading only footers and indices —
+**no decompression** — and any uncompressed offset can then be reached by decoding just the
+block(s) that contain it. This is the same structural property `lzip` has (a trailer with sizes),
+which is why both share one framework.
+
+### Alternatives considered
+
+- **stdlib `lzma.open` (the previous default)** — correct, zero-dep, but **cannot seek
+  efficiently**: a `SEEK_END` (or any backward seek) re-decompresses the entire file, and the
+  old single-file metadata path read only the *last* stream's index, so it **reported the wrong
+  size for multi-stream XZ files**. Rejected as the seeking/metadata backend (still the
+  underlying codec — the native parser drives `lzma` block by block).
+- **[`python-xz`](https://github.com/Rogdham/python-xz)** — does give block-level random access,
+  but: it is an **external dependency**, it **requires a seekable input** (no forward-only/pipe
+  support), and it always performs an **upfront full index scan** on open. Rejected: a native
+  parser on stdlib `lzma` removes the dependency and lifts both limitations.
+
+### What the native parser does (`XzDecompressorStream`)
+
+- **Block-level random access** via the XZ stream index: a seek jumps to the block containing the
+  target offset and decodes forward within it, not from the start of the file. (Block-level, not
+  just stream-level, because the index already carries per-block records — and a typical
+  single-stream `.tar.xz` is one stream with one large block, where stream-level seeking would
+  give only a single useless seek point at offset 0.)
+- **Efficient `SEEK_END`** via a backward index scan: walk streams from EOF, reading each
+  footer + index (and skipping 4-byte stream padding) to build the block table without
+  decompressing anything.
+- **Block decompression via a synthetic single-block XZ stream**: each block's raw bytes are
+  wrapped in a minimal complete XZ stream (`[stream header][block][index+footer]`) and fed to
+  `lzma.LZMADecompressor(format=FORMAT_XZ)`. The three values needed to synthesize the wrapper —
+  `check`, `unpadded_size`, `uncompressed_size` — all come from the index, so the block header's
+  filter chain never has to be parsed by hand (`lzma` parses it). (This is the same technique
+  `python-xz` uses internally.)
+- **Correct multi-stream handling**, both forward (a `NEED_HEADER` ↔ `IN_STREAM` state machine
+  that consumes concatenated streams and inter-stream padding) and backward (the scan walks every
+  stream), fixing the old last-stream-only size bug. During a forward read, each completed stream
+  triggers a mini backward scan of just that stream to populate its block seek points
+  progressively.
+- **Graceful fallbacks**: a non-seekable source decodes sequentially (no index built); an
+  index-less or truncated stream falls back to per-stream sequential scanning; a corrupt index is
+  logged and skipped rather than failing the read.
+- **`file_size` is read from the stream** (via the backward scan on open) rather than a separate
+  metadata pass, so XZ and lzip populate size uniformly with no per-format code.
+- **Architectural uniformity**: shares the `_SegmentedDecompressorStream` framework with
+  `LzipDecompressorStream`.
+
+Out of scope (matching the original decision): XZ *writing*, parallel/threaded decode, and a
+block-reader LRU cache.
+
+### `python-xz` is not a dependency at all
+
+DEV kept `python-xz` only as a *disabled-by-default* comparison/benchmark backend. **v2 did not
+carry that over** — there is no `use_python_xz` config, no `src/` import, and the test oracle
+does not use it — so the `python-xz` pin that lingered in `[all]` was entirely dead and has been
+**removed** (`packaging-and-extras`).
+
+---
+
+## The rest — chosen library, rejected alternatives, reason
+
+### gzip — stdlib `gzip`, accelerated by `rapidgzip`
+
+Default decode is stdlib `gzip` (zero-dep core). For **random access**, the optional
+`rapidgzip` (`[seekable]`) builds an index for true seeking; without it, stdlib `gzip` seeks by
+re-decompressing from the start (rewind warning). `rapidgzip` is the single accelerator library
+for both gzip and bzip2 — see bzip2 below and `docs/known-issues.md` for why the standalone
+`indexed_gzip`/`indexed_bzip2` are not used. Truncation: stdlib raises `EOFError`; `rapidgzip`
+needs the ISIZE backstop (`seekable-decompressor-streams`).
+
+### bzip2 — stdlib `bz2`, accelerated by `rapidgzip.IndexedBzip2File`
+
+Default decode is stdlib `bz2`. Random access uses **`rapidgzip`'s bundled `IndexedBzip2File`**,
+*not* the standalone `indexed_bzip2` package: loading both `rapidgzip` and `indexed_bzip2` into
+one process corrupts the heap and aborts on macOS (overlapping statically-linked C++ symbols
+coalesced by dyld). Routing both gzip and bzip2 through `rapidgzip` keeps a single accelerator
+library in the process. This is the **single-accelerator macOS constraint** documented in full in
+[`docs/known-issues.md`](known-issues.md) and matches the rapidgzip author's own guidance.
+
+### lzip — native `lzip.py` over stdlib `lzma`
+
+Read by Archivey's own `LzipDecompressorStream` (the framework `xz.py` later reused): stdlib
+`lzma` provides the LZMA1 codec, and the lzip member trailer (CRC32 + sizes) is scanned for
+efficient seeking and size reporting. Zero-dep core; no third-party lzip library is needed or
+preferred.
+
+### LZMA1 / LZMA2 (raw) and the filter stages (Delta, BCJ family)
+
+Raw LZMA1/LZMA2 (7z/ZIP coder streams) use stdlib `lzma` in `FORMAT_RAW` with the coder's filter
+properties. The Delta and BCJ (x86/ARM/ARMT/PPC/SPARC/IA64) stages are stdlib `lzma` raw filters
+composed into the chain. All stdlib, zero-dep core.
+
+### raw Deflate / zlib — stdlib `zlib`
+
+Raw deflate (`-15`, ZIP/7z members) and zlib-wrapped deflate use stdlib `zlib`. No native index,
+so a rewind re-decodes from the start (warning). A future seekable-deflate accelerator is an idea
+in `IDEAS.md` (rapidgzip for zlib/raw-deflate), valuable mainly for a native ZIP reader.
+
+### lz4 — `lz4`
+
+The `lz4` package's frame reader (`lz4.frame`). Standard, broadly-wheeled, actively maintained.
+Forward-only seek (rewind + warning). No compelling alternative for the LZ4 frame format in
+Python.
+
+### brotli — `brotli`
+
+Google's `brotli` package, used via its incremental `Decompressor` (it exposes no file-like
+`open()`, so Archivey wraps it in `BrotliDecompressorStream`). Brotli has no magic and no
+length/CRC trailer, so it is detected by trial-decoding a bounded prefix, and truncation is
+caught only by "never finished at EOF". Pulled by the `[7z]` bundle (7z can use Brotli) and used
+for standalone `.br`. The `brotlicffi` fork is an alternative for PyPy but adds nothing on
+CPython.
+
+### unix-compress (`.Z`) — `uncompresspy`
+
+LZW (`.Z`) decode via `uncompresspy`. It decodes via random access, so it currently **requires a
+seekable source** (a `.Z` pipe reports `StreamNotSeekableError`); making it forward-only is an
+idea in `IDEAS.md`. The format has no length/checksum, so truncation is undetectable. Chosen
+because it is the maintained pure-Python `.Z` *decoder*; `ncompress` is a *compressor* only (used
+as a test-fixture generator in the `dev` group, not a runtime decoder).
+
+### Deflate64 — `inflate64`
+
+Deflate64 (a.k.a. Enhanced Deflate, used by some ZIP/7z members) via `inflate64`. The de-facto
+Python implementation (same author as `pyppmd`/`py7zr`); no real alternative. `[7z]` bundle.
+
+### PPMd (var.H) — `pyppmd`
+
+PPMd variant H (7z) via `pyppmd`. The only maintained Python PPMd binding. `[7z]` bundle.
+(Concrete construction lands with the native 7z reader in Phase 7; the backend selection and
+missing-dependency gating are already wired.)
+
+---
+
+## Test-only libraries (not runtime, not in any user-facing extra)
+
+These live in the `dev` dependency group, never an extra (`packaging-and-extras`): `py7zr` and
+`rarfile` (decode **oracles** to cross-check the native 7z reader and RAR metadata parser),
+`ncompress` (an LZW **compressor** to generate `.Z` fixtures, since `uncompresspy` only
+decodes). `pyzstd` used to sit in `[all]` as a zstd-fixture generator but is removed — the active
+suite uses `zstandard` for that.
+
+A guard test (`tests/test_extras_imported.py`) asserts that every package pinned in a
+user-facing extra is actually imported by some `src/` code path (with a small, documented
+allowlist for features whose implementation is a later phase: `tqdm` for `[cli]`, `py7zr` for
+`[7z-write]`), so a dead or test-only dependency cannot slip back into an extra.
+
+## Follow-up changes
+
+The decisions above that imply a behaviour change are deferred to their own proposals:
+
+- **zstd backend migration** — replace `zstandard` decode with `compression.zstd` /
+  `backports.zstd`, delete `_ZstdReopenStream`, update the `[zstd]` / `[7z]` extras and the
+  `compressed-streams` backend table. (Filed by `compression-library-evaluation` task 6.3.)
+- **Efficient seekable zstd** — optional; **evaluate a native frame-index reader first**
+  (reusing the xz/lzip `_SegmentedDecompressorStream`), since `indexed_zstd` only seeks at frame
+  granularity, which that infrastructure already provides — avoiding the heavy C++ dependency and
+  its macOS coexistence risk. Tracked in `IDEAS.md`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,7 @@ site_url: https://davitf.github.io/archivey/
 nav:
   - Home: index.md
   - API reference: api.md
+  - Compression-library analysis: library-analysis.md
   - Known issues: known-issues.md
 
 plugins:

--- a/openspec/changes/compression-library-evaluation/specs/documentation/spec.md
+++ b/openspec/changes/compression-library-evaluation/specs/documentation/spec.md
@@ -8,16 +8,18 @@ The documentation SHALL include a per-format compression-library analysis
 (`docs/library-analysis.md`) that, for each codec the library reads, names the chosen
 library, the alternatives considered, and the criteria behind the decision (non-seekable
 support, efficient seeking, corruption detection, truncation detection, error-reporting
-fidelity, install/availability, maintenance). Where a decision was already made and recorded
-elsewhere, the analysis SHALL cite it — e.g. the native XZ parser choice in
-`davitf/archivey-dev#214`.
+fidelity, install/availability, maintenance). Each decision SHALL be documented **in full**
+within the analysis — its rationale and the alternatives weighed — so the record does not
+depend on external sources that may later be retired. An external origin (e.g.
+`davitf/archivey-dev#214` for the native XZ parser) MAY be linked for provenance, but the link
+SHALL NOT be a substitute for the recorded rationale.
 
 #### Scenario: every read codec has a recorded rationale
 
 - **WHEN** a contributor reads `docs/library-analysis.md`
 - **THEN** for each codec (gzip, bzip2, xz/lzma, lzip, zstd, lz4, brotli, unix-compress, deflate64, ppmd) they find the chosen library, the rejected alternatives, and the reason
 
-#### Scenario: an already-recorded decision is cited, not re-derived
+#### Scenario: a decision is documented in full, not merely cited
 
-- **WHEN** the analysis covers XZ
-- **THEN** it states the native-parser decision and links `davitf/archivey-dev#214` rather than re-litigating it
+- **WHEN** the analysis covers XZ (a decision originally made in another repository)
+- **THEN** it records the native-parser rationale in full — the alternatives considered (stdlib `lzma.open`, `python-xz`) and why each was rejected — self-containedly, linking `davitf/archivey-dev#214` only as provenance, so the decision survives the old repository being retired

--- a/openspec/changes/compression-library-evaluation/tasks.md
+++ b/openspec/changes/compression-library-evaluation/tasks.md
@@ -6,58 +6,67 @@
 
 ## 1. Build the comparison matrix
 
-- [ ] 1.1 For each codec the library reads (gzip, bzip2, xz/lzma, lzip, zstd, lz4, brotli,
+- [x] 1.1 For each codec the library reads (gzip, bzip2, xz/lzma, lzip, zstd, lz4, brotli,
       unix-compress, deflate64, ppmd), list the candidate libraries and the chosen one today.
-- [ ] 1.2 Define the scoring columns: non-seekable support, efficient seeking,
+- [x] 1.2 Define the scoring columns: non-seekable support, efficient seeking,
       corruption detection, truncation detection, error-reporting fidelity (translatable?),
       install/availability (pure-Python vs. native wheels, platform/arch), maintenance, notes.
 
 ## 2. Investigate zstd (the open question)
 
-- [ ] 2.1 `zstandard` (current): document the no-backward-seek behavior we wrap in
+- [x] 2.1 `zstandard` (current): document the no-backward-seek behavior we wrap in
       `_ZstdReopenStream`, and which corruption/truncation cases it does and does not raise.
-- [ ] 2.2 `pyzstd`: decode behavior, seeking (incl. `SeekableZstdFile` — confirm it only
+- [x] 2.2 `pyzstd`: decode behavior, seeking (incl. `SeekableZstdFile` — confirm it only
       reads the **Seekable Zstd** format, not arbitrary `.zst`), error reporting, availability.
-- [ ] 2.3 stdlib `compression.zstd` (3.14+) and `backports.zstd` (older Pythons): seeking
+- [x] 2.3 stdlib `compression.zstd` (3.14+) and `backports.zstd` (older Pythons): seeking
       support (likely none/limited), error reporting, the "prefer stdlib when present" angle.
-- [ ] 2.4 `indexed_zstd` (martinellimarco; used by ratarmount): efficient seeking, non-seekable
+- [x] 2.4 `indexed_zstd` (martinellimarco; used by ratarmount): efficient seeking, non-seekable
       behavior, availability, and the same-process-as-rapidgzip concern (does it bundle a C++
       core that could collide like indexed_bzip2 — see `docs/known-issues.md`?).
-- [ ] 2.5 Decide: primary decode backend (validate/revise the `zstandard`→`pyzstd` intent) +
+- [x] 2.5 Decide: primary decode backend (validate/revise the `zstandard`→`pyzstd` intent) +
       the seekable-zstd story (indexed_zstd / SeekableZstdFile / none). Record the rationale.
 
 ## 3. xz (own parser vs python-xz) — decision already made, just carry it over
 
-- [ ] 3.1 Summarize the recorded DEV decision (`davitf/archivey-dev#214`) in the analysis
+- [x] 3.1 Summarize the recorded DEV decision (`davitf/archivey-dev#214`) in the analysis
       doc: native `xz.py` on stdlib `lzma` for block-index random access, efficient
       `SEEK_END` (backwards index scan), correct multi-stream handling, per-stream fallback
       for index-less/truncated files, and `DecompressorStream` uniformity with lzip. Link the PR.
-- [ ] 3.2 Note that v2 did **not** carry over DEV's disabled-by-default `python-xz`
+- [x] 3.2 Note that v2 did **not** carry over DEV's disabled-by-default `python-xz`
       comparison backend, so the `python-xz` `[all]` pin is dead — remove it (§5.2).
 
 ## 4. Record the rest
 
-- [ ] 4.1 Document the chosen library + rejected alternatives + reason for gzip, bzip2, lzip,
+- [x] 4.1 Document the chosen library + rejected alternatives + reason for gzip, bzip2, lzip,
       lz4, brotli, unix-compress, deflate64, ppmd. Cross-link the rapidgzip/indexed_bzip2
       single-accelerator macOS constraint already in `docs/known-issues.md`.
 
 ## 5. Write the doc + clean up deps
 
-- [ ] 5.1 Add `docs/library-analysis.md` with the filled matrix + per-codec decisions; add a
+- [x] 5.1 Add `docs/library-analysis.md` with the filled matrix + per-codec decisions; add a
       nav entry in `mkdocs.yml`; cross-link from `docs/known-issues.md` / `COMPARISON.md`.
-- [ ] 5.2 Audit `pyproject.toml` against `src/` imports and sort each dep into the right
+- [x] 5.2 Audit `pyproject.toml` against `src/` imports and sort each dep into the right
       bucket: **remove** `python-xz` from `[all]` (imported nowhere); **move** `pyzstd` from
       `[all]` to the `dev` group (test-only fixture generator) unless the evaluation promotes
       it to the runtime `[zstd]` backend; confirm the existing test-only oracles
       (`rarfile`, `py7zr`, `ncompress`) stay in `dev`; ensure `[zstd]` matches the decision.
-- [ ] 5.3 Add a guard (a `check_zero_dep_core.py`-style script or unit test) that every
+      RESOLUTION: `pyzstd` was **removed entirely** (not moved to `dev`) — the active v2 suite
+      generates zstd fixtures with `zstandard`; only the frozen `tests/_dev_oracle` referenced
+      `pyzstd`, and it guards for its absence. `[zstd]` stays `zstandard` for now (the swap to
+      the stdlib backend is the deferred follow-up; see §6.3). `[all]` now equals `[recommended]`.
+- [x] 5.3 Add a guard (a `check_zero_dep_core.py`-style script or unit test) that every
       package pinned in a **user-facing extra** is imported by some `src/` code path, so a
       dead/test-only dep can't slip back into an extra.
 
 ## 6. Verify + hand off
 
-- [ ] 6.1 `uv run pytest` / `pyrefly` / `ty` / `ruff` green (doc + packaging only — no
+- [x] 6.1 `uv run pytest` / `pyrefly` / `ty` / `ruff` green (doc + packaging only — no
       runtime behavior change in this change).
-- [ ] 6.2 Sync the spec deltas (`packaging-and-extras`, `documentation`).
-- [ ] 6.3 File the follow-up swap changes the decisions call for (zstd backend migration,
+- [x] 6.2 Sync the spec deltas (`packaging-and-extras`, `documentation`).
+- [x] 6.3 File the follow-up swap changes the decisions call for (zstd backend migration,
       optional seekable-zstd support, any xz change) — each its own proposal.
+      DONE: filed `zstd-stdlib-backend-migration` (zstandard → stdlib `compression.zstd` /
+      `backports.zstd`, delete `_ZstdReopenStream`). Seekable-zstd (`indexed_zstd`) registered
+      in `IDEAS.md` rather than a change (deferred, gated on the macOS C++-coexistence risk). No
+      xz change needed — v2 never carried `python-xz`, so removing the dead `[all]` pin (§3.2)
+      fully resolves it.

--- a/openspec/changes/zstd-stdlib-backend-migration/proposal.md
+++ b/openspec/changes/zstd-stdlib-backend-migration/proposal.md
@@ -1,0 +1,49 @@
+# Migrate the zstd decode backend from `zstandard` to the stdlib `compression.zstd` line
+
+## Why
+
+The compression-library evaluation (`docs/library-analysis.md`) decided to move zstd decoding
+off `zstandard` to the standard-library line — **stdlib `compression.zstd` on Python 3.14+,
+`backports.zstd` on 3.11–3.13** (the same `compression.zstd` API; `pyzstd >= 0.19` pulls
+`backports.zstd` transitively, so an env with `pyzstd` also satisfies it). That evaluation
+recorded the decision and its rationale but **deferred the swap** to this change.
+
+Measured on a 200 KB incompressible zstd frame (full table in `docs/library-analysis.md`),
+`zstandard` has two warts the stdlib line fixes:
+
+- **Truncation is silent** — `zstandard` returns a short read with no error; `compression.zstd`
+  / `backports.zstd` raise `EOFError` (which maps cleanly to `TruncatedError`, like gzip/bz2/lzma).
+- **No in-place backward seek** — `zstandard`'s reader raises on a backward seek, which is why
+  the code wraps it in `_ZstdReopenStream` (close → rewind source → reopen → re-decode forward).
+  The stdlib `ZstdFile` (built on `_compression.DecompressReader`) rewinds in place, so the
+  special-case wrapper can be deleted.
+
+## What Changes
+
+- **Backend swap (`compressed-streams`)**: zstd decodes via `compression.zstd` when present
+  (3.14+), else `backports.zstd`. Resolve the module once (like the other optional codecs) and
+  raise `PackageNotInstalledError` naming the backend when neither is importable.
+- **Delete `_ZstdReopenStream`** and the backward-seek reopen special-case: zstd now rewinds via
+  the stdlib reader like brotli/lz4/zlib (still emits the rewind warning — it has no index).
+- **Exception translation**: map `compression.zstd` `ZstdError` → `CorruptionError` and
+  `EOFError` → `TruncatedError`, replacing the `zstandard.ZstdError` translation.
+- **Packaging (`packaging-and-extras`)**: `[zstd]` pins `backports.zstd; python_version < "3.14"`
+  (no runtime dep on 3.14+); the `[7z]` bundle's zstd dependency follows the same backend. Drop
+  `zstandard` from the runtime extras (it may return to `[all]` later as an alternative backend
+  behind its own extra if there is ever a reason).
+- **Tests**: update the zstd fixtures/tests that import `zstandard` to the new backend; add a
+  truncation test that now asserts `TruncatedError` (previously impossible with `zstandard`).
+- **Seekable behaviour (`seekable-decompressor-streams`)**: zstd's rewinding seek is no longer a
+  "reopen from start" special-case; it is the ordinary index-less rewind. (Efficient seekable
+  zstd via `indexed_zstd` remains out of scope — tracked in `IDEAS.md`.)
+
+## Impact
+
+- **Files**: `src/archivey/internal/streams/codecs.py` (the `ZstdCodec` + `_ZstdReopenStream`
+  removal), `pyproject.toml` (extras), zstd tests.
+- **Behaviour**: truncated `.zst` now raises `TruncatedError` instead of a silent short read — a
+  strictly-better, but observable, change.
+- **Risk**: low–moderate. The backend is API-compatible with the stdlib codec family; the main
+  care points are the marker-gated `[zstd]` pin and the exception-translation taxonomy.
+- **Depends on**: `compression-library-evaluation` (records this decision). Coordinates with
+  `codec-descriptor-refactor` (where a codec's `open`/`translate` are wired).

--- a/openspec/changes/zstd-stdlib-backend-migration/specs/compressed-streams/spec.md
+++ b/openspec/changes/zstd-stdlib-backend-migration/specs/compressed-streams/spec.md
@@ -1,0 +1,49 @@
+# Compressed Streams — delta (zstd stdlib backend migration)
+
+## MODIFIED Requirements
+
+### Requirement: Each codec has a default backend
+
+The system SHALL decompress each supported codec through a default backend. zstd's default
+backend is the **standard-library `compression.zstd`** when importable (Python 3.14+),
+otherwise **`backports.zstd`** (the same `compression.zstd` API, for Python 3.11–3.13), in
+place of the previous `zstandard` backend. All other codec backends are unchanged (gzip →
+stdlib `gzip`; bzip2 → stdlib `bz2`; xz → native xz over stdlib `lzma`; raw LZMA1/LZMA2 →
+`lzma` `FORMAT_RAW`; Delta/BCJ → `lzma` raw filters; raw Deflate → `zlib`; Copy → pass-through;
+lz4 → `lz4`; Brotli → `brotli`; unix-compress → `uncompresspy`; PPMd → `pyppmd`; Deflate64 →
+`inflate64`; AES → the wrapped crypto backend).
+
+#### Scenario: default zstd backend on Python 3.14+
+
+- **WHEN** a zstd stream is opened with default configuration on Python 3.14 or newer
+- **THEN** it is decompressed using the standard-library `compression.zstd` module
+
+#### Scenario: default zstd backend on Python 3.11–3.13
+
+- **WHEN** a zstd stream is opened with default configuration on Python 3.11–3.13 and `backports.zstd` is installed
+- **THEN** it is decompressed using `backports.zstd` (the same `compression.zstd` API)
+
+#### Scenario: raw LZMA2 backend for a 7z folder
+
+- **WHEN** a 7z folder's LZMA2 stream is opened
+- **THEN** it is decompressed using `lzma` in `FORMAT_RAW` mode
+
+### Requirement: Returned streams translate decompression errors
+
+The system SHALL wrap each backend stream so decompression failures surface as the library's
+own exception types: corrupt data as `CorruptionError`, unexpected end-of-input as
+`TruncatedError`, and a backend that requires seeking on a non-seekable source as the
+documented non-seekable error. For the zstd backend specifically, the `compression.zstd`
+`ZstdError` SHALL map to `CorruptionError` and its `EOFError` (raised on a truncated frame —
+which the previous `zstandard` backend did **not** raise) SHALL map to `TruncatedError`. No raw
+backend exception escapes unwrapped.
+
+#### Scenario: truncated zstd data raises
+
+- **WHEN** a zstd stream that ends before its end-of-frame marker is read to EOF
+- **THEN** `TruncatedError` is raised (the stdlib backend reports the cut as `EOFError`), rather than a silent short read
+
+#### Scenario: corrupt zstd data raises
+
+- **WHEN** a zstd frame carrying a content checksum is corrupted and read
+- **THEN** `CorruptionError` is raised with the backend `ZstdError` attached as `__cause__`

--- a/openspec/changes/zstd-stdlib-backend-migration/specs/packaging-and-extras/spec.md
+++ b/openspec/changes/zstd-stdlib-backend-migration/specs/packaging-and-extras/spec.md
@@ -1,0 +1,25 @@
+# Packaging and Extras — delta (zstd stdlib backend migration)
+
+## MODIFIED Requirements
+
+### Requirement: Optional extras map to exactly the libraries the code uses
+
+User-facing optional **extras** SHALL list only libraries that `src/` imports at runtime for
+that capability. The `[zstd]` extra SHALL pin the chosen zstd decode backend: `backports.zstd`
+constrained to `python_version < "3.14"` (on 3.14+ the stdlib `compression.zstd` is used, so no
+runtime dependency is needed), replacing the previous `zstandard` pin. The `[7z]` bundle's zstd
+dependency SHALL follow the same backend. `zstandard` SHALL NOT be pinned in a runtime extra
+once the swap lands (it may return to `[all]` later as an alternative backend behind its own
+extra). Test-only oracles and fixture generators remain in the `dev` group. The per-codec choice
+and rationale are recorded in `docs/library-analysis.md`.
+
+#### Scenario: the zstd extra pins the stdlib-line backend
+
+- **WHEN** `pip install archivey[zstd]` is run on Python 3.11–3.13
+- **THEN** `backports.zstd` is installed and `.zst` / `.tar.zst` reading works via the `compression.zstd` API
+- **AND** `zstandard` is not pulled in
+
+#### Scenario: no zstd runtime dependency on Python 3.14+
+
+- **WHEN** `pip install archivey[zstd]` is resolved on Python 3.14 or newer
+- **THEN** no third-party zstd package is required, because the standard-library `compression.zstd` provides the backend

--- a/openspec/changes/zstd-stdlib-backend-migration/specs/seekable-decompressor-streams/spec.md
+++ b/openspec/changes/zstd-stdlib-backend-migration/specs/seekable-decompressor-streams/spec.md
@@ -1,0 +1,30 @@
+# Seekable Decompressor Streams — delta (zstd stdlib backend migration)
+
+## MODIFIED Requirements
+
+### Requirement: Index-less codecs warn on a rewinding seek
+
+The system SHALL service a backward seek on an index-less codec (gzip/bzip2 without an
+accelerator, and brotli/lz4/zstd/zlib) by re-decompressing from the start — O(n) per rewind —
+and SHALL log a one-time rewind warning via the `archivey` streams logger rather than rewinding
+silently. With the stdlib zstd backend (`compression.zstd` / `backports.zstd`), zstd rewinds
+**in place** like the other index-less codecs, so the previous reopen-from-source special case
+is removed; the cost and the warning are unchanged. Where an accelerator backend exists
+(gzip, bzip2) the warning names the `[seekable]` extra; for brotli/lz4/zstd/zlib it states that
+the codec re-decompresses from the start. Forward and no-op seeks SHALL NOT warn, and codecs
+that carry their own index (xz, lzip, unix-compress) SHALL NOT warn.
+
+#### Scenario: rewinding an index-less codec warns
+
+- **WHEN** a brotli, lz4, zstd, or zlib stream is read and then seeked backward to an earlier offset
+- **THEN** the data is delivered correctly **AND** a warning is logged that the codec re-decompresses from the start (no accelerator is named, because none exists for these codecs)
+
+#### Scenario: zstd rewinds in place via the stdlib backend
+
+- **WHEN** a zstd stream is read forward and then seeked backward
+- **THEN** the stdlib `ZstdFile` services the rewind by re-decompressing from the start (no reopen-from-source special case) and logs the index-less rewind warning once
+
+#### Scenario: a forward-only seek does not warn
+
+- **WHEN** an index-less codec stream is seeked only forward (or to its current position)
+- **THEN** no rewind warning is logged

--- a/openspec/changes/zstd-stdlib-backend-migration/tasks.md
+++ b/openspec/changes/zstd-stdlib-backend-migration/tasks.md
@@ -1,0 +1,36 @@
+# Tasks — zstd stdlib backend migration
+
+> Implements the zstd decision recorded in `docs/library-analysis.md` /
+> `compression-library-evaluation`. Run tools via `uv`.
+
+## 1. Backend
+
+- [ ] 1.1 Resolve the zstd backend module once: `compression.zstd` if importable (3.14+), else
+      `backports.zstd`; expose a sentinel like the other optional codecs in `codecs.py`.
+- [ ] 1.2 Rewrite `ZstdCodec.open` to use the resolved backend's `ZstdFile`/`open`; raise
+      `PackageNotInstalledError` naming the backend when neither module is importable.
+- [ ] 1.3 Delete `_ZstdReopenStream` and the backward-seek reopen special-case; rely on the
+      stdlib reader's in-place rewind. Keep the `RewindWarning("zstd")` (still index-less).
+- [ ] 1.4 Update `ZstdCodec.translate`: `ZstdError` → `CorruptionError`, `EOFError` →
+      `TruncatedError` (drop the `zstandard.ZstdError` branch).
+
+## 2. Packaging
+
+- [ ] 2.1 `[zstd]` → `backports.zstd>=…; python_version < "3.14"` (no runtime pin on 3.14+).
+      Point the `[7z]` bundle's zstd dependency at the same backend. Remove `zstandard` from the
+      runtime extras.
+- [ ] 2.2 Confirm `tests/test_extras_imported.py` still passes (the new backend's module is
+      imported by `src/`).
+
+## 3. Tests
+
+- [ ] 3.1 Update zstd fixtures/tests that import `zstandard` to the new backend (or a
+      backend-agnostic writer).
+- [ ] 3.2 Add a truncated-`.zst` test asserting `TruncatedError` (newly possible).
+- [ ] 3.3 Update the rewind test to expect the ordinary index-less rewind path (no reopen).
+
+## 4. Specs + verify
+
+- [ ] 4.1 Sync the `compressed-streams`, `packaging-and-extras`, and
+      `seekable-decompressor-streams` deltas.
+- [ ] 4.2 `uv run pytest` / `pyrefly` / `ty` / `ruff` green.

--- a/openspec/specs/documentation/spec.md
+++ b/openspec/specs/documentation/spec.md
@@ -56,3 +56,25 @@ symbol, or a rendering warning fails the build like any other check.
 - **WHEN** the docs reference a symbol that no longer exists, or a cross-reference cannot
   be resolved
 - **THEN** the strict docs build fails, surfacing the drift in CI
+
+### Requirement: Per-format compression-library choices are documented
+
+The documentation SHALL include a per-format compression-library analysis
+(`docs/library-analysis.md`) that, for each codec the library reads, names the chosen
+library, the alternatives considered, and the criteria behind the decision (non-seekable
+support, efficient seeking, corruption detection, truncation detection, error-reporting
+fidelity, install/availability, maintenance). Each decision SHALL be documented **in full**
+within the analysis — its rationale and the alternatives weighed — so the record does not
+depend on external sources that may later be retired. An external origin (e.g.
+`davitf/archivey-dev#214` for the native XZ parser) MAY be linked for provenance, but the link
+SHALL NOT be a substitute for the recorded rationale.
+
+#### Scenario: every read codec has a recorded rationale
+
+- **WHEN** a contributor reads `docs/library-analysis.md`
+- **THEN** for each codec (gzip, bzip2, xz/lzma, lzip, zstd, lz4, brotli, unix-compress, deflate64, ppmd) they find the chosen library, the rejected alternatives, and the reason
+
+#### Scenario: a decision is documented in full, not merely cited
+
+- **WHEN** the analysis covers XZ (a decision originally made in another repository)
+- **THEN** it records the native-parser rationale in full — the alternatives considered (stdlib `lzma.open`, `python-xz`) and why each was rejected — self-containedly, linking `davitf/archivey-dev#214` only as provenance, so the decision survives the old repository being retired

--- a/openspec/specs/packaging-and-extras/spec.md
+++ b/openspec/specs/packaging-and-extras/spec.md
@@ -63,7 +63,7 @@ compression formats, and the CLI. The mapping is:
 | `[seekable]` | `rapidgzip` | faster gzip/bzip2 decompression **and random access (seeking)** into gz/bz2 streams. rapidgzip backs both codecs (bzip2 via its bundled `IndexedBzip2File`); the standalone `indexed_bzip2` package is deliberately not used (loading both corrupts the heap on macOS). Native C++ lib: install needs a prebuilt wheel, or a C++17 compiler where no wheel exists |
 | `[recommended-lite]` | `[7z]` + `[rar]` + `[7z-write]` + `[iso]` + `[zstd]` + `[lz4]` + `[unix-compress]` + `[cli]` | every format/codec with broadly-wheeled deps; **no build-finicky C++ libs**. Use when `[recommended]` won't install |
 | `[recommended]` | `[recommended-lite]` + `[seekable]` | the **recommended** install — everything in `[recommended-lite]` plus gz/bz2 seeking and speed |
-| `[all]` | `[recommended]` **plus** every alternative/secondary backend | everything, including redundant alternative backends — mainly for testing/benchmarking |
+| `[all]` | `[recommended]` **plus** every alternative/secondary backend (currently none) | everything, including any redundant alternative backends — mainly for testing/benchmarking |
 
 `[recommended]` is the sensible "give me everything useful" install: every
 format/codec with one primary backend each, plus the `[seekable]` backends that add
@@ -77,13 +77,16 @@ that one: it keeps every format and codec (`cryptography`, `pyppmd`, `zstandard`
 fails. A user who hits a build error on `[recommended]` can fall back to
 `[recommended-lite]` without losing any format support.
 
-`[all]` is a superset of `[recommended]` that additionally pulls the **alternative**
+`[all]` is a superset of `[recommended]` that additionally pulls any **alternative**
 backends — performance or compatibility variants that duplicate a capability already
-covered (e.g. `python-xz` as an alternative xz backend, or a second zstd library
-alongside the primary one). Those alternatives are each available behind their own
-extra and exist mainly so the test suite and benchmarks can exercise them; **most
-users should install `[recommended]` (or `[recommended-lite]`), not `[all]`**, because
-the extra alternative libraries add install weight without adding capability.
+covered. **At present there are none**, so `[all]` currently resolves to exactly
+`[recommended]`: the two alternatives that used to live here (`python-xz` as an alternative
+xz backend, and `pyzstd` as a second zstd library) were dropped by the compression-library
+evaluation (`docs/library-analysis.md`) — v2 reads XZ with its own native parser
+(`davitf/archivey-dev#214`) and uses the stdlib zstd line, so neither alternative is
+imported by `src/`. The `[all]` alias is kept so a future alternative backend can be
+re-added behind it without churn; **most users should install `[recommended]` (or
+`[recommended-lite]`), not `[all]`**.
 
 `[7z]` and `[rar]` are **format bundles**: installing `[7z]` enables every 7z
 reading feature and `[rar]` every RAR reading feature that needs a Python package,
@@ -115,9 +118,10 @@ runtime extra. This contract is package-manager-agnostic — `pip install
 archivey[iso]` and `uv add archivey --extra iso` (or `uv pip install`) honor the
 same extras.
 
-Development-only tooling (test / lint / type-check) and the test-oracle libraries
-(`py7zr`, `rarfile`) are NOT runtime extras. They are declared as a PEP 735
-`[dependency-groups]` entry (`dev`), so they are never installed for end users and
+Development-only tooling (test / lint / type-check), the test-oracle libraries
+(`py7zr`, `rarfile`), and the fixture-generator libraries (`ncompress`, an LZW
+*compressor* used to produce `.Z` fixtures) are NOT runtime extras. They are declared as a
+PEP 735 `[dependency-groups]` entry (`dev`), so they are never installed for end users and
 are pulled in by `uv sync` (or `pip install --group dev`) for contributors.
 
 #### Scenario: installing an extra enables exactly its capability
@@ -142,12 +146,44 @@ are pulled in by `uv sync` (or `pip install --group dev`) for contributors.
 #### Scenario: `[all]` additionally pulls alternative backends
 
 - **WHEN** `pip install archivey[all]` is run
-- **THEN** everything in `[recommended]` is installed **plus** the alternative/secondary backends (e.g. `python-xz`, a second zstd library), which add no new capability and are intended for testing and benchmarking
+- **THEN** everything in `[recommended]` is installed **plus** any alternative/secondary backends that add no new capability — of which there are currently none, so `[all]` resolves to exactly `[recommended]` (the dropped `python-xz` / `pyzstd` alternatives are no longer pinned; see `docs/library-analysis.md`)
 
 #### Scenario: RAR reading requires only the system unrar binary
 
 - **WHEN** a core install is used to read RAR data but no `unrar` binary is on PATH
 - **THEN** RAR listing still works (native metadata), but RAR data reads fail with a clear error indicating the external `unrar` tool is required — no pip extra would fix this
+
+---
+
+### Requirement: Optional extras map to exactly the libraries the code uses
+
+User-facing optional **extras** (`[7z]`, `[zstd]`, `[all]`, …) SHALL list only libraries
+that `src/` imports at runtime for that capability; an extra MUST NOT pin a dependency that
+no `src/` code path uses. Libraries needed **only by the test suite** — decode oracles
+(`rarfile`, `py7zr`) and fixture generators (`ncompress`, and `pyzstd` while it is only used
+to *write* zstd fixtures) — SHALL live in the `dev` dependency group, never in a user-facing
+extra. The per-codec library choice and its rationale SHALL be recorded in
+`docs/library-analysis.md`, the source of truth for why each library is used or rejected.
+
+A guard (a unit test or check script) SHALL enforce this so a dead or test-only dependency
+cannot slip back into an extra. A library pinned in an extra **ahead of** its
+implementation phase (e.g. `tqdm` for `[cli]`, `py7zr` for `[7z-write]`) is permitted only
+via an explicit, documented allowlist in that guard.
+
+#### Scenario: no dead optional dependency in a user-facing extra
+
+- **WHEN** the `[all]` extra (or any user-facing extra) is audited against `src/` imports
+- **THEN** every pinned package is reachable from some `src/` code path (or an explicitly allowlisted not-yet-implemented capability), or it is removed
+
+#### Scenario: a test-only library lives in the dev group, not an extra
+
+- **WHEN** a library is imported only by the test suite (an oracle or a fixture generator), e.g. `rarfile`, `py7zr`, `ncompress`, or fixture-only `pyzstd`
+- **THEN** it is declared in the `dev` dependency group and is absent from every user-facing extra
+
+#### Scenario: the zstd extra matches the chosen backend
+
+- **WHEN** the evaluation selects the zstd decode backend
+- **THEN** the `[zstd]` extra pins exactly that package (plus any adopted seekable-zstd backend), and `docs/library-analysis.md` records the choice
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,10 +61,16 @@ recommended-lite = [
 recommended = [
     "archivey[recommended-lite,seekable]",
 ]
+# [all] is the "everything" alias. It currently equals [recommended]: after the
+# compression-library evaluation (docs/library-analysis.md) the two dead alternative
+# backends that used to live here were dropped — python-xz (v2 reads XZ with its own
+# native xz.py over stdlib lzma; archivey-dev#214 — never imported) and pyzstd (the zstd
+# decode decision is stdlib compression.zstd / backports.zstd, not pyzstd; it was only a
+# test-fixture generator and is now in the dev group). A future alternative/secondary
+# backend would be re-added here behind its own extra. tests/test_extras_imported.py guards
+# against a dead dependency slipping back into any user-facing extra.
 all = [
     "archivey[recommended]",
-    "python-xz>=0.5.0",
-    "pyzstd>=0.17.0",
 ]
 
 [dependency-groups]

--- a/tests/test_extras_imported.py
+++ b/tests/test_extras_imported.py
@@ -1,0 +1,122 @@
+"""Guard: every package pinned in a user-facing extra is used by ``src/``.
+
+The packaging contract (``packaging-and-extras``) is that an optional **extra** lists only
+libraries some ``src/`` code path actually imports for that capability — never a dead or
+test-only dependency. This test enforces it mechanically so a stray pin can't slip back in
+(as ``python-xz`` and ``pyzstd`` once had — see ``docs/library-analysis.md``).
+
+It parses ``[project.optional-dependencies]`` from ``pyproject.toml``, expands the bundle
+extras (``archivey[...]`` self-references) down to leaf third-party packages, and asserts each
+is referenced by some ``src/`` file — with a small, documented allowlist for capabilities whose
+implementation is a later phase.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+import tomllib
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_PYPROJECT = _REPO_ROOT / "pyproject.toml"
+_SRC = _REPO_ROOT / "src"
+
+# PyPI distribution name -> the module name ``src/`` would import, when they differ.
+# (Most match; listed here only for the exceptions / for clarity.)
+_IMPORT_NAME = {
+    "lz4": "lz4",
+    "backports-zstd": "backports.zstd",
+}
+
+# Packages pinned ahead of their implementation phase: the extra is part of the documented
+# packaging surface, but the feature's ``src/`` code lands later. Keep this list short and
+# justified; remove an entry once the feature is implemented and imports its package.
+_PENDING_IMPLEMENTATION = {
+    "tqdm": "the [cli] command-line interface is a later phase",
+    "py7zr": "7z writing ([7z-write]) lands with the native 7z reader work (Phase 7)",
+}
+
+
+def _load_optional_dependencies() -> dict[str, list[str]]:
+    with open(_PYPROJECT, "rb") as f:
+        data = tomllib.load(f)
+    return data["project"]["optional-dependencies"]
+
+
+def _requirement_dist_name(requirement: str) -> str:
+    """The bare PyPI name from a requirement string (drop version, markers, extras)."""
+    # Strip environment markers and version specifiers; keep the leading name token.
+    head = re.split(r"[<>=!~;\[ ]", requirement.strip(), maxsplit=1)[0]
+    return head.lower().replace("_", "-")
+
+
+def _leaf_packages(extras: dict[str, list[str]]) -> set[str]:
+    """All third-party leaf packages across every user-facing extra (bundles expanded)."""
+    leaves: set[str] = set()
+    for requirements in extras.values():
+        for req in requirements:
+            name = _requirement_dist_name(req)
+            if name == "archivey":
+                continue  # an ``archivey[...]`` bundle self-reference; its targets are also keys
+            leaves.add(name)
+    return leaves
+
+
+def _src_text() -> str:
+    return "\n".join(p.read_text(encoding="utf-8") for p in _SRC.rglob("*.py"))
+
+
+def test_every_extra_package_is_used_by_src() -> None:
+    extras = _load_optional_dependencies()
+    leaves = _leaf_packages(extras)
+    src_text = _src_text()
+
+    unused: list[str] = []
+    for dist in sorted(leaves):
+        if dist in _PENDING_IMPLEMENTATION:
+            continue
+        module = _IMPORT_NAME.get(dist, dist.replace("-", "_"))
+        if not re.search(rf"\b{re.escape(module)}\b", src_text):
+            unused.append(dist)
+
+    assert not unused, (
+        "These packages are pinned in a user-facing extra but are not imported by any "
+        f"src/ code path: {unused}. Either wire the dependency into src/, move it to the "
+        "dev dependency group (if it is test-only), or remove it. If it is pinned ahead of "
+        "its implementation phase, add it to _PENDING_IMPLEMENTATION with a justification. "
+        "See docs/library-analysis.md and the packaging-and-extras spec."
+    )
+
+
+def test_pending_allowlist_entries_are_still_unimplemented() -> None:
+    """Tighten the allowlist automatically: once a pending package IS imported, drop it."""
+    src_text = _src_text()
+    became_used: list[str] = []
+    for dist in _PENDING_IMPLEMENTATION:
+        module = _IMPORT_NAME.get(dist, dist.replace("-", "_"))
+        # A bare-word match in a docstring/comment is fine to ignore; require an import-ish use.
+        if re.search(
+            rf"(?m)^\s*(import|from)\s+{re.escape(module)}\b", src_text
+        ) or re.search(rf'import_module\(\s*["\']{re.escape(module)}', src_text):
+            became_used.append(dist)
+    assert not became_used, (
+        f"{became_used} are now imported by src/; remove them from _PENDING_IMPLEMENTATION "
+        "so the guard covers them like every other extra package."
+    )
+
+
+def test_pyzstd_and_python_xz_are_not_in_any_extra() -> None:
+    """Regression: the two evaluated-and-dropped libraries must not reappear in an extra."""
+    leaves = _leaf_packages(_load_optional_dependencies())
+    for dropped in ("pyzstd", "python-xz"):
+        assert dropped not in leaves, (
+            f"{dropped} was removed from the extras by the compression-library evaluation "
+            "(see docs/library-analysis.md); it must not be pinned in a user-facing extra."
+        )
+
+
+if __name__ == "__main__":  # pragma: no cover - convenience for manual runs
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -30,8 +30,6 @@ all = [
     { name = "py7zr" },
     { name = "pycdlib" },
     { name = "pyppmd" },
-    { name = "python-xz" },
-    { name = "pyzstd" },
     { name = "rapidgzip" },
     { name = "tqdm" },
     { name = "uncompresspy" },
@@ -130,8 +128,6 @@ requires-dist = [
     { name = "py7zr", marker = "extra == '7z-write'", specifier = ">=1.0.0" },
     { name = "pycdlib", marker = "extra == 'iso'", specifier = ">=1.14.0" },
     { name = "pyppmd", marker = "extra == '7z'", specifier = ">=1.1.0" },
-    { name = "python-xz", marker = "extra == 'all'", specifier = ">=0.5.0" },
-    { name = "pyzstd", marker = "extra == 'all'", specifier = ">=0.17.0" },
     { name = "rapidgzip", marker = "extra == 'seekable'", specifier = ">=0.16.0" },
     { name = "tqdm", marker = "extra == 'cli'", specifier = ">=4.67.0" },
     { name = "uncompresspy", marker = "extra == 'unix-compress'", specifier = ">=0.4.0" },
@@ -1481,15 +1477,6 @@ wheels = [
 ]
 
 [[package]]
-name = "python-xz"
-version = "0.6.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5b/ee/d04ea840d0b48d70ba6a3d679e3140c0451e672313fc811f5150484dac7a/python_xz-0.6.0.tar.gz", hash = "sha256:c8dc51070799ee9e77ddd9dd207a11cc9170e9298542f81e7187072e0d543478", size = 66779, upload-time = "2025-10-18T09:11:03.778Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/2a/fe8e0669c4bc5393b2de66085647dcaaa38fbc4cf29f05a189de7351aeee/python_xz-0.6.0-py3-none-any.whl", hash = "sha256:81bf89467cb0865fec10f5501295be0131962df53be1ef65e8d6bb72b6e2220a", size = 19591, upload-time = "2025-10-18T09:11:02.198Z" },
-]
-
-[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1554,19 +1541,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/eb/2e/79c822141bfd05a853236b504869ebc6b70159afc570e1d5a20641782eaa/pyyaml_env_tag-1.1.tar.gz", hash = "sha256:2eb38b75a2d21ee0475d6d97ec19c63287a7e140231e4214969d0eac923cd7ff", size = 5737, upload-time = "2025-05-13T15:24:01.64Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/11/432f32f8097b03e3cd5fe57e88efb685d964e2e5178a48ed61e841f7fdce/pyyaml_env_tag-1.1-py3-none-any.whl", hash = "sha256:17109e1a528561e32f026364712fee1264bc2ea6715120891174ed1b980d2e04", size = 4722, upload-time = "2025-05-13T15:23:59.629Z" },
-]
-
-[[package]]
-name = "pyzstd"
-version = "0.19.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "backports-zstd", marker = "python_full_version < '3.14'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/4c/66/59fed71d0d2065e02974b40296f836a237c364c8bbe07295f2d0dc33c278/pyzstd-0.19.1.tar.gz", hash = "sha256:36723d3c915b3981de9198d0a2c82b2f5fe3eaa36e4d8d586937830a8afc7d72", size = 69531, upload-time = "2025-12-13T08:15:33.455Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4d/62/f55d1363512d1b1cc122af6ca5951008e42605b63675c7d6781affc7c475/pyzstd-0.19.1-py3-none-any.whl", hash = "sha256:267e2eb0de0291dfcb7ccfebc4ffe75b2f9d84e7007ac38844f6ccafc6dce081", size = 23779, upload-time = "2025-12-13T08:15:31.979Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Implements the `compression-library-evaluation` OpenSpec change: a single source of truth for **which library backs each codec Archivey reads and why**, plus the dependency cleanup the findings call for. No runtime behaviour changes here — the library *swaps* it decides are deferred to a filed follow-up.

- **`docs/library-analysis.md`** (new) — scoring criteria, a per-codec summary matrix, and chosen/rejected/reason for every codec. The **XZ** decision is recorded **in full** (self-contained: structure, alternatives `lzma.open`/`python-xz` and why rejected, what the native parser does), with `archivey-dev#214` kept only as provenance since the old repo will be retired.
- **zstd decision** — migrate decode off `zstandard` to the stdlib line: `compression.zstd` on 3.14+, `backports.zstd` on 3.11–3.13. Verified empirically that `zstandard` **silently** short-reads truncated frames and can't seek backward (hence `_ZstdReopenStream`), while the stdlib line raises `EOFError` → `TruncatedError` and rewinds in place. Swap deferred to the filed **`zstd-stdlib-backend-migration`** change.
- **Seekable zstd** — registered in `IDEAS.md`: prefer a *native frame-index reader* reusing the xz/lzip `_SegmentedDecompressorStream` (confirmed via `libzstd-seek`'s own header that `indexed_zstd` only seeks at **frame granularity**, which that infra already provides), with a benchmarking step before depending on the heavy C++ lib + its macOS coexistence risk.
- **Packaging** — drop the dead `python-xz` and `pyzstd` pins from `[all]` (neither imported by `src/`); `[all]` now equals `[recommended]`.
- **Guard** — `tests/test_extras_imported.py`: every package pinned in a user-facing extra must be imported by some `src/` path (documented allowlist for not-yet-implemented `[cli]`/`[7z-write]`), so a dead/test-only dep can't slip back in.
- **Specs** — synced the `documentation` and `packaging-and-extras` deltas (incl. inverting the doc requirement to "document each decision in full, link origin only as provenance"); nav entry + cross-links from `known-issues.md` / `COMPARISON.md`.

## Follow-ups filed

- `zstd-stdlib-backend-migration` — the actual `zstandard` → stdlib/`backports.zstd` swap (deletes `_ZstdReopenStream`, updates `[zstd]`/`[7z]`), with spec deltas. Validates `--strict`.

## Test plan

- [x] `uv run pytest` — 530 passed, 15 skipped
- [x] `uv run ruff check`, `uv run pyrefly check`, `uv run ty check` — clean
- [x] `uv run --group docs mkdocs build --strict` — clean
- [x] `openspec validate --strict compression-library-evaluation` and `zstd-stdlib-backend-migration` — valid

Made with [Cursor](https://cursor.com)