### PR TITLE
Review fixes: availability gating, error translation, and robustness

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -227,7 +227,7 @@ def stream_members(
 
 `add_members()` in `ArchiveWriter` calls `reader.stream_members()` so conversions always take the bounded-memory streaming path.
 
-Everything else (`__iter__`, `__getitem__`, `read`, `open`, `stream_members`, `extract`, `extract_all`, `members`) is implemented once in the ABC.
+Everything else (`__iter__`, `get`, `read`, `open`, `stream_members`, `extract`, `extract_all`, `members`) is implemented once in the ABC.
 
 ### 2.4 Lazy member materialization
 
@@ -235,7 +235,7 @@ Everything else (`__iter__`, `__getitem__`, `read`, `open`, `stream_members`, `e
 
 `__iter__` calls `_iter_members()` directly — a generator that never loads all members.
 
-`members()` and `__len__` force materialization:
+`members()` forces materialization:
 ```python
 def members(self) -> list[ArchiveMember]:
     if self._members_cache is None:
@@ -245,7 +245,7 @@ def members(self) -> list[ArchiveMember]:
 
 After materialization, `__iter__` returns `iter(self._members_cache)` for efficiency (avoids re-reading on second iteration).
 
-**Streaming guard:** if the reader was opened with `streaming=True` (forward-only), materialization is forbidden. Calling `.members()` or `__len__` raises `UnsupportedOperationError` with a clear message.
+**Streaming guard:** if the reader was opened with `streaming=True` (forward-only), materialization is forbidden. Calling `.members()` raises `UnsupportedOperationError` with a clear message.
 
 ### 2.5 PeekableStream for non-seekable sources
 

--- a/IDEAS.md
+++ b/IDEAS.md
@@ -57,12 +57,23 @@
   `glob()`, `read_bytes()`, `is_dir()`, … over the member tree (precedent: `zipfile.Path`).
   Read-only wrapper; needs random access, so a `DIRECT`/indexed-archive convenience.
 
-- **fsspec integration** — three distinct directions, all useful:
+- **fsspec integration** — three distinct directions:
   (1) **expose** an opened archive as an `fsspec` filesystem so pandas/dask/pyarrow/etc.
-  read members by path (pairs with the pathlib navigation layer);
+  read members by path (pairs with the pathlib navigation layer) — the substantial one;
   (2) **open** archives *from* an `fsspec` URL (`s3://…/a.zip`, `http(s)://`, …) as the
-  `source`; (3) **extract** *to* an `fsspec` location as the `dest`. (2)/(3) mostly mean
-  accepting fsspec-opened file objects at the `open_archive`/`extract` boundary.
+  `source`; (3) **extract** *to* an `fsspec` location as the `dest`.
+  For (2), passing an fsspec-opened file object **already works** (the stream-input
+  tests exercise fsspec objects), so the remaining value is *URL-level* opening —
+  archivey calling `fsspec.open()` itself, behind an optional `[fsspec]` extra. What
+  that buys beyond "hand me a stream": archivey can pick sensible fsspec caching for
+  the access mode (`streaming=True` → plain forward read; random access → block/file
+  cache so ZIP central-directory + member seeks don't re-fetch), and — the real
+  unlock — it has **filesystem context**, which a bare stream can never provide:
+  multi-volume sets (`name.7z.001`…) need `fs.ls()` to discover sibling volumes, which
+  the Phase 7 volume-joining path requires. Shape TBD: a URL-string branch inside
+  `open_archive()` (gated on `"://" in source` + fsspec installed) vs. a separate
+  `open_archive_url()`; the separate function keeps typing/behavior of the core
+  entry point simple and the dependency boundary explicit.
 
 - **Configurable symlink-extraction behavior** — a policy knob (in the spirit of `OnError`
   / `ExtractionPolicy`) for what happens when a SYMLINK member cannot be created as a real
@@ -99,13 +110,25 @@
   match (e.g. deflate↔deflate; not deflate→zstd), so it's an opportunistic fast path with a
   decompress-recompress fallback. Pairs with the native ZIP parser (raw-deflate access) above.
 
-- **Parallel extraction** — extract independent members concurrently for
-  `AccessCost.DIRECT` archives (bounded by I/O). Also applies to **solid archives with
-  multiple independent blocks** — e.g. a 7z with several solid folders can decompress
-  folders in parallel (py7zr does this); members *within* one solid block stay
-  sequential. No benefit for a single-block solid archive.
+- **Parallel extraction / concurrent member streams** — extract independent members
+  concurrently for `AccessCost.DIRECT` archives (bounded by I/O). Also applies to
+  **solid archives with multiple independent blocks** — e.g. a 7z with several solid
+  folders can decompress folders in parallel (py7zr does this); members *within* one
+  solid block stay sequential. No benefit for a single-block solid archive.
+  **Constraint:** the concurrency model says readers are *not* thread-safe (one per
+  thread — `openspec/project.md`), so this must be designed as either N readers over
+  the same path or an explicit shared-source primitive — never silent sharing.
+  **Plumbing to consider before the native 7z/RAR/ZIP readers land (Phase 7):** a
+  `streamtools` shared-source view (the shape of stdlib `zipfile._SharedFile`: one
+  underlying handle + a lock + a per-view position, each read seeking under the lock)
+  so multiple open member streams over one seekable source are safe by construction;
+  interleaved single-threaded streams already work that way in zipfile. Whatever isn't
+  supported must **fail loudly** (detect concurrent misuse and raise) rather than
+  silently interleave reads and produce jumbled data.
 
 - **Efficient seekable zstd — probably a *native* frame-index reader, not `indexed_zstd`.**
+  *(Status: **scheduled** — promoted to the rescoped Phase 8 in `PLAN.md`; the analysis
+  below is the basis for that phase's benchmark-first task.)*
   zstd currently has *no* fast random access: a backward seek re-decompresses from the start
   (rewind + warning), like brotli/lz4/zlib. The obvious candidate,
   [`indexed_zstd`](https://github.com/martinellimarco/indexed_zstd) (martinellimarco; the zstd

--- a/PLAN.md
+++ b/PLAN.md
@@ -25,7 +25,7 @@ are archived to `openspec/changes/archive/`). Phases without a change yet need a
 | 2 | Stream layer (compressed + seekable) | `compressed-streams`, `seekable-decompressor-streams` | `archive/2026-06-21-phase-2-stream-layer` ✓ |
 | 3 | Indexed leaf formats + detection | `format-zip`, `format-tar` (random-access read), `format-single-file-compressors`, `format-iso`, `format-detection`, `backend-registry`, `access-mode-and-cost` | `archive/2026-06-30-phase-3-indexed-leaf-formats` ✓ |
 | 4 | TAR streaming + safe extraction | `format-tar` (forward-only `stream_members`, hardlinks, truncation), `safe-extraction`, `archive-reading` (sequential + `stream_members`), `format-detection` (gzip-wrapped tar regression), `testing-contract` (adversarial + non-seekable `tar.gz`) | `archive/2026-06-30-package-layout-restructure` ✓ → `phase-4-tar-streaming` + `phase-4-safe-extraction` |
-| 5 | Public API finalization & cost | `archive-reading`, `archive-data-model`, `access-mode-and-cost`, `error-handling` | — |
+| 5 | Public API finalization & cost | `archive-reading`, `archive-data-model`, `access-mode-and-cost`, `error-handling` | `phase-5-public-api` |
 | 6 | Writing support | `archive-writing`, `format-zip` / `format-tar` (writers) | — |
 | 7 | Native 7z + RAR read | `format-7z`, `format-rar`, `testing-contract` (oracle cross-validation) | — |
 | 8 | Seekable zstd + blocked gzip (rescoped; original zst/lz4 read goals landed in Phases 2–3, `w:zst` moved to Phase 6) | `seekable-decompressor-streams`, `format-single-file-compressors` | `seekable-gzip-and-block-writing` (partial) |
@@ -342,13 +342,14 @@ as a light tripwire, not a hard ban).
 3. Finalize `access-mode-and-cost` — streaming-mode enforcement and **CostReceipt
    values verified per format**; `error-handling` translation contract (cause/
    traceback preserved; genuine I/O not reclassified; context filled by base reader).
-4. **Finalize the public config surface** — graduate the Phase 4 *stopgap* keyword args
-   into their finalized public form per `SPEC.md`: the decompression-bomb limits
-   (`max_extracted_bytes`, `max_ratio`, `ratio_activation_threshold`, `max_entries`), the
-   `strict_eof` flag (shipped bare on `open_archive()` in `phase-4-tar-streaming`), and the
-   extraction policies (`ExtractionPolicy` / `OverwritePolicy` / `OnError`). Decide whether
-   these live as keyword args or a consolidated config object and lock their defaults —
-   Phase 4 deliberately deferred this "full public config surface" here.
+4. **Finalize the public config surface** — **decided** (see the `phase-5-public-api`
+   change): a frozen `ArchiveyConfig` object passed explicitly (`config=`), carrying the
+   accelerator modes, `strict_archive_eof` (the renamed Phase 4 `strict_eof` stopgap,
+   default False), and `ExtractionLimits` (the bomb knobs). Extraction policies
+   (`ExtractionPolicy` / `OverwritePolicy` / `OnError`) stay per-call keyword args. No
+   ambient (contextvars/global) configuration. Also decided there: the password
+   candidate-sequence + provider model, multi-source acceptance + path volume-set
+   discovery, and the MemberSelector collection semantics.
 
 ### Tests added
 `archive-data-model`, `access-mode-and-cost`, `error-handling`, and the remaining
@@ -371,7 +372,18 @@ correct for every format implemented so far.
 ### Tasks
 `ArchiveWriter` ABC (`add`/`add_bytes`/`add_stream`/`add_member`/`add_members`/
 `close`); `ZipWriter` (`ZipFile.open(name,'w')`, data descriptor for unknown
-size); `TarWriter`; `create_archive()`; `CompressionSpec` model.
+size); `TarWriter` (incl. compressed-tar output — `w:zst` and friends, moved here
+from the original Phase 8); `create_archive()`; `CompressionSpec` model.
+
+> **Pending decisions (resolve in this phase's change proposal):**
+> - *Per-entry `compression` on stream-compressed containers* (`tar.gz`/`tar.zst`):
+>   the codec is stream-level, so a per-entry override is meaningless — error, or
+>   warn-and-ignore? (Leaning: `ValueError` on an explicit per-entry algo; the
+>   writer-level `CompressionSpec` selects the outer codec.)
+> - *`password=` on formats whose writer can't encrypt* (stdlib zipfile cannot write
+>   encryption): must fail fast at `create()` — decide the error type
+>   (`UnsupportedFeatureError` vs `UnsupportedOperationError`) and add a
+>   SUPPORTS_PASSWORD-style WriteBackend field to enforce it centrally.
 
 ### Tests added
 `archive-writing` scenarios; `testing-contract` ZIP/TAR round-trip; conversion
@@ -391,7 +403,12 @@ passing; wire the oracles. See `format-7z/spec.md`, `format-rar/spec.md`,
 `testing-contract/spec.md`.
 
 **Entry criteria:** Phase 6 green; `py7zr`/`rarfile`/`unrar` available as
-dev-group oracles.
+dev-group oracles; the **shared-source stream plumbing** decided/landed — a
+`streamtools` shared-source view (the shape of stdlib `zipfile._SharedFile`: one
+handle + a lock + per-view positions) so the native readers support multiple
+concurrently-open member streams by construction, and a decided concurrency
+contract (what is supported vs. what fails loudly — never silent interleaving);
+see the parallel-extraction entry in `IDEAS.md`.
 
 ### Tasks
 1. **Native 7z** header parse (packed streams, folders/coder chains, substreams,

--- a/PLAN.md
+++ b/PLAN.md
@@ -28,7 +28,7 @@ are archived to `openspec/changes/archive/`). Phases without a change yet need a
 | 5 | Public API finalization & cost | `archive-reading`, `archive-data-model`, `access-mode-and-cost`, `error-handling` | — |
 | 6 | Writing support | `archive-writing`, `format-zip` / `format-tar` (writers) | — |
 | 7 | Native 7z + RAR read | `format-7z`, `format-rar`, `testing-contract` (oracle cross-validation) | — |
-| 8 | Zstandard + extended compression | `format-single-file-compressors`, `format-tar`, `format-detection` | — |
+| 8 | Seekable zstd + blocked gzip (rescoped; original zst/lz4 read goals landed in Phases 2–3, `w:zst` moved to Phase 6) | `seekable-decompressor-streams`, `format-single-file-compressors` | `seekable-gzip-and-block-writing` (partial) |
 | 9 | CLI | `cli` | — |
 | 10 | Polish + oracle retirement | `packaging-and-extras` (finalize), `cli`, `testing-contract` (full corpus) | — |
 
@@ -332,11 +332,12 @@ as a light tripwire, not a hard ban).
 **Entry criteria:** Phase 4 green.
 
 ### Tasks
-1. Finalize `archive-reading` (metadata access, membership/random access,
-   `read`/`open`, transparent **link following** with depth limit, context-manager
-   lifecycle).
+1. Finalize `archive-reading` (metadata access, name lookup / identity membership,
+   `read`/`open`, transparent **link following** with cycle detection (no fixed depth
+   limit, per the spec), context-manager lifecycle).
 2. Finalize `archive-data-model` (`ArchiveFormat`/`MemberType` taxonomy,
-   compression-method model, the full `Member` record — hashable, `extra`, digests
+   compression-method model, the full `Member` record — deliberately **unhashable**
+   (mutable; callers key by `name`/`member_id`, per the spec), `extra`, digests
    under algorithm keys, name normalization — and `ArchiveInfo`).
 3. Finalize `access-mode-and-cost` — streaming-mode enforcement and **CostReceipt
    values verified per format**; `error-handling` translation contract (cause/
@@ -417,21 +418,36 @@ output matches oracles across the corpus; solid `stream_members()` uses one
 
 ---
 
-## Phase 8 — Zstandard & extended compression
+## Phase 8 — Seekable zstd & blocked-gzip native readers
 
-**Goal:** `.zst`/`.tar.zst` and `.tar.lz4` support.
+> **Rescoped (2026-07):** the original Phase 8 goal — `.zst`/`.tar.zst`/`.tar.lz4`
+> *reading* and `.zst` magic detection — landed early with the Phase 2/3 codec layer
+> (round-trip tests pass today). The remaining write-side piece (`w:zst`) moves to
+> Phase 6 with the other writers. This phase is repurposed for the seekable-stream
+> follow-ons that reuse the segmented-decompressor infrastructure.
+
+**Goal:** frame/block-granular random access for zstd (native, no new dependency) and
+blocked gzip (BGZF/mgzip), per the `seekable-gzip-and-block-writing` change and the
+seekable-zstd analysis in `IDEAS.md` (now scheduled).
 
 ### Tasks
-Single-file `ZST` (`[zstd]`); `.tar.zst` and `w:zst`; `.tar.lz4` (`[lz4]`); `.zst`
-magic in detection.
+1. **Native zstd frame-index reader** on `SegmentedDecompressorStream`: build the frame
+   index from frame headers (`Frame_Content_Size`) and/or the *Seekable Zstd* seek
+   table; fall back to the sequential/rewind path when sizes are absent. Benchmark
+   against stdlib `compression.zstd` and `indexed_zstd` first (per IDEAS: decide with
+   numbers; a `benchmarks/` script).
+2. **Native blocked-gzip (BGZF/mgzip) reader**: member walk via the `BC`/`MZ` extra
+   subfields, per the `seekable-gzip-and-block-writing` proposal (stdlib `zlib` only).
 
 ### Tests added
-`format-single-file-compressors` ZST scenarios; `format-tar` `.tar.zst`/`.tar.lz4`;
-`format-detection` zst magic — all skip when the optional lib is absent.
+Seek-pattern coverage for multi-frame `.zst` (cold sequential, `SEEK_END`, scattered
+seeks, rewind) and BGZF fixtures; plain single-frame `.zst` / non-blocked gzip fall
+back unchanged.
 
 ### Acceptance — spec scenarios covered
-ZST/LZ4 paths of `format-single-file-compressors`, `format-tar`, `format-detection`.
-**Gates:** Pyrefly + ty + ruff clean; tests skip cleanly without the extras.
+The added `seekable-decompressor-streams` requirements (blocked gzip; zstd frame index
+once specced via its own change).
+**Gates:** Pyrefly + ty + ruff clean; no new runtime dependency.
 
 ---
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -95,11 +95,11 @@ class ArchiveReader:
     # --- Member iteration ---
     def __iter__(self) -> Iterator[ArchiveMember]: ...    # sequential, in-order
     def members(self) -> list[ArchiveMember]: ...         # materializes all (may trigger scan)
-    def __len__(self) -> int: ...                         # may trigger scan
-    def __contains__(self, name: str) -> bool: ...
+    # (deliberately no __len__/__getitem__: the reader is not a collection; see the
+    # archive-reading spec. `member in reader` is identity membership, any mode.)
+    def __contains__(self, member: ArchiveMember) -> bool: ...
 
-    # --- Random access (default streaming=False; raises under streaming=True) ---
-    def __getitem__(self, name: str) -> ArchiveMember: ...  # KeyError if absent
+    # --- Name lookup (default streaming=False; raises under streaming=True) ---
     def get(self, name: str, default=None) -> ArchiveMember | None: ...
 
     # --- Data access ---
@@ -144,7 +144,7 @@ class ArchiveReader:
     def close(self) -> None: ...
 ```
 
-**Constraint:** calling `__getitem__`, `get`, or random `extract_all(members=[name])` on a reader opened with `streaming=True` raises `UnsupportedOperationError`. `members()` and `__len__` likewise raise under `streaming=True`, since they require materializing all members. The enforcement is **uniform** — it does not depend on whether a backend happens to have an index loaded — so streaming behaviour is deterministic across formats. (`get_members_if_available()` is exempt: it never scans, so it stays callable.)
+**Constraint:** calling `get`, or random `extract_all(members=[name])`, on a reader opened with `streaming=True` raises `UnsupportedOperationError`. `members()` likewise raises under `streaming=True`, since it requires materializing all members. The enforcement is **uniform** — it does not depend on whether a backend happens to have an index loaded — so streaming behaviour is deterministic across formats. (`get_members_if_available()` is exempt: it never scans, so it stays callable.)
 
 **Two sequential access patterns — different memory profiles:**
 

--- a/openspec/changes/phase-4-safe-extraction/specs/safe-extraction/spec.md
+++ b/openspec/changes/phase-4-safe-extraction/specs/safe-extraction/spec.md
@@ -6,12 +6,18 @@
 
 The system SHALL evaluate an archive-wide decompression ratio during `extract()` /
 `extract_all()` when a member's `compressed_size` is unknown or zero but the reader exposes a
-known outer `compressed_source_size` (the byte size of the archive's source, generalized:
-any path source is `stat`-ed, a stream advertising an integer `size` attribute — fsspec file
-objects — is trusted, and a seekable stream is probed with a `SEEK_END`/restore round trip;
-only a non-seekable sizeless stream yields `None`. For zip/7z/rar/compressed-tar this *is*
-the compressed size; for an uncompressed container the resulting ~1:1 ratio never trips the
-guard, which is why reporting it for every source is safe), computed as:
+known outer `compressed_source_size` (the byte size of the archive's source, generalized
+and **cheap-only** — it never reads or decompresses data to answer: a path source is
+`stat`-ed; an integer `size` attribute is trusted (the fsspec convention, which archivey's
+own member/codec stream wrappers also expose from archive metadata or a cheap
+index/trailer scan — so a *nested* archive opened from a member stream gets its source
+size for free); a `try_get_size()` method (archivey's decompressor streams) is the final
+answer for streams whose end-seek would decompress; and a `SEEK_END`/restore probe runs
+only for provably O(1) types (real files, `BytesIO`, `mmap`). Anything else — notably any
+foreign decompressor stream like `gzip.GzipFile`, whose end-seek decodes the whole
+payload — yields `None`. For zip/7z/rar/compressed-tar this *is* the compressed size; for
+an uncompressed container the resulting ~1:1 ratio never trips the guard, which is why
+reporting it for every source is safe), computed as:
 
 ```
 cumulative_bytes_written / compressed_source_size
@@ -22,7 +28,7 @@ per-member ratio check. The check SHALL run in `BombTracker.count()` alongside t
 cumulative `max_extracted_bytes` guard. Unlike the per-member ratio (which activates on the
 **current member's** output), the archive-wide ratio activates on the **cumulative** output
 across the call: it is evaluated only once `_total_bytes` exceeds `ratio_activation_threshold`.
-When `compressed_source_size` is `None` (a non-seekable sizeless stream source),
+When `compressed_source_size` is `None` (a source whose size is not cheaply knowable),
 the archive-wide ratio check is skipped.
 
 The `compressed_source_size` is supplied to the `BombTracker` once per extraction call (the

--- a/openspec/changes/phase-4-safe-extraction/specs/safe-extraction/spec.md
+++ b/openspec/changes/phase-4-safe-extraction/specs/safe-extraction/spec.md
@@ -6,8 +6,12 @@
 
 The system SHALL evaluate an archive-wide decompression ratio during `extract()` /
 `extract_all()` when a member's `compressed_size` is unknown or zero but the reader exposes a
-known outer `compressed_source_size` (the byte length of the compressed container stream —
-e.g. a `.tar.gz` file's size on disk), computed as:
+known outer `compressed_source_size` (the byte size of the archive's source, generalized:
+any path source is `stat`-ed, a stream advertising an integer `size` attribute — fsspec file
+objects — is trusted, and a seekable stream is probed with a `SEEK_END`/restore round trip;
+only a non-seekable sizeless stream yields `None`. For zip/7z/rar/compressed-tar this *is*
+the compressed size; for an uncompressed container the resulting ~1:1 ratio never trips the
+guard, which is why reporting it for every source is safe), computed as:
 
 ```
 cumulative_bytes_written / compressed_source_size
@@ -18,7 +22,7 @@ per-member ratio check. The check SHALL run in `BombTracker.count()` alongside t
 cumulative `max_extracted_bytes` guard. Unlike the per-member ratio (which activates on the
 **current member's** output), the archive-wide ratio activates on the **cumulative** output
 across the call: it is evaluated only once `_total_bytes` exceeds `ratio_activation_threshold`.
-When `compressed_source_size` is `None` (unknown source size, plain uncompressed container),
+When `compressed_source_size` is `None` (a non-seekable sizeless stream source),
 the archive-wide ratio check is skipped.
 
 The `compressed_source_size` is supplied to the `BombTracker` once per extraction call (the

--- a/openspec/changes/phase-4-tar-streaming/tasks.md
+++ b/openspec/changes/phase-4-tar-streaming/tasks.md
@@ -59,7 +59,7 @@
       unselected members without opening streams; late-bound fields visible on original
       member object after read.
 - [x] 2.4 **Tests** — non-seekable plain tar: `stream_members()` + `__iter__` over corpus
-      tar fixtures; `members()` / `__getitem__` raise `UnsupportedOperationError` on
+      tar fixtures; `members()` / `get()` raise `UnsupportedOperationError` on
       `streaming=True` reader (may already be covered by `test_reader_contract.py` — extend
       with real TAR backend).
 

--- a/openspec/changes/phase-5-public-api/.openspec.yaml
+++ b/openspec/changes/phase-5-public-api/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-02

--- a/openspec/changes/phase-5-public-api/design.md
+++ b/openspec/changes/phase-5-public-api/design.md
@@ -1,0 +1,162 @@
+# Phase 5 design — public API finalization
+
+## Context
+
+The public surface has three "deferred until Phase 5" clusters: (a) the config surface
+(`strict_eof` shipped bare on `open_archive`; bomb limits exist only in the
+safe-extraction spec), (b) input shapes Phase 7 requires (multi-volume sources,
+multi-password archives), and (c) selector semantics left open (`MemberSelector`'s
+collection form). DEV precedent exists for a config object (contextvars-based) and is
+deliberately *not* copied. Maintainer decisions for each cluster were taken in the
+2026-07 review; this document records the rationale so implementation doesn't relitigate
+them.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Lock `open_archive()` / `extract()` signatures so Phase 6–7 add no breaking changes.
+- Password model that keeps single-pass streaming viable on multi-password archives.
+- Multi-source entry paths ready for Phase 7's volume-joining readers.
+- One explicit, immutable config object; no ambient state.
+
+**Non-Goals:**
+
+- Implementing the volume-joining readers themselves (Phase 7).
+- A `collect_results=False` extraction mode (deferred: readers cache the member list
+  internally anyway, so skipping result accumulation alone doesn't bound memory — doing
+  it properly is a larger no-member-cache change; revisit post-v1 if needed).
+- Ambient configuration (contextvars / global mutable defaults).
+- fsspec URL opening (IDEAS; supplies remote filesystem context for volume discovery).
+
+## Decisions
+
+### 1. Password: single value | sequence | provider callable
+
+`password: str | bytes | Sequence[str | bytes] | PasswordProvider | None` where
+`PasswordProvider = Callable[[ArchiveMember | None], str | bytes | None]`.
+
+- **Per encrypted unit** (a 7z folder, a RAR/ZIP member, an encrypted header), the
+  reader tries the per-archive **known-good list** first (passwords that already
+  succeeded, most-recent first), then remaining sequence candidates, then — if a
+  provider was given — calls it, passing the `ArchiveMember` being decrypted (`None`
+  for archive-level/header decryption, where no member exists yet) so interactive UIs
+  can show what is being asked about. A provider may be called repeatedly for the same
+  unit until it returns `None` (= give up → `EncryptionError`). Every success is
+  appended to the known-good list for the rest of the operation, so a provider is asked
+  once per *new* password, not once per member.
+- **Why not per-call `open(member, password=...)`:** it forces random access — a
+  streaming pass over a multi-password 7z could not supply the second password without
+  aborting the pass. The candidate list + provider covers both random and streaming
+  access with one mechanism, so the per-call parameter is dropped from `format-7z`'s
+  phrasing (alternative considered and rejected for v1: both mechanisms — needless
+  surface).
+- **Cost note (drives the "known-good first" rule):** ZIP (1-byte ZipCrypto check /
+  AES verifier) and RAR5 (explicit password-check value) validate candidates cheaply;
+  **7z has no check value** — a candidate costs a deliberately expensive key derivation
+  (2^19 SHA-256 rounds) plus decode-until-CRC-failure. Docs say "most likely password
+  first"; the derived-key cache is keyed by (password, salt, cycles).
+
+### 2. Multi-source: explicit list now, path discovery, stream discovery never
+
+`source: str | Path | BinaryIO | Sequence[str | Path | BinaryIO]`.
+
+- An explicit `Sequence` is the ordered volume list, exactly as given (works for
+  streams; each seekable stream gets the standard origin normalization). Length-1
+  sequence ≡ single source.
+- A **single path** whose name matches a volume pattern (`.7z.001`/`.7z.NNN`,
+  `.partN.rar`, `.rNN`) triggers sibling discovery in its directory, natural-ordered;
+  opening any part of the set works (per `format-7z`/`format-rar`). Discovery is
+  **path-only by design** — a bare stream has no filesystem to enumerate; remote sets
+  get discovery via the future fsspec URL layer, which has an `fs.ls()`.
+- Detection runs on the first volume only. In Phase 5 (before the joining readers
+  exist) a multi-source open of any format resolves the backend and raises
+  `UnsupportedFeatureError` ("multi-volume X lands in Phase 7" for 7z/RAR; "not a
+  multi-volume format" otherwise) — the signature and plumbing are real, the joining is
+  not. Alternative considered: defer the signature to Phase 7 with the readers —
+  rejected because Phase 5 is the API freeze.
+
+### 3. Config: explicit frozen `ArchiveyConfig`, no ambient state
+
+```python
+@dataclass(frozen=True)
+class ExtractionLimits:
+    max_extracted_bytes: int = 2 * 2**30
+    max_ratio: float = 1000.0
+    ratio_activation_threshold: int = 5 * 2**20
+    max_entries: int = 1_048_576
+
+@dataclass(frozen=True)
+class ArchiveyConfig:
+    use_rapidgzip: AcceleratorMode = AcceleratorMode.AUTO
+    use_indexed_bzip2: AcceleratorMode = AcceleratorMode.AUTO
+    strict_archive_eof: bool = False
+    extraction_limits: ExtractionLimits = ExtractionLimits()
+```
+
+- Passed explicitly: `open_archive(..., config=None)` (None → module default constant),
+  `extract(..., config=None)`. The reader carries its config; `extract_all()` inherits
+  the reader's unless overridden.
+- **Why not contextvars (DEV's approach):** ambient config makes behavior depend on
+  call-site-invisible state — hard to trace in applications embedding archivey, and
+  interacts confusingly with threads/executors (a worker thread silently misses the
+  caller's context). Explicit-with-`replace()` is boring and predictable. A read-only
+  process default (`archivey.set_default_config`) can be added later without breaking
+  anything, so deciding "no" now is cheap. Alternative considered: kwargs-only (no
+  object) — rejected by maintainer decision; the knob count (accelerators + limits +
+  strictness, growing in Phase 7 with e.g. RAR temp-dir policy) justifies the object.
+- Config **excludes** per-call operationals: `format`, `streaming`, `password`,
+  `encoding`, extraction's `members`/`filter`/`policy`/`overwrite`/`on_error`/
+  `on_progress`. Rule of thumb: *what* to do per call = kwarg; *how* the library
+  behaves = config.
+- Internal `StreamConfig` remains as the codec-layer view, constructed from
+  `ArchiveyConfig` + the access mode (its `streaming` field is derived, not public).
+
+### 4. `strict_archive_eof` defaults to False
+
+Truncated-but-readable tars are common in the wild (trailer-less writers, `cat`-joined
+archives); GNU tar itself warns rather than fails on a missing trailer. The failure
+mode of default-True is also awkward: the error necessarily surfaces at the *end* of an
+otherwise successful iteration (the trailer can only be checked after the last member),
+so `extract()` would fail an entire run after extracting everything — and under
+`OnError.CONTINUE` semantics there is no "member" to attribute the failure to. The
+warning already surfaces the condition for the default case; callers validating
+untrusted feeds opt in via config. (Renamed from `strict_eof`: it is an
+*archive-level* end-of-data check, extensible to ZIP trailing junk / gzip trailing
+garbage later; TAR is just the first implementation.)
+
+### 5. MemberSelector collection form: names match all duplicates; members match identity
+
+`Collection[str | ArchiveMember]` normalizes to a predicate at the API boundary:
+
+- a `str` entry matches **every** member with that (normalized) name — duplicate names
+  in a tar all match, and sequential extraction preserves last-wins-on-disk;
+- an `ArchiveMember` entry matches by identity (`_archive_id` + `member_id`;
+  members are unhashable so the normalizer builds an id-set, not a member-set);
+- strings and members may be mixed. A `Callable` selector is unchanged. (Selecting
+  "just the last duplicate by name" — `get()`'s rule — was considered and rejected:
+  a selector answers "should this member be included", and silently dropping earlier
+  duplicates would surprise both streaming consumers and extraction, where writing all
+  duplicates is what sequential extraction does anyway.)
+
+## Risks / Trade-offs
+
+- [7z candidate passwords are expensive to try] → known-good-first ordering, derived-key
+  cache, and documentation ("likely password first"); a wrong candidate list on a large
+  solid archive costs one key derivation per candidate per folder, bounded and loud.
+- [Provider called during a streaming pass can block (interactive prompt) mid-iteration]
+  → documented; the provider contract is synchronous by design in the sync-only v1.
+- [Multi-source signature lands before any joining reader] → the
+  `UnsupportedFeatureError` path is tested now so the signature is honest; Phase 7
+  replaces the rejection with real joining without a signature change.
+- [Config object grows into a god-object] → additions require a spec delta; per-call
+  operationals are explicitly barred from it (rule recorded in the spec).
+- [`strict_archive_eof=False` hides truncation from inattentive callers] → the warning
+  remains; `archivey test` (CLI, Phase 9) and extraction integrity checks are the
+  loud paths.
+
+## Migration Plan
+
+Pre-1.0, no deprecation cycle: the `strict_eof=` keyword is removed in the same change
+that adds `config=`; `openspec` specs, `SPEC.md` signature blocks, and tests move
+together. Phase 6/7 proposals build on the frozen signatures.

--- a/openspec/changes/phase-5-public-api/proposal.md
+++ b/openspec/changes/phase-5-public-api/proposal.md
@@ -1,0 +1,90 @@
+# Phase 5: Public API finalization & cost surface
+
+## Why
+
+Phases 1–4 grew the public surface incrementally, deferring several signature decisions
+("Phase 5 stopgaps"): `strict_eof` sits bare on `open_archive()`, the bomb limits and
+extraction knobs have no agreed home, `MemberSelector`'s collection form is specced but
+unimplemented, and `password` is a single value. Meanwhile Phase 7's native 7z/RAR
+readers need API shapes that don't exist yet — multi-volume sources and multi-password
+archives — and finalizing the surface *before* those consumers land (the PLAN ordering)
+only works if their requirements are designed in now. This change locks the public API
+per the maintainer decisions from the 2026-07 whole-codebase review.
+
+## What Changes
+
+- **Passwords become multi-candidate** (`archive-reading`): `password` accepts a single
+  value, a **sequence** of candidates, or a **provider callable**
+  (`Callable[[ArchiveMember | None], str | bytes | None]`) that is invoked per encrypted
+  unit — receiving the member so a UI can show what is being asked about, or `None` for
+  archive-level (header) decryption. Candidates that succeed join a per-archive
+  known-good list tried first for later units, keeping single-pass streaming viable for
+  archives whose folders/members use different passwords (7z has no cheap password
+  check, so candidate order matters; RAR5/ZIP validate cheaply). Provider returning
+  `None` → `EncryptionError`.
+- **Multi-source input is implemented** (`archive-reading`, already specced):
+  `open_archive()` accepts `Sequence[str | Path | BinaryIO]` as the explicit ordered
+  volume list, and single-path volume-set **auto-discovery** (a path matching a volume
+  pattern discovers its siblings on the same filesystem). Discovery is path-only —
+  streams cannot enumerate siblings; the future fsspec URL layer supplies filesystem
+  context for remote sets. Phase 5 lands the signature, detection plumbing, and the
+  rejection behavior (multi-source for a format without volume support raises
+  `UnsupportedFeatureError`); the actual joining readers land with their formats in
+  Phase 7.
+- **`ArchiveyConfig` public config object** (`archive-reading`; graduates the internal
+  `StreamConfig`): a frozen dataclass passed explicitly as `open_archive(...,
+  config=...)` / `extract(..., config=...)` — accelerator selection
+  (gzip/bzip2 tri-state modes), `strict_eof`, and default `ExtractionLimits`
+  (`max_extracted_bytes`, `max_ratio`, `ratio_activation_threshold`, `max_entries`).
+  Per-call operational arguments (`format`, `streaming`, `password`, `members`,
+  `filter`, `policy`, `overwrite`, `on_error`) stay keyword arguments — config is for
+  tuning/policy knobs that rarely vary per call. No contextvars and no mutable global in
+  v1 (decided: DEV's ambient-config approach traded traceability for convenience);
+  a process-wide default stays possible to add later without breaking.
+- **`strict_eof` moves into the config** (default **False** — see design.md for the
+  rationale) and is renamed `strict_archive_eof` (format-agnostic: TAR trailer today,
+  applicable to ZIP trailing-junk / gzip trailing-garbage checks later). **BREAKING**
+  for the Phase 4 stopgap keyword (pre-1.0; the bare `strict_eof=` kwarg is removed).
+- **`MemberSelector` collection form is implemented** (`archive-reading`): a
+  `Collection[str | ArchiveMember]` selects by **name match — every duplicate with that
+  name — or by member identity** for `ArchiveMember` entries (matched via
+  `member_id`/`archive_id`, since members are unhashable). Equivalent to a predicate;
+  extraction of duplicate selected names keeps sequential last-wins-on-disk semantics.
+- **Finalization sweep** (mostly verification, not new behavior): `archive-data-model`,
+  `access-mode-and-cost` (CostReceipt values asserted per format), `error-handling`
+  (context stamping verified end-to-end), remaining `archive-reading` scenarios.
+
+## Capabilities
+
+### New Capabilities
+
+_None — this change finalizes existing capabilities._
+
+### Modified Capabilities
+
+- `archive-reading`: password sequence/provider model; multi-source
+  discovery/rejection details; `ArchiveyConfig` / `ExtractionLimits` definition and the
+  `config=` parameter; `MemberSelector` collection semantics; `strict_eof` →
+  `config.strict_archive_eof`.
+- `safe-extraction`: `extract()`/`extract_all()` gain `config=`; the bomb-limit
+  requirements reference `ExtractionLimits` (defaults unchanged); results-list
+  accumulation documented as unconditional for v1 (a no-tracking mode interacts with
+  the readers' internal member caching and is deferred — see design.md).
+- `format-7z`: the per-call-password phrasing is replaced by the
+  candidate-list/provider model (no separate `open(member, password=...)` parameter).
+  (`format-rar`'s password wording already fits the model; no delta needed.)
+- (`compressed_source_size` generalization — any path source, `size`-advertising
+  streams, seekable streams — is implemented and recorded in the in-flight
+  `phase-4-safe-extraction` delta, not here.)
+
+## Impact
+
+- `archivey.open_archive()` / `archivey.extract()` signatures (password type widens;
+  `config=` added; `strict_eof=` removed; `source` union widens).
+- `archivey/internal/config.py`: `StreamConfig` folds into the public `ArchiveyConfig`
+  (internal plumbing keeps a derived view).
+- `BaseArchiveReader`: selector normalization for the collection form; password
+  candidate/known-good bookkeeping helper for Phase 7 backends.
+- Phase 7 consumes: multi-volume entry paths, the password model, and (already landed)
+  the generalized `compressed_source_size`.
+- Docs: `SPEC.md` §2 signature blocks updated to match.

--- a/openspec/changes/phase-5-public-api/specs/archive-reading/spec.md
+++ b/openspec/changes/phase-5-public-api/specs/archive-reading/spec.md
@@ -1,0 +1,165 @@
+# archive-reading — Phase 5 deltas
+
+## MODIFIED Requirements
+
+### Requirement: Opening an archive for reading
+
+The system SHALL expose a top-level `archivey.open_archive()` function that accepts a file path, `Path`, or binary stream and returns an `ArchiveReader`.
+
+```python
+archivey.open_archive(
+    source: str | Path | BinaryIO | Sequence[str | Path | BinaryIO],
+    *,
+    format: ArchiveFormat | None = None,  # override detection
+    streaming: bool = False,             # False = random access; True = forward-only one pass
+    password: str | bytes | Sequence[str | bytes] | PasswordProvider | None = None,
+    encoding: str | None = None,         # None = auto-detect member-name encoding
+    config: ArchiveyConfig | None = None,  # None = the library default configuration
+) -> ArchiveReader
+```
+
+The `format` parameter MAY be omitted; when omitted the library performs automatic
+format detection. `encoding` defaults to `None`, meaning the library auto-detects the
+encoding of member-name fields: it uses the **format's internal signal** when present
+(e.g. the ZIP UTF-8 general-purpose-bit, RAR5 UTF-8 names, tar PAX UTF-8 records), and
+otherwise detects from the raw name bytes. A caller MAY pass an explicit `encoding` as a
+last-resort override when the format records none and detection is unreliable; the
+verbatim bytes are always preserved in `ArchiveMember.raw_name` so names can be
+re-decoded losslessly. `source` MAY also be an ordered sequence of files/streams that
+together form a single multi-volume archive (see the multi-volume requirement below).
+`password` accepts a single value, an ordered sequence of candidate values, or a
+provider callable (see the password requirement below). `config` carries the library's
+tuning/policy knobs (see the configuration requirement below); per-call operational
+arguments remain keyword parameters and MUST NOT move into the config object. The
+Phase 4 `strict_eof` keyword is removed — end-of-archive strictness lives at
+`config.strict_archive_eof`.
+
+#### Scenario: open with auto-detected format
+
+- **WHEN** `archivey.open_archive("archive.tar.gz")` is called with no `format` override
+- **THEN** the library detects the format from magic bytes and returns an `ArchiveReader` wrapping the appropriate backend
+
+#### Scenario: open with explicit format override
+
+- **WHEN** `archivey.open_archive(source, format=ArchiveFormat.ZIP)` is called
+- **THEN** the library uses the specified format backend without running detection
+
+#### Scenario: open with password
+
+- **WHEN** `archivey.open_archive(source, password="secret")` is called
+- **THEN** the returned `ArchiveReader` uses the provided password for encrypted members
+
+## ADDED Requirements
+
+### Requirement: Password candidates and provider
+
+`password` SHALL accept, besides a single `str | bytes` value:
+
+- an **ordered sequence** of candidate values, and/or
+- a **provider callable** `PasswordProvider = Callable[[ArchiveMember | None], str | bytes | None]`.
+
+For each encrypted unit (an encrypted member, a 7z folder, or an encrypted archive
+header), the reader SHALL try, in order: the per-archive **known-good list** (passwords
+that already succeeded during this open, most recent first), then the remaining sequence
+candidates, then — when a provider is given — the provider, repeatedly, until it returns
+`None`. The provider receives the `ArchiveMember` being decrypted so an interactive
+caller can present which entry is being asked about, or `None` when decryption is
+archive-level (a header-encrypted 7z/RAR5, where no member exists yet). Every password
+that succeeds SHALL be added to the known-good list for the remainder of the operation,
+so a provider is consulted once per *new* password rather than once per member, and a
+single forward streaming pass stays viable on archives whose members use different
+passwords. When all candidates are exhausted (or the provider returns `None`) for a unit
+that needs one, the reader SHALL raise `EncryptionError`. There is no per-call password
+parameter on `open()`/`read()` — the candidate model subsumes it.
+
+#### Scenario: sequence of candidates across differently-encrypted members
+
+- **WHEN** an archive whose members are encrypted with two different passwords is opened with `password=[pw_a, pw_b]` and iterated in one streaming pass
+- **THEN** every member decrypts using whichever candidate matches its unit, and the pass completes without random access
+
+#### Scenario: provider is consulted and its answer is reused
+
+- **WHEN** a provider callable is given and a member needs a password not yet known
+- **THEN** the provider is called with that `ArchiveMember`; a returned password that succeeds is added to the known-good list and later members encrypted with it do not trigger further provider calls
+
+#### Scenario: provider gives up
+
+- **WHEN** the provider returns `None` for a unit no known candidate decrypts
+- **THEN** `EncryptionError` is raised for that unit
+
+#### Scenario: header decryption passes None to the provider
+
+- **WHEN** a header-encrypted archive is opened with only a provider and the header must be decrypted to list members
+- **THEN** the provider is called with `None` (no member exists yet)
+
+### Requirement: Explicit configuration object
+
+The system SHALL define a frozen `ArchiveyConfig` dataclass carrying the library's
+tuning/policy knobs, passed explicitly as `config=` to `open_archive()` and
+`extract()` (`None` selects the immutable library default):
+
+```python
+@dataclass(frozen=True)
+class ExtractionLimits:
+    max_extracted_bytes: int = 2 * 2**30
+    max_ratio: float = 1000.0
+    ratio_activation_threshold: int = 5 * 2**20
+    max_entries: int = 1_048_576
+
+@dataclass(frozen=True)
+class ArchiveyConfig:
+    use_rapidgzip: AcceleratorMode = AcceleratorMode.AUTO
+    use_indexed_bzip2: AcceleratorMode = AcceleratorMode.AUTO
+    strict_archive_eof: bool = False
+    extraction_limits: ExtractionLimits = ExtractionLimits()
+```
+
+A reader carries the config it was opened with; `extract_all()` uses the reader's
+config unless the call overrides it. Configuration is **explicit only**: the library
+SHALL NOT read ambient state (no context variables, no mutable global default) to
+resolve configuration. Per-call operational arguments — `format`, `streaming`,
+`password`, `encoding`, and extraction's `members`/`filter`/`policy`/`overwrite`/
+`on_error`/`on_progress` — are keyword parameters and MUST NOT be absorbed into the
+config object.
+
+`strict_archive_eof` governs archive-level end-of-data verification (today: the TAR
+two-block trailer check; extensible to other formats): `False` (default) emits a
+`logging.WARNING` on a failed check, `True` raises `TruncatedError`. The check
+necessarily runs only after a full pass reaches the archive's end.
+
+#### Scenario: default configuration without a config argument
+
+- **WHEN** `archivey.open_archive(source)` is called with no `config`
+- **THEN** the library default `ArchiveyConfig()` applies (accelerators AUTO, `strict_archive_eof=False`, default limits)
+
+#### Scenario: strict end-of-archive via config
+
+- **WHEN** a truncated TAR (missing trailer) is fully read under `config=ArchiveyConfig(strict_archive_eof=True)`
+- **THEN** `TruncatedError` is raised at the end of the pass; with the default config the same condition only logs a warning
+
+#### Scenario: extraction limits travel in the config
+
+- **WHEN** `archivey.extract(src, dest, config=ArchiveyConfig(extraction_limits=ExtractionLimits(max_ratio=100)))` runs
+- **THEN** the 100:1 per-member ratio limit is enforced (see `safe-extraction`)
+
+### Requirement: Collection form of MemberSelector
+
+`MemberSelector` SHALL accept, besides a predicate, a `Collection[str | ArchiveMember]`,
+normalized to a predicate at the API boundary:
+
+- a `str` entry matches **every** member whose normalized name equals it — duplicate
+  names all match (extraction of duplicate selected names keeps sequential
+  last-wins-on-disk semantics);
+- an `ArchiveMember` entry matches by **identity** (`archive_id` + `member_id`;
+  members are unhashable, so normalization builds an id set, never a member set);
+- string and member entries MAY be mixed in one collection.
+
+#### Scenario: name entry selects all duplicates
+
+- **WHEN** `stream_members(members=["a.txt"])` runs on an archive containing two members named `a.txt`
+- **THEN** both are yielded, in archive order
+
+#### Scenario: member entry selects by identity
+
+- **WHEN** a specific `ArchiveMember` (one of two duplicates) is passed in the collection
+- **THEN** only that member is selected, not its same-named sibling

--- a/openspec/changes/phase-5-public-api/specs/format-7z/spec.md
+++ b/openspec/changes/phase-5-public-api/specs/format-7z/spec.md
@@ -1,0 +1,42 @@
+# format-7z — Phase 5 deltas
+
+## MODIFIED Requirements
+
+### Requirement: Decrypt AES-encrypted 7z, honoring per-member passwords
+
+The system SHALL read AES-256-encrypted 7z archives — including header-encrypted
+archives — when a password and the `[crypto]` extra are available. Decryption uses
+the wrapped crypto backend as a per-folder AES decrypt stage (see
+`compressed-streams`); the key is derived per the 7z SHA-256 scheme and applied
+ahead of decompression. For a header-encrypted archive the encrypted end header is
+decrypted before parsing, so even *listing* requires the password and crypto
+backend; without them the system SHALL raise `EncryptionError` (or
+`PackageNotInstalledError` if the crypto backend is missing). When the archive (or
+any folder) is encrypted, `ArchiveInfo.is_encrypted` SHALL be `True`.
+
+The system SHALL resolve each folder's password through the **candidate model** of
+`archive-reading` (known-good list, then remaining sequence candidates, then the
+provider callable — the provider receiving the member being decrypted, or `None` for
+the header), so members in folders encrypted with different passwords can each be
+decrypted within the same open — including in a single forward `stream_members()`
+pass — with no global password state and no per-call password parameter. Because 7z
+has **no password check value**, trying a candidate costs a full key derivation
+(2^19 SHA-256 rounds) plus decoding until corruption surfaces; the reader SHALL cache
+derived keys by (password, salt, cycles) and try known-good passwords first, and an
+incorrect password SHALL surface as an encrypted/corrupted failure
+(`EncryptionError`/`CorruptionError`), not silent garbage.
+
+#### Scenario: members with different passwords
+
+- **WHEN** an encrypted 7z archive holds members in folders encrypted with different passwords and is opened with `password=[pw_a, pw_b]` (or a provider that supplies each on request)
+- **THEN** each member decrypts with its matching candidate and verifies its CRC, including during a single streaming pass
+
+#### Scenario: wrong password
+
+- **WHEN** an encrypted member is opened and no candidate decrypts it (or the sole password is incorrect)
+- **THEN** decryption fails and surfaces as `EncryptionError`/`CorruptionError`, never incorrect bytes
+
+#### Scenario: header-encrypted 7z opened without a password
+
+- **WHEN** a header-encrypted 7z archive is opened without a password (and any provider returns `None` for the header request)
+- **THEN** the system raises `EncryptionError`, because the end header cannot be decrypted to list members

--- a/openspec/changes/phase-5-public-api/specs/safe-extraction/spec.md
+++ b/openspec/changes/phase-5-public-api/specs/safe-extraction/spec.md
@@ -1,0 +1,30 @@
+# safe-extraction — Phase 5 deltas
+
+## ADDED Requirements
+
+### Requirement: Extraction reads limits and strictness from the configuration object
+
+`archivey.extract()` and `ArchiveReader.extract_all()` SHALL accept
+`config: ArchiveyConfig | None` (see `archive-reading`), whose `extraction_limits`
+field (an `ExtractionLimits` of `max_extracted_bytes`, `max_ratio`,
+`ratio_activation_threshold`, `max_entries` — defaults unchanged from the individual
+requirements) supplies the decompression-bomb limits. `extract_all()` SHALL default to
+the config the reader was opened with; `archivey.extract()` SHALL default to the
+library default config. Per-call operational parameters (`members`, `filter`,
+`policy`, `overwrite`, `on_error`, `on_progress`, `password`) remain keyword
+arguments and are not part of the config object.
+
+The returned `list[ExtractionResult]` is accumulated unconditionally in v1: a
+no-tracking mode would not bound memory on its own (readers cache the member list
+internally), so it is deferred until a no-member-cache reader mode exists (see the
+phase-5 design document).
+
+#### Scenario: limits taken from the config
+
+- **WHEN** `archivey.extract(src, dest, config=ArchiveyConfig(extraction_limits=ExtractionLimits(max_extracted_bytes=10 * 2**30)))` is called
+- **THEN** the cumulative byte limit enforced is 10 GiB
+
+#### Scenario: extract_all inherits the reader's config
+
+- **WHEN** a reader opened with a custom `ArchiveyConfig` runs `extract_all(dest)` with no `config` argument
+- **THEN** the reader's config (including its extraction limits) governs the run

--- a/openspec/changes/phase-5-public-api/tasks.md
+++ b/openspec/changes/phase-5-public-api/tasks.md
@@ -1,0 +1,75 @@
+# Phase 5 tasks — public API finalization
+
+> Order matters: the config object (1) unblocks strict_eof relocation (its tests) and
+> extraction limits; the password model (2) and multi-source (3) are independent of each
+> other; the sweep (5) runs last.
+
+## 1. ArchiveyConfig / ExtractionLimits
+
+- [ ] 1.1 Define public `ExtractionLimits` and `ArchiveyConfig` frozen dataclasses
+      (fields per design.md), exported from `archivey`; module default constant.
+- [ ] 1.2 `open_archive(..., config: ArchiveyConfig | None = None)`; the reader stores
+      its config; internal `StreamConfig` becomes a view derived from
+      `ArchiveyConfig` + the access mode (`streaming` stays derived, not public).
+- [ ] 1.3 Relocate `strict_eof` → `config.strict_archive_eof`; **remove** the
+      `open_archive(strict_eof=)` keyword and the `ReadBackend.open_read` parameter
+      (readers read it from their config). Update TAR backend + tests.
+- [ ] 1.4 Tests: default config equivalence; accelerator modes honored via config
+      (monkeypatched sentinels); `strict_archive_eof=True` raises / default warns;
+      frozen-ness (`dataclasses.FrozenInstanceError` on mutation).
+
+## 2. Password candidates and provider
+
+- [ ] 2.1 Widen `password` typing on `open_archive` (`str | bytes | Sequence[str |
+      bytes] | PasswordProvider | None`); normalize once into an internal
+      `_PasswordCandidates` helper on `BaseArchiveReader` (known-good list +
+      remaining candidates + optional provider; `provider(member_or_none)`).
+- [ ] 2.2 Wire the ZIP backend (the only current consumer) through the helper: try
+      known-good → candidates → provider per encrypted member; successful password
+      appended to known-good; exhaustion → `EncryptionError`. Encrypted-symlink
+      listing path uses the same resolution.
+- [ ] 2.3 Tests: sequence across two differently-encrypted members in one pass;
+      provider called once per *new* password (call-count assertion) and receives the
+      member; provider `None` → `EncryptionError`; header-level call passes `None`
+      (unit-test the helper; the real header-encrypted case lands with Phase 7).
+- [ ] 2.4 Docs: candidate-order note ("most likely password first" — 7z key derivation
+      is deliberately expensive) in the open_archive docstring.
+
+## 3. Multi-source input
+
+- [ ] 3.1 Accept `Sequence[str | Path | BinaryIO]` in `open_archive` (length-1 ≡
+      single source); detection runs on the first volume; origin-normalize each
+      seekable stream.
+- [ ] 3.2 Single-path volume-set discovery: `.7z.NNN` / `.partN.rar` / `.rNN` name
+      patterns → sibling scan in the path's directory, natural order (path sources
+      only; a helper the Phase 7 readers reuse).
+- [ ] 3.3 Phase-5 behavior: a resolved multi-source open raises
+      `UnsupportedFeatureError` with a format-appropriate message (7z/RAR: "lands in
+      Phase 7"; others: "not a multi-volume format"). Tests for both messages and
+      for discovery ordering (fixture files, no real volume parsing).
+
+## 4. MemberSelector collection form
+
+- [ ] 4.1 Normalizer: `Collection[str | ArchiveMember]` → predicate (name set matches
+      all duplicates; `ArchiveMember` entries matched by `_archive_id` + `member_id`
+      id-set; mixed collections fine); wire into `stream_members` (and the
+      `extract_all(members=)` path when 4b lands).
+- [ ] 4.2 Update the `MemberSelector` alias + docstring in `reader.py` (drop the
+      "Phase 5 pending" note); tests: duplicate-name tar selects both; member-entry
+      selects only its identity; mixed collection.
+
+## 5. Finalization sweep
+
+- [ ] 5.1 Per-format `CostReceipt` value assertions (zip/tar/all-compressed-tar/
+      single-file/iso/directory) in one parametrized contract test.
+- [ ] 5.2 Error-context stamping verified end-to-end for every backend (archive_name/
+      member_name/format present on translated errors).
+- [ ] 5.3 Remaining `archive-reading` / `archive-data-model` scenarios audited against
+      the test suite; add the missing ones.
+- [ ] 5.4 `SPEC.md` §2 signature blocks + `ARCHITECTURE.md` sketches updated to the
+      final signatures; `openspec validate --strict` clean for the touched specs.
+
+## 6. Sync
+
+- [ ] 6.1 Sync delta specs to `openspec/specs/` (archive-reading, safe-extraction,
+      format-7z) and archive the change.

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,1 @@
+schema: spec-driven

--- a/openspec/project.md
+++ b/openspec/project.md
@@ -81,7 +81,7 @@ once. Specs themselves remain order-free; this table is the association.
 | 5 | Public API finalization & cost surface | `archive-reading`, `archive-data-model`, `access-mode-and-cost`, `error-handling` |
 | 6 | Writing support | `archive-writing` (+ `format-zip` / `format-tar` writers) |
 | 7 | Native 7z reader + native RAR metadata parser | `format-7z`, `format-rar` (native-first: read path imports no third-party lib; `unrar` binary stays for RAR data; `py7zr` for 7z write only); `testing-contract` oracle cross-validation |
-| 8 | Zstandard + extended compression | `format-single-file-compressors`, `format-tar`, `format-detection` |
+| 8 | Seekable zstd + blocked gzip (rescoped — the original zst/lz4 *read* goals landed with Phases 2–3; `w:zst` writing moved to Phase 6) | `seekable-decompressor-streams`, `format-single-file-compressors` |
 | 9 | CLI | `cli` |
 | 10 | Polish, packaging & oracle retirement | `cli`, `packaging-and-extras` (finalize), full `testing-contract` (corpus complete, frozen DEV oracle deleted) (+ cross-cutting: README, final CI tuning — the matrix is stood up in Phase 1; coverage is reported, **not** gated) |
 

--- a/openspec/specs/access-mode-and-cost/spec.md
+++ b/openspec/specs/access-mode-and-cost/spec.md
@@ -34,14 +34,14 @@ The system SHALL accept a `streaming: bool` parameter in `archivey.open_archive(
 
 ### Requirement: Access-mode enforcement — streaming is forward-only
 
-A reader opened with `streaming=True` is forward-only. The system SHALL raise `UnsupportedOperationError` from every random-access or full-materialization method — `members()`, `__contains__`, `__getitem__`, `get()`, `open()`, and `read()` — while `__len__` SHALL raise `TypeError` (the length-hint protocol behind `list(reader)` probes `__len__` implicitly and suppresses only `TypeError`; see `archive-reading`). This holds **uniformly**, regardless of whether the backend happens to have an index loaded, so streaming behaviour does not vary by format. Only a single forward pass via `__iter__`/`stream_members` (or one `extract_all`) is permitted. (There is no single-member `extract()`; selecting members for extraction is `extract_all(members=...)` — see `safe-extraction`.)
+A reader opened with `streaming=True` is forward-only. The system SHALL raise `UnsupportedOperationError` from every random-access or full-materialization method — `members()`, `get()`, `open()`, and `read()`. (`ArchiveReader` defines no `__len__`/`__getitem__` at all — see `archive-reading` — and `member in reader` is scan-free identity membership, allowed in both modes.) This holds **uniformly**, regardless of whether the backend happens to have an index loaded, so streaming behaviour does not vary by format. Only a single forward pass via `__iter__`/`stream_members` (or one `extract_all`) is permitted. (There is no single-member `extract()`; selecting members for extraction is `extract_all(members=...)` — see `safe-extraction`.)
 
 `get_members_if_available()` is exempt: it never scans (see the next requirement), so it remains callable on any reader.
 
 #### Scenario: random access raises on a streaming reader
 
-- **WHEN** any of `ar["f"]`, `ar.get("f")`, `ar.members()`, `ar.open(m)`, or `ar.read(m)` is called on a reader opened with `streaming=True`
-- **THEN** `UnsupportedOperationError` is raised (`len(ar)` raises `TypeError` instead — see `archive-reading`)
+- **WHEN** any of `ar.get("f")`, `ar.members()`, `ar.open(m)`, or `ar.read(m)` is called on a reader opened with `streaming=True`
+- **THEN** `UnsupportedOperationError` is raised
 
 #### Scenario: a single forward pass is allowed on a streaming reader
 
@@ -75,11 +75,10 @@ The per-method behaviour is the composition of the rules above. There are exactl
 | `__iter__`, `stream_members` | ✅ | ✅ (one pass only) |
 | `extract_all` | ✅ | ✅ (the one pass) |
 | `get_members_if_available` | ✅ | ✅ (no-scan; may be `None`) |
-| `members` | ✅ (may scan) | ⛔ `UnsupportedOperationError` |
-| `__len__` | ✅ (may scan) | ⛔ `TypeError` |
-| `__contains__` | ✅ | ⛔ |
-| `__getitem__`, `get` | ✅ | ⛔ |
+| `members` | ✅ (may scan) | ⛔ |
+| `get` | ✅ (may scan) | ⛔ |
 | `open`, `read` | ✅ | ⛔ |
+| `in` (`__contains__`, identity — see `archive-reading`) | ✅ (no scan) | ✅ (no scan) |
 | `cost`, `info`, `format`, `close`, context manager | ✅ | ✅ |
 | at `open_archive()` | fail fast if the source can't be random-accessed | works on any source |
 

--- a/openspec/specs/access-mode-and-cost/spec.md
+++ b/openspec/specs/access-mode-and-cost/spec.md
@@ -34,14 +34,14 @@ The system SHALL accept a `streaming: bool` parameter in `archivey.open_archive(
 
 ### Requirement: Access-mode enforcement — streaming is forward-only
 
-A reader opened with `streaming=True` is forward-only. The system SHALL raise `UnsupportedOperationError` from every random-access or full-materialization method — `members()`, `__len__`, `__contains__`, `__getitem__`, `get()`, `open()`, and `read()`. This holds **uniformly**, regardless of whether the backend happens to have an index loaded, so streaming behaviour does not vary by format. Only a single forward pass via `__iter__`/`stream_members` (or one `extract_all`) is permitted. (There is no single-member `extract()`; selecting members for extraction is `extract_all(members=...)` — see `safe-extraction`.)
+A reader opened with `streaming=True` is forward-only. The system SHALL raise `UnsupportedOperationError` from every random-access or full-materialization method — `members()`, `__contains__`, `__getitem__`, `get()`, `open()`, and `read()` — while `__len__` SHALL raise `TypeError` (the length-hint protocol behind `list(reader)` probes `__len__` implicitly and suppresses only `TypeError`; see `archive-reading`). This holds **uniformly**, regardless of whether the backend happens to have an index loaded, so streaming behaviour does not vary by format. Only a single forward pass via `__iter__`/`stream_members` (or one `extract_all`) is permitted. (There is no single-member `extract()`; selecting members for extraction is `extract_all(members=...)` — see `safe-extraction`.)
 
 `get_members_if_available()` is exempt: it never scans (see the next requirement), so it remains callable on any reader.
 
 #### Scenario: random access raises on a streaming reader
 
-- **WHEN** any of `ar["f"]`, `ar.get("f")`, `len(ar)`, `ar.members()`, `ar.open(m)`, or `ar.read(m)` is called on a reader opened with `streaming=True`
-- **THEN** `UnsupportedOperationError` is raised
+- **WHEN** any of `ar["f"]`, `ar.get("f")`, `ar.members()`, `ar.open(m)`, or `ar.read(m)` is called on a reader opened with `streaming=True`
+- **THEN** `UnsupportedOperationError` is raised (`len(ar)` raises `TypeError` instead — see `archive-reading`)
 
 #### Scenario: a single forward pass is allowed on a streaming reader
 
@@ -75,7 +75,8 @@ The per-method behaviour is the composition of the rules above. There are exactl
 | `__iter__`, `stream_members` | ✅ | ✅ (one pass only) |
 | `extract_all` | ✅ | ✅ (the one pass) |
 | `get_members_if_available` | ✅ | ✅ (no-scan; may be `None`) |
-| `members`, `__len__` | ✅ (may scan) | ⛔ |
+| `members` | ✅ (may scan) | ⛔ `UnsupportedOperationError` |
+| `__len__` | ✅ (may scan) | ⛔ `TypeError` |
 | `__contains__` | ✅ | ⛔ |
 | `__getitem__`, `get` | ✅ | ⛔ |
 | `open`, `read` | ✅ | ⛔ |

--- a/openspec/specs/archive-reading/spec.md
+++ b/openspec/specs/archive-reading/spec.md
@@ -109,21 +109,21 @@ def format(self) -> ArchiveFormat: ...
 
 ### Requirement: Sequential in-order iteration
 
-The system SHALL support iterating all members in archive order via `__iter__`, and MAY materialize the full member list via `members()` or `__len__`.
+The system SHALL support iterating all members in archive order via `__iter__`, and MAY materialize the full member list via `members()`.
 
 ```python
 def __iter__(self) -> Iterator[ArchiveMember]: ...     # sequential, in-order
 def members(self) -> list[ArchiveMember]: ...          # materializes all (may trigger scan)
 def get_members_if_available(self) -> list[ArchiveMember] | None: ...  # no-scan peek
-def __len__(self) -> int: ...                   # may trigger scan
-def __contains__(self, name: str) -> bool: ...
 ```
 
-`__iter__` MUST yield `ArchiveMember` objects one at a time without loading all members into memory. `members()` and `__len__` MAY trigger a full scan for streaming formats that have no central directory. After the member list has been materialized once, subsequent `__iter__` calls MUST return from the cache rather than re-reading the archive.
+`__iter__` MUST yield `ArchiveMember` objects one at a time without loading all members into memory. `members()` MAY trigger a full scan for streaming formats that have no central directory. After the member list has been materialized once, subsequent `__iter__` calls MUST return from the cache rather than re-reading the archive.
+
+The reader deliberately defines **no `__len__`** (and no `__getitem__` — see the name-lookup requirement): the reader is not a collection, and the sequence/mapping protocols get probed *implicitly* in ways the library does not control (`list(reader)` probes `__len__` for preallocation via the length-hint protocol). `len(reader)` therefore raises Python's own `TypeError` in every mode; a caller that wants a count uses `len(ar.members())`, `ar.info.member_count` (when cheaply known), or counts during iteration. `list(reader)` just iterates.
 
 `get_members_if_available()` returns the member list only when it is available **without scanning** (already materialized, or the backend has a true upfront index), else `None`; it never scans, so it is callable under any intent. See `access-mode-and-cost` for its full contract.
 
-When opened with `streaming=True`, the reader is forward-only: `members()`, `__contains__`, `__getitem__`, `get()`, `open()`, and `read()` all SHALL raise `UnsupportedOperationError` (uniformly, not depending on a loaded index). `__len__` SHALL raise `TypeError` instead: `len()` is also probed *implicitly* — `list(reader)` calls `__len__` for preallocation via the length-hint protocol, which suppresses only `TypeError` — so any other exception type would break `list(reader)` even though plain iteration is exactly what a streaming reader supports. Only a single forward pass — `__iter__`/`stream_members` or one `extract_all` — plus `get_members_if_available()` is allowed. See the access mode × method table in `access-mode-and-cost`.
+When opened with `streaming=True`, the reader is forward-only: `members()`, `get()`, `open()`, and `read()` all SHALL raise `UnsupportedOperationError` (uniformly, not depending on a loaded index). Only a single forward pass — `__iter__`/`stream_members` or one `extract_all` — plus `get_members_if_available()` is allowed. See the access mode × method table in `access-mode-and-cost`.
 
 #### Scenario: forward iteration
 
@@ -135,39 +135,68 @@ When opened with `streaming=True`, the reader is forward-only: `members()`, `__c
 - **WHEN** `ar.members()` is called on a reader opened with `streaming=True`
 - **THEN** `UnsupportedOperationError` is raised
 
-#### Scenario: len() and list() on a streaming reader
+#### Scenario: no len(); list() iterates
 
-- **WHEN** `len(ar)` is called on a reader opened with `streaming=True`
-- **THEN** `TypeError` is raised
-- **AND** `list(ar)` (which probes `__len__` via the length-hint protocol, suppressing `TypeError`) still iterates the single forward pass successfully
+- **WHEN** `len(ar)` is called on any reader
+- **THEN** Python's own `TypeError` is raised (`ArchiveReader` defines no `__len__`)
+- **AND** `list(ar)` iterates normally (on a streaming reader, consuming the single forward pass)
 
 ---
 
-### Requirement: Membership and random access by name
+### Requirement: Name lookup and member identity
 
-The system SHALL support dictionary-style lookup of members by normalized name, subject to an access-mode constraint.
+The system SHALL provide name lookup through the explicit `get()` method — the reader is
+deliberately **not** a mapping (no `__getitem__`): duplicate member names mean the mapping
+contract cannot be honored, and dunder protocols get probed implicitly in ways the library
+does not control. `open()`/`read()` also accept a name directly and raise `KeyError` when
+it is absent.
 
 ```python
-def __getitem__(self, name: str) -> ArchiveMember: ...    # KeyError if absent
 def get(self, name: str, default=None) -> ArchiveMember | None: ...
+def __contains__(self, member: ArchiveMember) -> bool: ...   # identity, O(1), any mode
 ```
 
-Calling `__getitem__` or `get` on a reader opened with `streaming=True` SHALL raise `UnsupportedOperationError` — uniformly, regardless of whether the backend has an index loaded (a streaming reader is forward-only; this keeps its behaviour deterministic across formats). A caller that wants a no-scan peek at the member list on any reader uses `get_members_if_available()` instead.
+`get()` looks up a member by its normalized name; with duplicate names it returns the
+**last** one (the member a sequential extraction would leave on disk — callers needing all
+duplicates iterate). Calling `get` on a reader opened with `streaming=True` SHALL raise
+`UnsupportedOperationError` — uniformly, regardless of whether the backend has an index
+loaded (a streaming reader is forward-only; this keeps its behaviour deterministic across
+formats). A caller that wants a no-scan peek at the member list on any reader uses
+`get_members_if_available()` instead.
 
-#### Scenario: successful key lookup
+`member in reader` is **identity membership**: `True` iff the `ArchiveMember` object was
+yielded by this reader. It is O(1) (no scan), so it is valid in any access mode; its use
+is disambiguating members when several readers are in play. A non-`ArchiveMember` operand
+(notably a name string) SHALL raise `TypeError` directing the caller to `get()`.
+`__contains__` MUST be defined even though it is a convenience: without it, Python's `in`
+operator falls back to iterating `__iter__`, which would silently consume a streaming
+reader's single forward pass and compare members by value.
 
-- **WHEN** `ar["path/to/file.txt"]` is called and the member exists
+#### Scenario: successful name lookup
+
+- **WHEN** `ar.get("path/to/file.txt")` is called and the member exists
 - **THEN** the corresponding `ArchiveMember` object is returned
 
-#### Scenario: missing key lookup
+#### Scenario: missing name lookup
 
-- **WHEN** `ar["nonexistent.txt"]` is called and the member does not exist
-- **THEN** `KeyError` is raised
+- **WHEN** `ar.get("nonexistent.txt")` is called and the member does not exist
+- **THEN** `None` (or the caller's `default`) is returned
+- **AND** `ar.open("nonexistent.txt")` / `ar.read("nonexistent.txt")` raise `KeyError`
 
-#### Scenario: random access on a streaming reader
+#### Scenario: name lookup on a streaming reader
 
-- **WHEN** `ar["file.txt"]` is called on a reader opened with `streaming=True`
+- **WHEN** `ar.get("file.txt")` is called on a reader opened with `streaming=True`
 - **THEN** `UnsupportedOperationError` is raised (regardless of any loaded index)
+
+#### Scenario: identity membership
+
+- **WHEN** `member in ar` is evaluated with an `ArchiveMember` yielded by `ar`
+- **THEN** it is `True` (and `False` for a member from a different reader), without scanning, in either access mode
+
+#### Scenario: string operand for `in` is rejected
+
+- **WHEN** `"file.txt" in ar` is evaluated
+- **THEN** `TypeError` is raised, directing the caller to `ar.get(name)` (the `in` operator never falls back to iterating the reader)
 
 ---
 

--- a/openspec/specs/archive-reading/spec.md
+++ b/openspec/specs/archive-reading/spec.md
@@ -123,7 +123,7 @@ def __contains__(self, name: str) -> bool: ...
 
 `get_members_if_available()` returns the member list only when it is available **without scanning** (already materialized, or the backend has a true upfront index), else `None`; it never scans, so it is callable under any intent. See `access-mode-and-cost` for its full contract.
 
-When opened with `streaming=True`, the reader is forward-only: `members()`, `__len__`, `__contains__`, `__getitem__`, `get()`, `open()`, and `read()` all SHALL raise `UnsupportedOperationError` (uniformly, not depending on a loaded index). Only a single forward pass — `__iter__`/`stream_members` or one `extract_all` — plus `get_members_if_available()` is allowed. See the access mode × method table in `access-mode-and-cost`.
+When opened with `streaming=True`, the reader is forward-only: `members()`, `__contains__`, `__getitem__`, `get()`, `open()`, and `read()` all SHALL raise `UnsupportedOperationError` (uniformly, not depending on a loaded index). `__len__` SHALL raise `TypeError` instead: `len()` is also probed *implicitly* — `list(reader)` calls `__len__` for preallocation via the length-hint protocol, which suppresses only `TypeError` — so any other exception type would break `list(reader)` even though plain iteration is exactly what a streaming reader supports. Only a single forward pass — `__iter__`/`stream_members` or one `extract_all` — plus `get_members_if_available()` is allowed. See the access mode × method table in `access-mode-and-cost`.
 
 #### Scenario: forward iteration
 
@@ -132,8 +132,14 @@ When opened with `streaming=True`, the reader is forward-only: `members()`, `__l
 
 #### Scenario: materialization on a streaming reader
 
-- **WHEN** `ar.members()` or `len(ar)` is called on a reader opened with `streaming=True`
+- **WHEN** `ar.members()` is called on a reader opened with `streaming=True`
 - **THEN** `UnsupportedOperationError` is raised
+
+#### Scenario: len() and list() on a streaming reader
+
+- **WHEN** `len(ar)` is called on a reader opened with `streaming=True`
+- **THEN** `TypeError` is raised
+- **AND** `list(ar)` (which probes `__len__` via the length-hint protocol, suppressing `TypeError`) still iterates the single forward pass successfully
 
 ---
 
@@ -287,6 +293,17 @@ The system SHALL transparently follow symlinks and hardlinks in `open()` and `re
 which a hardlink entry refers back to a previously-seen file); the library relies on
 this ordering so a hardlink can always be resolved during a single forward pass.
 
+**Target-name resolution.** The stored target string is resolved to an archive-namespace
+member name before lookup, because the two link kinds store targets in different
+namespaces: a **hardlink** target is archive-relative from the root (the linkname is the
+earlier member's own stored path) and is normalized as-is, while a **symlink** target is
+a filesystem path relative to the link's *own directory* (`dir/link -> file` means
+`dir/file`) and is joined to that directory first. An absolute symlink target, or one
+that `..`-escapes the archive root, cannot name a member — it stays unresolved
+(`link_target_member` is `None`; opening through it raises `LinkTargetNotFoundError`).
+Directory members carry a trailing `/` in their normalized names, so target lookup tries
+both the bare and the `/`-suffixed form.
+
 If the link target is not present in the archive, `LinkTargetNotFoundError` (a
 `ReadError`/member error) SHALL be raised. Chains SHALL be followed recursively with
 **cycle detection** — the set of members already visited on the current chain is
@@ -315,6 +332,16 @@ This does not rely on format-level link resolution; format-level resolution (e.g
 
 - **WHEN** `ar.read("data/latest")` is called and `"data/latest"` is a `SYMLINK` pointing to `"data/v1.0/report.txt"`
 - **THEN** the content of `"data/v1.0/report.txt"` is returned transparently
+
+#### Scenario: relative symlink target resolves against the link's directory
+
+- **WHEN** member `"dir/link"` is a `SYMLINK` whose stored target is `"file"` and the archive contains both `"dir/file"` and a root-level `"file"`
+- **THEN** `ar.read("dir/link")` returns the content of `"dir/file"` (not the root-level `"file"`), and `member.link_target_member` points at `"dir/file"`
+
+#### Scenario: absolute symlink target stays unresolved
+
+- **WHEN** a `SYMLINK` member's stored target is absolute (e.g. `"/etc/passwd"`)
+- **THEN** `member.link_target_member` is `None` and `ar.open()` on it raises `LinkTargetNotFoundError`
 
 #### Scenario: hardlink resolves to an earlier member
 

--- a/openspec/specs/archive-writing/spec.md
+++ b/openspec/specs/archive-writing/spec.md
@@ -195,7 +195,9 @@ writer (which would force a reopen). When given an `ArchiveReader`, `add_members
 ### Requirement: CompressionSpec model and convenience constants
 
 The system SHALL define a `CompressionSpec` dataclass describing the compression
-algorithm and level for entries written to an archive. The `algo` field is **nullable**
+algorithm and level for entries written to an archive. The algorithm field reuses the
+data model's existing `CompressionAlgorithm` enum (see `archive-data-model`) — no
+separate writer-side enum. The `algo` field is **nullable**
 (`None` = let the backend choose the appropriate algorithm for the format and level),
 and `level` accepts either a numeric value **or** a format-agnostic `CompressionLevel`
 enum so callers can ask for a relative effort without knowing a format's numeric scale.
@@ -209,14 +211,14 @@ class CompressionLevel(Enum):
 
 @dataclass
 class CompressionSpec:
-    algo: CompressionAlgo | None = None                 # None = backend auto-selects
+    algo: CompressionAlgorithm | None = None                 # None = backend auto-selects
     level: int | CompressionLevel = CompressionLevel.DEFAULT
 
 # Convenience constants:
-CompressionSpec.STORED      = CompressionSpec(algo=CompressionAlgo.STORED)
-CompressionSpec.DEFLATE     = CompressionSpec(algo=CompressionAlgo.DEFLATE, level=6)
-CompressionSpec.DEFLATE_MAX = CompressionSpec(algo=CompressionAlgo.DEFLATE, level=CompressionLevel.MAX)
-CompressionSpec.LZMA        = CompressionSpec(algo=CompressionAlgo.LZMA2, level=CompressionLevel.DEFAULT)
+CompressionSpec.STORED      = CompressionSpec(algo=CompressionAlgorithm.STORED)
+CompressionSpec.DEFLATE     = CompressionSpec(algo=CompressionAlgorithm.DEFLATE, level=6)
+CompressionSpec.DEFLATE_MAX = CompressionSpec(algo=CompressionAlgorithm.DEFLATE, level=CompressionLevel.MAX)
+CompressionSpec.LZMA        = CompressionSpec(algo=CompressionAlgorithm.LZMA2, level=CompressionLevel.DEFAULT)
 ```
 
 **Resolution table** (how `(algo, level)` is resolved by the backend). `compression=None`
@@ -233,7 +235,7 @@ at `create()`/`add_*` is equivalent to `CompressionSpec(algo=None, level=DEFAULT
 Convenience constants SHALL be available as class attributes on `CompressionSpec`.
 
 **Fail fast on an unavailable codec — never silently fall back.** When the caller names an
-explicit `algo` whose backend is not installed (e.g. `algo=CompressionAlgo.ZSTD` without the
+explicit `algo` whose backend is not installed (e.g. `algo=CompressionAlgorithm.ZSTD` without the
 `[zstd]` extra, or a `[7z]`-only codec for a 7z write), `create()` (or the first `add_*` that
 would use it) SHALL raise immediately — `PackageNotInstalledError` when a package/tool is
 missing, or `UnsupportedFeatureError` when the target format cannot represent the codec at
@@ -244,7 +246,7 @@ one that is actually available.)
 
 #### Scenario: explicit codec without its extra fails fast
 
-- **WHEN** `archivey.create(dest, fmt, compression=CompressionSpec(algo=CompressionAlgo.ZSTD))` is called and the `[zstd]` extra is not installed
+- **WHEN** `archivey.create(dest, fmt, compression=CompressionSpec(algo=CompressionAlgorithm.ZSTD))` is called and the `[zstd]` extra is not installed
 - **THEN** `PackageNotInstalledError` is raised naming the missing package; no archive is written and no fallback codec is substituted
 
 #### Scenario: auto algorithm at a symbolic level
@@ -264,7 +266,7 @@ one that is actually available.)
 
 #### Scenario: STORE level overrides an explicit algorithm
 
-- **WHEN** `compression=CompressionSpec(algo=CompressionAlgo.LZMA2, level=CompressionLevel.STORE)` is passed
+- **WHEN** `compression=CompressionSpec(algo=CompressionAlgorithm.LZMA2, level=CompressionLevel.STORE)` is passed
 - **THEN** the entry is written `STORED` (uncompressed) and a `logging.WARNING` notes the contradictory combination
 
 #### Scenario: out-of-range numeric level is rejected

--- a/openspec/specs/cli/spec.md
+++ b/openspec/specs/cli/spec.md
@@ -18,7 +18,7 @@ The system SHALL provide an `archivey` command that exposes at minimum the follo
 #### Scenario: verifying archive integrity
 
 - **WHEN** the user runs `archivey test <archive>`
-- **THEN** the command verifies each member's CRC and SHA256 integrity and reports any failures
+- **THEN** the command reads every member fully, verifying each stored digest (e.g. CRC32; Blake2sp for RAR5) via the shared verification stage, and reports any failures
 
 #### Scenario: extracting archive contents
 

--- a/openspec/specs/error-handling/spec.md
+++ b/openspec/specs/error-handling/spec.md
@@ -49,7 +49,7 @@ incompatible at open), **not** `UnsupportedOperationError`.
 **`UnsupportedOperationError` vs `UnsupportedFeatureError` — a deliberate split:**
 
 - `UnsupportedOperationError` signals **API misuse**: the caller asked for something this
-  reader's *mode* does not permit — random access (`__getitem__`, `get`, materialization)
+  reader's *mode* does not permit — random access (`get`, materialization)
   on a `streaming=True` reader, writing through a read-only RAR backend, or using a
   closed reader. It is not caused by the archive's contents; choosing a different
   access mode/usage avoids it. It can therefore occur in normal use when the wrong access mode

--- a/openspec/specs/format-7z/spec.md
+++ b/openspec/specs/format-7z/spec.md
@@ -224,8 +224,12 @@ decoded once, its members yielded in archive order as the decompressor produces
 bytes, with no buffering of the whole folder and no background thread or queue.
 Peak memory is bounded by the decompressor's working set rather than the folder's
 uncompressed size. For random `ar.open()` of a member inside a solid folder, the
-backend decodes the folder from its start; it MAY cache the decoded folder so that
-repeated access to members of the same folder is served without re-decoding.
+backend decodes the folder from its start; it MAY retain decoded folder output so that
+repeated access to members of the same folder is served without re-decoding — but any
+such retention MUST honor `archive-reading`'s bounded-memory rule (no growing cache of
+decompressed block data held in RAM until `close()`): a decoded-folder cache is spilled
+to a temporary file on disk and/or explicitly bounded, with the exact mechanism decided
+in the Phase 7 change proposal.
 
 #### Scenario: streaming a solid 7z archive
 
@@ -235,7 +239,7 @@ repeated access to members of the same folder is served without re-decoding.
 #### Scenario: random access into a solid folder
 
 - **WHEN** `ar.open(member)` is called for a member inside a multi-file folder
-- **THEN** the backend decodes the folder from its start to produce the member's bytes, optionally caching the decoded folder for subsequent access
+- **THEN** the backend decodes the folder from its start to produce the member's bytes, optionally retaining the decoded output for subsequent access within the bounded-memory rule (disk spill / explicit bound)
 
 ---
 

--- a/openspec/specs/format-detection/spec.md
+++ b/openspec/specs/format-detection/spec.md
@@ -277,10 +277,12 @@ and the backend rather than detection consuming bytes the caller can no longer r
 
 - For **paths and seekable streams**: detection reads via `peek`/`read` and restores
   the stream's **starting position** (its `tell()` on entry) afterwards; no wrapper is
-  needed. The archive is taken to begin wherever the caller positioned the stream, so
-  an archive embedded mid-file detects against the right bytes and the backend then
-  reads from the same origin (backends that address the source absolutely — ISO via
-  `pycdlib` — still require position 0; see `format-iso`).
+  needed for detection itself. The archive is taken to begin wherever the caller
+  positioned the stream, so an archive embedded mid-file detects against the right
+  bytes. `open_archive()` then normalizes the origin for the backend: a seekable
+  stream positioned mid-file is wrapped in a zero-origin view (`SlicingStream`) so
+  every backend — including those that address the source with absolute offsets, like
+  ISO via `pycdlib` — sees the archive begin at `tell() == 0`.
 - For **non-seekable streams**: `open_archive()` SHALL wrap the source in a
   `PeekableStream` **before** running detection and pass that same `PeekableStream`
   to both detection and the backend. Detection inspects bytes through

--- a/openspec/specs/format-detection/spec.md
+++ b/openspec/specs/format-detection/spec.md
@@ -276,7 +276,11 @@ responsibility, not `detect_format()`'s, so that one wrapper is shared by detect
 and the backend rather than detection consuming bytes the caller can no longer reach:
 
 - For **paths and seekable streams**: detection reads via `peek`/`read` and restores
-  the position with `seek(0)` afterwards; no wrapper is needed.
+  the stream's **starting position** (its `tell()` on entry) afterwards; no wrapper is
+  needed. The archive is taken to begin wherever the caller positioned the stream, so
+  an archive embedded mid-file detects against the right bytes and the backend then
+  reads from the same origin (backends that address the source absolutely — ISO via
+  `pycdlib` — still require position 0; see `format-iso`).
 - For **non-seekable streams**: `open_archive()` SHALL wrap the source in a
   `PeekableStream` **before** running detection and pass that same `PeekableStream`
   to both detection and the backend. Detection inspects bytes through
@@ -308,11 +312,11 @@ this wrapping internally, so callers of the high-level API never wrap by hand.
 └──────────────────────────────────────────────────────────────┘
 ```
 
-#### Scenario: seekable stream is rewound
+#### Scenario: seekable stream position is preserved
 
-- **WHEN** `detect_format()` is called with a seekable `BinaryIO` at position 0
-- **THEN** after detection completes the stream position SHALL be 0
-- **AND** the backend can read the full stream from the start without any data loss
+- **WHEN** `detect_format()` is called with a seekable `BinaryIO` at any position N
+- **THEN** after detection completes the stream position SHALL again be N
+- **AND** the backend can read the full archive from that origin without any data loss
 
 #### Scenario: non-seekable source wrapped once by the opener and shared
 

--- a/openspec/specs/format-rar/spec.md
+++ b/openspec/specs/format-rar/spec.md
@@ -65,6 +65,20 @@ obtain all other member *data* by invoking the system `unrar` binary. If `unrar`
 required but not available on PATH, the system SHALL raise
 `PackageNotInstalledError` naming `unrar`. Listing never requires `unrar`.
 
+**Supported decompressor: RARLAB `unrar` only** (maintainer decision, 2026-07).
+Several other tools answer to RAR extraction — `unrar-free` (libarchive-based, with a
+long history of failing on real-world archives), `unar`, `bsdtar`, `7z` — and
+`rarfile` grew a whole backend-detection layer to juggle them; Archivey deliberately
+does not. The backend SHALL verify the binary is RARLAB `unrar` (its version banner)
+and treat an incompatible flavor like a missing tool — a clear error naming RARLAB
+`unrar`, never silently degraded output. Additional decompressor backends can be
+added later if a real need appears.
+
+#### Scenario: an incompatible unrar flavor on PATH
+
+- **WHEN** the `unrar` on PATH is not RARLAB unrar (e.g. `unrar-free`) and a compressed member is read
+- **THEN** the system raises `PackageNotInstalledError` naming RARLAB `unrar`, rather than piping data through the incompatible tool
+
 #### Scenario: reading a compressed member without unrar installed
 
 - **WHEN** `reader.read(member)` is called on a non-stored member and `unrar` is not on PATH

--- a/openspec/specs/format-zip/spec.md
+++ b/openspec/specs/format-zip/spec.md
@@ -33,10 +33,28 @@ The system SHALL expose the following cost and capability properties for every o
 The system SHALL map each `ZipInfo` entry to a `ArchiveMember` dataclass using the following field rules:
 
 - `mode`: parsed from `external_attr >> 16`. If `external_attr == 0` and `create_system != 3` (Unix), `mode` is set to `None`.
-- `modified`: from the `date_time` tuple, constructed as a naive `datetime` (no TZ; DOS format has 2-second granularity). If the ZIP64 extra field contains an NT timestamp, use that as a timezone-aware UTC `datetime` instead.
+- `modified`/`accessed`/`created`: layered by precedence, each layer overriding only the
+  times it actually carries. Base: the DOS `date_time` tuple as a naive `datetime` (no TZ;
+  local wall-clock, 2-second granularity; `None` for the year-1980 "no timestamp"
+  sentinel). Above it: the NTFS extra field (`0x000A`) — three 64-bit FILETIMEs
+  (modification/access/creation, 100 ns UTC ticks since 1601, zero = "not set"; written
+  by Windows tools such as 7-Zip) — as timezone-aware UTC `datetime`s. Highest: the
+  Extended Timestamp extra field (`0x5455`) — signed 32-bit Unix times, its flags byte
+  signaling which of modification/access/creation are present — as timezone-aware UTC
+  `datetime`s.
 - `type`: inferred from `mode` if Unix, otherwise from `is_dir()` and symlink detection via extra field `0x000A` (NTFS) or `0x7875` (Unix UID/GID).
 - `compression`: map `compress_type` integer to `CompressionMethod`.
 - `is_encrypted`: set to `True` when `flag_bits & 0x1` is non-zero.
+
+> **Phase 3 → 7 gap (member decode via stdlib zipfile).** Until the
+> `compressed-streams` codec layer is wired into ZIP member reads (Phase 7, alongside
+> the native 7z reader's container codecs), member *data* decompression goes through
+> stdlib `zipfile`, which cannot decode deflate64/PPMd (or zstd before Python 3.14)
+> even when the corresponding codec packages are installed — reading such a member
+> raises `UnsupportedFeatureError`. `format_availability(ZIP)`'s FULL/PARTIAL result
+> (see `backend-registry`) describes the intended post-Phase-7 composition over those
+> codecs, so until then it can report FULL while these rare member codecs still fail
+> at read time. Listing is unaffected.
 
 #### Scenario: Unix mode from external_attr
 
@@ -48,10 +66,15 @@ The system SHALL map each `ZipInfo` entry to a `ArchiveMember` dataclass using t
 - **WHEN** a ZIP entry has `external_attr == 0` or `create_system != 3`
 - **THEN** `member.mode` is set to `None`
 
-#### Scenario: NT timestamp takes precedence over DOS date_time
+#### Scenario: Extended Timestamp takes precedence over DOS date_time
 
-- **WHEN** a ZIP entry carries a ZIP64 extra field containing an NT timestamp
-- **THEN** `member.modified` is a timezone-aware UTC `datetime` derived from that NT timestamp, overriding the value from `date_time`
+- **WHEN** a ZIP entry carries an Extended Timestamp extra field (`0x5455`) with a modification time
+- **THEN** `member.modified` is a timezone-aware UTC `datetime` derived from that Unix time, overriding the value from `date_time`
+
+#### Scenario: NTFS timestamps used when no Extended Timestamp is present
+
+- **WHEN** a ZIP entry carries an NTFS extra field (`0x000A`) with non-zero FILETIMEs and no `0x5455` field
+- **THEN** `member.modified`/`accessed`/`created` are timezone-aware UTC `datetime`s derived from those FILETIMEs, overriding the value from `date_time`
 
 #### Scenario: Encrypted entry detection
 

--- a/openspec/specs/format-zip/spec.md
+++ b/openspec/specs/format-zip/spec.md
@@ -26,7 +26,7 @@ The system SHALL expose the following cost and capability properties for every o
 #### Scenario: Central directory lookup is O(1)
 
 - **WHEN** `reader.get("some/member.txt")` is called on a ZIP reader
-- **THEN** the lookup is satisfied via the in-memory `NameToInfo` dict with no additional I/O
+- **THEN** the lookup is satisfied via the reader's in-memory name→member map (built from the central directory) with no additional I/O
 
 ### Requirement: Map ZIP member metadata to the unified ArchiveMember model
 
@@ -46,15 +46,21 @@ The system SHALL map each `ZipInfo` entry to a `ArchiveMember` dataclass using t
 - `compression`: map `compress_type` integer to `CompressionMethod`.
 - `is_encrypted`: set to `True` when `flag_bits & 0x1` is non-zero.
 
-> **Phase 3 → 7 gap (member decode via stdlib zipfile).** Until the
-> `compressed-streams` codec layer is wired into ZIP member reads (Phase 7, alongside
-> the native 7z reader's container codecs), member *data* decompression goes through
-> stdlib `zipfile`, which cannot decode deflate64/PPMd (or zstd before Python 3.14)
-> even when the corresponding codec packages are installed — reading such a member
-> raises `UnsupportedFeatureError`. `format_availability(ZIP)`'s FULL/PARTIAL result
-> (see `backend-registry`) describes the intended post-Phase-7 composition over those
-> codecs, so until then it can report FULL while these rare member codecs still fail
-> at read time. Listing is unaffected.
+> **Phase 3 → 7 gap (member decode via stdlib zipfile).** Member *data* decompression
+> currently goes through stdlib `zipfile`, which cannot decode deflate64/PPMd (or zstd
+> before Python 3.14) even when the corresponding codec packages are installed —
+> reading such a member raises `UnsupportedFeatureError`. `format_availability(ZIP)`'s
+> FULL/PARTIAL result (see `backend-registry`) describes the intended composition over
+> those codecs, so until the gap closes it can report FULL while these rare member
+> codecs still fail at read time. Listing is unaffected.
+>
+> The intended fix (Phase 7, alongside the 7z container codecs — see
+> `openspec/project.md`) keeps `zipfile` for the central directory but bypasses its
+> decompressor for member data: locate the member's raw compressed bytes (local-header
+> offset + a `SlicingStream` view) and decode them through the shared
+> `compressed-streams` codec layer. `zipfile` exposes no decompressor plug-in point, so
+> this raw-slice route — a first step toward the full native ZIP reader in `IDEAS.md` —
+> is the mechanism; the Phase 7 change proposal specifies it.
 
 #### Scenario: Unix mode from external_attr
 

--- a/openspec/specs/format-zip/spec.md
+++ b/openspec/specs/format-zip/spec.md
@@ -25,7 +25,7 @@ The system SHALL expose the following cost and capability properties for every o
 
 #### Scenario: Central directory lookup is O(1)
 
-- **WHEN** `reader["some/member.txt"]` is called on a ZIP reader
+- **WHEN** `reader.get("some/member.txt")` is called on a ZIP reader
 - **THEN** the lookup is satisfied via the in-memory `NameToInfo` dict with no additional I/O
 
 ### Requirement: Map ZIP member metadata to the unified ArchiveMember model

--- a/openspec/specs/safe-extraction/spec.md
+++ b/openspec/specs/safe-extraction/spec.md
@@ -276,14 +276,27 @@ The transforms per policy are:
 
 ### Requirement: Overwrite Policy
 
-The system SHALL enforce the `OverwritePolicy` when a destination file already exists at the path a member would be written to.
+The system SHALL enforce the `OverwritePolicy` when a destination entry already exists at the path a member would be written to.
 
 ```python
 class OverwritePolicy(Enum):
-    ERROR   = "error"   # raise ExtractionError if destination file exists
-    SKIP    = "skip"    # silently skip existing files
-    REPLACE = "replace" # overwrite unconditionally
+    ERROR   = "error"   # raise ExtractionError if destination entry exists
+    SKIP    = "skip"    # silently skip existing entries
+    REPLACE = "replace" # replace unconditionally (unlink, then create fresh)
 ```
+
+Two symlink-safety rules apply to all three policies:
+
+- **Existence is checked with `lstat` semantics** (the entry itself, never its target).
+  A *dangling* symlink at the destination path counts as an existing entry — a
+  follow-the-link existence check would report "absent" and a subsequent
+  `open(path, "wb")` would create the file at the symlink's **target**, an attacker-
+  controllable location.
+- **`REPLACE` means unlink-then-create, never write-through.** If the existing entry is
+  a symlink (planted by an earlier hostile member, a previous extraction, or anything
+  else), replacing the member MUST remove the link itself and create a fresh entry at
+  the path — it MUST NOT open the existing path for writing, which would follow the
+  link and write somewhere else under the member's name.
 
 #### Scenario: ERROR raises on existing file
 
@@ -298,7 +311,17 @@ class OverwritePolicy(Enum):
 #### Scenario: REPLACE overwrites unconditionally
 
 - **WHEN** a member would write to an existing path and `OverwritePolicy.REPLACE` is active
-- **THEN** the existing file is overwritten with the member's data
+- **THEN** the existing entry is removed and replaced with the member's data
+
+#### Scenario: REPLACE of an existing symlink does not write through it
+
+- **WHEN** the destination path is an existing symlink (e.g. planted by an earlier member) and `OverwritePolicy.REPLACE` is active
+- **THEN** the symlink itself is unlinked and the member is created fresh at the path; no bytes are ever written through the old link to its target
+
+#### Scenario: dangling symlink at the destination counts as existing
+
+- **WHEN** the destination path is a dangling symlink and `OverwritePolicy.ERROR` (or `SKIP`) is active
+- **THEN** the entry is treated as existing — `ExtractionError` is raised (or the member is skipped); the extractor never opens the path for writing, which would create the file at the link's target
 
 ---
 

--- a/src/archivey/core.py
+++ b/src/archivey/core.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import BinaryIO
 
-from archivey.exceptions import StreamNotSeekableError
+from archivey.exceptions import StreamNotSeekableError, UnsupportedOperationError
 from archivey.internal.detection import DetectionConfidence, FormatInfo, detect_format
 from archivey.internal.registry import (
     FormatAvailability,
@@ -17,7 +17,12 @@ from archivey.internal.registry import (
     list_supported_formats,
 )
 from archivey.internal.streams.peekable import PeekableStream
-from archivey.internal.streams.streamtools import is_seekable, is_stream, source_name
+from archivey.internal.streams.streamtools import (
+    fix_stream_start_position,
+    is_seekable,
+    is_stream,
+    source_name,
+)
 from archivey.reader import ArchiveReader
 from archivey.types import ArchiveFormat
 
@@ -63,11 +68,10 @@ def open_archive(
     consumes bytes the backend still needs.
 
     A seekable stream source is taken to hold the archive **starting at its current
-    position** — detection peeks from there and restores the position, and the TAR /
-    single-file-compressor backends read from there (so an archive embedded mid-file
-    works without slicing). ZIP tolerates prefix data by design (offsets are resolved
-    from the end-of-central-directory). ISO is the exception: ``pycdlib`` addresses the
-    image with absolute offsets, so an ISO stream must start at position 0.
+    position**: detection peeks from there and restores the position, and the opener
+    then wraps a mid-positioned stream in a zero-origin view so every backend sees the
+    archive begin at ``tell() == 0`` (an archive embedded mid-file works uniformly,
+    without manual slicing).
     """
     # Import backends to ensure they are registered
     import archivey.internal.backends  # noqa: F401
@@ -99,6 +103,15 @@ def open_archive(
     registry = get_registry()
     backend_cls = registry.reader_for_format(format)
 
+    # A password for a format that has no encryption is API misuse, rejected centrally
+    # (backends declare SUPPORTS_PASSWORD as data and never see the argument otherwise).
+    if password is not None and not backend_cls.SUPPORTS_PASSWORD:
+        raise UnsupportedOperationError(
+            f"Format {format!r} does not support passwords (it carries no encryption).",
+            source_format=format,
+            archive_name=archive_name,
+        )
+
     # Fail fast for a seek-requiring backend on a non-seekable source (the access-mode
     # contract: streaming=False does not implicitly buffer). Per-backend opt-in only:
     # TAR may open non-seekable sources under streaming=True; ZIP/ISO still fail fast.
@@ -114,6 +127,13 @@ def open_archive(
             source_format=format,
             archive_name=archive_name,
         )
+
+    # Normalize the stream origin once for every backend: a seekable stream positioned
+    # mid-file is wrapped so the backend sees tell() == 0 at the archive's first byte
+    # (the stream-position contract in format-detection). Done after detection, which
+    # peeks from and restores the same origin.
+    if is_stream(open_source) and is_seekable(open_source):
+        open_source = fix_stream_start_position(open_source)
 
     # Thread the encoding: an explicit caller encoding wins, else the detector's hint, else
     # None (the backend auto-detects).

--- a/src/archivey/core.py
+++ b/src/archivey/core.py
@@ -17,7 +17,7 @@ from archivey.internal.registry import (
     list_supported_formats,
 )
 from archivey.internal.streams.peekable import PeekableStream
-from archivey.internal.streams.streamtools import is_seekable, is_stream
+from archivey.internal.streams.streamtools import is_seekable, is_stream, source_name
 from archivey.reader import ArchiveReader
 from archivey.types import ArchiveFormat
 
@@ -32,21 +32,8 @@ __all__ = [
     "list_known_formats",
     "list_supported_formats",
     "open_archive",
-    "source_name",
+    "source_name",  # re-exported from streamtools (the single implementation)
 ]
-
-
-def source_name(source: str | Path | BinaryIO) -> str | None:
-    """Best-effort human-readable name for a source, for error messages and metadata.
-
-    A path-like source yields its string form; a file-like stream yields its ``name``
-    attribute when that is a string (``open()`` sets it, ``BytesIO`` does not, and some
-    streams expose an integer fd there — both of those yield ``None``).
-    """
-    if isinstance(source, (str, Path)):
-        return str(source)
-    name = getattr(source, "name", None)
-    return name if isinstance(name, str) else None
 
 
 def open_archive(
@@ -74,6 +61,13 @@ def open_archive(
     ``format=`` is passed explicitly. A directory path opens as a directory pseudo-archive.
     A non-seekable stream is wrapped in a :class:`PeekableStream` so detection never
     consumes bytes the backend still needs.
+
+    A seekable stream source is taken to hold the archive **starting at its current
+    position** — detection peeks from there and restores the position, and the TAR /
+    single-file-compressor backends read from there (so an archive embedded mid-file
+    works without slicing). ZIP tolerates prefix data by design (offsets are resolved
+    from the end-of-central-directory). ISO is the exception: ``pycdlib`` addresses the
+    image with absolute offsets, so an ISO stream must start at position 0.
     """
     # Import backends to ensure they are registered
     import archivey.internal.backends  # noqa: F401

--- a/src/archivey/internal/backends/directory_reader.py
+++ b/src/archivey/internal/backends/directory_reader.py
@@ -14,6 +14,7 @@ from archivey.cost import (
     ListingCost,
     StreamCapability,
 )
+from archivey.exceptions import UnsupportedOperationError
 from archivey.internal.base_reader import BaseArchiveReader, ReadBackend
 from archivey.internal.registry import register_reader
 from archivey.types import (
@@ -225,6 +226,11 @@ class DirectoryReadBackend(ReadBackend):
         # uniform ReadBackend signature.
         if not isinstance(source, Path):
             raise TypeError("Directory backend requires a Path source")
+        if password is not None:
+            raise UnsupportedOperationError(
+                "Directories do not support passwords (they carry no encryption).",
+                archive_name=archive_name,
+            )
         return DirectoryReader(source, streaming, archive_name or str(source))
 
 

--- a/src/archivey/internal/backends/directory_reader.py
+++ b/src/archivey/internal/backends/directory_reader.py
@@ -14,7 +14,6 @@ from archivey.cost import (
     ListingCost,
     StreamCapability,
 )
-from archivey.exceptions import UnsupportedOperationError
 from archivey.internal.base_reader import BaseArchiveReader, ReadBackend
 from archivey.internal.registry import register_reader
 from archivey.types import (
@@ -223,14 +222,9 @@ class DirectoryReadBackend(ReadBackend):
         strict_eof: bool = False,
     ) -> DirectoryReader:
         # `format` is always DIRECTORY here (single-format backend); accepted for the
-        # uniform ReadBackend signature.
+        # uniform ReadBackend signature. Password rejection is central (SUPPORTS_PASSWORD).
         if not isinstance(source, Path):
             raise TypeError("Directory backend requires a Path source")
-        if password is not None:
-            raise UnsupportedOperationError(
-                "Directories do not support passwords (they carry no encryption).",
-                archive_name=archive_name,
-            )
         return DirectoryReader(source, streaming, archive_name or str(source))
 
 

--- a/src/archivey/internal/backends/iso_reader.py
+++ b/src/archivey/internal/backends/iso_reader.py
@@ -147,6 +147,7 @@ class IsoReader(BaseArchiveReader):
     ) -> None:
         # password rejection is central: open_archive checks ReadBackend.SUPPORTS_PASSWORD.
         super().__init__(format, streaming, archive_name)
+        self._source = source
         if pycdlib is None:
             raise PackageNotInstalledError(
                 "The 'pycdlib' package is required to read ISO images "

--- a/src/archivey/internal/backends/iso_reader.py
+++ b/src/archivey/internal/backends/iso_reader.py
@@ -12,6 +12,11 @@ The directory tree lives in the header region, giving O(1) (``INDEXED``) listing
 out of scope (``UnsupportedOperationError``). The image is read uncompressed in place — a
 compressed ``.iso.xz`` is a single-file compressor wrapping the image, not mounted here
 (see the seek-heavy-container note in the proposal).
+
+Stream-position caveat: unlike the TAR/single-file backends, an ISO stream source must
+start at position 0 — ``pycdlib`` addresses the image with absolute offsets (the PVD at
+32 KiB etc.), so a mid-positioned stream is not supported (wrap the region in a
+``SlicingStream`` first if that is ever needed).
 """
 
 from __future__ import annotations

--- a/src/archivey/internal/backends/iso_reader.py
+++ b/src/archivey/internal/backends/iso_reader.py
@@ -321,7 +321,7 @@ class IsoReader(BaseArchiveReader):
                 self._stamp_error_context(translated, member.name)
                 raise translated from exc
             raise
-        return self._wrap_member_stream(stream, member.name)
+        return self._wrap_member_stream(stream, member.name, size=member.size)
 
     def _get_archive_info(self) -> ArchiveInfo:
         cost = CostReceipt(

--- a/src/archivey/internal/backends/iso_reader.py
+++ b/src/archivey/internal/backends/iso_reader.py
@@ -13,10 +13,10 @@ out of scope (``UnsupportedOperationError``). The image is read uncompressed in 
 compressed ``.iso.xz`` is a single-file compressor wrapping the image, not mounted here
 (see the seek-heavy-container note in the proposal).
 
-Stream-position caveat: unlike the TAR/single-file backends, an ISO stream source must
-start at position 0 — ``pycdlib`` addresses the image with absolute offsets (the PVD at
-32 KiB etc.), so a mid-positioned stream is not supported (wrap the region in a
-``SlicingStream`` first if that is ever needed).
+``pycdlib`` addresses the image with absolute offsets (the PVD at 32 KiB etc.), so it
+needs the archive to start at ``tell() == 0`` — which ``open_archive`` guarantees by
+wrapping any mid-positioned seekable stream in a zero-origin view before handing it to
+a backend (the stream-position contract in ``format-detection``).
 """
 
 from __future__ import annotations
@@ -42,7 +42,6 @@ from archivey.exceptions import (
     ArchiveyError,
     CorruptionError,
     PackageNotInstalledError,
-    UnsupportedOperationError,
 )
 from archivey.internal.base_reader import BaseArchiveReader, ReadBackend
 from archivey.internal.naming import normalize_member_name
@@ -146,12 +145,8 @@ class IsoReader(BaseArchiveReader):
         encoding: str | None,
         archive_name: str | None,
     ) -> None:
+        # password rejection is central: open_archive checks ReadBackend.SUPPORTS_PASSWORD.
         super().__init__(format, streaming, archive_name)
-        if password is not None:
-            raise UnsupportedOperationError(
-                "ISO 9660 images do not support passwords (they carry no encryption).",
-                archive_name=archive_name,
-            )
         if pycdlib is None:
             raise PackageNotInstalledError(
                 "The 'pycdlib' package is required to read ISO images "

--- a/src/archivey/internal/backends/single_file_reader.py
+++ b/src/archivey/internal/backends/single_file_reader.py
@@ -147,6 +147,7 @@ class SingleFileReader(BaseArchiveReader):
         from archivey.internal.streams.peekable import PeekableStream
 
         src = self._source
+        assert src is not None  # always set in __init__
         if isinstance(src, Path):
             with open(src, "rb") as f:
                 return f.read(length)
@@ -190,6 +191,7 @@ class SingleFileReader(BaseArchiveReader):
     def _open_codec_stream(self) -> BinaryIO:
         """Open a fresh decompression stream over the source (rewinding a seekable one)."""
         src = self._source
+        assert src is not None  # always set in __init__
         if is_stream(src) and is_seekable(src):
             src.seek(0)  # origin-normalized by open_archive; 0 is the archive start
         codec_source = str(src) if isinstance(src, Path) else src

--- a/src/archivey/internal/backends/single_file_reader.py
+++ b/src/archivey/internal/backends/single_file_reader.py
@@ -25,10 +25,7 @@ from archivey.cost import (
     ListingCost,
     StreamCapability,
 )
-from archivey.exceptions import (
-    ArchiveyError,
-    UnsupportedOperationError,
-)
+from archivey.exceptions import ArchiveyError
 from archivey.internal.base_reader import BaseArchiveReader, ReadBackend
 from archivey.internal.config import StreamConfig
 from archivey.internal.registry import register_reader
@@ -82,20 +79,12 @@ class SingleFileReader(BaseArchiveReader):
         encoding: str | None,
         archive_name: str | None,
     ) -> None:
-        if password is not None:
-            raise UnsupportedOperationError(
-                "Single-file compressors do not support passwords (they carry no encryption)."
-            )
+        # password rejection is central: open_archive checks ReadBackend.SUPPORTS_PASSWORD.
         super().__init__(format, streaming, archive_name)
         self._source = source
         self._stream_codec = stream_codec_for_format(format.stream)
         self._codec = self._stream_codec.codec
         self._seekable = not is_stream(source) or is_seekable(source)
-        # The compressed stream starts wherever the caller positioned the source (the
-        # stream-position contract): remember it so re-opens rewind *here*, not to 0.
-        self._source_start = (
-            source.tell() if is_stream(source) and is_seekable(source) else 0
-        )
 
         # A non-seekable source cannot be randomly accessed, so engaging a random-access
         # accelerator (rapidgzip) is pointless — and would in fact fail at *open*: rapidgzip
@@ -164,8 +153,10 @@ class SingleFileReader(BaseArchiveReader):
         if isinstance(src, PeekableStream):
             return src.peek(length)
         if is_seekable(src):
+            # open_archive normalizes the origin (a mid-positioned stream arrives wrapped
+            # with tell() == 0 at the archive's first byte), so 0 is the archive start.
             pos = src.tell()
-            src.seek(self._source_start)
+            src.seek(0)
             data = read_exact(src, length)
             src.seek(pos)
             return data
@@ -197,11 +188,10 @@ class SingleFileReader(BaseArchiveReader):
         yield self._member
 
     def _open_codec_stream(self) -> BinaryIO:
-        """Open a fresh decompression stream over the source (rewinding a seekable one
-        to the position it had when handed to the reader)."""
+        """Open a fresh decompression stream over the source (rewinding a seekable one)."""
         src = self._source
         if is_stream(src) and is_seekable(src):
-            src.seek(self._source_start)
+            src.seek(0)  # origin-normalized by open_archive; 0 is the archive start
         codec_source = str(src) if isinstance(src, Path) else src
         return open_codec_stream(
             self._codec,

--- a/src/archivey/internal/backends/single_file_reader.py
+++ b/src/archivey/internal/backends/single_file_reader.py
@@ -40,7 +40,7 @@ from archivey.internal.streams.codecs import (
     stream_codec_for_format,
 )
 from archivey.internal.streams.decompressor_stream import DecompressorStream
-from archivey.internal.streams.streamtools import is_seekable, is_stream
+from archivey.internal.streams.streamtools import is_seekable, is_stream, read_exact
 from archivey.types import (
     ArchiveFormat,
     ArchiveInfo,
@@ -91,6 +91,11 @@ class SingleFileReader(BaseArchiveReader):
         self._stream_codec = stream_codec_for_format(format.stream)
         self._codec = self._stream_codec.codec
         self._seekable = not is_stream(source) or is_seekable(source)
+        # The compressed stream starts wherever the caller positioned the source (the
+        # stream-position contract): remember it so re-opens rewind *here*, not to 0.
+        self._source_start = (
+            source.tell() if is_stream(source) and is_seekable(source) else 0
+        )
 
         # A non-seekable source cannot be randomly accessed, so engaging a random-access
         # accelerator (rapidgzip) is pointless — and would in fact fail at *open*: rapidgzip
@@ -159,8 +164,10 @@ class SingleFileReader(BaseArchiveReader):
         if isinstance(src, PeekableStream):
             return src.peek(length)
         if is_seekable(src):
-            data = src.read(length)
-            src.seek(0)
+            pos = src.tell()
+            src.seek(self._source_start)
+            data = read_exact(src, length)
+            src.seek(pos)
             return data
         return b""
 
@@ -190,10 +197,11 @@ class SingleFileReader(BaseArchiveReader):
         yield self._member
 
     def _open_codec_stream(self) -> BinaryIO:
-        """Open a fresh decompression stream over the source (rewinding a seekable one)."""
+        """Open a fresh decompression stream over the source (rewinding a seekable one
+        to the position it had when handed to the reader)."""
         src = self._source
         if is_stream(src) and is_seekable(src):
-            src.seek(0)
+            src.seek(self._source_start)
         codec_source = str(src) if isinstance(src, Path) else src
         return open_codec_stream(
             self._codec,

--- a/src/archivey/internal/backends/tar_reader.py
+++ b/src/archivey/internal/backends/tar_reader.py
@@ -234,13 +234,14 @@ class TarReader(BaseArchiveReader):
         self._verify_tar_eof()
 
     def _iter_members_progressive(self) -> Iterator[ArchiveMember]:
-        """Forward-only member walk — never calls ``getmembers()``."""
+        """Forward-only member walk — never calls ``getmembers()``.
+
+        Yields bare members; the base's streaming ``__iter__`` (via
+        ``_register_progressively``) stamps ids and resolves backward links.
+        """
         try:
-            for idx, info in enumerate(self._tar):
-                member = self._to_member(info)
-                member._member_id = idx
-                member._archive_id = self._archive_id
-                yield member
+            for info in self._tar:
+                yield self._to_member(info)
         except tarfile.TarError as exc:
             translated = self._translate_exception(exc)
             if translated is not None:
@@ -253,12 +254,15 @@ class TarReader(BaseArchiveReader):
         if not self._streaming:
             yield from super()._iter_with_data()
             return
+        # _register_progressively stamps ids and resolves backward links (hardlinks
+        # always point at an earlier member, so they resolve in this single pass); each
+        # member carries its TarInfo in _raw, which extractfile() uses directly.
         try:
-            for idx, info in enumerate(self._tar):
-                member = self._to_member(info)
-                member._member_id = idx
-                member._archive_id = self._archive_id
+            for member in self._register_progressively(
+                self._to_member(info) for info in self._tar
+            ):
                 if member.is_file:
+                    info = cast("tarfile.TarInfo", member._raw)
                     raw = self._tar.extractfile(info)
                     if raw is None:
                         raw = BytesIO(b"")

--- a/src/archivey/internal/backends/tar_reader.py
+++ b/src/archivey/internal/backends/tar_reader.py
@@ -306,12 +306,6 @@ class TarReader(BaseArchiveReader):
             raise err
         backends_logger.warning(msg)
 
-    @property
-    def compressed_source_size(self) -> int | None:
-        if not self._compressed or not isinstance(self._source, Path):
-            return None
-        return self._source.stat().st_size
-
     def _source_stream_capability(self) -> StreamCapability:
         if isinstance(self._source, Path):
             return StreamCapability.SEEKABLE

--- a/src/archivey/internal/backends/tar_reader.py
+++ b/src/archivey/internal/backends/tar_reader.py
@@ -27,6 +27,7 @@ from archivey.exceptions import (
     ArchiveyError,
     CorruptionError,
     TruncatedError,
+    UnsupportedOperationError,
 )
 from archivey.internal.base_reader import BaseArchiveReader, ReadBackend
 from archivey.internal.config import StreamConfig
@@ -132,6 +133,11 @@ class TarReader(BaseArchiveReader):
         archive_name: str | None,
         strict_eof: bool = False,
     ) -> None:
+        if password is not None:
+            raise UnsupportedOperationError(
+                "TAR archives do not support passwords (they carry no encryption).",
+                archive_name=archive_name,
+            )
         super().__init__(format, streaming, archive_name)
         self._encoding = encoding
         self._strict_eof = strict_eof
@@ -328,8 +334,16 @@ class TarReader(BaseArchiveReader):
         )
 
         # tarfile folds a PAX mtime (sub-second/timezone) into TarInfo.mtime already, so this
-        # one field honors both the standard ustar mtime and the PAX override.
-        modified = datetime.fromtimestamp(info.mtime, tz=timezone.utc)
+        # one field honors both the standard ustar mtime and the PAX override. A hostile
+        # out-of-range value (e.g. a crafted PAX mtime beyond datetime's range) must not
+        # sink the whole listing, so it degrades to None like _pax_time does.
+        try:
+            modified = datetime.fromtimestamp(info.mtime, tz=timezone.utc)
+        except (ValueError, OverflowError, OSError):
+            backends_logger.warning(
+                "Invalid TAR mtime for %r: %r", info.name, info.mtime
+            )
+            modified = None
 
         compression = (
             (CompressionMethod(algo=CompressionAlgorithm.STORED),)

--- a/src/archivey/internal/backends/tar_reader.py
+++ b/src/archivey/internal/backends/tar_reader.py
@@ -27,7 +27,6 @@ from archivey.exceptions import (
     ArchiveyError,
     CorruptionError,
     TruncatedError,
-    UnsupportedOperationError,
 )
 from archivey.internal.base_reader import BaseArchiveReader, ReadBackend
 from archivey.internal.config import StreamConfig
@@ -133,11 +132,7 @@ class TarReader(BaseArchiveReader):
         archive_name: str | None,
         strict_eof: bool = False,
     ) -> None:
-        if password is not None:
-            raise UnsupportedOperationError(
-                "TAR archives do not support passwords (they carry no encryption).",
-                archive_name=archive_name,
-            )
+        # password rejection is central: open_archive checks ReadBackend.SUPPORTS_PASSWORD.
         super().__init__(format, streaming, archive_name)
         self._encoding = encoding
         self._strict_eof = strict_eof

--- a/src/archivey/internal/backends/tar_reader.py
+++ b/src/archivey/internal/backends/tar_reader.py
@@ -262,7 +262,7 @@ class TarReader(BaseArchiveReader):
                     if raw is None:
                         raw = BytesIO(b"")
                     yield member, self._wrap_member_stream(
-                        ensure_binaryio(raw), member.name
+                        ensure_binaryio(raw), member.name, size=member.size
                     )
                 else:
                     yield member, None
@@ -389,7 +389,7 @@ class TarReader(BaseArchiveReader):
             # Only FILE members reach here (the base follows links/skips non-data members),
             # so a None stream means a zero-length or special entry; present an empty stream.
             raw = BytesIO(b"")
-        return self._wrap_member_stream(ensure_binaryio(raw), member.name)
+        return self._wrap_member_stream(ensure_binaryio(raw), member.name, size=member.size)
 
     def _get_archive_info(self) -> ArchiveInfo:
         stream_cap = self._source_stream_capability()

--- a/src/archivey/internal/backends/zip_reader.py
+++ b/src/archivey/internal/backends/zip_reader.py
@@ -75,17 +75,40 @@ def _decode_with_fallback(data: bytes) -> str:
     raise AssertionError("unreachable: cp437 decodes every byte")
 
 
+# Seconds between the NTFS FILETIME epoch (1601-01-01) and the Unix epoch (1970-01-01).
+_NTFS_EPOCH_OFFSET = 11_644_473_600
+
+
+def _filetime_to_datetime(value: int, filename: str) -> datetime | None:
+    """An NTFS FILETIME (100 ns ticks since 1601, UTC) as a datetime; 0 means "not set"."""
+    if value == 0:
+        return None
+    try:
+        return datetime.fromtimestamp(
+            value / 10_000_000 - _NTFS_EPOCH_OFFSET, tz=timezone.utc
+        )
+    except (ValueError, OverflowError, OSError):
+        logger.warning("Invalid NTFS timestamp for %r: %r", filename, value)
+        return None
+
+
 def _zip_timestamps(
     info: zipfile.ZipInfo,
 ) -> tuple[datetime | None, datetime | None, datetime | None]:
     """Return ``(modified, accessed, created)`` for a member.
 
-    The DOS ``date_time`` gives a 2-second-granularity modification time (``None`` for the
-    "no timestamp" sentinel year 1980). An Extended Timestamp extra field (0x5455) records
-    real Unix timestamps and takes precedence: its flags byte signals which of
-    modification/access/creation times follow (in that order), each a signed 32-bit Unix
-    time interpreted as UTC. The central directory typically carries only the modification
-    time even when the flags advertise more, so access/creation are often ``None``.
+    Sources, lowest to highest precedence (each layer overrides only the times it
+    actually carries):
+
+    1. The DOS ``date_time``: a 2-second-granularity local wall-clock modification time
+       (naive ``datetime``; ``None`` for the "no timestamp" sentinel year 1980).
+    2. An NTFS extra field (0x000A): three 64-bit FILETIMEs (modification, access,
+       creation) in 100 ns UTC ticks since 1601; zero means "not set". Written by
+       Windows tools (e.g. 7-Zip).
+    3. An Extended Timestamp extra field (0x5455): real Unix timestamps, its flags byte
+       signaling which of modification/access/creation follow (in that order), each a
+       signed 32-bit Unix time interpreted as UTC. The central directory typically
+       carries only the modification time even when the flags advertise more.
     """
     if info.date_time == (1980, 0, 0, 0, 0, 0):
         modified: datetime | None = None
@@ -98,27 +121,50 @@ def _zip_timestamps(
     accessed: datetime | None = None
     created: datetime | None = None
 
+    # One scan collecting both timestamp extra fields, applied afterwards in precedence
+    # order (NTFS below Extended Timestamp) regardless of their order in the blob.
+    ntfs_field: bytes | None = None
+    ut_field: bytes | None = None
     extra = info.extra or b""
     pos = 0
     while pos + 4 <= len(extra):
         tag, length = struct.unpack("<HH", extra[pos : pos + 4])
         field = extra[pos + 4 : pos + 4 + length]
-        if tag == 0x5455 and field:  # Extended Timestamp: flags byte + present times
-            flags = field[0]
-            cursor = 1
-            for bit in (0x01, 0x02, 0x04):  # mtime, atime, ctime, in order
-                if flags & bit and cursor + 4 <= len(field):
-                    ts = int.from_bytes(field[cursor : cursor + 4], "little", signed=True)
-                    when = datetime.fromtimestamp(ts, tz=timezone.utc)
-                    if bit == 0x01:
-                        modified = when
-                    elif bit == 0x02:
-                        accessed = when
-                    else:
-                        created = when
-                    cursor += 4
-            break
+        if tag == 0x000A and ntfs_field is None:
+            ntfs_field = field
+        elif tag == 0x5455 and field and ut_field is None:
+            ut_field = field
         pos += 4 + length
+
+    if ntfs_field is not None:
+        # Layout: 4 reserved bytes, then (tag, size) attributes; tag 1 carries the three
+        # FILETIMEs. Malformed/short fields are skipped rather than failing the listing.
+        cursor = 4
+        while cursor + 4 <= len(ntfs_field):
+            attr_tag, attr_size = struct.unpack_from("<HH", ntfs_field, cursor)
+            cursor += 4
+            if attr_tag == 0x0001 and attr_size >= 24 and cursor + 24 <= len(ntfs_field):
+                mtime, atime, ctime = struct.unpack_from("<QQQ", ntfs_field, cursor)
+                modified = _filetime_to_datetime(mtime, info.filename) or modified
+                accessed = _filetime_to_datetime(atime, info.filename) or accessed
+                created = _filetime_to_datetime(ctime, info.filename) or created
+                break
+            cursor += attr_size
+
+    if ut_field is not None:
+        flags = ut_field[0]
+        cursor = 1
+        for bit in (0x01, 0x02, 0x04):  # mtime, atime, ctime, in order
+            if flags & bit and cursor + 4 <= len(ut_field):
+                ts = int.from_bytes(ut_field[cursor : cursor + 4], "little", signed=True)
+                when = datetime.fromtimestamp(ts, tz=timezone.utc)
+                if bit == 0x01:
+                    modified = when
+                elif bit == 0x02:
+                    accessed = when
+                else:
+                    created = when
+                cursor += 4
 
     return modified, accessed, created
 

--- a/src/archivey/internal/backends/zip_reader.py
+++ b/src/archivey/internal/backends/zip_reader.py
@@ -326,7 +326,7 @@ class ZipReader(BaseArchiveReader):
             "BinaryIO",
             self._archive.open(info, pwd=self._password),
         )
-        return self._wrap_member_stream(raw, member.name)
+        return self._wrap_member_stream(raw, member.name, size=member.size)
 
     def _get_archive_info(self) -> ArchiveInfo:
         comment = self._archive.comment

--- a/src/archivey/internal/backends/zip_reader.py
+++ b/src/archivey/internal/backends/zip_reader.py
@@ -184,6 +184,7 @@ class ZipReader(BaseArchiveReader):
         archive_name: str | None,
     ) -> None:
         super().__init__(ArchiveFormat.ZIP, streaming, archive_name)
+        self._source = source
         self._password = password
         self._encoding = encoding
 

--- a/src/archivey/internal/backends/zip_reader.py
+++ b/src/archivey/internal/backends/zip_reader.py
@@ -46,8 +46,9 @@ from archivey.types import (
     MemberType,
 )
 
-# Encoding fallbacks for ZIP metadata stored without the UTF-8 flag.
-_ZIP_ENCODINGS = ("utf-8", "cp437", "cp1252", "latin-1")
+# Comment decoding: try UTF-8 first, else fall back to cp437 (the ZIP appnote default,
+# which maps every byte and therefore never fails — no further fallbacks are reachable).
+_ZIP_ENCODINGS = ("utf-8", "cp437")
 
 # A ".z01"/".z42"/… segment name — the obvious signal of a split (multi-volume) ZIP set.
 _SPLIT_SEGMENT_RE = re.compile(r"\.z\d{2}$", re.IGNORECASE)
@@ -71,7 +72,7 @@ def _decode_with_fallback(data: bytes) -> str:
             return data.decode(encoding)
         except UnicodeDecodeError:
             continue
-    return data.decode("latin-1")
+    raise AssertionError("unreachable: cp437 decodes every byte")
 
 
 def _zip_timestamps(
@@ -156,8 +157,14 @@ class ZipReader(BaseArchiveReader):
             )
 
         try:
+            # `metadata_encoding` (3.11+) decodes names stored without the UTF-8 flag with
+            # the caller's encoding instead of the cp437 default (UTF-8-flagged names are
+            # unaffected). A wrong explicit encoding may raise UnicodeDecodeError — caller
+            # misuse, propagated unchanged like other genuine errors.
             # typeshed types ZipFile too narrowly; a binary stream is valid here.
-            self._archive: zipfile.ZipFile = zipfile.ZipFile(source, "r")  # type: ignore[arg-type]
+            self._archive: zipfile.ZipFile = zipfile.ZipFile(  # type: ignore[arg-type]
+                source, "r", metadata_encoding=encoding
+            )
         except zipfile.BadZipFile as exc:
             if _looks_like_multivolume(exc):
                 raise UnsupportedFeatureError(
@@ -205,8 +212,12 @@ class ZipReader(BaseArchiveReader):
 
         decoded = info.filename
         name = normalize_member_name(decoded.replace("\\", "/"), member_type)
+        # Recover the stored bytes by re-encoding with the codec zipfile decoded with:
+        # UTF-8 when the entry's UTF-8 flag is set, else the caller's metadata encoding
+        # (when given) or zipfile's cp437 default.
         raw_name = info.orig_filename.encode(
-            "utf-8" if info.flag_bits & 0x800 else "cp437", errors="surrogateescape"
+            "utf-8" if info.flag_bits & 0x800 else (self._encoding or "cp437"),
+            errors="surrogateescape",
         )
 
         algo = _ZIP_COMPRESSION_ALGOS.get(info.compress_type, CompressionAlgorithm.UNKNOWN)
@@ -218,8 +229,26 @@ class ZipReader(BaseArchiveReader):
 
         link_target = None
         if member_type == MemberType.SYMLINK:
-            with self._archive.open(info, pwd=self._password) as f:
-                link_target = f.read().decode("utf-8", errors="surrogateescape")
+            # A symlink's target is its (possibly encrypted) file data. Listing must stay
+            # usable without a password, so a missing/wrong password leaves link_target
+            # unset (following the link later fails with LinkTargetNotFoundError); other
+            # errors surface translated like any member-read error.
+            try:
+                with self._archive.open(info, pwd=self._password) as f:
+                    link_target = f.read().decode("utf-8", errors="surrogateescape")
+            except (RuntimeError, zipfile.BadZipFile) as exc:
+                translated = self._translate_exception(exc)
+                if isinstance(translated, EncryptionError):
+                    logger.warning(
+                        "Cannot read the symlink target of %r without the correct "
+                        "password; leaving link_target unset.",
+                        info.filename,
+                    )
+                elif translated is not None:
+                    self._stamp_error_context(translated, info.filename)
+                    raise translated from exc
+                else:
+                    raise
 
         modified, accessed, created = _zip_timestamps(info)
         return ArchiveMember(

--- a/src/archivey/internal/backends/zip_reader.py
+++ b/src/archivey/internal/backends/zip_reader.py
@@ -366,6 +366,7 @@ class ZipReadBackend(ReadBackend):
         MagicSignature(0, b"\x50\x4b\x07\x08", ArchiveFormat.ZIP),  # spanned marker
     )
     REQUIRES_SEEK = True
+    SUPPORTS_PASSWORD = True  # per-member ZipCrypto/AES encryption
 
     def open_read(
         self,

--- a/src/archivey/internal/base_reader.py
+++ b/src/archivey/internal/base_reader.py
@@ -14,7 +14,7 @@ from archivey.exceptions import (
 )
 from archivey.internal.naming import resolve_link_target_name
 from archivey.internal.streams.archive_stream import ArchiveStream
-from archivey.internal.streams.streamtools import is_seekable
+from archivey.internal.streams.streamtools import is_seekable, source_byte_size
 from archivey.reader import ArchiveReader, MemberSelector
 from archivey.types import (
     ArchiveFormat,
@@ -163,6 +163,9 @@ class BaseArchiveReader(ArchiveReader):
         self._streaming = streaming
         self._archive_name = archive_name
         self._archive_id = str(id(self))
+        # The archive's source, recorded by backends that have one (path or stream);
+        # backs the generalized compressed_source_size property below.
+        self._source: Path | BinaryIO | None = None
         self._members_cache: list[ArchiveMember] | None = None
         self._members_by_name: dict[str, ArchiveMember] | None = None
         self._closed = False
@@ -362,8 +365,18 @@ class BaseArchiveReader(ArchiveReader):
 
     @property
     def compressed_source_size(self) -> int | None:
-        """Outer compressed byte length when known (``Path``-backed compressed tars); else ``None``."""
-        return None
+        """Byte size of the archive's source when cheaply knowable, else ``None``.
+
+        The denominator for extraction's archive-wide decompression-ratio guard (see
+        ``safe-extraction``): for zip/7z/rar/compressed-tar the source size *is* the
+        compressed size, and for a plain tar or other uncompressed container the
+        resulting ~1:1 ratio simply never trips the guard. Covers path sources
+        (``stat``), streams advertising a ``size`` attribute (fsspec), and seekable
+        streams (a ``SEEK_END``/restore probe) — see ``source_byte_size``. Backends
+        record their source in ``self._source``; readers without one (directory) or
+        with a non-seekable sizeless stream report ``None``.
+        """
+        return source_byte_size(self._source) if self._source is not None else None
 
     def __iter__(self) -> Iterator[ArchiveMember]:
         if self._streaming and self._members_cache is None:

--- a/src/archivey/internal/base_reader.py
+++ b/src/archivey/internal/base_reader.py
@@ -310,8 +310,16 @@ class BaseArchiveReader(ArchiveReader):
 
     def __iter__(self) -> Iterator[ArchiveMember]:
         if self._streaming and self._members_cache is None:
-            # Forward-only: stream directly without caching the whole list.
-            yield from self._iter_members()
+            # Forward-only: stream directly without caching the whole list. Members are
+            # still stamped with their ids progressively (a backend that already assigns
+            # them, like TAR's progressive walk, is left untouched) so member_id/
+            # archive_id work on a streamed member too. Links are NOT resolved here — a
+            # single forward pass cannot see later members.
+            for idx, member in enumerate(self._iter_members()):
+                if member._member_id is None:
+                    member._member_id = idx
+                    member._archive_id = self._archive_id
+                yield member
         else:
             yield from self._get_members_registered()
 

--- a/src/archivey/internal/base_reader.py
+++ b/src/archivey/internal/base_reader.py
@@ -12,6 +12,7 @@ from archivey.exceptions import (
     LinkTargetNotFoundError,
     UnsupportedOperationError,
 )
+from archivey.internal.naming import resolve_link_target_name
 from archivey.internal.streams.archive_stream import ArchiveStream
 from archivey.internal.streams.streamtools import is_seekable
 from archivey.reader import ArchiveReader, MemberSelector
@@ -246,6 +247,29 @@ class BaseArchiveReader(ArchiveReader):
         self._members_by_name = by_name
         return members
 
+    @staticmethod
+    def _lookup_link_target(
+        member: ArchiveMember, by_name: Mapping[str, ArchiveMember]
+    ) -> ArchiveMember | None:
+        """The member ``member``'s link target refers to, or ``None`` if not present.
+
+        Resolves the stored target string to an archive-namespace name first (a symlink
+        target is relative to the link's own directory — see
+        :func:`resolve_link_target_name`), then looks it up; directory members carry a
+        trailing ``/`` in their names, so both forms are tried.
+        """
+        if not member.link_target:
+            return None
+        target_name = resolve_link_target_name(
+            member.name, member.link_target, member.type
+        )
+        if target_name is None:
+            return None
+        target = by_name.get(target_name)
+        if target is None and not target_name.endswith("/"):
+            target = by_name.get(target_name + "/")
+        return target
+
     def _resolve_link(
         self,
         member: ArchiveMember,
@@ -255,22 +279,49 @@ class BaseArchiveReader(ArchiveReader):
         visited: set[str] = set()
         current = member
 
-        while current.link_target is not None:
-            target_name = current.link_target
-            if target_name in visited:
+        while current.is_link and current.link_target:
+            if current.name in visited:
                 # Cycle detected; leave link_target_member unset (None) rather than
                 # pointing at an intermediate link in the cycle.
                 return
             visited.add(current.name)
-            target = by_name.get(target_name)
+            target = self._lookup_link_target(current, by_name)
             if target is None:
-                # Missing target - leave link_target_member as None
+                # Missing/unresolvable target - leave link_target_member as None
                 return
             current = target
 
         # Set on the original member (the final resolved target or None on cycle)
         if current is not member:
             member.link_target_member = current
+
+    def _register_progressively(
+        self, members: Iterator[ArchiveMember]
+    ) -> Iterator[ArchiveMember]:
+        """Stamp ids and resolve *backward-pointing* links during a single forward pass.
+
+        Backs the streaming iteration paths. Hardlinks always refer to an earlier member
+        (the TAR model — see ``archive-reading``), so they resolve during the pass; a
+        symlink to an earlier member resolves too, while a forward-pointing one stays
+        unresolved (``link_target_member`` ``None``). A backend that already stamps ids
+        is left untouched (the stamp only fills unset fields).
+        """
+        by_name: dict[str, ArchiveMember] = {}
+        for idx, member in enumerate(members):
+            if member._member_id is None:
+                member._member_id = idx
+                member._archive_id = self._archive_id
+            if member.is_link and member.link_target_member is None:
+                target = self._lookup_link_target(member, by_name)
+                if target is not None and target is not member:
+                    # An earlier link's own resolution is already final; reuse it (an
+                    # unresolved earlier link yields None, i.e. stays unresolved).
+                    if target.is_link:
+                        target = target.link_target_member
+                    if target is not None:
+                        member.link_target_member = target
+            by_name[member.name] = member
+            yield member
 
     # --- Public API ---
 
@@ -310,16 +361,10 @@ class BaseArchiveReader(ArchiveReader):
 
     def __iter__(self) -> Iterator[ArchiveMember]:
         if self._streaming and self._members_cache is None:
-            # Forward-only: stream directly without caching the whole list. Members are
-            # still stamped with their ids progressively (a backend that already assigns
-            # them, like TAR's progressive walk, is left untouched) so member_id/
-            # archive_id work on a streamed member too. Links are NOT resolved here — a
-            # single forward pass cannot see later members.
-            for idx, member in enumerate(self._iter_members()):
-                if member._member_id is None:
-                    member._member_id = idx
-                    member._archive_id = self._archive_id
-                yield member
+            # Forward-only: stream directly without caching the whole list, stamping ids
+            # and resolving backward-pointing links progressively (a forward-pointing
+            # symlink stays unresolved — a single pass cannot see later members).
+            yield from self._register_progressively(self._iter_members())
         else:
             yield from self._get_members_registered()
 
@@ -344,7 +389,16 @@ class BaseArchiveReader(ArchiveReader):
         return None
 
     def __len__(self) -> int:
-        self._require_random_access("len()")
+        # TypeError, not UnsupportedOperationError: len() is also probed *implicitly* —
+        # list(reader) calls __len__ for preallocation via the length-hint protocol,
+        # which suppresses only TypeError. Any other exception type would make
+        # list(reader) blow up even though plain iteration is exactly what a streaming
+        # reader supports.
+        if self._streaming:
+            raise TypeError(
+                "len() is not available on a streaming (forward-only) reader. "
+                "Iterate the reader (or stream_members()) instead.",
+            )
         return len(self._get_members_registered())
 
     def __contains__(self, name: object) -> bool:
@@ -405,7 +459,7 @@ class BaseArchiveReader(ArchiveReader):
                     member_name=member.name,
                 )
             target = (
-                self._members_by_name.get(member.link_target)
+                self._lookup_link_target(member, self._members_by_name)
                 if self._members_by_name
                 else None
             )

--- a/src/archivey/internal/base_reader.py
+++ b/src/archivey/internal/base_reader.py
@@ -47,6 +47,11 @@ class ReadBackend(ABC):
     REQUIRES_SEEK: bool = False
     # When True, open_archive(streaming=True) may open a non-seekable source (TAR only).
     SUPPORTS_STREAMING_NON_SEEKABLE: bool = False
+    # Whether this backend's format has encryption a password could unlock. Checked
+    # centrally by open_archive(): a password passed for a format that cannot use one is
+    # API misuse and is rejected uniformly (backends never see it). ZIP sets this True;
+    # the native 7z/RAR readers (Phase 7) will too.
+    SUPPORTS_PASSWORD: bool = False
     # Name of the optional dependency this backend needs (e.g. "pycdlib"); the registry
     # derives availability centrally from whether it imports. ``None`` for core backends.
     OPTIONAL_DEPENDENCY: str | None = None

--- a/src/archivey/internal/base_reader.py
+++ b/src/archivey/internal/base_reader.py
@@ -124,10 +124,11 @@ class BaseArchiveReader(ArchiveReader):
       with format detection in Phase 3.)
 
     Access-mode enforcement (independent of the flags above): a ``streaming=True`` reader
-    is forward-only, so ``members``/``len``/``__contains__``/``__getitem__``/``get``/
-    ``open``/``read`` all raise ``UnsupportedOperationError`` — uniformly, not
-    per-backend. Only a single pass of ``__iter__``/``stream_members``/``extract_all``
-    (and ``get_members_if_available``) is allowed.
+    is forward-only, so ``members``/``get``/``open``/``read`` all raise
+    ``UnsupportedOperationError`` — uniformly, not per-backend. Only a single pass of
+    ``__iter__``/``stream_members``/``extract_all`` (and ``get_members_if_available``)
+    is allowed. ``member in reader`` is identity-based and scan-free, so it works in
+    either mode; there is no ``__len__``/``__getitem__`` (name lookup is ``get()``).
 
     **MAY override**:
 
@@ -388,38 +389,22 @@ class BaseArchiveReader(ArchiveReader):
             return self._get_members_registered()
         return None
 
-    def __len__(self) -> int:
-        # TypeError, not UnsupportedOperationError: len() is also probed *implicitly* —
-        # list(reader) calls __len__ for preallocation via the length-hint protocol,
-        # which suppresses only TypeError. Any other exception type would make
-        # list(reader) blow up even though plain iteration is exactly what a streaming
-        # reader supports.
-        if self._streaming:
-            raise TypeError(
-                "len() is not available on a streaming (forward-only) reader. "
-                "Iterate the reader (or stream_members()) instead.",
-            )
-        return len(self._get_members_registered())
-
-    def __contains__(self, name: object) -> bool:
-        if not isinstance(name, str):
-            return False
-        self._require_random_access("membership ('in') test")
-        self._get_members_registered()
-        assert self._members_by_name is not None
-        return name in self._members_by_name
-
-    def __getitem__(self, name: str) -> ArchiveMember:
-        self._require_random_access("key lookup")
-        self._get_members_registered()
-        assert self._members_by_name is not None
-        try:
-            return self._members_by_name[name]
-        except KeyError:
-            raise KeyError(f"Member {name!r} not found") from None
+    def __contains__(self, member: object) -> bool:
+        # Identity membership for ArchiveMembers: O(1), no scan, so it works in any
+        # access mode. This method must exist even though it is a convenience — without
+        # a __contains__, the `in` operator falls back to iterating __iter__, which
+        # would silently consume a streaming reader's single forward pass (and compare
+        # members by value). Strings are rejected: name lookup is get().
+        if isinstance(member, ArchiveMember):
+            return member._archive_id == self._archive_id
+        raise TypeError(
+            f"'in <ArchiveReader>' tests whether an ArchiveMember belongs to this "
+            f"reader (by identity); to look up a member by name use reader.get(name). "
+            f"Got {type(member).__name__}.",
+        )
 
     def get(self, name: str, default: ArchiveMember | None = None) -> ArchiveMember | None:
-        self._require_random_access("key lookup")
+        self._require_random_access("get()")
         self._get_members_registered()
         assert self._members_by_name is not None
         return self._members_by_name.get(name, default)
@@ -436,7 +421,10 @@ class BaseArchiveReader(ArchiveReader):
                 "iterate with stream_members() instead.",
             )
         if isinstance(member, str):
-            member = self[member]
+            found = self.get(member)
+            if found is None:
+                raise KeyError(f"Member {member!r} not found")
+            member = found
         return self._open_with_link_follow(member, visited=set())
 
     def _open_with_link_follow(

--- a/src/archivey/internal/base_reader.py
+++ b/src/archivey/internal/base_reader.py
@@ -210,14 +210,20 @@ class BaseArchiveReader(ArchiveReader):
         return None
 
     def _wrap_member_stream(
-        self, inner: BinaryIO, member_name: str | None, *, lazy: bool = False
+        self,
+        inner: BinaryIO,
+        member_name: str | None,
+        *,
+        lazy: bool = False,
+        size: int | None = None,
     ) -> BinaryIO:
         """Wrap a raw member stream so read/seek errors route through the backend's
         translator and are stamped with format/archive/member context.
 
-        Backends return ``_wrap_member_stream(raw, member.name)`` from ``_open_member`` so
-        a decode error surfaces as a stamped ``ArchiveyError`` rather than a raw codec
-        exception.
+        Backends return ``_wrap_member_stream(raw, member.name, size=member.size)`` from
+        ``_open_member`` so a decode error surfaces as a stamped ``ArchiveyError`` rather
+        than a raw codec exception, and so the handle advertises its decompressed length
+        (the fsspec-style ``size``) for cheap nested-archive source sizing.
         """
         return ArchiveStream(
             lambda: inner,
@@ -225,6 +231,7 @@ class BaseArchiveReader(ArchiveReader):
             stamp=lambda exc: self._stamp_error_context(exc, member_name),
             lazy=lazy,
             seekable=is_seekable(inner),
+            size=size,
         )
 
     @abstractmethod
@@ -370,11 +377,13 @@ class BaseArchiveReader(ArchiveReader):
         The denominator for extraction's archive-wide decompression-ratio guard (see
         ``safe-extraction``): for zip/7z/rar/compressed-tar the source size *is* the
         compressed size, and for a plain tar or other uncompressed container the
-        resulting ~1:1 ratio simply never trips the guard. Covers path sources
-        (``stat``), streams advertising a ``size`` attribute (fsspec), and seekable
-        streams (a ``SEEK_END``/restore probe) — see ``source_byte_size``. Backends
-        record their source in ``self._source``; readers without one (directory) or
-        with a non-seekable sizeless stream report ``None``.
+        resulting ~1:1 ratio simply never trips the guard. Cheap only — see
+        ``source_byte_size``: path ``stat``, a ``size`` attribute (fsspec convention,
+        also on archivey's own member/codec streams, enabling nested archives), a
+        ``try_get_size()`` index scan, or a ``SEEK_END`` probe restricted to provably
+        O(1) types (never a decompressor). Backends record their source in
+        ``self._source``; readers without one (directory) or with an unknowable
+        source report ``None``.
         """
         return source_byte_size(self._source) if self._source is not None else None
 

--- a/src/archivey/internal/detection.py
+++ b/src/archivey/internal/detection.py
@@ -7,7 +7,10 @@ as data and the detector aggregates them, so a new format becomes detectable by
 registering its backend (see ``format-detection`` and ``backend-registry``).
 
 Detection never consumes bytes from the source: paths are opened and closed; seekable
-streams are read and rewound to position 0; a non-seekable stream must be wrapped in a
+streams are read and restored to their **starting position** (the archive is taken to
+begin wherever the stream is positioned when handed in, so a mid-positioned stream —
+e.g. an archive embedded in a larger file — detects against the right bytes); a
+non-seekable stream must be wrapped in a
 :class:`~archivey.internal.streams.peekable.PeekableStream` first (the opener does this),
 which detection inspects via ``peek``.
 
@@ -31,7 +34,7 @@ from archivey.exceptions import ArchiveyError, FormatDetectionError
 from archivey.internal.logs import detection as logger
 from archivey.internal.registry import get_registry
 from archivey.internal.streams.peekable import DETECTION_LIMIT, PeekableStream
-from archivey.internal.streams.streamtools import is_seekable, read_exact
+from archivey.internal.streams.streamtools import is_seekable, read_exact, source_name
 from archivey.types import (
     ArchiveFormat,
     ContainerFormat,
@@ -61,19 +64,13 @@ class FormatInfo:
     payload_offset: int = 0  # nonzero only for SFX archives (is-SFX == payload_offset > 0)
 
 
-def _source_extension_name(source: object) -> str | None:
-    """The filename to match an extension against, or ``None`` when the source is anonymous."""
-    if isinstance(source, (str, Path)):
-        return str(source)
-    name = getattr(source, "name", None)
-    return name if isinstance(name, str) else None
-
-
 def _peek_prefix(source: str | Path | BinaryIO, length: int) -> bytes:
-    """Return the source's first ``length`` bytes without consuming them.
+    """Return the source's next ``length`` bytes without consuming them.
 
-    Paths are opened and closed; a :class:`PeekableStream` is peeked; a seekable stream is
-    read and rewound to position 0. A raw non-seekable stream would lose the prefix, so the
+    Paths are opened and closed; a :class:`PeekableStream` is peeked; a seekable stream
+    is read from its **current position** and restored to it (the archive starts
+    wherever the caller positioned the stream — see the stream-position contract in
+    ``format-detection``). A raw non-seekable stream would lose the prefix, so the
     caller (the opener) must wrap it in a ``PeekableStream`` first.
     """
     if isinstance(source, (str, Path)):
@@ -82,8 +79,9 @@ def _peek_prefix(source: str | Path | BinaryIO, length: int) -> bytes:
     if isinstance(source, PeekableStream):
         return source.peek(length)
     if is_seekable(source):
+        start = source.tell()
         data = read_exact(source, length)
-        source.seek(0)
+        source.seek(start)
         return data
     # Raw non-seekable stream used standalone: reading consumes bytes the caller can no
     # longer reach. Detection still works, but the prefix is gone — the opener avoids this
@@ -204,7 +202,7 @@ def detect_format(source: str | Path | BinaryIO) -> FormatInfo:
     registry = get_registry()
     magic_entries = registry.magic_entries()
     extension_map = registry.extension_map()
-    name = _source_extension_name(source)
+    name = source_name(source)
     ext_fmt = _match_extension(name, extension_map)
 
     # Magic signals split by where they live: "near" ones fit in the default window; "far"

--- a/src/archivey/internal/naming.py
+++ b/src/archivey/internal/naming.py
@@ -1,12 +1,16 @@
-"""Member-name normalization.
+"""Member-name normalization and link-target name resolution.
 
 Implements the ``ArchiveMember.name`` normalization rules from the
 ``archive-data-model`` spec. Format backends call :func:`normalize_member_name`
 when decoding a stored name so that every backend produces names under the same
 deterministic rules, while keeping the verbatim bytes in ``ArchiveMember.raw_name``.
+:func:`resolve_link_target_name` maps a link member's stored target string to the
+archive-namespace name it refers to (see ``archive-reading``: link following).
 """
 
 from __future__ import annotations
+
+import posixpath
 
 from archivey.internal.logs import normalization as logger
 from archivey.types import MemberType
@@ -56,3 +60,38 @@ def normalize_member_name(decoded: str, member_type: MemberType) -> str:
         logger.warning("Member name normalized: %r -> %r", decoded, name)
 
     return name
+
+
+def resolve_link_target_name(
+    link_name: str, target: str, member_type: MemberType
+) -> str | None:
+    """The archive-namespace member name a link's stored target refers to, or ``None``
+    when the target cannot name a member of this archive.
+
+    The two link kinds store targets in different namespaces:
+
+    - A **hardlink** target is archive-relative from the root (the TAR model: the
+      linkname is the earlier member's own stored path), so it is normalized as-is.
+    - A **symlink** target is a filesystem path relative to the link's *own directory*
+      (``dir/link -> file`` means ``dir/file``), so it is joined to that directory
+      before normalization.
+
+    Returns ``None`` for a target that cannot be a member: an absolute symlink target
+    (it points outside the archive namespace) or one that ``..``-escapes the archive
+    root. The caller looks the result up against normalized member names; directory
+    members carry a trailing ``/`` in their names, so lookups should try both forms.
+    """
+    if not target:
+        return None
+    normalized_target = target.replace("\\", "/")
+    if member_type == MemberType.SYMLINK:
+        if normalized_target.startswith("/"):
+            return None  # absolute: outside the archive namespace
+        base_dir = posixpath.dirname(link_name.rstrip("/"))
+        joined = posixpath.join(base_dir, normalized_target)
+    else:
+        joined = normalized_target
+    resolved = posixpath.normpath(joined)
+    if resolved in (".", "/") or resolved.startswith(("../", "/")) or resolved == "..":
+        return None  # escapes the archive root (or names the root itself)
+    return resolved

--- a/src/archivey/internal/registry.py
+++ b/src/archivey/internal/registry.py
@@ -172,9 +172,21 @@ class BackendRegistry:
                 (MissingComponent(dep, hint),),
             )
 
-        # Backend itself is usable; fold in the optional codecs the format can use.
+        # The format's own stream codec — a bare single-file compressor's sole codec, or
+        # the outer codec of a compressed tar (`tar.<codec>`). With it missing the archive
+        # cannot even be listed, so the format is NONE (the single-codec rule in
+        # ``backend-registry``), not PARTIAL.
+        if fmt.stream != StreamFormat.UNCOMPRESSED:
+            stream_codec = codec_for_stream_format(fmt.stream)
+            if not is_codec_available(stream_codec):
+                requirement = codec_requirement(stream_codec)
+                assert requirement is not None  # an optional codec always declares one
+                return FormatAvailability(fmt, FormatSupport.NONE, (requirement,))
+
+        # Backend + stream codec usable; fold in the optional *member* codecs the
+        # container can use. A multi-codec container missing some still opens -> PARTIAL.
         missing: list[MissingComponent] = []
-        for codec in self._optional_codecs_for_format(fmt):
+        for codec in _CONTAINER_OPTIONAL_CODECS.get(fmt.container, ()):
             if not is_codec_available(codec):
                 requirement = codec_requirement(codec)
                 assert requirement is not None  # an optional codec always declares one
@@ -182,23 +194,7 @@ class BackendRegistry:
 
         if not missing:
             return FormatAvailability(fmt, FormatSupport.FULL, ())
-
-        # A single-codec format (a bare RAW_STREAM single-file compressor) whose sole codec
-        # is missing is unreadable -> NONE; a multi-codec container still opens -> PARTIAL.
-        support = (
-            FormatSupport.NONE
-            if fmt.container == ContainerFormat.RAW_STREAM
-            else FormatSupport.PARTIAL
-        )
-        return FormatAvailability(fmt, support, tuple(missing))
-
-    def _optional_codecs_for_format(self, fmt: ArchiveFormat) -> tuple[Codec, ...]:
-        if fmt.container == ContainerFormat.RAW_STREAM:
-            # A single-file compressor's readability hinges on its one stream codec.
-            if fmt.stream == StreamFormat.UNCOMPRESSED:
-                return ()
-            return (codec_for_stream_format(fmt.stream),)
-        return _CONTAINER_OPTIONAL_CODECS.get(fmt.container, ())
+        return FormatAvailability(fmt, FormatSupport.PARTIAL, tuple(missing))
 
     # --- selection -----------------------------------------------------------------------
 

--- a/src/archivey/internal/registry.py
+++ b/src/archivey/internal/registry.py
@@ -72,8 +72,15 @@ class FormatAvailability:
 
 # Optional member-codecs each container can use, beyond the always-present stdlib codecs.
 # A format is FULL when all of these are available, PARTIAL when some are missing (a
-# multi-codec container still opens and lists). Single-codec RAW_STREAM formats are handled
-# separately (their sole codec missing makes them NONE, not PARTIAL).
+# multi-codec container still opens and lists). Single-codec formats (bare RAW_STREAM
+# compressors and compressed tars) are handled separately: their sole stream codec
+# missing makes them NONE, not PARTIAL.
+#
+# NOTE (Phase 3 → 7 gap): ZIP member *decode* currently goes through stdlib zipfile,
+# which cannot decompress deflate64/ppmd (or zstd before Python 3.14) even when these
+# codec packages are installed — such members raise UnsupportedFeatureError at read.
+# This table describes the intended post-Phase-7 composition, where the codec layer is
+# wired into ZIP member reads (see ``format-zip`` / ``compressed-streams``).
 _CONTAINER_OPTIONAL_CODECS: dict[ContainerFormat, tuple[Codec, ...]] = {
     ContainerFormat.ZIP: (Codec.DEFLATE64, Codec.ZSTD, Codec.PPMD),
 }

--- a/src/archivey/internal/streams/archive_stream.py
+++ b/src/archivey/internal/streams/archive_stream.py
@@ -168,12 +168,20 @@ class ArchiveStream(ReadOnlyIOStream):
         return self._seekable_hint
 
     def close(self) -> None:
-        if self._inner is not None:
-            try:
-                self._inner.close()
-            except Exception as e:  # noqa: BLE001 - re-raised via the translator
-                self._fail(e)
-        super().close()
+        if self.closed:
+            return
+        # The finally ensures the wrapper is marked closed even when the inner close
+        # raises (which _fail re-raises translated): a half-open wrapper would hand out
+        # further reads on a dead stream, and a retried close() would fail again
+        # instead of no-opping (the guard above makes it a no-op instead).
+        try:
+            if self._inner is not None:
+                try:
+                    self._inner.close()
+                except Exception as e:  # noqa: BLE001 - re-raised via the translator
+                    self._fail(e)
+        finally:
+            super().close()
 
     def __repr__(self) -> str:
         return f"<ArchiveStream inner={self._inner!r}>"

--- a/src/archivey/internal/streams/archive_stream.py
+++ b/src/archivey/internal/streams/archive_stream.py
@@ -63,6 +63,7 @@ class ArchiveStream(ReadOnlyIOStream):
         lazy: bool = False,
         seekable: bool = True,
         rewind_warning: RewindWarning | None = None,
+        size: int | None = None,
     ) -> None:
         super().__init__()
         self._open_fn: Callable[[], BinaryIO] | None = open_fn
@@ -73,8 +74,35 @@ class ArchiveStream(ReadOnlyIOStream):
         self._seekable_hint = seekable
         self._rewind_warning = rewind_warning
         self._rewind_warned = False
+        self._size = size
         if not lazy:
             self._ensure_open()
+
+    @property
+    def size(self) -> int | None:
+        """Total decompressed byte length when cheaply known, else ``None``.
+
+        The fsspec-style ``size`` convention (see ``source_byte_size``): the creator may
+        supply it up front (a member stream knows ``member.size`` from the archive
+        metadata), else an opened inner decompressor with a cheap ``try_get_size()``
+        (index/trailer scan, no decompression) is consulted. Lets a nested
+        ``open_archive(reader.open("inner.zip"))`` learn its source size — e.g. for the
+        extraction bomb tracker — without an expensive end-seek. A lazy, still-unopened
+        stream reports ``None`` rather than opening itself just to answer.
+        """
+        if self._size is not None:
+            return self._size
+        inner = self._inner
+        if inner is None:
+            return None
+        try_get_size = getattr(inner, "try_get_size", None)
+        if callable(try_get_size):
+            result = try_get_size()
+            return result if isinstance(result, int) else None
+        inner_size = getattr(inner, "size", None)
+        if isinstance(inner_size, int) and not isinstance(inner_size, bool):
+            return inner_size
+        return None
 
     def _ensure_open(self) -> BinaryIO:
         if self.closed:

--- a/src/archivey/internal/streams/codecs.py
+++ b/src/archivey/internal/streams/codecs.py
@@ -253,6 +253,8 @@ class _GzipTruncationCheckStream(DelegatingStream):
         self._verify = True
 
     def read(self, size: int = -1, /) -> bytes:
+        if size == 0:
+            return b""  # an explicit read(0) is not EOF; it must not trip the check
         data = self._inner.read(size)
         if data:
             self._total += len(data)

--- a/src/archivey/internal/streams/codecs.py
+++ b/src/archivey/internal/streams/codecs.py
@@ -52,6 +52,7 @@ from archivey.internal.streams.streamtools import (
     DelegatingStream,
     ensure_binaryio,
     ensure_bufferedio,
+    fix_stream_start_position,
 )
 from archivey.internal.streams.xz import XzDecompressorStream
 from archivey.types import (
@@ -264,8 +265,13 @@ class _GzipTruncationCheckStream(DelegatingStream):
         return data
 
     def seek(self, offset: int, whence: int = io.SEEK_SET, /) -> int:
-        self._verify = False  # random access invalidates the sequential byte total
-        return super().seek(offset, whence)
+        result = super().seek(offset, whence)
+        # Random access invalidates the sequential byte total — but only when the seek
+        # actually moved off the sequential frontier. A no-op seek (tell()-style
+        # seek(0, SEEK_CUR), or a seek to the current position) keeps the check armed.
+        if result != self._total:
+            self._verify = False
+        return result
 
     def _verify_not_truncated(self) -> None:
         try:
@@ -1077,6 +1083,13 @@ def open_codec_stream(
     The returned stream wraps the backend so corrupt/truncated/non-seekable errors surface
     as ``ArchiveyError`` subclasses (never raw codec exceptions).
     """
+    if not isinstance(source, (str, os.PathLike)):
+        # A seekable stream positioned mid-file gets a clean tell()==0 origin (a
+        # SlicingStream view), because codec backends address the source with absolute
+        # offsets — the seekable XZ/lzip index, stdlib gzip's rewind — and would
+        # otherwise read the wrong bytes. Streams at position 0 pass through unchanged
+        # (see the stream-position contract in ``format-detection``).
+        source = fix_stream_start_position(source)
     backend = resolve_codec(codec, config)
     # Opened eagerly (lazy=False), so ArchiveStream.seekable() reflects the real backend
     # stream — no seekable hint needed (that only matters for a lazily-opened stream).

--- a/src/archivey/internal/streams/peekable.py
+++ b/src/archivey/internal/streams/peekable.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from typing import BinaryIO
 
-from archivey.internal.streams.streamtools import ReadOnlyIOStream
+from archivey.internal.streams.streamtools import ReadOnlyIOStream, source_name
 
 # Default amount buffered for detection (matches ``format-detection``'s DETECTION_LIMIT).
 # The buffer grows on demand up to whatever ``peek(n)`` asks for — e.g. 32 774 bytes when
@@ -83,9 +83,11 @@ class PeekableStream(ReadOnlyIOStream):
         return self._pos
 
     @property
-    def name(self) -> str | None:
-        name = getattr(self._underlying, "name", None)
-        return name if isinstance(name, str) else None
+    def name(self) -> str:
+        resolved = source_name(self._underlying)
+        if resolved is not None:
+            return resolved
+        raise AttributeError("name")
 
     def close(self) -> None:
         # Do NOT close the underlying stream — the caller owns it.

--- a/src/archivey/internal/streams/streamtools/__init__.py
+++ b/src/archivey/internal/streams/streamtools/__init__.py
@@ -24,6 +24,7 @@ from archivey.internal.streams.streamtools.binaryio import (
     is_seekable,
     is_stream,
     read_exact,
+    source_byte_size,
     source_name,
 )
 from archivey.internal.streams.streamtools.slice import (
@@ -44,5 +45,6 @@ __all__ = [
     "is_seekable",
     "is_stream",
     "read_exact",
+    "source_byte_size",
     "source_name",
 ]

--- a/src/archivey/internal/streams/streamtools/__init__.py
+++ b/src/archivey/internal/streams/streamtools/__init__.py
@@ -24,6 +24,7 @@ from archivey.internal.streams.streamtools.binaryio import (
     is_seekable,
     is_stream,
     read_exact,
+    source_name,
 )
 from archivey.internal.streams.streamtools.slice import (
     SlicingStream,
@@ -43,4 +44,5 @@ __all__ = [
     "is_seekable",
     "is_stream",
     "read_exact",
+    "source_name",
 ]

--- a/src/archivey/internal/streams/streamtools/base.py
+++ b/src/archivey/internal/streams/streamtools/base.py
@@ -23,7 +23,7 @@ import abc
 import io
 from typing import TYPE_CHECKING, Any, BinaryIO
 
-from archivey.internal.streams.streamtools.binaryio import is_seekable
+from archivey.internal.streams.streamtools.binaryio import is_seekable, source_name
 
 if TYPE_CHECKING:
     from _typeshed import WriteableBuffer
@@ -80,6 +80,15 @@ class ReadOnlyIOStream(io.RawIOBase, BinaryIO):
         # crash on our wrappers. Every stream here is read-only binary by construction.
         return "rb"
 
+    @property
+    def name(self) -> str:
+        # Same typing.IO stub issue for `name`: pycdlib on Windows does
+        # `hasattr(fp, 'name') and fp.name.startswith(r'\\.\')` and crashes when the
+        # stub returns None. Streams without a real path name (BytesIO, in-memory views)
+        # must not expose `name` at all — match their duck-typing surface where
+        # hasattr(..., 'name') is False.
+        raise AttributeError("name")
+
 
 class DelegatingStream(ReadOnlyIOStream):
     """A read-only wrapper around one inner ``BinaryIO``, forwarding to it by default.
@@ -131,3 +140,10 @@ class DelegatingStream(ReadOnlyIOStream):
             return
         self._inner.close()
         super().close()
+
+    @property
+    def name(self) -> str:
+        resolved = source_name(self._inner)
+        if resolved is not None:
+            return resolved
+        raise AttributeError("name")

--- a/src/archivey/internal/streams/streamtools/base.py
+++ b/src/archivey/internal/streams/streamtools/base.py
@@ -73,6 +73,13 @@ class ReadOnlyIOStream(io.RawIOBase, BinaryIO):
     def write(self, b: Any, /) -> int:
         raise io.UnsupportedOperation("write")
 
+    @property
+    def mode(self) -> str:
+        # typing.IO declares an abstract `mode` property whose stub body returns None at
+        # runtime; libraries that duck-type it (pycdlib does `'b' not in fp.mode`) then
+        # crash on our wrappers. Every stream here is read-only binary by construction.
+        return "rb"
+
 
 class DelegatingStream(ReadOnlyIOStream):
     """A read-only wrapper around one inner ``BinaryIO``, forwarding to it by default.

--- a/src/archivey/internal/streams/streamtools/binaryio.py
+++ b/src/archivey/internal/streams/streamtools/binaryio.py
@@ -156,6 +156,33 @@ def source_name(source: Any) -> str | None:
     return name if isinstance(name, str) else None
 
 
+def source_byte_size(source: Any) -> int | None:
+    """Total byte size of a path or stream source when cheaply knowable, else ``None``.
+
+    Cheap means no data is read: a path is ``stat``-ed; a stream advertising an integer
+    ``size`` attribute (fsspec's file objects do) is trusted; a seekable stream is probed
+    with a ``SEEK_END``/restore round trip. A non-seekable stream without a ``size``
+    yields ``None`` — its length is unknowable without consuming it.
+    """
+    if is_filename(source):
+        try:
+            return os.stat(source).st_size
+        except OSError:
+            return None
+    size = getattr(source, "size", None)
+    if isinstance(size, int) and not isinstance(size, bool):
+        return size
+    if is_seekable(source):
+        try:
+            pos = source.tell()
+            end = source.seek(0, io.SEEK_END)
+            source.seek(pos)
+        except OSError:
+            return None
+        return end
+    return None
+
+
 def is_stream(obj: Any) -> TypeGuard[BinaryIO]:
     """Whether ``obj`` already satisfies the ``BinaryIO`` interface we rely on.
 

--- a/src/archivey/internal/streams/streamtools/binaryio.py
+++ b/src/archivey/internal/streams/streamtools/binaryio.py
@@ -156,13 +156,42 @@ def source_name(source: Any) -> str | None:
     return name if isinstance(name, str) else None
 
 
-def source_byte_size(source: Any) -> int | None:
-    """Total byte size of a path or stream source when cheaply knowable, else ``None``.
+def _seek_end_is_cheap(stream: Any) -> bool:
+    """Whether ``SEEK_END`` on ``stream`` is O(1) — never a decompression or scan.
 
-    Cheap means no data is read: a path is ``stat``-ed; a stream advertising an integer
-    ``size`` attribute (fsspec's file objects do) is trusted; a seekable stream is probed
-    with a ``SEEK_END``/restore round trip. A non-seekable stream without a ``size``
-    yields ``None`` — its length is unknowable without consuming it.
+    Deliberately a **whitelist** of concrete types whose end-seek is a plain offset
+    move: a decompressor stream (stdlib ``GzipFile``/``BZ2File``/``LZMAFile``, our
+    ``DecompressorStream`` family, accelerator wrappers) services ``SEEK_END`` by
+    decoding to the end, which :func:`source_byte_size` must never trigger. Duck checks
+    (``fileno`` + ``S_ISREG``) are unsafe here — wrappers like ``GzipFile`` forward
+    ``fileno`` to their *compressed* underlying file. Streams outside the whitelist
+    advertise their size via a ``size`` attribute or a ``try_get_size()`` method
+    instead.
+    """
+    if isinstance(stream, (io.BytesIO, io.FileIO, mmap.mmap)):
+        return True
+    if isinstance(stream, (io.BufferedReader, io.BufferedRandom)):
+        return _seek_end_is_cheap(stream.raw)
+    return False
+
+
+def source_byte_size(source: Any) -> int | None:
+    """Total byte size of a path or stream source when **cheaply** knowable, else ``None``.
+
+    Cheap means no data is read or decompressed. Probe order:
+
+    1. a path-like is ``stat``-ed;
+    2. an integer ``size`` attribute is trusted — the fsspec convention, also exposed
+       by archivey's own wrappers (``ArchiveStream``, ``SlicingStream``) when they
+       know their length;
+    3. a ``try_get_size()`` method (archivey's decompressor streams) is called — it
+       answers from an index/trailer scan or returns ``None``, and its presence marks
+       the stream as one whose ``SEEK_END`` may decompress, so its answer is final
+       (no fall-through to the probe);
+    4. a ``SEEK_END``/restore round trip, but **only** for types whose end-seek is
+       provably O(1) (real files, ``BytesIO``, ``mmap`` — see ``_seek_end_is_cheap``);
+       an unrecognized seekable stream could be a decompressor whose end-seek decodes
+       the entire payload, so it yields ``None`` instead.
     """
     if is_filename(source):
         try:
@@ -172,7 +201,11 @@ def source_byte_size(source: Any) -> int | None:
     size = getattr(source, "size", None)
     if isinstance(size, int) and not isinstance(size, bool):
         return size
-    if is_seekable(source):
+    try_get_size = getattr(source, "try_get_size", None)
+    if callable(try_get_size):
+        result = try_get_size()
+        return result if isinstance(result, int) else None
+    if is_seekable(source) and _seek_end_is_cheap(source):
         try:
             pos = source.tell()
             end = source.seek(0, io.SEEK_END)

--- a/src/archivey/internal/streams/streamtools/binaryio.py
+++ b/src/archivey/internal/streams/streamtools/binaryio.py
@@ -143,6 +143,19 @@ def is_filename(obj: Any) -> TypeGuard[str | bytes | os.PathLike]:
     return isinstance(obj, (str, bytes, os.PathLike))
 
 
+def source_name(source: Any) -> str | None:
+    """Best-effort human-readable name for a source, for error messages and metadata.
+
+    A path-like source yields its string form; a file-like stream yields its ``name``
+    attribute when that is a string (``open()`` sets it, ``BytesIO`` does not, and some
+    streams expose an integer fd there — both of those yield ``None``).
+    """
+    if is_filename(source):
+        return os.fsdecode(source)
+    name = getattr(source, "name", None)
+    return name if isinstance(name, str) else None
+
+
 def is_stream(obj: Any) -> TypeGuard[BinaryIO]:
     """Whether ``obj`` already satisfies the ``BinaryIO`` interface we rely on.
 

--- a/src/archivey/internal/streams/streamtools/slice.py
+++ b/src/archivey/internal/streams/streamtools/slice.py
@@ -11,11 +11,7 @@ import io
 from typing import BinaryIO
 
 from archivey.internal.streams.streamtools.base import ReadOnlyIOStream
-from archivey.internal.streams.streamtools.binaryio import (
-    is_seekable,
-    source_byte_size,
-    source_name,
-)
+from archivey.internal.streams.streamtools.binaryio import is_seekable, source_byte_size
 
 
 class SlicingStream(ReadOnlyIOStream):
@@ -37,6 +33,9 @@ class SlicingStream(ReadOnlyIOStream):
     *non-owning view*: it must NOT close the underlying stream (the container owns it), whereas
     ``DelegatingStream.close`` closes its inner. So delegation would be both useless (almost
     everything is overridden) and unsafe (the close default).
+
+    It also does not expose ``name``: a slice view remaps the origin, so forwarding the
+    underlying path would mislead libraries that reopen or stat by ``stream.name``.
     """
 
     def __init__(
@@ -130,13 +129,6 @@ class SlicingStream(ReadOnlyIOStream):
         if underlying is None:
             return None
         return max(underlying - self._start, 0)
-
-    @property
-    def name(self) -> str:
-        resolved = source_name(self._stream)
-        if resolved is not None:
-            return resolved
-        raise AttributeError("name")
 
 
 def fix_stream_start_position(stream: BinaryIO) -> BinaryIO:

--- a/src/archivey/internal/streams/streamtools/slice.py
+++ b/src/archivey/internal/streams/streamtools/slice.py
@@ -11,7 +11,7 @@ import io
 from typing import BinaryIO
 
 from archivey.internal.streams.streamtools.base import ReadOnlyIOStream
-from archivey.internal.streams.streamtools.binaryio import is_seekable
+from archivey.internal.streams.streamtools.binaryio import is_seekable, source_byte_size
 
 
 class SlicingStream(ReadOnlyIOStream):
@@ -109,6 +109,23 @@ class SlicingStream(ReadOnlyIOStream):
 
     def seekable(self) -> bool:
         return self._seekable
+
+    @property
+    def size(self) -> int | None:
+        """Total slice length when cheaply knowable (the fsspec-style ``size`` convention).
+
+        A declared ``length`` answers directly; an open-ended slice derives it from the
+        underlying stream's cheap size (``source_byte_size``), and reports ``None`` when
+        that is unknowable — never by an expensive end-seek.
+        """
+        if self._length is not None:
+            return self._length
+        if self._start is None:
+            return None  # non-seekable underlying stream: length unknowable cheaply
+        underlying = source_byte_size(self._stream)
+        if underlying is None:
+            return None
+        return max(underlying - self._start, 0)
 
 
 def fix_stream_start_position(stream: BinaryIO) -> BinaryIO:

--- a/src/archivey/internal/streams/streamtools/slice.py
+++ b/src/archivey/internal/streams/streamtools/slice.py
@@ -11,7 +11,11 @@ import io
 from typing import BinaryIO
 
 from archivey.internal.streams.streamtools.base import ReadOnlyIOStream
-from archivey.internal.streams.streamtools.binaryio import is_seekable, source_byte_size
+from archivey.internal.streams.streamtools.binaryio import (
+    is_seekable,
+    source_byte_size,
+    source_name,
+)
 
 
 class SlicingStream(ReadOnlyIOStream):
@@ -126,6 +130,13 @@ class SlicingStream(ReadOnlyIOStream):
         if underlying is None:
             return None
         return max(underlying - self._start, 0)
+
+    @property
+    def name(self) -> str:
+        resolved = source_name(self._stream)
+        if resolved is not None:
+            return resolved
+        raise AttributeError("name")
 
 
 def fix_stream_start_position(stream: BinaryIO) -> BinaryIO:

--- a/src/archivey/internal/streams/streamtools/slice.py
+++ b/src/archivey/internal/streams/streamtools/slice.py
@@ -83,7 +83,6 @@ class SlicingStream(ReadOnlyIOStream):
 
         assert self._start is not None  # always set for seekable streams
         start_abs = self._start
-        current_abs = start_abs + self._pos
 
         if whence == io.SEEK_SET:
             new_relative = offset
@@ -91,16 +90,12 @@ class SlicingStream(ReadOnlyIOStream):
             new_relative = self._pos + offset
         elif whence == io.SEEK_END:
             if self._length is None:
-                if offset != 0:
-                    raise io.UnsupportedOperation(
-                        "SEEK_END is not supported when slice length is not defined "
-                        "and offset is non-zero"
-                    )
-                underlying_end = self._stream.seek(0, io.SEEK_END)
-                self._stream.seek(current_abs)  # restore for the caller's mental model
-                new_relative = underlying_end - start_abs
+                # No declared length: the slice ends where the underlying stream does,
+                # so probe that end on demand (the seek below repositions regardless).
+                end_relative = self._stream.seek(0, io.SEEK_END) - start_abs
             else:
-                new_relative = self._length + offset
+                end_relative = self._length
+            new_relative = end_relative + offset
         else:
             raise ValueError(f"Invalid whence: {whence}")
 

--- a/src/archivey/reader.py
+++ b/src/archivey/reader.py
@@ -64,34 +64,32 @@ class ArchiveReader(ABC):
         ...
 
     @abstractmethod
-    def __len__(self) -> int:
-        """Member count (may trigger a scan). On a streaming reader raises ``TypeError``
-        — not ``UnsupportedOperationError`` like :meth:`members` — because ``list(reader)``
-        probes ``__len__`` implicitly via the length-hint protocol, which suppresses only
-        ``TypeError``; iteration must keep working there."""
-        ...
+    def __contains__(self, member: object) -> bool:
+        """Whether ``member`` (an :class:`ArchiveMember`) was yielded by *this* reader.
 
-    @abstractmethod
-    def __contains__(self, name: object) -> bool:
-        """Whether a member with the given name exists."""
-        ...
-
-    @abstractmethod
-    def __getitem__(self, name: str) -> ArchiveMember:
-        """Look up a member by name; raises ``KeyError`` if absent."""
+        Identity-based and O(1) — no scan — so it is valid in any access mode; useful to
+        disambiguate members when several readers are in play. Name lookup is
+        :meth:`get`, and a non-``ArchiveMember`` operand raises ``TypeError`` (this also
+        keeps the ``in`` operator from silently falling back to a full iteration, which
+        would consume a streaming reader's single forward pass)."""
         ...
 
     @abstractmethod
     def get(
         self, name: str, default: ArchiveMember | None = None
     ) -> ArchiveMember | None:
-        """Look up a member by name, returning ``default`` if absent."""
+        """Look up a member by its normalized name, returning ``default`` if absent.
+        This is the name-lookup entry point; :meth:`open`/:meth:`read` also accept a
+        name directly. May trigger a scan; on a streaming reader raises
+        ``UnsupportedOperationError``. With duplicate member names, returns the last
+        (the one a sequential extraction would leave on disk)."""
         ...
 
     @abstractmethod
     def open(self, member: str | ArchiveMember) -> BinaryIO:
-        """Open a member as a binary stream, following symlinks/hardlinks. The caller
-        is responsible for closing the returned stream."""
+        """Open a member as a binary stream, following symlinks/hardlinks. Accepts a
+        member object or a name (an unknown name raises ``KeyError``). The caller is
+        responsible for closing the returned stream."""
         ...
 
     @abstractmethod

--- a/src/archivey/reader.py
+++ b/src/archivey/reader.py
@@ -9,7 +9,11 @@ from typing import BinaryIO, Callable, Iterator
 from archivey.cost import CostReceipt
 from archivey.types import ArchiveFormat, ArchiveInfo, ArchiveMember
 
-# Type alias for member selector filter
+# Type alias for the member selector passed to stream_members(). Only the predicate form
+# is implemented today. The archive-reading spec also allows a Collection[ArchiveMember |
+# str] form ("yield exactly these names/members"); that lands with the Phase 5 public-API
+# finalization, where its semantics under duplicate member names must be decided (match
+# by name? by identity?) — see PLAN.md Phase 5.
 MemberSelector = Callable[[ArchiveMember], bool] | None
 
 
@@ -61,7 +65,10 @@ class ArchiveReader(ABC):
 
     @abstractmethod
     def __len__(self) -> int:
-        """Member count (same constraints as :meth:`members`)."""
+        """Member count (may trigger a scan). On a streaming reader raises ``TypeError``
+        — not ``UnsupportedOperationError`` like :meth:`members` — because ``list(reader)``
+        probes ``__len__`` implicitly via the length-hint protocol, which suppresses only
+        ``TypeError``; iteration must keep working there."""
         ...
 
     @abstractmethod

--- a/tests/test_binaryio.py
+++ b/tests/test_binaryio.py
@@ -446,3 +446,61 @@ def test_ensure_bufferedio_source_still_readable_after_buffer_closed() -> None:
     # guaranteed (the buffer read ahead), but it must remain usable, not closed.
     assert not inner.closed
     assert inner.read(0) == b""  # a live, non-raising operation on an open stream
+
+
+# ---------------------------------------------------------------------------
+# source_byte_size: cheap-only contract
+# ---------------------------------------------------------------------------
+
+
+class TestSourceByteSize:
+    def test_path_is_stated(self, tmp_path) -> None:
+        from archivey.internal.streams.streamtools import source_byte_size
+
+        p = tmp_path / "f.bin"
+        p.write_bytes(b"x" * 1234)
+        assert source_byte_size(p) == 1234
+        assert source_byte_size(str(p)) == 1234
+
+    def test_size_attribute_is_trusted(self) -> None:
+        from archivey.internal.streams.streamtools import source_byte_size
+
+        class _Sized(io.BytesIO):
+            @property
+            def size(self) -> int:
+                return 999  # deliberately different from the buffer length
+
+        assert source_byte_size(_Sized(b"abc")) == 999
+
+    def test_whitelisted_types_are_probed(self, tmp_path) -> None:
+        from archivey.internal.streams.streamtools import source_byte_size
+
+        buf = io.BytesIO(b"x" * 77)
+        buf.seek(10)
+        assert source_byte_size(buf) == 77
+        assert buf.tell() == 10  # position restored
+
+        p = tmp_path / "f.bin"
+        p.write_bytes(b"y" * 55)
+        with open(p, "rb") as f:  # BufferedReader over FileIO
+            assert source_byte_size(f) == 55
+
+    def test_decompressor_streams_are_never_probed(self, tmp_path) -> None:
+        # SEEK_END on a decompressor means decompressing to the end; the helper must
+        # return None for such streams rather than trigger that work. GzipFile is the
+        # canonical trap: it is seekable and even forwards fileno() to the *compressed*
+        # file, so neither a seekable() check nor an fstat duck-check is safe.
+        import gzip
+
+        from archivey.internal.streams.streamtools import source_byte_size
+
+        p = tmp_path / "f.gz"
+        p.write_bytes(gzip.compress(b"payload " * 10_000))
+        with gzip.open(p, "rb") as f:
+            assert source_byte_size(f) is None
+            assert f.tell() == 0  # nothing was decompressed to answer
+
+    def test_non_seekable_stream_is_none(self) -> None:
+        from archivey.internal.streams.streamtools import source_byte_size
+
+        assert source_byte_size(NonSeekableBytesIO(b"abc")) is None

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -346,3 +346,37 @@ def test_verify_oversized_int_digest_mismatches_not_raises() -> None:
     with pytest.raises(CorruptionError, match="crc32"):
         while stream.read(64):  # read to EOF; the terminal read verifies
             pass
+
+
+# --- gzip ISIZE truncation backstop -------------------------------------------------------
+
+
+def test_gzip_truncation_check_read0_mid_stream_is_not_eof(tmp_path) -> None:
+    # read(0) is not EOF: mid-stream it must not run the ISIZE trailer comparison (which
+    # would spuriously report truncation because the byte total is still partial).
+    from archivey.internal.streams.codecs import _GzipTruncationCheckStream
+
+    payload = b"hello world" * 100
+    path = tmp_path / "f.gz"
+    path.write_bytes(gzip.compress(payload))
+
+    # A plain BytesIO stands in for the accelerator's decompressed output.
+    stream = _GzipTruncationCheckStream(io.BytesIO(payload), str(path))
+    assert stream.read(5) == b"hello"
+    assert stream.read(0) == b""  # must not raise TruncatedError
+    assert stream.read(-1) == payload[5:]
+    assert stream.read() == b""  # clean EOF: the full total matches ISIZE
+
+
+def test_gzip_truncation_check_detects_short_output(tmp_path) -> None:
+    from archivey.internal.streams.codecs import _GzipTruncationCheckStream
+
+    payload = b"hello world" * 100
+    path = tmp_path / "f.gz"
+    path.write_bytes(gzip.compress(payload))
+
+    # Simulate an accelerator that silently stopped short of the real payload.
+    stream = _GzipTruncationCheckStream(io.BytesIO(payload[:64]), str(path))
+    stream.read(-1)
+    with pytest.raises(TruncatedError):
+        stream.read()

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -412,3 +412,18 @@ def test_gzip_truncation_check_real_seek_disables_verification(tmp_path) -> None
     stream.seek(0)  # genuine random access: the sequential total is meaningless now
     stream.read(-1)
     assert stream.read() == b""  # no spurious TruncatedError after a real seek
+
+
+def test_codec_stream_size_via_cheap_index(tmp_path) -> None:
+    # An xz codec stream reports its decompressed size through the seekable reader's
+    # try_get_size (a backward index scan, no decompression), surfaced as `.size`.
+    import lzma
+
+    payload = b"sizeable " * 4096
+    stream = open_codec_stream(Codec.XZ, io.BytesIO(lzma.compress(payload)))
+    assert stream.size == len(payload)
+    # gzip via stdlib has no cheap index; its stream must not claim a size.
+    gz = open_codec_stream(
+        Codec.GZIP, io.BytesIO(gzip.compress(payload)), config=_STDLIB_GZIP
+    )
+    assert gz.size is None

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -380,3 +380,35 @@ def test_gzip_truncation_check_detects_short_output(tmp_path) -> None:
     stream.read(-1)
     with pytest.raises(TruncatedError):
         stream.read()
+
+
+def test_gzip_truncation_check_noop_seek_keeps_verification(tmp_path) -> None:
+    # A seek that does not leave the sequential frontier (tell()-style seek(0, SEEK_CUR),
+    # or a seek to the current offset) keeps the ISIZE check armed, so a short
+    # accelerator output is still caught at EOF.
+    from archivey.internal.streams.codecs import _GzipTruncationCheckStream
+
+    payload = b"hello world" * 100
+    path = tmp_path / "f.gz"
+    path.write_bytes(gzip.compress(payload))
+
+    stream = _GzipTruncationCheckStream(io.BytesIO(payload[:64]), str(path))
+    stream.read(16)
+    stream.seek(0, io.SEEK_CUR)  # no-op: must not disarm the check
+    stream.read(-1)
+    with pytest.raises(TruncatedError):
+        stream.read()
+
+
+def test_gzip_truncation_check_real_seek_disables_verification(tmp_path) -> None:
+    from archivey.internal.streams.codecs import _GzipTruncationCheckStream
+
+    payload = b"hello world" * 100
+    path = tmp_path / "f.gz"
+    path.write_bytes(gzip.compress(payload))
+
+    stream = _GzipTruncationCheckStream(io.BytesIO(payload[:64]), str(path))
+    stream.read(16)
+    stream.seek(0)  # genuine random access: the sequential total is meaningless now
+    stream.read(-1)
+    assert stream.read() == b""  # no spurious TruncatedError after a real seek

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -333,3 +333,19 @@ def test_small_zip_still_detected_despite_iso_probe() -> None:
     # A 2 KiB-ish ZIP is matched by its offset-0 magic without ever taking the ISO window.
     data = _zip_bytes()
     assert detect_format(io.BytesIO(data)).format == ArchiveFormat.ZIP
+
+
+# ---------------------------------------------------------------------------
+# Stream-position contract: detection reads from and restores the current position
+# ---------------------------------------------------------------------------
+
+
+def test_detection_from_mid_positioned_stream() -> None:
+    # The archive starts wherever the caller positioned the stream: detection must peek
+    # from there (an embedded archive after junk bytes) and restore the position.
+    junk = b"JUNKJUNK" * 16
+    stream = io.BytesIO(junk + _zip_bytes())
+    stream.seek(len(junk))
+    info = detect_format(stream)
+    assert info.format == ArchiveFormat.ZIP
+    assert stream.tell() == len(junk)  # starting position restored, not rewound to 0

--- a/tests/test_directory.py
+++ b/tests/test_directory.py
@@ -448,3 +448,12 @@ def test_source_name_for_path_and_stream(tmp_path: Path) -> None:
         assert source_name(f) == str(p)
     # An in-memory stream has no name attribute -> None.
     assert source_name(io.BytesIO(b"")) is None
+
+
+def test_password_rejected(simple_dir: Path) -> None:
+    # Directories carry no encryption; a password is API misuse, rejected like the
+    # other unencrypted formats rather than silently ignored.
+    from archivey.exceptions import UnsupportedOperationError
+
+    with pytest.raises(UnsupportedOperationError):
+        open_archive(simple_dir, password="x")

--- a/tests/test_directory.py
+++ b/tests/test_directory.py
@@ -190,33 +190,29 @@ def test_iter_yields_members(simple_dir: Path) -> None:
             assert isinstance(m, ArchiveMember)
 
 
-def test_len(simple_dir: Path) -> None:
+def test_no_len(simple_dir: Path) -> None:
+    # The reader is deliberately not a collection: no __len__ (see archive-reading);
+    # counting goes through members() or iteration.
     with open_archive(simple_dir) as reader:
-        assert len(reader) == len(reader.members())
+        with pytest.raises(TypeError):
+            len(reader)
+        assert len(reader.members()) == len(list(reader))
 
 
-def test_contains(simple_dir: Path) -> None:
-    with open_archive(simple_dir) as reader:
-        assert "a.txt" in reader
-        assert "nonexistent.txt" not in reader
-
-
-def test_getitem(simple_dir: Path) -> None:
-    with open_archive(simple_dir) as reader:
-        member = reader["a.txt"]
-        assert member.name == "a.txt"
-        assert member.type == MemberType.FILE
-
-
-def test_getitem_missing_raises_key_error(simple_dir: Path) -> None:
-    with open_archive(simple_dir) as reader:
-        with pytest.raises(KeyError):
-            _ = reader["does_not_exist.txt"]
-
-
-def test_get_returns_none_for_missing(simple_dir: Path) -> None:
-    with open_archive(simple_dir) as reader:
-        assert reader.get("does_not_exist.txt") is None
+def test_contains_is_identity_membership(simple_dir: Path, tmp_path: Path) -> None:
+    # `member in reader` is identity-based: True for a member this reader yielded,
+    # False for one from a different reader; a string operand raises TypeError
+    # (name lookup is get()).
+    other_dir = tmp_path / "other"
+    other_dir.mkdir()
+    (other_dir / "b.txt").write_bytes(b"x")
+    with open_archive(simple_dir) as reader, open_archive(other_dir) as other:
+        member = reader.get("a.txt")
+        assert member is not None
+        assert member in reader
+        assert member not in other
+        with pytest.raises(TypeError):
+            "a.txt" in reader  # noqa: B015 - the expression itself must raise
 
 
 def test_get_returns_member(simple_dir: Path) -> None:
@@ -224,6 +220,18 @@ def test_get_returns_member(simple_dir: Path) -> None:
         member = reader.get("a.txt")
         assert member is not None
         assert member.name == "a.txt"
+        assert member.type == MemberType.FILE
+
+
+def test_open_missing_name_raises_key_error(simple_dir: Path) -> None:
+    with open_archive(simple_dir) as reader:
+        with pytest.raises(KeyError):
+            reader.open("does_not_exist.txt")
+
+
+def test_get_returns_none_for_missing(simple_dir: Path) -> None:
+    with open_archive(simple_dir) as reader:
+        assert reader.get("does_not_exist.txt") is None
 
 
 # ---------------------------------------------------------------------------
@@ -239,7 +247,7 @@ def test_read_file_by_name(simple_dir: Path) -> None:
 
 def test_read_file_by_member(simple_dir: Path) -> None:
     with open_archive(simple_dir) as reader:
-        member = reader["b.txt"]
+        member = reader.get("b.txt")
         data = reader.read(member)
         assert data == b"world"
 
@@ -272,7 +280,7 @@ def test_symlink_member_type(symlink_dir: Path) -> None:
 
 def test_symlink_link_target_member_resolved(symlink_dir: Path) -> None:
     with open_archive(symlink_dir) as reader:
-        link = reader["link.txt"]
+        link = reader.get("link.txt")
         assert link.link_target_member is not None
         assert link.link_target_member.name == "real.txt"
 
@@ -354,7 +362,7 @@ def test_stream_members_with_filter(simple_dir: Path) -> None:
 
 def test_member_is_file_property(simple_dir: Path) -> None:
     with open_archive(simple_dir) as reader:
-        m = reader["a.txt"]
+        m = reader.get("a.txt")
         assert m.is_file is True
         assert m.is_dir is False
         assert m.is_link is False
@@ -362,7 +370,7 @@ def test_member_is_file_property(simple_dir: Path) -> None:
 
 def test_member_is_dir_property(simple_dir: Path) -> None:
     with open_archive(simple_dir) as reader:
-        m = reader["sub/"]
+        m = reader.get("sub/")
         assert m.is_dir is True
         assert m.is_file is False
 

--- a/tests/test_error_translation.py
+++ b/tests/test_error_translation.py
@@ -99,3 +99,31 @@ def test_untranslated_exception_propagates_unchanged() -> None:
     reader = _Unmapped(ArchiveFormat.ZIP, False, "archive.zip")
     with pytest.raises(_RawDecodeError):
         reader.read("member.bin")
+
+
+# ---------------------------------------------------------------------------
+# ArchiveStream close(): failure still marks the wrapper closed
+# ---------------------------------------------------------------------------
+
+
+def test_archive_stream_close_failure_still_closes_wrapper() -> None:
+    from archivey.internal.streams.archive_stream import ArchiveStream
+
+    class _FailingClose(io.BytesIO):
+        def close(self) -> None:  # noqa: D102
+            raise RuntimeError("simulated close failure")
+
+    def _translate(exc: Exception) -> ArchiveyError | None:
+        if isinstance(exc, RuntimeError):
+            return CorruptionError(f"translated: {exc}")
+        return None
+
+    stream = ArchiveStream(lambda: _FailingClose(b"data"), translate=_translate)
+    with pytest.raises(CorruptionError):
+        stream.close()
+    # The wrapper is closed despite the inner failure: reads are refused and a retried
+    # close() is a no-op instead of failing again.
+    assert stream.closed
+    with pytest.raises(ValueError):
+        stream.read()
+    stream.close()  # idempotent

--- a/tests/test_iso.py
+++ b/tests/test_iso.py
@@ -258,3 +258,13 @@ def test_filesystem_oserror_propagates_unwrapped(tmp_path: Path) -> None:
 
 def test_iso_full_support_with_pycdlib() -> None:
     assert format_availability(ArchiveFormat.ISO).support == FormatSupport.FULL
+
+
+def test_open_from_mid_positioned_stream(rock_ridge_iso: Path) -> None:
+    # pycdlib addresses the image with absolute offsets; open_archive normalizes a
+    # mid-positioned stream to a zero-origin view, so an embedded image still opens.
+    junk = b"J" * 51
+    stream = io.BytesIO(junk + rock_ridge_iso.read_bytes())
+    stream.seek(len(junk))
+    with open_archive(stream, format=ArchiveFormat.ISO) as ar:
+        assert any(m.is_file for m in ar.members())

--- a/tests/test_iso.py
+++ b/tests/test_iso.py
@@ -131,7 +131,7 @@ def test_joliet_namespace_and_fidelity(tmp_path: Path) -> None:
     path.write_bytes(_build_iso(rock_ridge=False, joliet=True))
     with open_archive(path) as ar:
         assert ar.info.extra["iso.namespace"] == "joliet"
-        f = ar["file.txt"]  # Joliet preserves case
+        f = ar.get("file.txt")  # Joliet preserves case
         # Joliet carries no POSIX metadata.
         assert f.mode is None and f.uid is None and f.gid is None
 
@@ -145,7 +145,7 @@ def test_plain_iso_namespace_and_fidelity(tmp_path: Path) -> None:
         # Plain ISO 9660: upper-case 8.3 names, ;version suffix stripped.
         assert "FILE.TXT" in names
         assert "DIR/" in names
-        assert ar["FILE.TXT"].mode is None  # no POSIX metadata
+        assert ar.get("FILE.TXT").mode is None  # no POSIX metadata
 
 
 # ---------------------------------------------------------------------------
@@ -199,7 +199,7 @@ def test_streaming_over_seekable_iso(rock_ridge_iso: Path) -> None:
 def test_file_member_storage_attributes(rock_ridge_iso: Path) -> None:
     # ISO members are stored uncompressed and unencrypted, with no per-member checksum.
     with open_archive(rock_ridge_iso) as ar:
-        m = ar["file.txt"]
+        m = ar.get("file.txt")
         assert m.type == MemberType.FILE
         assert m.size == len(b"hello world")
         assert m.compressed_size == m.size

--- a/tests/test_peekable.py
+++ b/tests/test_peekable.py
@@ -84,9 +84,10 @@ def test_name_passthrough(tmp_path) -> None:
         assert stream.name == str(path)
 
 
-def test_name_none_for_anonymous_stream() -> None:
+def test_name_absent_for_anonymous_stream() -> None:
+    # Same contract as SlicingStream: no name attr when the underlying has none.
     stream = PeekableStream(NonSeekableBytesIO(b"abc"))
-    assert stream.name is None
+    assert not hasattr(stream, "name")
 
 
 def test_works_as_binaryio_for_buffered_reader() -> None:

--- a/tests/test_reader_contract.py
+++ b/tests/test_reader_contract.py
@@ -115,8 +115,6 @@ def test_streaming_disables_random_access_on_capable_backend() -> None:
     reader = _IndexedReader(ArchiveFormat.ZIP, True, "x.zip")  # streaming=True
     for call in (
         lambda: reader.members(),
-        lambda: "a.txt" in reader,
-        lambda: reader["a.txt"],
         lambda: reader.get("a.txt"),
         lambda: reader.open("a.txt"),
         lambda: reader.read("a.txt"),
@@ -127,14 +125,26 @@ def test_streaming_disables_random_access_on_capable_backend() -> None:
     assert [m.name for m in reader] == ["a.txt"]
 
 
-def test_streaming_len_raises_typeerror_so_list_works() -> None:
-    # len() raises TypeError (not UnsupportedOperationError): list(reader) probes
-    # __len__ implicitly via the length-hint protocol, which suppresses only TypeError,
-    # so plain list(reader) must still perform the forward pass.
+def test_no_len_so_list_works_on_streaming_reader() -> None:
+    # The reader defines no __len__ (it is not a collection), so len() raises Python's
+    # own TypeError — and list(reader), which probes __len__ via the length-hint
+    # protocol (suppressing TypeError), performs the plain forward pass.
     reader = _IndexedReader(ArchiveFormat.ZIP, True, "x.zip")  # streaming=True
     with pytest.raises(TypeError):
         len(reader)
     assert [m.name for m in list(reader)] == ["a.txt"]
+
+
+def test_contains_is_identity_and_mode_free() -> None:
+    # Identity membership works even on a streaming reader (no scan involved), and a
+    # string operand raises TypeError instead of falling back to iteration.
+    reader = _IndexedReader(ArchiveFormat.ZIP, True, "x.zip")  # streaming=True
+    (member,) = list(reader)
+    assert member in reader
+    other = _IndexedReader(ArchiveFormat.ZIP, False, "y.zip")
+    assert other.members()[0] not in reader
+    with pytest.raises(TypeError):
+        "a.txt" in reader  # noqa: B015 - the expression itself must raise
 
 
 # --- get_members_if_available: never scans; safe on any reader ----------------------

--- a/tests/test_reader_contract.py
+++ b/tests/test_reader_contract.py
@@ -115,7 +115,6 @@ def test_streaming_disables_random_access_on_capable_backend() -> None:
     reader = _IndexedReader(ArchiveFormat.ZIP, True, "x.zip")  # streaming=True
     for call in (
         lambda: reader.members(),
-        lambda: len(reader),
         lambda: "a.txt" in reader,
         lambda: reader["a.txt"],
         lambda: reader.get("a.txt"),
@@ -126,6 +125,16 @@ def test_streaming_disables_random_access_on_capable_backend() -> None:
             call()
     # A single forward pass is still allowed.
     assert [m.name for m in reader] == ["a.txt"]
+
+
+def test_streaming_len_raises_typeerror_so_list_works() -> None:
+    # len() raises TypeError (not UnsupportedOperationError): list(reader) probes
+    # __len__ implicitly via the length-hint protocol, which suppresses only TypeError,
+    # so plain list(reader) must still perform the forward pass.
+    reader = _IndexedReader(ArchiveFormat.ZIP, True, "x.zip")  # streaming=True
+    with pytest.raises(TypeError):
+        len(reader)
+    assert [m.name for m in list(reader)] == ["a.txt"]
 
 
 # --- get_members_if_available: never scans; safe on any reader ----------------------
@@ -157,8 +166,6 @@ def test_streaming_iteration_registers_member_ids() -> None:
     # A streaming pass must still stamp identity onto the members it yields (the
     # progressive path bypasses _get_members_registered).
     reader = _IndexedReader(ArchiveFormat.ZIP, True, "x.zip")  # streaming=True
-    # Note: list(reader) would call __len__ for list preallocation, which the streaming
-    # gate blocks — go through iter() so len() is never touched.
-    member = next(iter(reader))
+    (member,) = list(reader)
     assert member.member_id == 0
     assert member.archive_id == reader._archive_id

--- a/tests/test_reader_contract.py
+++ b/tests/test_reader_contract.py
@@ -151,3 +151,14 @@ def test_get_members_if_available_returns_cache_once_materialized() -> None:
     assert reader.get_members_if_available() is None
     _ = list(reader)
     assert reader.get_members_if_available() is not None
+
+
+def test_streaming_iteration_registers_member_ids() -> None:
+    # A streaming pass must still stamp identity onto the members it yields (the
+    # progressive path bypasses _get_members_registered).
+    reader = _IndexedReader(ArchiveFormat.ZIP, True, "x.zip")  # streaming=True
+    # Note: list(reader) would call __len__ for list preallocation, which the streaming
+    # gate blocks — go through iter() so len() is never touched.
+    member = next(iter(reader))
+    assert member.member_id == 0
+    assert member.archive_id == reader._archive_id

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -263,3 +263,35 @@ def test_iso_none_without_pycdlib(monkeypatch: pytest.MonkeyPatch) -> None:
     with pytest.raises(UnsupportedFormatError) as excinfo:
         open_archive(io.BytesIO(b"not an iso"), format=ArchiveFormat.ISO)
     assert "pycdlib" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# Compressed tar: the outer stream codec is a single-codec gate (NONE, not PARTIAL)
+# ---------------------------------------------------------------------------
+
+
+def test_compressed_tar_none_when_stream_codec_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import io
+
+    # A compressed tar cannot even be listed without its outer codec, so per the
+    # single-codec rule tar.zst is NONE with the codec's install hint — not FULL.
+    monkeypatch.setattr(codecs_module, "_zstd", None)
+    avail = format_availability(ArchiveFormat.TAR_ZST)
+    assert avail.support is FormatSupport.NONE
+    assert avail.missing[0].name == "backports.zstd"
+    assert ArchiveFormat.TAR_ZST in list_known_formats()
+    assert ArchiveFormat.TAR_ZST not in list_supported_formats()
+
+    # Selecting it raises an install-hint error rather than failing later at decode time.
+    with pytest.raises(UnsupportedFormatError) as excinfo:
+        open_archive(io.BytesIO(b"not a tar.zst"), format=ArchiveFormat.TAR_ZST)
+    assert "backports.zstd" in str(excinfo.value)
+
+
+def test_compressed_tar_full_when_stream_codec_present(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(codecs_module, "_zstd", object())
+    assert format_availability(ArchiveFormat.TAR_ZST).support is FormatSupport.FULL

--- a/tests/test_single_file.py
+++ b/tests/test_single_file.py
@@ -320,3 +320,16 @@ def test_corrupt_gzip_raises_corruption() -> None:
     with open_archive(NonSeekableBytesIO(bytes(data))) as ar:
         with pytest.raises(CorruptionError):
             ar.read(ar.members()[0])
+
+
+def test_open_from_mid_positioned_stream() -> None:
+    # The compressed stream starts at the caller's position (an embedded .gz after junk
+    # bytes); reads — including a re-open for a second read — must use that origin.
+    junk = b"X" * 37
+    payload = b"embedded payload " * 20
+    stream = io.BytesIO(junk + gzip.compress(payload))
+    stream.seek(len(junk))
+    with open_archive(stream, format=ArchiveFormat.GZ) as ar:
+        (member,) = ar.members()
+        assert ar.read(member) == payload
+        assert ar.read(member) == payload  # re-open rewinds to the embedded origin

--- a/tests/test_slice.py
+++ b/tests/test_slice.py
@@ -7,6 +7,7 @@ corner-case coverage (per CONTRIBUTING's narrow exception for stream primitives)
 from __future__ import annotations
 
 import io
+from pathlib import Path
 
 import pytest
 
@@ -130,9 +131,30 @@ class TestFixStreamStartPosition:
         assert fixed.tell() == 0
         assert fixed.read(5) == DATA[10:15]
 
+    def test_midstream_slice_has_no_name(self) -> None:
+        # pycdlib on Windows: hasattr(fp, 'name') and fp.name.startswith(r'\\.\')
+        # crashes when typing.BinaryIO's stub name is None; BytesIO has no name attr.
+        stream = io.BytesIO(DATA)
+        stream.seek(10)
+        fixed = fix_stream_start_position(stream)
+        assert not hasattr(fixed, "name")
+
     def test_non_seekable_passthrough(self) -> None:
         stream = NonSeekableBytesIO(DATA)
         assert fix_stream_start_position(stream) is stream
+
+
+class TestSlicingStreamName:
+    def test_no_name_for_bytesio_underlying(self) -> None:
+        sliced = SlicingStream(io.BytesIO(DATA), start=5)
+        assert not hasattr(sliced, "name")
+
+    def test_forwards_file_name(self, tmp_path: Path) -> None:
+        path = tmp_path / "data.bin"
+        path.write_bytes(DATA)
+        with open(path, "rb") as underlying:
+            sliced = SlicingStream(underlying, start=5, length=10)
+            assert sliced.name == str(path)
 
 
 class TestSlicingStreamSize:

--- a/tests/test_slice.py
+++ b/tests/test_slice.py
@@ -131,13 +131,16 @@ class TestFixStreamStartPosition:
         assert fixed.tell() == 0
         assert fixed.read(5) == DATA[10:15]
 
-    def test_midstream_slice_has_no_name(self) -> None:
-        # pycdlib on Windows: hasattr(fp, 'name') and fp.name.startswith(r'\\.\')
-        # crashes when typing.BinaryIO's stub name is None; BytesIO has no name attr.
-        stream = io.BytesIO(DATA)
-        stream.seek(10)
-        fixed = fix_stream_start_position(stream)
-        assert not hasattr(fixed, "name")
+    def test_midstream_slice_has_no_name(self, tmp_path: Path) -> None:
+        # fix_stream_start_position wraps mid-positioned streams; see
+        # TestSlicingStreamName.test_name_not_forwarded_from_underlying for why name
+        # must stay absent (pycdlib Windows + reopen-by-name footgun).
+        path = tmp_path / "data.bin"
+        path.write_bytes(DATA)
+        with open(path, "rb") as stream:
+            stream.seek(10)
+            fixed = fix_stream_start_position(stream)
+            assert not hasattr(fixed, "name")
 
     def test_non_seekable_passthrough(self) -> None:
         stream = NonSeekableBytesIO(DATA)
@@ -145,16 +148,33 @@ class TestFixStreamStartPosition:
 
 
 class TestSlicingStreamName:
-    def test_no_name_for_bytesio_underlying(self) -> None:
-        sliced = SlicingStream(io.BytesIO(DATA), start=5)
-        assert not hasattr(sliced, "name")
+    def test_name_not_forwarded_from_underlying(self, tmp_path: Path) -> None:
+        """SlicingStream must not expose ``name``, even when the underlying stream has one.
 
-    def test_forwards_file_name(self, tmp_path: Path) -> None:
+        Two independent reasons — do not "fix" this by forwarding ``underlying.name``
+        without considering both:
+
+        1. **View semantics.** A slice remaps the origin (``tell()==0`` is mid-file on the
+           underlying). ``stream.name`` conventionally means "reopen this path from byte 0";
+           forwarding would mislead libraries that stat or ``open()`` by name into reading
+           the unsliced file (embedded-archive / ``fix_stream_start_position`` cases).
+
+        2. **Stub vs absent.** Our wrappers inherit ``typing.BinaryIO``'s stub ``name``
+           (``None`` at runtime). ``hasattr(stream, 'name')`` must stay ``False`` on
+           nameless views so consumers like pycdlib's Windows raw-device check
+           (``fp.name.startswith(r'\\.\')``) do not crash on ``None``. Real file objects
+           and ``BytesIO`` already behave this way; the slice wrapper must match.
+
+        Callers that need a path for errors/metadata should use ``source_name()`` on the
+        *original* source before wrapping (``open_archive`` captures ``archive_name`` that
+        way). Logical slice length is ``SlicingStream.size``, not ``name``.
+        """
         path = tmp_path / "data.bin"
         path.write_bytes(DATA)
         with open(path, "rb") as underlying:
+            assert underlying.name == str(path)
             sliced = SlicingStream(underlying, start=5, length=10)
-            assert sliced.name == str(path)
+            assert not hasattr(sliced, "name")
 
 
 class TestSlicingStreamSize:

--- a/tests/test_slice.py
+++ b/tests/test_slice.py
@@ -91,10 +91,15 @@ class TestSlicingStream:
         assert sliced.seek(0, io.SEEK_END) == len(DATA) - 10
         assert sliced.read(1) == b""
 
-    def test_seek_end_no_length_nonzero_offset_unsupported(self) -> None:
+    def test_seek_end_no_length_nonzero_offset(self) -> None:
+        # With no declared length the slice ends at the underlying EOF; SEEK_END with a
+        # non-zero offset probes that end on demand and positions relative to it.
         sliced = SlicingStream(io.BytesIO(DATA), start=5)
-        with pytest.raises(io.UnsupportedOperation, match="SEEK_END is not supported"):
-            sliced.seek(-1, io.SEEK_END)
+        slice_len = len(DATA) - 5
+        assert sliced.seek(-3, io.SEEK_END) == slice_len - 3
+        assert sliced.read() == DATA[-3:]
+        assert sliced.seek(2, io.SEEK_END) == slice_len + 2  # past-end allowed, like BytesIO
+        assert sliced.read(1) == b""
 
     def test_non_seekable_no_start(self) -> None:
         sliced = SlicingStream(NonSeekableBytesIO(DATA), length=15)

--- a/tests/test_slice.py
+++ b/tests/test_slice.py
@@ -133,3 +133,17 @@ class TestFixStreamStartPosition:
     def test_non_seekable_passthrough(self) -> None:
         stream = NonSeekableBytesIO(DATA)
         assert fix_stream_start_position(stream) is stream
+
+
+class TestSlicingStreamSize:
+    def test_size_with_declared_length(self) -> None:
+        sliced = SlicingStream(io.BytesIO(DATA), start=5, length=7)
+        assert sliced.size == 7
+
+    def test_size_derived_from_cheap_underlying(self) -> None:
+        sliced = SlicingStream(io.BytesIO(DATA), start=5)
+        assert sliced.size == len(DATA) - 5
+
+    def test_size_none_when_underlying_unknowable(self) -> None:
+        sliced = SlicingStream(NonSeekableBytesIO(DATA), length=None)
+        assert sliced.size is None

--- a/tests/test_tar.py
+++ b/tests/test_tar.py
@@ -573,3 +573,86 @@ def test_out_of_range_mtime_degrades_to_none() -> None:
     with open_archive(io.BytesIO(buf.getvalue()), format=ArchiveFormat.TAR) as reader:
         (member,) = reader.members()
         assert member.modified is None
+
+
+# ---------------------------------------------------------------------------
+# Link-target name resolution (relative symlinks, hardlinks, streaming pass)
+# ---------------------------------------------------------------------------
+
+
+def _build_link_tar() -> bytes:
+    """dir/file + a root-level decoy `file`, and links exercising target resolution."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as t:
+        for name, data in [("file", b"ROOT"), ("dir/file", b"NESTED"), ("top.txt", b"TOP")]:
+            info = tarfile.TarInfo(name)
+            info.size = len(data)
+            t.addfile(info, io.BytesIO(data))
+        rel = tarfile.TarInfo("dir/rel_link")  # -> dir/file, not the root decoy
+        rel.type = tarfile.SYMTYPE
+        rel.linkname = "file"
+        t.addfile(rel)
+        up = tarfile.TarInfo("dir/up_link")  # ../top.txt -> top.txt
+        up.type = tarfile.SYMTYPE
+        up.linkname = "../top.txt"
+        t.addfile(up)
+        absolute = tarfile.TarInfo("dir/abs_link")  # absolute: outside the archive
+        absolute.type = tarfile.SYMTYPE
+        absolute.linkname = "/etc/passwd"
+        t.addfile(absolute)
+        hard = tarfile.TarInfo("dir/hard")  # hardlink targets are archive-relative
+        hard.type = tarfile.LNKTYPE
+        hard.linkname = "dir/file"
+        t.addfile(hard)
+    return buf.getvalue()
+
+
+def test_relative_symlink_resolves_against_link_directory() -> None:
+    with open_archive(io.BytesIO(_build_link_tar()), format=ArchiveFormat.TAR) as ar:
+        member = ar["dir/rel_link"]
+        assert member.link_target == "file"  # raw stored target is untouched
+        assert member.link_target_member is not None
+        assert member.link_target_member.name == "dir/file"
+        assert ar.read("dir/rel_link") == b"NESTED"  # not the root-level decoy
+
+
+def test_dotdot_symlink_resolves_upward() -> None:
+    with open_archive(io.BytesIO(_build_link_tar()), format=ArchiveFormat.TAR) as ar:
+        assert ar["dir/up_link"].link_target_member.name == "top.txt"
+        assert ar.read("dir/up_link") == b"TOP"
+
+
+def test_absolute_symlink_stays_unresolved() -> None:
+    from archivey.exceptions import LinkTargetNotFoundError
+
+    with open_archive(io.BytesIO(_build_link_tar()), format=ArchiveFormat.TAR) as ar:
+        member = ar["dir/abs_link"]
+        assert member.link_target == "/etc/passwd"
+        assert member.link_target_member is None
+        with pytest.raises(LinkTargetNotFoundError):
+            ar.open(member)
+
+
+def test_hardlink_target_is_archive_relative() -> None:
+    with open_archive(io.BytesIO(_build_link_tar()), format=ArchiveFormat.TAR) as ar:
+        assert ar["dir/hard"].link_target_member.name == "dir/file"
+        assert ar.read("dir/hard") == b"NESTED"
+
+
+def test_streaming_pass_resolves_backward_links() -> None:
+    # Hardlinks always point at an earlier member (the TAR model), so a single
+    # streaming pass resolves them progressively; relative symlinks to earlier
+    # members resolve too.
+    source = NonSeekableBytesIO(_build_link_tar())
+    with open_archive(source, format=ArchiveFormat.TAR, streaming=True) as ar:
+        resolved = {
+            m.name: (m.link_target_member.name if m.link_target_member else None)
+            for m, _stream in ar.stream_members()
+            if m.is_link
+        }
+    assert resolved == {
+        "dir/rel_link": "dir/file",
+        "dir/up_link": "top.txt",
+        "dir/abs_link": None,
+        "dir/hard": "dir/file",
+    }

--- a/tests/test_tar.py
+++ b/tests/test_tar.py
@@ -548,3 +548,28 @@ def test_corrupt_compressed_tar_surfaces_codec_corruption(tmp_path: Path) -> Non
             for _member, stream in ar.stream_members():
                 if stream is not None:
                     stream.read()
+
+
+# ---------------------------------------------------------------------------
+# Password rejection and hostile metadata robustness
+# ---------------------------------------------------------------------------
+
+
+def test_password_rejected() -> None:
+    # TAR carries no encryption; a password is API misuse, rejected like the other
+    # unencrypted formats (single-file compressors, ISO, directory) rather than ignored.
+    with pytest.raises(UnsupportedOperationError):
+        open_archive(io.BytesIO(_build_tar()), format=ArchiveFormat.TAR, password="x")
+
+
+def test_out_of_range_mtime_degrades_to_none() -> None:
+    # A crafted PAX mtime beyond datetime's range must not sink the listing.
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w", format=tarfile.PAX_FORMAT) as t:
+        info = tarfile.TarInfo("weird.txt")
+        info.size = 0
+        info.mtime = 10**18
+        t.addfile(info)
+    with open_archive(io.BytesIO(buf.getvalue()), format=ArchiveFormat.TAR) as reader:
+        (member,) = reader.members()
+        assert member.modified is None

--- a/tests/test_tar.py
+++ b/tests/test_tar.py
@@ -385,10 +385,16 @@ def test_compressed_source_size_on_path(tmp_path: Path) -> None:
         assert ar.compressed_source_size == path.stat().st_size
 
 
-def test_compressed_source_size_none_for_plain_and_stream(plain_tar: Path) -> None:
+def test_compressed_source_size_generalized(plain_tar: Path) -> None:
+    # Generalized (for the archive-wide extraction ratio guard): known for any path
+    # source — a plain tar simply yields a harmless ~1:1 ratio — and for seekable
+    # streams via a SEEK_END probe; only a non-seekable stream is unknowable.
     with open_archive(plain_tar) as ar:
-        assert ar.compressed_source_size is None
-    with open_archive(NonSeekableBytesIO(_build_tar("w:gz")), streaming=True) as ar:
+        assert ar.compressed_source_size == plain_tar.stat().st_size
+    data = _build_tar("w:gz")
+    with open_archive(io.BytesIO(data), format=ArchiveFormat.TAR_GZ) as ar:
+        assert ar.compressed_source_size == len(data)
+    with open_archive(NonSeekableBytesIO(data), streaming=True) as ar:
         assert ar.compressed_source_size is None
 
 

--- a/tests/test_tar.py
+++ b/tests/test_tar.py
@@ -235,7 +235,7 @@ def test_pax_mtime_override(tmp_path: Path) -> None:
     path = tmp_path / "pax.tar"
     path.write_bytes(buf.getvalue())
     with open_archive(path) as ar:
-        m = ar["p.txt"]
+        m = ar.get("p.txt")
         assert m.modified is not None
         assert abs(m.modified.timestamp() - 1_600_000_000.123456) < 1e-3
 
@@ -249,7 +249,7 @@ def test_raw_name_preserved(tmp_path: Path) -> None:
     path = tmp_path / "u.tar"
     path.write_bytes(buf.getvalue())
     with open_archive(path) as ar:
-        m = ar["café.txt"]
+        m = ar.get("café.txt")
         assert m.name == "café.txt"  # decoded name round-trips
         assert m.raw_name == "café.txt".encode("utf-8")  # verbatim stored bytes
 
@@ -267,7 +267,7 @@ def test_pax_atime_ctime(tmp_path: Path) -> None:
     path = tmp_path / "pax_times.tar"
     path.write_bytes(buf.getvalue())
     with open_archive(path) as ar:
-        m = ar["p.txt"]
+        m = ar.get("p.txt")
         assert m.accessed is not None
         assert abs(m.accessed.timestamp() - 1_600_000_100.5) < 1e-3
         assert m.created is not None
@@ -609,7 +609,7 @@ def _build_link_tar() -> bytes:
 
 def test_relative_symlink_resolves_against_link_directory() -> None:
     with open_archive(io.BytesIO(_build_link_tar()), format=ArchiveFormat.TAR) as ar:
-        member = ar["dir/rel_link"]
+        member = ar.get("dir/rel_link")
         assert member.link_target == "file"  # raw stored target is untouched
         assert member.link_target_member is not None
         assert member.link_target_member.name == "dir/file"
@@ -618,7 +618,7 @@ def test_relative_symlink_resolves_against_link_directory() -> None:
 
 def test_dotdot_symlink_resolves_upward() -> None:
     with open_archive(io.BytesIO(_build_link_tar()), format=ArchiveFormat.TAR) as ar:
-        assert ar["dir/up_link"].link_target_member.name == "top.txt"
+        assert ar.get("dir/up_link").link_target_member.name == "top.txt"
         assert ar.read("dir/up_link") == b"TOP"
 
 
@@ -626,7 +626,7 @@ def test_absolute_symlink_stays_unresolved() -> None:
     from archivey.exceptions import LinkTargetNotFoundError
 
     with open_archive(io.BytesIO(_build_link_tar()), format=ArchiveFormat.TAR) as ar:
-        member = ar["dir/abs_link"]
+        member = ar.get("dir/abs_link")
         assert member.link_target == "/etc/passwd"
         assert member.link_target_member is None
         with pytest.raises(LinkTargetNotFoundError):
@@ -635,7 +635,7 @@ def test_absolute_symlink_stays_unresolved() -> None:
 
 def test_hardlink_target_is_archive_relative() -> None:
     with open_archive(io.BytesIO(_build_link_tar()), format=ArchiveFormat.TAR) as ar:
-        assert ar["dir/hard"].link_target_member.name == "dir/file"
+        assert ar.get("dir/hard").link_target_member.name == "dir/file"
         assert ar.read("dir/hard") == b"NESTED"
 
 

--- a/tests/test_zip.py
+++ b/tests/test_zip.py
@@ -103,7 +103,7 @@ def test_random_access_read_by_name(simple_zip: Path) -> None:
 
 
 def test_central_directory_lookup_no_io(simple_zip: Path) -> None:
-    # reader["name"] is served from the in-memory name map with no extra archive reads.
+    # reader.get("name") is served from the in-memory name map with no extra archive reads.
     with open_archive(simple_zip) as ar:
         ar.members()  # materialize
         archive = ar._archive  # type: ignore[attr-defined]
@@ -115,7 +115,7 @@ def test_central_directory_lookup_no_io(simple_zip: Path) -> None:
             return original_open(*args, **kwargs)
 
         archive.open = counting_open  # type: ignore[method-assign]
-        member = ar["hello.txt"]
+        member = ar.get("hello.txt")
         assert member.name == "hello.txt"
         assert calls["open"] == 0  # lookup touched no archive data
 
@@ -129,7 +129,7 @@ def test_unix_mode_from_external_attr(tmp_path: Path) -> None:
     path = tmp_path / "moded.zip"
     _zip_with_unix_mode(path, "script.sh", b"#!/bin/sh\n", 0o755)
     with open_archive(path) as ar:
-        member = ar["script.sh"]
+        member = ar.get("script.sh")
         assert member.mode == 0o755
 
 
@@ -144,7 +144,7 @@ def test_none_mode_when_external_attr_zero() -> None:
     cd = raw.index(b"PK\x01\x02")
     raw[cd + 38 : cd + 42] = b"\x00\x00\x00\x00"
     with open_archive(io.BytesIO(bytes(raw))) as ar:
-        assert ar["plain.txt"].mode is None
+        assert ar.get("plain.txt").mode is None
 
 
 def test_directory_member_type(simple_zip: Path) -> None:
@@ -174,7 +174,7 @@ def test_symlink_member(tmp_path: Path) -> None:
     with zipfile.ZipFile(path, "w") as z:
         z.writestr(info, b"target.txt")
     with open_archive(path) as ar:
-        member = ar["link"]
+        member = ar.get("link")
         assert member.type == MemberType.SYMLINK
         assert member.link_target == "target.txt"
 
@@ -202,12 +202,12 @@ def test_encrypted_flag() -> None:
     flags = int.from_bytes(raw[cd + 8 : cd + 10], "little") | 0x1
     raw[cd + 8 : cd + 10] = flags.to_bytes(2, "little")
     with open_archive(io.BytesIO(bytes(raw))) as ar:
-        assert ar["e.txt"].is_encrypted is True
+        assert ar.get("e.txt").is_encrypted is True
 
 
 def test_size_fields(simple_zip: Path) -> None:
     with open_archive(simple_zip) as ar:
-        member = ar["hello.txt"]
+        member = ar.get("hello.txt")
         assert member.size == len(b"hello world")
         assert member.compressed_size is not None
 
@@ -217,7 +217,7 @@ def test_raw_name_preserved(tmp_path: Path) -> None:
     with zipfile.ZipFile(path, "w") as z:
         z.writestr("café.txt", b"x")  # forces the UTF-8 flag
     with open_archive(path) as ar:
-        member = ar["café.txt"]
+        member = ar.get("café.txt")
         assert member.raw_name == "café.txt".encode("utf-8")
 
 
@@ -232,7 +232,7 @@ def test_extended_timestamp_precedence(tmp_path: Path) -> None:
     with zipfile.ZipFile(path, "w") as z:
         z.writestr(info, b"data")
     with open_archive(path) as ar:
-        member = ar["t.txt"]
+        member = ar.get("t.txt")
         assert member.modified is not None
         assert member.modified.tzinfo is not None
         assert member.modified == datetime.fromtimestamp(unix_time, tz=timezone.utc)
@@ -252,7 +252,7 @@ def test_unknown_extra_field_before_timestamp(tmp_path: Path) -> None:
     with zipfile.ZipFile(path, "w") as z:
         z.writestr(info, b"data")
     with open_archive(path) as ar:
-        assert ar["file.txt"].modified == datetime.fromtimestamp(unix_time, tz=timezone.utc)
+        assert ar.get("file.txt").modified == datetime.fromtimestamp(unix_time, tz=timezone.utc)
 
 
 def test_extended_timestamp_fills_mtime_atime_ctime(tmp_path: Path) -> None:
@@ -266,7 +266,7 @@ def test_extended_timestamp_fills_mtime_atime_ctime(tmp_path: Path) -> None:
     with zipfile.ZipFile(path, "w") as z:
         z.writestr(info, b"data")
     with open_archive(path) as ar:
-        member = ar["t.txt"]
+        member = ar.get("t.txt")
         assert member.modified == datetime.fromtimestamp(mtime, tz=timezone.utc)
         assert member.accessed == datetime.fromtimestamp(atime, tz=timezone.utc)
         assert member.created == datetime.fromtimestamp(ctime, tz=timezone.utc)
@@ -461,7 +461,7 @@ def test_ntfs_timestamps_used_when_no_extended_timestamp(tmp_path: Path) -> None
     with zipfile.ZipFile(path, "w") as z:
         z.writestr(info, b"data")
     with open_archive(path) as ar:
-        member = ar["t.txt"]
+        member = ar.get("t.txt")
         assert member.modified == datetime.fromtimestamp(mtime, tz=timezone.utc)
         assert member.accessed == datetime.fromtimestamp(atime, tz=timezone.utc)
         assert member.created == datetime.fromtimestamp(ctime, tz=timezone.utc)
@@ -481,7 +481,7 @@ def test_extended_timestamp_beats_ntfs(tmp_path: Path) -> None:
     with zipfile.ZipFile(path, "w") as z:
         z.writestr(info, b"data")
     with open_archive(path) as ar:
-        member = ar["t.txt"]
+        member = ar.get("t.txt")
         assert member.modified == datetime.fromtimestamp(ut_mtime, tz=timezone.utc)
         assert member.accessed == datetime.fromtimestamp(nt_atime, tz=timezone.utc)
         assert member.created is None  # NTFS ctime was 0 = "not set"

--- a/tests/test_zip.py
+++ b/tests/test_zip.py
@@ -439,3 +439,49 @@ def test_explicit_encoding_overrides_cp437_default() -> None:
         (member,) = reader.members()
         assert member.name == "é.txt"
         assert member.raw_name == b"\xe9.txt"
+
+
+def _ntfs_extra(mtime_ft: int, atime_ft: int, ctime_ft: int) -> bytes:
+    """An NTFS extra field (0x000A): 4 reserved bytes, then tag 1 with three FILETIMEs."""
+    body = struct.pack("<I", 0) + struct.pack("<HHQQQ", 0x0001, 24, mtime_ft, atime_ft, ctime_ft)
+    return struct.pack("<HH", 0x000A, len(body)) + body
+
+
+def _to_filetime(unix_time: int) -> int:
+    return (unix_time + 11_644_473_600) * 10_000_000
+
+
+def test_ntfs_timestamps_used_when_no_extended_timestamp(tmp_path: Path) -> None:
+    # An NTFS extra field (0x000A) carries FILETIME mtime/atime/ctime; with no 0x5455
+    # field they populate all three member times as tz-aware UTC datetimes.
+    mtime, atime, ctime = 1_600_000_000, 1_600_000_100, 1_600_000_200
+    path = tmp_path / "ntfs.zip"
+    info = zipfile.ZipInfo("t.txt", date_time=(1990, 1, 1, 0, 0, 0))
+    info.extra = _ntfs_extra(_to_filetime(mtime), _to_filetime(atime), _to_filetime(ctime))
+    with zipfile.ZipFile(path, "w") as z:
+        z.writestr(info, b"data")
+    with open_archive(path) as ar:
+        member = ar["t.txt"]
+        assert member.modified == datetime.fromtimestamp(mtime, tz=timezone.utc)
+        assert member.accessed == datetime.fromtimestamp(atime, tz=timezone.utc)
+        assert member.created == datetime.fromtimestamp(ctime, tz=timezone.utc)
+
+
+def test_extended_timestamp_beats_ntfs(tmp_path: Path) -> None:
+    # Precedence: 0x5455 (Unix) > 0x000A (NTFS) > DOS date_time — regardless of the
+    # fields' order in the extra blob. Here NTFS carries all three times but the UT
+    # field's mtime wins for `modified`; atime/ctime stay from NTFS (UT carries none).
+    ut_mtime, nt_mtime, nt_atime = 1_600_000_000, 1_500_000_000, 1_500_000_100
+    extra = _ntfs_extra(_to_filetime(nt_mtime), _to_filetime(nt_atime), 0) + struct.pack(
+        "<HHBI", 0x5455, 5, 0x01, ut_mtime
+    )
+    path = tmp_path / "both.zip"
+    info = zipfile.ZipInfo("t.txt", date_time=(1990, 1, 1, 0, 0, 0))
+    info.extra = extra
+    with zipfile.ZipFile(path, "w") as z:
+        z.writestr(info, b"data")
+    with open_archive(path) as ar:
+        member = ar["t.txt"]
+        assert member.modified == datetime.fromtimestamp(ut_mtime, tz=timezone.utc)
+        assert member.accessed == datetime.fromtimestamp(nt_atime, tz=timezone.utc)
+        assert member.created is None  # NTFS ctime was 0 = "not set"

--- a/tests/test_zip.py
+++ b/tests/test_zip.py
@@ -381,3 +381,61 @@ def test_corrupt_member_data_raises_corruption_on_read() -> None:
         assert ar.members()[0].name == "data.txt"  # listing is unaffected
         with pytest.raises(CorruptionError):
             ar.read("data.txt")
+
+
+# ---------------------------------------------------------------------------
+# Encrypted symlink targets and explicit metadata encoding
+# ---------------------------------------------------------------------------
+
+
+def _flag_first_entry_encrypted(data: bytes) -> bytes:
+    """Set bit 0 (encryption) of the general-purpose flags in both headers."""
+    raw = bytearray(data)
+    raw[raw.find(b"PK\x03\x04") + 6] |= 1
+    raw[raw.find(b"PK\x01\x02") + 8] |= 1
+    return bytes(raw)
+
+
+def test_encrypted_symlink_listing_without_password() -> None:
+    # A symlink's target is its (encrypted) file data; listing must still succeed with
+    # link_target unset — not leak zipfile's raw RuntimeError("password required").
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as z:
+        info = zipfile.ZipInfo("link")
+        info.create_system = 3  # Unix
+        info.external_attr = 0o120777 << 16  # symlink mode
+        z.writestr(info, b"target.txt")
+    data = _flag_first_entry_encrypted(buf.getvalue())
+
+    with open_archive(io.BytesIO(data), format=ArchiveFormat.ZIP) as reader:
+        (member,) = reader.members()
+        assert member.type is MemberType.SYMLINK
+        assert member.is_encrypted
+        assert member.link_target is None
+
+
+def _zip_with_non_utf8_name(name_byte: bytes) -> bytes:
+    """A ZIP whose single member name contains ``name_byte``, stored without the UTF-8 flag."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as z:
+        z.writestr("X.txt", b"data")  # ASCII name -> no UTF-8 flag
+    # Same length, so all header offsets stay valid; replaces the name in both the local
+    # header and the central directory.
+    return buf.getvalue().replace(b"X.txt", name_byte + b".txt")
+
+
+def test_explicit_encoding_overrides_cp437_default() -> None:
+    data = _zip_with_non_utf8_name(b"\xe9")
+
+    # Default: zipfile's cp437 fallback (0xE9 -> Greek Theta).
+    with open_archive(io.BytesIO(data), format=ArchiveFormat.ZIP) as reader:
+        (member,) = reader.members()
+        assert member.name == "Θ.txt"
+
+    # Explicit caller encoding wins, and raw_name still round-trips the stored bytes.
+    with open_archive(
+        io.BytesIO(data), format=ArchiveFormat.ZIP, encoding="latin-1"
+    ) as reader:
+        (member,) = reader.members()
+        assert member.name == "é.txt"
+        assert member.raw_name == b"\xe9.txt"

--- a/tests/test_zip.py
+++ b/tests/test_zip.py
@@ -485,3 +485,25 @@ def test_extended_timestamp_beats_ntfs(tmp_path: Path) -> None:
         assert member.modified == datetime.fromtimestamp(ut_mtime, tz=timezone.utc)
         assert member.accessed == datetime.fromtimestamp(nt_atime, tz=timezone.utc)
         assert member.created is None  # NTFS ctime was 0 = "not set"
+
+
+def test_compressed_source_size(simple_zip: Path) -> None:
+    # The archive-wide extraction ratio guard's denominator: for ZIP the source size is
+    # the compressed size; known for paths and seekable streams alike.
+    with open_archive(simple_zip) as ar:
+        assert ar.compressed_source_size == simple_zip.stat().st_size
+    data = simple_zip.read_bytes()
+    with open_archive(io.BytesIO(data), format=ArchiveFormat.ZIP) as ar:
+        assert ar.compressed_source_size == len(data)
+
+
+def test_compressed_source_size_from_size_attribute(simple_zip: Path) -> None:
+    # An fsspec-style object advertising `.size` is trusted without a seek probe.
+    class _SizedBytesIO(io.BytesIO):
+        @property
+        def size(self) -> int:
+            return len(self.getvalue())
+
+    data = simple_zip.read_bytes()
+    with open_archive(_SizedBytesIO(data), format=ArchiveFormat.ZIP) as ar:
+        assert ar.compressed_source_size == len(data)

--- a/tests/test_zip.py
+++ b/tests/test_zip.py
@@ -507,3 +507,36 @@ def test_compressed_source_size_from_size_attribute(simple_zip: Path) -> None:
     data = simple_zip.read_bytes()
     with open_archive(_SizedBytesIO(data), format=ArchiveFormat.ZIP) as ar:
         assert ar.compressed_source_size == len(data)
+
+
+def test_member_stream_advertises_size(simple_zip: Path) -> None:
+    # Member streams expose the fsspec-style `.size` from archive metadata, so a
+    # nested open_archive (or any consumer) can learn the payload size cheaply.
+    with open_archive(simple_zip) as ar:
+        member = ar.get("hello.txt")
+        assert member is not None
+        with ar.open(member) as stream:
+            assert stream.size == member.size == 11
+
+
+def test_nested_archive_source_size_is_cheap(tmp_path: Path) -> None:
+    # A zip inside a tar: opening the inner archive straight from the member stream
+    # gives the bomb tracker its source size from metadata — no end-seek needed.
+    import tarfile as tarfile_mod
+
+    inner = io.BytesIO()
+    with zipfile.ZipFile(inner, "w") as z:
+        z.writestr("data.txt", b"nested payload")
+    inner_bytes = inner.getvalue()
+
+    outer = tmp_path / "outer.tar"
+    with tarfile_mod.open(outer, "w") as t:
+        info = tarfile_mod.TarInfo("inner.zip")
+        info.size = len(inner_bytes)
+        t.addfile(info, io.BytesIO(inner_bytes))
+
+    with open_archive(outer) as outer_ar:
+        inner_stream = outer_ar.open("inner.zip")
+        with open_archive(inner_stream, format=ArchiveFormat.ZIP) as inner_ar:
+            assert inner_ar.compressed_source_size == len(inner_bytes)
+            assert inner_ar.read("data.txt") == b"nested payload"


### PR DESCRIPTION
Fixes from a full spec-vs-code review, grown through three review rounds into six commits (plus one maintainer commit). Every fix has a regression test; the full suite (628 passed / 15 skipped), Pyrefly, ty, and ruff are clean, and `openspec validate` failures are identical before/after (all pre-existing; the new `phase-5-public-api` change validates strict).

## Commit 1 — straightforward bug fixes

1. **Registry: compressed-tar availability ignored the outer stream codec.** `format_availability(TAR_ZST)` reported `FULL` with the zstd backend absent. Per the `backend-registry` single-codec rule, `tar.` with its sole codec missing is now `NONE` with the codec's install hint, and selection raises `UnsupportedFormatError` up front.
2. **ZIP: raw `RuntimeError` escaped when listing an archive with an encrypted symlink.** The symlink-target read is now routed through the translator: a password failure logs a warning and leaves `link_target` unset (listing stays usable); other failures surface as stamped `ArchiveyError`s.
3. **ZIP: `encoding` parameter was accepted but ignored** — now wired to `zipfile.ZipFile(..., metadata_encoding=...)`, with `raw_name` re-encoding to match.
4. **Gzip accelerator ISIZE backstop: spurious `TruncatedError` on `read(0)`** mid-stream; an explicit `read(0)` is now recognized as not-EOF.
5. **TAR: a crafted PAX mtime beyond `datetime`'s range crashed the listing**; now degrades to `modified=None` with a warning, like `_pax_time` already did.
6. **Password on unencrypted formats was inconsistent** — TAR and directory now raise `UnsupportedOperationError` like single-file and ISO already did.
7. **Streaming `__iter__` yielded members with no `member_id`/`archive_id`** on every backend except TAR; the base now stamps ids progressively.
8. **Cleanup:** unreachable ZIP comment-decoding fallbacks dropped (cp437 maps every byte).

## Commit 2 — review follow-ups

1. **Relative link-target resolution.** A symlink target is now resolved against the link's *own directory* (`dir/link → file` means `dir/file`; `../` walks up; absolute targets stay unresolved and raise `LinkTargetNotFoundError` on open); hardlink targets remain archive-relative (the TAR model). Directory targets match their trailing-slash names. The `archive-reading` spec documents target-name resolution with scenarios.
2. **Streaming passes resolve backward-pointing links progressively.** Hardlinks always point at an earlier member, so a single forward pass resolves them; shared between the base streaming `__iter__` and TAR's streaming `stream_members` via a new `_register_progressively` helper (which also absorbed TAR's duplicated id-stamping).
3. **Stream-position contract.** Detection and the TAR/single-file backends treat a seekable stream's current position as the archive origin (embedded archives work) instead of rewinding to absolute 0; `open_codec_stream` gives mid-positioned streams a clean origin via `fix_stream_start_position` so absolute-offset codec indexes (XZ/lzip, stdlib gzip rewind) stay correct. ZIP tolerates prefix data natively; ISO's position-0 requirement (pycdlib seeks absolutely) is documented. `format-detection` spec updated.
4. **ZIP timestamps.** The NTFS extra field (`0x000A`) FILETIMEs are now parsed; precedence is Extended Timestamp (`0x5455`) > NTFS > DOS `date_time`, each layer overriding only the times it carries. The `format-zip` spec — which previously described a "ZIP64 NT timestamp" matching neither the old code nor reality — is rewritten to match.
5. **`format-zip` spec: Phase 3 → 7 gap documented** — stdlib zipfile cannot decode deflate64/ppmd/zstd members even with the extras installed, so `format_availability(ZIP)` describes the post-Phase-7 composition; mirrored on `_CONTAINER_OPTIONAL_CODECS`.
6. **`MemberSelector`:** documented that the spec's `Collection[ArchiveMember | str]` form is a Phase 5 item; only the predicate form exists today.
7. **Smaller fixes:** the gzip ISIZE check is no longer disarmed by no-op seeks; `ArchiveStream.close()` marks the wrapper closed even when the inner close raises, and a retried `close()` no-ops; `source_name` now lives once in streamtools.

## Commit 3 — drop the dict-style reader protocol (maintainer decision)

- **`__getitem__` and `__len__` removed.** Name lookup is the explicit `get(name, default=None)` (with duplicate names it returns the last — what a sequential extraction leaves on disk); `open()`/`read()` keep accepting a name directly and raise `KeyError` when absent. `len(reader)` raises Python's own `TypeError` in every mode; `list(reader)` simply iterates — which also retires commit 2's `__len__`-raises-`TypeError` workaround.
- **`__contains__` redefined rather than removed** — without it, `in` silently falls back to iterating `__iter__`, which would consume a streaming reader's single forward pass and compare members by value. `member in reader` is now **identity membership** (was this `ArchiveMember` yielded by this reader?): O(1), scan-free, valid in either access mode, useful for disambiguating members across readers. A string operand raises `TypeError` pointing at `get()`.
- Specs updated (`archive-reading` iteration + new "Name lookup and member identity" requirement, `access-mode-and-cost` gate/table, `error-handling`, `format-zip`), plus the SPEC.md/ARCHITECTURE.md prose sketches.

## Commit 4 — review round 3: PR feedback, SlicingStream SEEK_END, roadmap reconciliation

- **`SUPPORTS_PASSWORD` is now `ReadBackend` data**, checked centrally by `open_archive`; the per-backend password rejections in tar/directory/single-file/ISO are gone (ZIP declares `True`; the native 7z/RAR readers will too).
- **Stream-origin normalization moved to `open_archive`:** after detection (which peeks and restores), a seekable stream positioned mid-file is wrapped once in a zero-origin `SlicingStream`, so every backend — including pycdlib's absolute-offset ISO reader — sees the archive begin at `tell() == 0`. Retires the single-file reader's `_source_start` bookkeeping and the ISO position-0 caveat. `ReadOnlyIOStream` gains `mode = "rb"` (typing.IO's abstract `mode` returns `None` at runtime, crashing pycdlib's `'b' not in fp.mode` duck-typing).
- **`SlicingStream`: `SEEK_END` with a non-zero offset and no declared length now works** (probes the underlying end on demand) instead of raising `UnsupportedOperation` for no structural reason.
- **Roadmap/spec reconciliation from the plan review:** PLAN Phase 5 "hashable" → deliberately unhashable, "depth limit" → cycle detection; Phase 8 rescoped to the native seekable-zstd frame-index reader + blocked-gzip; `format-rar` pins the decompressor to RARLAB unrar only (version-verified; unrar-free = missing tool, with a scenario); `format-7z` folder cache bounded per the no-growing-RAM rule; `safe-extraction` lstat-semantics existence checks and unlink-then-create REPLACE; `cli`/`archive-writing` stale wording fixed; Phase 6 pending writing decisions and Phase 7 shared-source plumbing recorded in PLAN; IDEAS gains the fsspec-URL and parallel-extraction sketches, seekable-zstd marked scheduled.

## Commit 5 — `phase-5-public-api` OpenSpec change (proposal, design, spec deltas, tasks)

Encodes the maintainer decisions from the roadmap review, ready for `/opsx:apply`:

- **Passwords:** `password` accepts a single value, an ordered candidate sequence, or a **provider callable** receiving the member being decrypted (`None` for header-level); successful passwords join a per-archive known-good list so streaming passes stay single-pass on multi-password archives. No per-call `open(member, password=)` (the `format-7z` delta is rewritten to the candidate model).
- **Multi-source:** `Sequence[...]` accepted + single-path volume-set sibling discovery (path-only by design); Phase 5 lands signature/plumbing with an explicit `UnsupportedFeatureError` until the Phase 7 joining readers.
- **Config:** frozen `ArchiveyConfig` dataclass (accelerator modes, `strict_archive_eof`, nested `ExtractionLimits`) passed explicitly — no contextvars/ambient config (deliberate departure from DEV); the `strict_eof` kwarg folds into `config.strict_archive_eof`, default `False`.
- **`MemberSelector` collection form:** `str` entries match all duplicates by name; `ArchiveMember` entries match by identity (members are unhashable by design).
- `extract()` results list stays unconditional in v1 (a no-tracking mode needs a no-member-cache reader mode; deferred, recorded in the design).

## Commit 6 — size discovery is cheap-only; streams advertise fsspec-style `.size`

- **`source_byte_size()` no longer `SEEK_END`-probes arbitrary seekable streams** — on a decompressor an end-seek means decompressing the entire payload (and `GzipFile` forwards `fileno()` to the *compressed* file, so fstat duck-checks are unsafe too). New probe order: path stat → integer `.size` attribute (the fsspec convention) → `try_get_size()` (our decompressors' compute-if-cheap hook; its presence makes its answer final) → `SEEK_END` only for a whitelist of provably-O(1) types (`FileIO`, `BufferedReader`/`BufferedRandom` over one, `BytesIO`, `mmap`).
- **`ArchiveStream` and `SlicingStream` gain a `.size` property** — member streams carry `member.size` from archive metadata, codec streams consult the inner `try_get_size()`/`.size` once opened. Net effect: `open_archive(reader.open("inner.zip"))` gets `compressed_source_size` from metadata with zero extra I/O, so the extraction bomb tracker works on nested archives.
- Regression tests pin the trap: `source_byte_size(gzip.open(...))` returns `None` with `tell()` still at 0 — nothing decompressed.

*(Commit 7, `fix: hide stub name on stream wrappers for pycdlib on Windows`, is the maintainer's follow-up to the same typing.IO-stub family of issues as commit 4's `mode` fix.)*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hQi3WhKr3LnvViH9smD3j