### PR TITLE
Fix TAR EOF check false-positive on minimal two-block trailer

### DIFF
--- a/src/archivey/internal/backends/tar_reader.py
+++ b/src/archivey/internal/backends/tar_reader.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import stat
 import tarfile
 from datetime import datetime, timezone
+from io import BytesIO
 from pathlib import Path
 from typing import BinaryIO, Iterator, Mapping, cast
 
@@ -254,8 +255,6 @@ class TarReader(BaseArchiveReader):
                 if member.is_file:
                     raw = self._tar.extractfile(info)
                     if raw is None:
-                        from io import BytesIO
-
                         raw = BytesIO(b"")
                     yield member, self._wrap_member_stream(
                         ensure_binaryio(raw), member.name
@@ -271,13 +270,26 @@ class TarReader(BaseArchiveReader):
         self._verify_tar_eof()
 
     def _verify_tar_eof(self) -> None:
-        """Check for two null-filled 512-byte end-of-archive blocks after the last member."""
+        """Verify the two-block null end-of-archive marker.
+
+        The POSIX trailer is two null-filled 512-byte blocks, but ``tarfile`` has
+        already consumed the *first* one by the time we get here — stopping on a null
+        block (``EOFHeaderError``) is exactly how it detects the end of the archive,
+        and with the default ``ignore_zeros=False`` it stops after that single block.
+        So ``fileobj`` is positioned just past the first marker block, and we only need
+        to confirm the *second* one follows. (Reading two blocks here would demand a
+        third block of trailing zeros and wrongly flag a valid archive whose trailer is
+        the minimal two blocks with no record padding — e.g. ``tar -b1``.)
+
+        A short or non-zero read means the marker is missing or truncated: a truncation
+        right after the last member leaves no first block for ``tarfile`` to consume,
+        so ``fileobj`` is at EOF and this read comes up empty.
+        """
         fileobj = self._tar.fileobj
         if fileobj is None:
             return
-        expected = 512 * 2
-        chunk = fileobj.read(expected)
-        if len(chunk) == expected and chunk == b"\x00" * expected:
+        chunk = fileobj.read(512)
+        if len(chunk) == 512 and chunk == b"\x00" * 512:
             return
         msg = (
             "TAR archive may be truncated: missing or invalid "
@@ -369,8 +381,6 @@ class TarReader(BaseArchiveReader):
         if raw is None:
             # Only FILE members reach here (the base follows links/skips non-data members),
             # so a None stream means a zero-length or special entry; present an empty stream.
-            from io import BytesIO
-
             raw = BytesIO(b"")
         return self._wrap_member_stream(ensure_binaryio(raw), member.name)
 

--- a/tests/test_tar.py
+++ b/tests/test_tar.py
@@ -71,6 +71,23 @@ def _tar_missing_eof_block() -> bytes:
     return full[: eof_start + 512]
 
 
+def _tar_minimal_eof() -> bytes:
+    """A fully valid archive terminated by exactly the two required EOF null blocks.
+
+    ``tarfile`` pads its own output to a 10240-byte record boundary, so a tar it wrote
+    always has plenty of trailing zeros. This helper strips that padding down to the
+    bare POSIX minimum (two 512-byte null blocks, no record padding) — what e.g.
+    ``tar -b1`` or a streaming producer emits — to exercise the EOF check's boundary.
+    """
+    full = _build_tar()
+    with tarfile.open(fileobj=io.BytesIO(full), mode="r:") as t:
+        members = t.getmembers()
+        last = members[-1]
+        blocks = (last.size + 511) & ~511
+        eof_start = last.offset_data + blocks
+    return full[: eof_start + 512 * 2]
+
+
 @pytest.fixture
 def plain_tar(tmp_path: Path) -> Path:
     path = tmp_path / "simple.tar"
@@ -424,6 +441,44 @@ def test_missing_eof_blocks_streaming_strict_raises() -> None:
             strict_eof=True,
         ) as ar:
             list(ar.stream_members())
+
+
+def test_minimal_eof_trailer_silent() -> None:
+    # A valid archive whose trailer is exactly the two required null blocks (no record
+    # padding) must not be flagged: tarfile consumes the first block detecting EOF, so the
+    # check must only require the second block, not two more. Random-access path.
+    data = _tar_minimal_eof()
+    with open_archive(io.BytesIO(data), format=ArchiveFormat.TAR) as ar:
+        with mock.patch("archivey.internal.backends.tar_reader.backends_logger") as log:
+            ar.members()
+            log.warning.assert_not_called()
+
+
+def test_minimal_eof_trailer_streaming_silent() -> None:
+    # Same minimal-but-valid trailer over the forward-only streaming path.
+    data = _tar_minimal_eof()
+    with open_archive(
+        NonSeekableBytesIO(data), format=ArchiveFormat.TAR, streaming=True
+    ) as ar:
+        with mock.patch("archivey.internal.backends.tar_reader.backends_logger") as log:
+            list(ar.stream_members())
+            log.warning.assert_not_called()
+
+
+def test_minimal_eof_trailer_strict_does_not_raise() -> None:
+    # strict_eof must accept the minimal valid trailer on both access modes.
+    data = _tar_minimal_eof()
+    with open_archive(
+        io.BytesIO(data), format=ArchiveFormat.TAR, strict_eof=True
+    ) as ar:
+        assert [m.name for m in ar.members()]
+    with open_archive(
+        NonSeekableBytesIO(data),
+        format=ArchiveFormat.TAR,
+        streaming=True,
+        strict_eof=True,
+    ) as ar:
+        assert [m for m, _ in ar.stream_members()]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Superseded — the fix was pushed directly onto `phase-4-tar-streaming` (PR #25), so this branch and its base are now identical. Closing.