### PR TITLE
Phase 4b: safe extraction (ExtractionCoordinator + bomb limits)

### DIFF
--- a/openspec/changes/minimal-name-normalization/tasks.md
+++ b/openspec/changes/minimal-name-normalization/tasks.md
@@ -35,23 +35,21 @@
 
 ## 3. Extraction check on `member.name` (depends on phase-4-safe-extraction)
 
-> **Deferred to the phase-4b rebase.** `internal/filters.py` / `check_universal` is a
-> `phase-4-safe-extraction` (#28) artifact and does not exist on this branch (which is off
-> `main`). These two tasks are performed when #28 is rebased onto the merged normalization —
-> the same commit that removes the interim `raw_name` check. Tracked here so the change is
-> not considered complete until that rebase lands.
+> **Done at the phase-4b rebase** (`phase-4-safe-extraction` / #28): once this change merged,
+> #28 was reset onto the new `main` and these tasks landed in that same PR, removing the
+> interim `raw_name` check.
 
-- [ ] 3.1 Point `check_universal` (`internal/filters.py`) at `member.name`: reject absolute,
+- [x] 3.1 Point `check_universal` (`internal/filters.py`) at `member.name`: reject absolute,
       reject **any** `..` component (split on `/` and `\`), reject null bytes; keep the
-      parent-directory resolve-within-`dest` guarantor for `..`-free names. Remove the interim
+      parent-directory resolve-within-`dest` guarantor for `..`-free names. Removed the interim
       `raw_name` structural check (`_stored_name_violation` / `_decoded_raw`) and the
       `# NOTE (interim)` comment.
-- [ ] 3.2 Update the `safe-extraction` extraction tests: internal `foo/../bar` now rejected
-      under the default `RAISE`; add a test that a *listed* member exposes the true unsafe
-      `name` (e.g. `member.name == "../evil"`).
+- [x] 3.2 Update the `safe-extraction` extraction tests: internal `foo/../bar` now rejected
+      under the default `RAISE`; a *listed* member exposes the true unsafe `name` (verified
+      `member.name == "../evil.txt"`).
 
 ## 4. Gates
 
 - [x] 4.1 `uv run pyrefly check` + `uv run ty check` + `uv run ruff` clean.
-- [ ] 4.2 Full suite green (✓ on this branch: 635 passed); the `testing-contract` traversal
-      scenarios raising on `member.name` land with §3 at the phase-4b rebase.
+- [x] 4.2 Full suite green (684 passed on the rebased phase-4b branch); the `testing-contract`
+      traversal scenarios now raise on `member.name` (verified end-to-end).

--- a/openspec/changes/phase-4-safe-extraction/specs/safe-extraction/spec.md
+++ b/openspec/changes/phase-4-safe-extraction/specs/safe-extraction/spec.md
@@ -169,6 +169,72 @@ guarantees, so a failure is surfaced via `OnError` instead. A future opt-in poli
 
 ## MODIFIED Requirements
 
+### Requirement: Overwrite Policy
+
+The system SHALL enforce the `OverwritePolicy` when a destination entry already exists at the
+path a member would be written to.
+
+```python
+class OverwritePolicy(Enum):
+    ERROR   = "error"   # raise ExtractionError if destination entry exists
+    SKIP    = "skip"    # silently skip existing entries
+    REPLACE = "replace" # replace unconditionally (atomically, never write-through)
+```
+
+`ERROR` raises an `ExtractionError` for the member, which is a per-member failure governed by
+the `OnError` policy (`STOP` re-raises and halts; `CONTINUE` records a `FAILED`
+`ExtractionResult` and proceeds). `SKIP` records a `SKIPPED` result regardless of `OnError`.
+
+Two symlink-safety rules apply to all three policies:
+
+- **Existence is checked with `lstat` semantics** (the entry itself, never its target). A
+  *dangling* symlink at the destination path counts as an existing entry — a follow-the-link
+  existence check would report "absent" and a subsequent open-for-writing would create the
+  file at the symlink's **target**, an attacker-controllable location.
+- **`REPLACE` is atomic and never writes through a symlink.** A FILE is streamed into a temp
+  file in the destination directory, has its metadata applied, and is then moved onto the
+  destination path with `os.replace()` — a single atomic operation that overwrites an existing
+  file or **replaces an existing symlink with the fresh file** (it operates on the directory
+  entry, so bytes never follow the link to its target). Because the move is atomic and the
+  existing entry is untouched until the new file is fully written, a failure **mid-extraction**
+  (a decompression error, a bomb-limit trip, a write error) leaves the previous destination
+  intact and discards only the temp file — it never truncates or removes the old data. An
+  existing **directory** being replaced by a file is removed first (`os.replace` cannot
+  overwrite a directory with a file). DIR / SYMLINK / HARDLINK members, which carry no streamed
+  data, are still created by removing any existing entry and creating fresh.
+
+#### Scenario: ERROR raises on existing file
+
+- **WHEN** a member would write to a path that already exists on disk and `OverwritePolicy.ERROR` is active
+- **THEN** `ExtractionError` is raised and the existing file is not modified
+
+#### Scenario: SKIP silently bypasses existing files
+
+- **WHEN** a member would write to an existing path and `OverwritePolicy.SKIP` is active
+- **THEN** the member is skipped; its `ExtractionResult` carries `ExtractionStatus.SKIPPED`
+
+#### Scenario: REPLACE overwrites atomically
+
+- **WHEN** a member would write to an existing path and `OverwritePolicy.REPLACE` is active
+- **THEN** the existing entry is replaced with the member's data via a temp file + `os.replace`
+
+#### Scenario: REPLACE of an existing symlink does not write through it
+
+- **WHEN** the destination path is an existing symlink (e.g. planted by an earlier member) and `OverwritePolicy.REPLACE` is active
+- **THEN** the symlink itself is replaced by the fresh file and no bytes are ever written through the old link to its target
+
+#### Scenario: a failed REPLACE preserves the existing file
+
+- **WHEN** a member is extracted under `OverwritePolicy.REPLACE` over an existing file but extraction fails mid-stream (e.g. a bomb-limit trip or a corrupt/truncated source)
+- **THEN** the existing file is left unchanged and only the temp file is discarded; the old data is never truncated or removed
+
+#### Scenario: dangling symlink at the destination counts as existing
+
+- **WHEN** the destination path is a dangling symlink and `OverwritePolicy.ERROR` (or `SKIP`) is active
+- **THEN** the entry is treated as existing — `ExtractionError` is raised (or the member is skipped); the extractor never opens the path for writing, which would create the file at the link's target
+
+---
+
 ### Requirement: Hardlink Two-Pass Extraction
 
 The system SHALL support hardlinks (as found in TAR archives) through the

--- a/openspec/changes/phase-4-safe-extraction/tasks.md
+++ b/openspec/changes/phase-4-safe-extraction/tasks.md
@@ -19,71 +19,71 @@
 
 ## 0. Decisions locked in this change (no code, just honored below)
 
-- [ ] 0.1 **Pull-based sink** driving `_iter_with_data()` `(member, stream)` pairs — algorithm
+- [x] 0.1 **Pull-based sink** driving `_iter_with_data()` `(member, stream)` pairs — algorithm
       selected from `get_members_if_available()` and (on an orphan) source re-readability, no
       `SOLID`/`DIRECT` cost lookup; follows `safe-extraction` spec, not
       ARCHITECTURE §2.6's old `open_fn` sketch.
-- [ ] 0.2 **Archive-wide bomb ratio** when `compressed_source_size` is known (spec delta);
+- [x] 0.2 **Archive-wide bomb ratio** when `compressed_source_size` is known (spec delta);
       per-member ratio when `member.compressed_size` is known (ZIP).
-- [ ] 0.3 **Transforms on transient copy**; `BombTracker` + `ExtractionResult` use
+- [x] 0.3 **Transforms on transient copy**; `BombTracker` + `ExtractionResult` use
       **original** member.
-- [ ] 0.4 **Pull-model sink, no push-model state machine** — bounded state (plan, per-source
+- [x] 0.4 **Pull-model sink, no push-model state machine** — bounded state (plan, per-source
       path list, orphan list) is fine; do not reintroduce DEV's `pending_*` /
       `can_move_file` / `process_file_extracted` sprawl.
-- [ ] 0.5 **Bomb limits only on extract paths** — `read()` / `open()` unchanged.
+- [x] 0.5 **Bomb limits only on extract paths** — `read()` / `open()` unchanged.
 
 ## 1. Types and filters
 
-- [ ] 1.1 **Enums** — `ExtractionPolicy`, `OverwritePolicy`, `OnError`, `ExtractionStatus`
+- [x] 1.1 **Enums** — `ExtractionPolicy`, `OverwritePolicy`, `OnError`, `ExtractionStatus`
       (public exports in `__init__.py`).
-- [ ] 1.2 **Progress/result types** — `ExtractionProgress`, `ExtractionResult` dataclasses
+- [x] 1.2 **Progress/result types** — `ExtractionProgress`, `ExtractionResult` dataclasses
       (`src/archivey/internal/progress.py` or `src/archivey/internal/types.py` per existing
       conventions).
-- [ ] 1.3 **`src/archivey/internal/filters.py`** — `check_universal()` (path traversal, absolute paths,
+- [x] 1.3 **`src/archivey/internal/filters.py`** — `check_universal()` (path traversal, absolute paths,
       null bytes, symlink/hardlink escape at planning time, `MemberType.OTHER`);
       `transform_strict` / `transform_standard` / identity for `TRUSTED`;
       `POLICY_TRANSFORMS` dict.
-- [ ] 1.4 **Filter unit tests** — universal rejections; STRICT strips execute/normalizes;
+- [x] 1.4 **Filter unit tests** — universal rejections; STRICT strips execute/normalizes;
       STANDARD preserves execute; TRUSTED still rejects `..` paths.
 
 ## 2. `BombTracker`
 
-- [ ] 2.1 **Implement `BombTracker`** per `safe-extraction` spec — cumulative
+- [x] 2.1 **Implement `BombTracker`** per `safe-extraction` spec — cumulative
       `max_extracted_bytes`, per-member ratio with activation threshold, **archive-wide
       ratio** using the new optional `compressed_source_size` constructor arg (coordinator
       reads `reader.compressed_source_size` and passes it in). Archive-wide ratio activates
       on **cumulative** output (`_total_bytes`), not per-member.
-- [ ] 2.2 **`max_entries` guard** — cumulative entry counter incremented in `start_member()`;
+- [x] 2.2 **`max_entries` guard** — cumulative entry counter incremented in `start_member()`;
       raise `ExtractionError` when exceeded; always-stop (like `max_extracted_bytes`, halts
       even under `OnError.CONTINUE`); default `1_048_576`, caller-overridable.
-- [ ] 2.3 **Tests** — cumulative byte limit; per-member ratio (ZIP fixture); activation
+- [x] 2.3 **Tests** — cumulative byte limit; per-member ratio (ZIP fixture); activation
       threshold false-positive guard; archive-wide ratio with known outer size; skip when
       denominators unknown; `max_entries` exceeded (many-tiny-files fixture) halts even under
       `CONTINUE`; entry count independent of byte/ratio guards.
 
 ## 3. `ExtractionCoordinator` core
 
-- [ ] 3.1 **`src/archivey/internal/extraction.py`** — `ExtractionCoordinator.run(reader, dest, …)`
+- [x] 3.1 **`src/archivey/internal/extraction.py`** — `ExtractionCoordinator.run(reader, dest, …)`
       as a pull-based sink: call `reader.get_members_if_available()` to decide the optional
       planned-pass optimization (§4), then drive `reader._iter_with_data()` (respect `members`
       selector + user `filter` on transient copy).
-- [ ] 3.2 **FILE extraction** — chunked copy with `BombTracker.count()`; apply mode/mtime
+- [x] 3.2 **FILE extraction** — chunked copy with `BombTracker.count()`; apply mode/mtime
       best-effort after write; honor `OverwritePolicy`.
-- [ ] 3.3 **DIR extraction** — `mkdir` with policy mode.
-- [ ] 3.4 **SYMLINK extraction** — `os.symlink` + post-creation resolve check with
+- [x] 3.3 **DIR extraction** — `mkdir` with policy mode.
+- [x] 3.4 **SYMLINK extraction** — `os.symlink` + post-creation resolve check with
       `ELOOP`/`RuntimeError` guard (per spec pseudocode). Target-independent: a symlink to a
       filtered-out/later/external target is created and may dangle (only the within-`dest`
       escape check applies), no copy. `os.symlink` failure on an unsupported filesystem →
       per-member `OnError` failure; **no** copy-the-target fallback.
-- [ ] 3.5 **`OnError.STOP` vs `CONTINUE`** — partial file cleanup; `ExtractionResult` with
+- [x] 3.5 **`OnError.STOP` vs `CONTINUE`** — partial file cleanup; `ExtractionResult` with
       `FAILED`/`REJECTED` + `error`; cumulative bomb always stops.
-- [ ] 3.6 **`on_progress` callback** — once per member with counters from spec.
-- [ ] 3.7 **Wire `ArchiveReader.extract_all()`** — replace `NotImplementedError`; return
+- [x] 3.6 **`on_progress` callback** — once per member with counters from spec.
+- [x] 3.7 **Wire `ArchiveReader.extract_all()`** — replace `NotImplementedError`; return
       `list[ExtractionResult]`.
 
 ## 4. Hardlinks (source precedes its links in TAR order; algorithm-selected — see `format-tar` MODIFIED delta)
 
-- [ ] 4.1 **Core algorithm — sequential pass + conditional second pass** (subsumes the
+- [x] 4.1 **Core algorithm — sequential pass + conditional second pass** (subsumes the
       no-filter case; no separate (A) implementation). One forward pass records each written
       FILE under a per-source **list of on-disk paths**; a link to an already-written source is
       created by trying `os.link` against those paths in turn. No filter → no orphans → one
@@ -97,45 +97,48 @@
       into a `source → selected-link-paths` map and stage each needed (even excluded) source to
       the first selected link's path during the single pass, skipping the second pass. Layered on
       the core; can be deferred without affecting correctness.
-- [ ] 4.3 **Cross-device handling (try-list)** — to create a link, try `os.link` against the
+      **DEFERRED** — the core algorithm (4.1) handles every case correctly; this is a pure
+      optimization the current TAR backend rarely triggers (it exposes no free member list until
+      materialized). Left for a follow-up to keep this security-sensitive change scoped.
+- [x] 4.3 **Cross-device handling (try-list)** — to create a link, try `os.link` against the
       source's recorded on-disk paths in turn; first success wins. On all-`EXDEV`, `shutil.copy2`
       and append the new path so a later same-device link reuses it (handles `C → A` via
       `os.link(B, C)`; better than `tarfile`, which recopies from the archive per link). `st_dev`
       is an optional optimization to skip doomed attempts, not required.
-- [ ] 4.4 **Tests** — unfiltered → single pass, no list fetched; filter + plain-tar orphan → one
+- [x] 4.4 **Tests** — unfiltered → single pass, no list fetched; filter + plain-tar orphan → one
       re-scan second pass; filter + compressed-tar orphan → one second pass (assert decompressed
       ≤ 2×); filter + no orphan → single pass, no speculative list; forward-only orphan →
       `OnError` STOP/CONTINUE; (optional) filter + free-list orphan → planned single pass, no
       second pass; chained cross-device link reuses the sibling copy (mock devices / `os.link`
       `EXDEV`).
-- [ ] 4.5 **Symlink tests** — dangling symlink to a filtered-out target created within `dest`
+- [x] 4.5 **Symlink tests** — dangling symlink to a filtered-out target created within `dest`
       (no copy, no error); `os.symlink` failure on an unsupported filesystem → `OnError`
       STOP/CONTINUE (no copy-the-target fallback, a deliberate deviation from `tarfile`).
 
 ## 5. Public API + ZIP vertical slice
 
-- [ ] 5.1 **`archivey.extract()`** — top-level one-shot API per spec (no member selector).
-- [ ] 5.2 **ZIP extract tests** — corpus archives extract cleanly under STRICT; overwrite
+- [x] 5.1 **`archivey.extract()`** — top-level one-shot API per spec (no member selector).
+- [x] 5.2 **ZIP extract tests** — corpus archives extract cleanly under STRICT; overwrite
       policies; `extract_all(members=[...])` subset in one pass.
-- [ ] 5.3 **Seekable TAR extract** — basic extract via default `_iter_with_data()`; the
+- [x] 5.3 **Seekable TAR extract** — basic extract via default `_iter_with_data()`; the
       archive-wide ratio uses `compressed_source_size` from `phase-4-tar-streaming` (merged
       first), so a seekable `.tar.gz` exercises that guard here too.
 
 ## 6. Adversarial corpus + integration
 
-- [ ] 6.1 **Fixtures** — committed adversarial archives under `tests/fixtures/adversarial/`
+- [x] 6.1 **Fixtures** — committed adversarial archives under `tests/fixtures/adversarial/`
       (path traversal, zip bomb) + JSON sidecars if needed; or generate via
       `tests/create_adversarial.py` per `testing-contract`.
-- [ ] 6.2 **`testing-contract` scenarios** — *path traversal member*; *zip bomb
+- [x] 6.2 **`testing-contract` scenarios** — *path traversal member*; *zip bomb
       extraction* (per-member + cumulative limits).
-- [ ] 6.3 **Non-seekable `tar.gz` extract** — integration test over the forward-only
+- [x] 6.3 **Non-seekable `tar.gz` extract** — integration test over the forward-only
       `_iter_with_data()` override from `phase-4-tar-streaming` (merged first).
-- [ ] 6.4 **Retire** matching frozen-oracle extraction coverage as tests transfer.
+- [x] 6.4 **Retire** matching frozen-oracle extraction coverage as tests transfer.
 
 ## 7. Gates
 
-- [ ] 7.1 `uv run pyrefly check` + `uv run ty check` + `uv run ruff` clean.
-- [ ] 7.2 Coordinator is a pull-based sink (no push-model `ExtractionHelper`); bounded maps
+- [x] 7.1 `uv run pyrefly check` + `uv run ty check` + `uv run ruff` clean.
+- [x] 7.2 Coordinator is a pull-based sink (no push-model `ExtractionHelper`); bounded maps
       are fine. A `pending_*` grep over `src/archivey/` stays as a light tripwire against
       reintroducing the DEV state sprawl, not a hard architectural ban.
-- [ ] 7.3 All new tests green; adversarial scenarios pass.
+- [x] 7.3 All new tests green; adversarial scenarios pass.

--- a/src/archivey/__init__.py
+++ b/src/archivey/__init__.py
@@ -14,6 +14,7 @@ from archivey.core import (
     FormatSupport,
     MissingComponent,
     detect_format,
+    extract,
     format_availability,
     list_known_formats,
     list_supported_formats,
@@ -46,6 +47,14 @@ from archivey.exceptions import (
     UnsupportedOperationError,
     WriteError,
 )
+from archivey.internal.progress import (
+    ExtractionPolicy,
+    ExtractionProgress,
+    ExtractionResult,
+    ExtractionStatus,
+    OnError,
+    OverwritePolicy,
+)
 from archivey.reader import ArchiveReader
 from archivey.types import (
     ArchiveFormat,
@@ -62,6 +71,13 @@ from archivey.types import (
 __all__ = [
     "__version__",
     "open_archive",
+    "extract",
+    "ExtractionPolicy",
+    "OverwritePolicy",
+    "OnError",
+    "ExtractionStatus",
+    "ExtractionProgress",
+    "ExtractionResult",
     "detect_format",
     "FormatInfo",
     "DetectionConfidence",

--- a/src/archivey/__init__.py
+++ b/src/archivey/__init__.py
@@ -47,7 +47,7 @@ from archivey.exceptions import (
     UnsupportedOperationError,
     WriteError,
 )
-from archivey.internal.progress import (
+from archivey.internal.extraction_types import (
     ExtractionPolicy,
     ExtractionProgress,
     ExtractionResult,

--- a/src/archivey/core.py
+++ b/src/archivey/core.py
@@ -3,10 +3,17 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import BinaryIO
+from typing import BinaryIO, Callable
 
 from archivey.exceptions import StreamNotSeekableError, UnsupportedOperationError
 from archivey.internal.detection import DetectionConfidence, FormatInfo, detect_format
+from archivey.internal.progress import (
+    ExtractionPolicy,
+    ExtractionProgress,
+    ExtractionResult,
+    OnError,
+    OverwritePolicy,
+)
 from archivey.internal.registry import (
     FormatAvailability,
     FormatSupport,
@@ -33,6 +40,7 @@ __all__ = [
     "FormatSupport",
     "MissingComponent",
     "detect_format",
+    "extract",
     "format_availability",
     "list_known_formats",
     "list_supported_formats",
@@ -151,3 +159,42 @@ def open_archive(
         archive_name=archive_name,
         strict_eof=strict_eof,
     )
+
+
+def extract(
+    source: str | Path | BinaryIO,
+    dest: str | Path,
+    *,
+    policy: ExtractionPolicy = ExtractionPolicy.STRICT,
+    overwrite: OverwritePolicy = OverwritePolicy.ERROR,
+    on_error: OnError = OnError.STOP,
+    format: ArchiveFormat | None = None,
+    password: bytes | str | None = None,
+    on_progress: Callable[[ExtractionProgress], None] | None = None,
+    max_extracted_bytes: int = 2 * 2**30,
+    max_ratio: float = 1000.0,
+    ratio_activation_threshold: int = 5 * 2**20,
+    max_entries: int = 1_048_576,
+) -> list[ExtractionResult]:
+    """Open ``source``, apply safety checks, and write **all** members to ``dest``.
+
+    The one-shot extraction API (see ``safe-extraction``). It deliberately has **no**
+    member-selection parameter — selecting a subset requires the member list, which would
+    force a reopen; use :meth:`ArchiveReader.extract_all` with ``members=`` on an already
+    open reader instead. Extraction is safe-by-default: ``ExtractionPolicy.STRICT`` and
+    ``OverwritePolicy.ERROR``, with the decompression-bomb guards active.
+
+    Returns one :class:`~archivey.ExtractionResult` per member processed.
+    """
+    with open_archive(source, format=format, password=password) as reader:
+        return reader.extract_all(
+            dest,
+            policy=policy,
+            overwrite=overwrite,
+            on_error=on_error,
+            on_progress=on_progress,
+            max_extracted_bytes=max_extracted_bytes,
+            max_ratio=max_ratio,
+            ratio_activation_threshold=ratio_activation_threshold,
+            max_entries=max_entries,
+        )

--- a/src/archivey/core.py
+++ b/src/archivey/core.py
@@ -7,7 +7,7 @@ from typing import BinaryIO, Callable
 
 from archivey.exceptions import StreamNotSeekableError, UnsupportedOperationError
 from archivey.internal.detection import DetectionConfidence, FormatInfo, detect_format
-from archivey.internal.progress import (
+from archivey.internal.extraction_types import (
     ExtractionPolicy,
     ExtractionProgress,
     ExtractionResult,

--- a/src/archivey/internal/base_reader.py
+++ b/src/archivey/internal/base_reader.py
@@ -13,6 +13,15 @@ from archivey.exceptions import (
     UnsupportedOperationError,
 )
 from archivey.internal.naming import resolve_link_target_name
+from archivey.internal.progress import (
+    ExtractionPolicy,
+    ExtractionProgress,
+    ExtractionResult,
+    MemberFilter,
+    MemberSelectorArg,
+    OnError,
+    OverwritePolicy,
+)
 from archivey.internal.streams.archive_stream import ArchiveStream
 from archivey.internal.streams.streamtools import is_seekable, source_byte_size
 from archivey.reader import ArchiveReader, MemberSelector
@@ -502,9 +511,39 @@ class BaseArchiveReader(ArchiveReader):
             elif stream is not None:
                 stream.close()
 
-    def extract_all(self, dest: str | Path) -> None:
-        """Extract all members to dest. (Coordinator implementation deferred to Phase 4.)"""
-        raise NotImplementedError("extract_all is deferred to Phase 4")
+    def extract_all(
+        self,
+        dest: str | Path,
+        *,
+        members: MemberSelectorArg = None,
+        filter: MemberFilter | None = None,
+        policy: ExtractionPolicy = ExtractionPolicy.STRICT,
+        overwrite: OverwritePolicy = OverwritePolicy.ERROR,
+        on_error: OnError = OnError.STOP,
+        on_progress: Callable[[ExtractionProgress], None] | None = None,
+        max_extracted_bytes: int = 2 * 2**30,
+        max_ratio: float = 1000.0,
+        ratio_activation_threshold: int = 5 * 2**20,
+        max_entries: int = 1_048_576,
+    ) -> list[ExtractionResult]:
+        """Extract members to dest via the shared ``ExtractionCoordinator``."""
+        # Imported here (not at module top) to keep the import graph tidy: extraction.py
+        # type-checks against BaseArchiveReader.
+        from archivey.internal.extraction import ExtractionCoordinator
+
+        coordinator = ExtractionCoordinator(
+            policy=policy,
+            overwrite=overwrite,
+            on_error=on_error,
+            on_progress=on_progress,
+            members=members,
+            filter=filter,
+            max_extracted_bytes=max_extracted_bytes,
+            max_ratio=max_ratio,
+            ratio_activation_threshold=ratio_activation_threshold,
+            max_entries=max_entries,
+        )
+        return coordinator.run(self, dest)
 
     def close(self) -> None:
         if not self._closed:

--- a/src/archivey/internal/base_reader.py
+++ b/src/archivey/internal/base_reader.py
@@ -12,8 +12,7 @@ from archivey.exceptions import (
     LinkTargetNotFoundError,
     UnsupportedOperationError,
 )
-from archivey.internal.naming import resolve_link_target_name
-from archivey.internal.progress import (
+from archivey.internal.extraction_types import (
     ExtractionPolicy,
     ExtractionProgress,
     ExtractionResult,
@@ -22,6 +21,7 @@ from archivey.internal.progress import (
     OnError,
     OverwritePolicy,
 )
+from archivey.internal.naming import resolve_link_target_name
 from archivey.internal.streams.archive_stream import ArchiveStream
 from archivey.internal.streams.streamtools import is_seekable, source_byte_size
 from archivey.reader import ArchiveReader, MemberSelector

--- a/src/archivey/internal/extraction.py
+++ b/src/archivey/internal/extraction.py
@@ -618,11 +618,12 @@ class ExtractionCoordinator:
         truncates or removes an existing destination (only the temp is discarded), and the
         target name never appears half-written. The temp lives in the destination directory
         so the rename stays on one filesystem."""
+        # mkstemp hands back an already-open fd; write straight into it (no close+reopen).
         fd, tmp_name = tempfile.mkstemp(dir=dest_path.parent, prefix=".archivey-tmp-")
-        os.close(fd)
         tmp = Path(tmp_name)
         try:
-            self._copy_stream_to(stream, tmp, tracker)
+            with os.fdopen(fd, "wb") as dst:
+                self._copy_to_fileobj(stream, dst, tracker)
             self._apply_metadata(tmp, member)
             os.replace(tmp, dest_path)
         except BaseException:
@@ -632,19 +633,28 @@ class ExtractionCoordinator:
                 os.unlink(tmp)
             raise
 
+    @staticmethod
+    def _copy_to_fileobj(
+        stream: BinaryIO | None, dst: BinaryIO, tracker: BombTracker | None
+    ) -> None:
+        """Copy ``stream`` into the already-open ``dst`` in chunks, counting each toward the
+        bomb tracker. Cleanup of a partial ``dst`` on failure is the caller's job."""
+        if stream is None:
+            return
+        while True:
+            chunk = stream.read(_CHUNK)
+            if not chunk:
+                break
+            if tracker is not None:
+                tracker.count(len(chunk))
+            dst.write(chunk)
+
     def _copy_stream_to(
         self, stream: BinaryIO | None, path: Path, tracker: BombTracker | None
     ) -> None:
         try:
             with open(path, "wb") as dst:
-                if stream is not None:
-                    while True:
-                        chunk = stream.read(_CHUNK)
-                        if not chunk:
-                            break
-                        if tracker is not None:
-                            tracker.count(len(chunk))
-                        dst.write(chunk)
+                self._copy_to_fileobj(stream, dst, tracker)
         except BaseException:
             # Remove this member's partial output on any failure (bomb guard, write
             # error, KeyboardInterrupt) and re-raise. No log here on purpose: the failure

--- a/src/archivey/internal/extraction.py
+++ b/src/archivey/internal/extraction.py
@@ -20,10 +20,12 @@ optimization over this core, not a correctness requirement.
 
 from __future__ import annotations
 
+import contextlib
 import errno
 import logging
 import os
 import shutil
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, BinaryIO, Callable, Collection, cast
@@ -356,12 +358,11 @@ class ExtractionCoordinator:
         tracker: BombTracker,
         source_paths: dict[int, list[Path]],
     ) -> ExtractionResult:
-        if not self._prepare_destination(transformed, dest_path):
+        if not self._prepare_destination(transformed, dest_path, atomic=True):
             return ExtractionResult(original, None, ExtractionStatus.SKIPPED, None)
 
         os.makedirs(dest_path.parent, exist_ok=True)
-        self._copy_stream_to(stream, dest_path, tracker)
-        self._apply_metadata(dest_path, transformed)
+        self._write_file_atomic(stream, dest_path, transformed, tracker)
 
         # Record this FILE's path under the ORIGINAL member id so later hardlinks whose
         # link_target_member is this member can os.link against it.
@@ -562,10 +563,20 @@ class ExtractionCoordinator:
 
     # --- filesystem helpers --------------------------------------------------------
 
-    def _prepare_destination(self, member: ArchiveMember, dest_path: Path) -> bool:
+    def _prepare_destination(
+        self, member: ArchiveMember, dest_path: Path, *, atomic: bool = False
+    ) -> bool:
         """Apply the OverwritePolicy. Returns True to proceed with creation, False to
         skip (SKIP over an existing entry). Raises ExtractionError under ERROR when the
-        entry exists. Uses lstat semantics so a dangling symlink counts as existing."""
+        entry exists. Uses lstat semantics so a dangling symlink counts as existing.
+
+        ``atomic=True`` is used for FILE writes, which land via ``os.replace()`` over the
+        destination (see ``_write_file_atomic``): under REPLACE this leaves an existing
+        **file or symlink** in place for that atomic swap (so the old data survives until
+        the new file is fully written, and a symlink is replaced, never written through),
+        removing only an existing **directory** first — ``os.replace`` cannot overwrite a
+        directory with a file. ``atomic=False`` (DIR / SYMLINK / HARDLINK) keeps the plain
+        unlink-then-create."""
         exists = os.path.lexists(dest_path)
         if not exists:
             return True
@@ -585,13 +596,41 @@ class ExtractionCoordinator:
         if self._overwrite is OverwritePolicy.SKIP:
             return False
 
-        # REPLACE: unlink-then-create, never write-through. Remove a symlink/file with
-        # unlink (so bytes never follow the link to its target); remove a real dir tree.
-        if dest_path.is_symlink() or not dest_path.is_dir():
-            dest_path.unlink()
-        else:
+        # REPLACE: never write-through a symlink. For an atomic FILE write, os.replace
+        # handles a file/symlink target atomically, so only a real directory must be
+        # removed up front. Otherwise unlink a symlink/file (bytes never follow the link)
+        # and rmtree a real directory tree.
+        if dest_path.is_dir() and not dest_path.is_symlink():
             shutil.rmtree(dest_path)
+        elif not atomic:
+            dest_path.unlink()
         return True
+
+    def _write_file_atomic(
+        self,
+        stream: BinaryIO | None,
+        dest_path: Path,
+        member: ArchiveMember,
+        tracker: BombTracker | None,
+    ) -> None:
+        """Write a FILE by streaming into a temp sibling, applying metadata, then
+        ``os.replace()``-ing it onto ``dest_path`` — atomic, so a mid-stream failure never
+        truncates or removes an existing destination (only the temp is discarded), and the
+        target name never appears half-written. The temp lives in the destination directory
+        so the rename stays on one filesystem."""
+        fd, tmp_name = tempfile.mkstemp(dir=dest_path.parent, prefix=".archivey-tmp-")
+        os.close(fd)
+        tmp = Path(tmp_name)
+        try:
+            self._copy_stream_to(stream, tmp, tracker)
+            self._apply_metadata(tmp, member)
+            os.replace(tmp, dest_path)
+        except BaseException:
+            # os.replace consumes the temp on success; on any earlier failure remove it so
+            # no .archivey-tmp-* file is left behind (the existing destination is untouched).
+            with contextlib.suppress(OSError):
+                os.unlink(tmp)
+            raise
 
     def _copy_stream_to(
         self, stream: BinaryIO | None, path: Path, tracker: BombTracker | None

--- a/src/archivey/internal/extraction.py
+++ b/src/archivey/internal/extraction.py
@@ -1,0 +1,695 @@
+"""The extraction coordinator and decompression-bomb tracker.
+
+``ExtractionCoordinator`` is a **pull-based sink**: it drives the reader
+(``get_members_if_available()``, ``_iter_with_data()``, ``compressed_source_size``) and
+selects an algorithm, rather than a push-model helper that buffers deferred link state.
+Per member it runs the universal safety check on the original, applies the policy
+transform (and optional user filter) to a transient copy, and writes FILE / DIR / SYMLINK
+/ HARDLINK, tracking bomb limits and per-member results.
+
+Hardlinks (TAR ordering guarantees the source precedes its links) are resolved by one
+**core** algorithm: a sequential forward pass with a conditional second pass. When a
+filter/selector orphans a selected link (its source excluded), a re-readable (seekable)
+source is recovered in a single second pass; a forward-only source is unrecoverable and
+fails per ``OnError``. See ``safe-extraction`` / ``format-tar`` for the normative spec.
+
+The optional *planned single pass* optimization (staging an excluded source during the
+first pass when a free member list exists) is deliberately not implemented here — it is an
+optimization over this core, not a correctness requirement.
+"""
+
+from __future__ import annotations
+
+import errno
+import logging
+import os
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, BinaryIO, Callable, Collection, cast
+
+from archivey.exceptions import (
+    ArchiveyError,
+    ExtractionError,
+    FilterRejectionError,
+    LinkTargetNotFoundError,
+    SymlinkEscapeError,
+)
+from archivey.internal.filters import POLICY_TRANSFORMS, check_universal
+from archivey.internal.progress import (
+    ExtractionPolicy,
+    ExtractionProgress,
+    ExtractionResult,
+    ExtractionStatus,
+    MemberFilter,
+    MemberSelectorArg,
+    OnError,
+    OverwritePolicy,
+)
+from archivey.types import ArchiveMember, MemberType
+
+if TYPE_CHECKING:
+    from archivey.internal.base_reader import BaseArchiveReader
+
+logger = logging.getLogger("archivey.extraction")
+
+_CHUNK = 1024 * 1024  # 1 MiB copy chunk
+
+# Defaults (see the safe-extraction spec); callers override via extract()/extract_all().
+DEFAULT_MAX_EXTRACTED_BYTES = 2 * 2**30  # 2 GiB
+DEFAULT_MAX_RATIO = 1000.0
+DEFAULT_RATIO_ACTIVATION_THRESHOLD = 5 * 2**20  # 5 MiB
+DEFAULT_MAX_ENTRIES = 1_048_576  # 2**20
+
+
+class _AlwaysStopExtractionError(ExtractionError):
+    """A cumulative/global bomb guard: halts extraction even under ``OnError.CONTINUE``.
+
+    A subclass of ``ExtractionError`` so callers catching ``ExtractionError`` still catch
+    it; the coordinator uses the type to distinguish it from a *skippable* per-member
+    ratio failure.
+    """
+
+
+class BombTracker:
+    """Cumulative byte / per-member ratio / archive-wide ratio / entry-count guards.
+
+    Constructed once per extraction call. ``start_member()`` is called (with the
+    **original** member) before each member; ``count()`` is called with each chunk
+    written.
+    """
+
+    def __init__(
+        self,
+        max_bytes: int,
+        max_ratio: float,
+        ratio_activation_threshold: int = DEFAULT_RATIO_ACTIVATION_THRESHOLD,
+        compressed_source_size: int | None = None,
+        max_entries: int = DEFAULT_MAX_ENTRIES,
+    ) -> None:
+        self._max_bytes = max_bytes
+        self._max_ratio = max_ratio
+        self._ratio_floor = ratio_activation_threshold
+        self._compressed_source_size = compressed_source_size
+        self._max_entries = max_entries
+        self._entry_count = 0
+        self._total_bytes = 0  # cumulative across all members
+        self._member_bytes = 0  # output bytes for the current member
+        self._member: ArchiveMember | None = None
+
+    @property
+    def total_bytes(self) -> int:
+        return self._total_bytes
+
+    def start_member(self, member: ArchiveMember) -> None:
+        # Called with the ORIGINAL member (not a filter copy), so compressed_size and any
+        # late-bound fields are accurate. Increments the entry-count guard, which — like
+        # the cumulative byte guard — halts even under OnError.CONTINUE.
+        self._member = member
+        self._member_bytes = 0
+        self._entry_count += 1
+        if self._entry_count > self._max_entries:
+            raise _AlwaysStopExtractionError(
+                f"Entry-count limit reached: {self._entry_count} > {self._max_entries}"
+            )
+
+    def count(self, chunk_bytes: int) -> None:
+        self._total_bytes += chunk_bytes
+        self._member_bytes += chunk_bytes
+
+        # Cumulative byte guard (always-stop).
+        if self._total_bytes > self._max_bytes:
+            raise _AlwaysStopExtractionError(
+                f"Extraction limit reached: {self._total_bytes} bytes > {self._max_bytes}"
+            )
+
+        # Per-member ratio: activates on THIS member's output; a per-member failure
+        # (skippable under OnError.CONTINUE).
+        member = self._member
+        cs = member.compressed_size if member is not None else None
+        if member is not None and self._member_bytes > self._ratio_floor and cs and cs > 0:
+            ratio = self._member_bytes / cs
+            if ratio > self._max_ratio:
+                raise ExtractionError(
+                    f"Decompression ratio {ratio:.0f}:1 exceeds limit "
+                    f"{self._max_ratio:.0f}:1 for {member.name!r}"
+                )
+
+        # Archive-wide ratio: activates on CUMULATIVE output; only when the outer
+        # compressed size is cheaply known. A whole-archive bomb signal (always-stop).
+        css = self._compressed_source_size
+        if self._total_bytes > self._ratio_floor and css and css > 0:
+            if self._total_bytes / css > self._max_ratio:
+                raise _AlwaysStopExtractionError(
+                    f"Archive-wide decompression ratio "
+                    f"{self._total_bytes / css:.0f}:1 exceeds limit "
+                    f"{self._max_ratio:.0f}:1"
+                )
+
+
+@dataclass
+class _Orphan:
+    """A selected hardlink whose (re-readable) source was excluded, awaiting the second
+    pass."""
+
+    result_index: int
+    original: ArchiveMember
+    dest_path: Path
+    source: ArchiveMember
+
+
+class ExtractionCoordinator:
+    """Drives a single forward pass over a reader's members, writing them safely to disk."""
+
+    def __init__(
+        self,
+        *,
+        policy: ExtractionPolicy = ExtractionPolicy.STRICT,
+        overwrite: OverwritePolicy = OverwritePolicy.ERROR,
+        on_error: OnError = OnError.STOP,
+        on_progress: Callable[[ExtractionProgress], None] | None = None,
+        members: MemberSelectorArg = None,
+        filter: MemberFilter | None = None,
+        max_extracted_bytes: int = DEFAULT_MAX_EXTRACTED_BYTES,
+        max_ratio: float = DEFAULT_MAX_RATIO,
+        ratio_activation_threshold: int = DEFAULT_RATIO_ACTIVATION_THRESHOLD,
+        max_entries: int = DEFAULT_MAX_ENTRIES,
+    ) -> None:
+        self._policy = policy
+        self._overwrite = overwrite
+        self._on_error = on_error
+        self._on_progress = on_progress
+        self._members = members
+        self._filter = filter
+        self._max_extracted_bytes = max_extracted_bytes
+        self._max_ratio = max_ratio
+        self._ratio_floor = ratio_activation_threshold
+        self._max_entries = max_entries
+
+    # --- entry point ---------------------------------------------------------------
+
+    def run(self, reader: "BaseArchiveReader", dest: str | Path) -> list[ExtractionResult]:
+        dest = Path(dest)
+        os.makedirs(dest, exist_ok=True)
+        dest_root = dest.resolve()
+        forward_only = bool(getattr(reader, "_streaming", False))
+
+        tracker = BombTracker(
+            self._max_extracted_bytes,
+            self._max_ratio,
+            self._ratio_floor,
+            reader.compressed_source_size,
+            self._max_entries,
+        )
+
+        selector = self._normalize_selector()
+
+        all_members = reader.get_members_if_available()
+        members_total = len(all_members) if all_members is not None else None
+        total_estimate = self._estimate_total_bytes(all_members)
+
+        results: list[ExtractionResult] = []
+        # source member_id -> list of on-disk paths holding that source's content.
+        source_paths: dict[int, list[Path]] = {}
+        orphans: list[_Orphan] = []
+        members_done = 0
+
+        for original, stream in reader._iter_with_data():
+            try:
+                if selector is not None and not selector(original):
+                    continue
+
+                tracker.start_member(original)  # entry-count guard + ratio bookkeeping
+
+                transformed = self._transform(original, dest_root)
+                if transformed is None:
+                    continue  # user filter skipped this member (deliberate exclusion)
+
+                result_index = len(results)
+                results.append(
+                    ExtractionResult(original, None, ExtractionStatus.FAILED, None)
+                )
+                results[result_index] = self._write_member(
+                    original,
+                    transformed,
+                    stream,
+                    dest,
+                    dest_root,
+                    tracker,
+                    source_paths,
+                    orphans,
+                    forward_only,
+                    result_index,
+                )
+            except _AlwaysStopExtractionError:
+                raise
+            except (ArchiveyError, OSError) as exc:
+                status = (
+                    ExtractionStatus.REJECTED
+                    if isinstance(exc, FilterRejectionError)
+                    else ExtractionStatus.FAILED
+                )
+                result = ExtractionResult(original, None, status, exc)
+                if results and results[-1].member is original:
+                    results[-1] = result
+                else:
+                    results.append(result)
+                if self._on_error is OnError.STOP:
+                    raise
+                logger.warning(
+                    "Skipping %s %r: %s", original.type.value, original.name, exc
+                )
+            finally:
+                self._close(stream)
+
+            members_done += 1
+            self._report_progress(
+                original, tracker, total_estimate, members_done, members_total
+            )
+
+        # Core second pass: resolve orphaned hardlinks whose (re-readable) source was
+        # excluded. Only populated for a seekable source; forward-only orphans already
+        # failed at the link during the main pass.
+        if orphans:
+            self._resolve_orphans(reader, source_paths, orphans, tracker, results)
+
+        return results
+
+    # --- selection / transform -----------------------------------------------------
+
+    def _normalize_selector(self) -> Callable[[ArchiveMember], bool] | None:
+        members = self._members
+        if members is None:
+            return None
+        # A predicate is callable; a names/members collection is not.
+        if callable(members):
+            return cast("Callable[[ArchiveMember], bool]", members)
+        collection = cast("Collection[str | ArchiveMember]", members)
+        names = {m.name if isinstance(m, ArchiveMember) else m for m in collection}
+        return lambda member: member.name in names
+
+    def _transform(
+        self, original: ArchiveMember, dest_root: Path
+    ) -> ArchiveMember | None:
+        """Universal check on the original, then policy transform and user filter on a
+        transient copy. Returns the copy to write, or ``None`` if the user filter skipped
+        the member. Raises a ``FilterRejectionError`` on a universal violation."""
+        check_universal(original, dest_root)
+        transformed = POLICY_TRANSFORMS[self._policy](original)
+        if self._filter is not None:
+            transformed = self._filter(transformed)
+            if transformed is None:
+                return None
+            # A caller filter can rename/relink; re-run the universal check on the result.
+            check_universal(transformed, dest_root)
+        return transformed
+
+    # --- per-member write ----------------------------------------------------------
+
+    def _write_member(
+        self,
+        original: ArchiveMember,
+        transformed: ArchiveMember,
+        stream: BinaryIO | None,
+        dest: Path,
+        dest_root: Path,
+        tracker: BombTracker,
+        source_paths: dict[int, list[Path]],
+        orphans: list[_Orphan],
+        forward_only: bool,
+        result_index: int,
+    ) -> ExtractionResult:
+        dest_path = dest / transformed.name
+
+        if transformed.type == MemberType.DIRECTORY:
+            if not self._prepare_destination(transformed, dest_path):
+                return ExtractionResult(original, None, ExtractionStatus.SKIPPED, None)
+            os.makedirs(dest_path, exist_ok=True)
+            self._apply_metadata(dest_path, transformed)
+            return ExtractionResult(original, dest_path, ExtractionStatus.EXTRACTED, None)
+
+        if transformed.type == MemberType.SYMLINK:
+            return self._write_symlink(original, transformed, dest_root, dest_path)
+
+        if transformed.type == MemberType.HARDLINK:
+            return self._write_hardlink(
+                original, transformed, dest_path, source_paths, orphans,
+                forward_only, result_index,
+            )
+
+        if transformed.type == MemberType.FILE:
+            return self._write_file(
+                original, transformed, stream, dest_path, tracker, source_paths
+            )
+
+        # MemberType.OTHER is rejected by check_universal; nothing else should reach here.
+        raise ExtractionError(
+            f"Unsupported member type {transformed.type!r} for {transformed.name!r}"
+        )
+
+    def _write_file(
+        self,
+        original: ArchiveMember,
+        transformed: ArchiveMember,
+        stream: BinaryIO | None,
+        dest_path: Path,
+        tracker: BombTracker,
+        source_paths: dict[int, list[Path]],
+    ) -> ExtractionResult:
+        if not self._prepare_destination(transformed, dest_path):
+            return ExtractionResult(original, None, ExtractionStatus.SKIPPED, None)
+
+        os.makedirs(dest_path.parent, exist_ok=True)
+        self._copy_stream_to(stream, dest_path, tracker)
+        self._apply_metadata(dest_path, transformed)
+
+        # Record this FILE's path under the ORIGINAL member id so later hardlinks whose
+        # link_target_member is this member can os.link against it.
+        source_paths.setdefault(original.member_id, []).append(dest_path)
+        return ExtractionResult(original, dest_path, ExtractionStatus.EXTRACTED, None)
+
+    def _write_symlink(
+        self,
+        original: ArchiveMember,
+        transformed: ArchiveMember,
+        dest_root: Path,
+        dest_path: Path,
+    ) -> ExtractionResult:
+        if not self._prepare_destination(transformed, dest_path):
+            return ExtractionResult(original, None, ExtractionStatus.SKIPPED, None)
+
+        target = transformed.link_target
+        if target is None:
+            raise LinkTargetNotFoundError(
+                f"Symlink {transformed.name!r} has no target",
+                member_name=transformed.name,
+            )
+
+        os.makedirs(dest_path.parent, exist_ok=True)
+        # A symlink is target-independent: create it even if the target was filtered out,
+        # appears later, or lies outside the archive — it may dangle. Only the escape
+        # check below constrains it. An os.symlink failure (unsupported FS) propagates as
+        # a per-member OnError failure; no copy-the-target fallback.
+        os.symlink(target, dest_path)
+
+        # Post-creation re-resolution (defense-in-depth layer 3): the created link's
+        # resolved target must stay within dest, catching chained-symlink TOCTOU. An
+        # unresolvable link (ELOOP / RuntimeError) is treated as an escape.
+        try:
+            resolved = (dest_path.parent / target).resolve()
+            escaped = not (resolved == dest_root or resolved.is_relative_to(dest_root))
+        except (OSError, RuntimeError):
+            escaped = True
+        if escaped:
+            try:
+                dest_path.unlink()
+            except OSError:
+                pass
+            raise SymlinkEscapeError(
+                f"Symlink target escapes destination: "
+                f"{transformed.name!r} -> {target!r}",
+                member_name=transformed.name,
+            )
+
+        return ExtractionResult(original, dest_path, ExtractionStatus.EXTRACTED, None)
+
+    def _write_hardlink(
+        self,
+        original: ArchiveMember,
+        transformed: ArchiveMember,
+        dest_path: Path,
+        source_paths: dict[int, list[Path]],
+        orphans: list[_Orphan],
+        forward_only: bool,
+        result_index: int,
+    ) -> ExtractionResult:
+        source = original.link_target_member
+        if source is None:
+            raise LinkTargetNotFoundError(
+                f"Hardlink target {original.link_target!r} not found for "
+                f"{transformed.name!r}",
+                member_name=transformed.name,
+            )
+
+        if source.member_id in source_paths:
+            if not self._prepare_destination(transformed, dest_path):
+                return ExtractionResult(original, None, ExtractionStatus.SKIPPED, None)
+            os.makedirs(dest_path.parent, exist_ok=True)
+            self._place_link(source_paths, source.member_id, dest_path, transformed)
+            return ExtractionResult(original, dest_path, ExtractionStatus.EXTRACTED, None)
+
+        # Source not written yet: the link is orphaned (its source was excluded).
+        if forward_only:
+            # Forward-only: the source's bytes already streamed past — unrecoverable. Per
+            # spec this is a per-member ExtractionError handled by OnError.
+            raise ExtractionError(
+                f"Hardlink source {source.name!r} for {transformed.name!r} was excluded "
+                f"and cannot be recovered on a forward-only stream",
+                member_name=transformed.name,
+            )
+        # Re-readable: resolve in the second pass.
+        orphans.append(_Orphan(result_index, original, dest_path, source))
+        return ExtractionResult(original, None, ExtractionStatus.FAILED, None)
+
+    # --- orphan (second pass) ------------------------------------------------------
+
+    def _resolve_orphans(
+        self,
+        reader: "BaseArchiveReader",
+        source_paths: dict[int, list[Path]],
+        orphans: list[_Orphan],
+        tracker: BombTracker,
+        results: list[ExtractionResult],
+    ) -> None:
+        needed = {orphan.source.member_id for orphan in orphans}
+        orphans_by_source: dict[int, list[_Orphan]] = {}
+        for orphan in orphans:
+            orphans_by_source.setdefault(orphan.source.member_id, []).append(orphan)
+
+        # One second forward pass over the (re-readable) source; write each needed source
+        # to the first of its selected link paths and os.link the rest.
+        for member, stream in reader._iter_with_data():
+            if member.member_id not in needed:
+                self._close(stream)
+                continue
+            group = orphans_by_source[member.member_id]
+            try:
+                self._materialize_orphan_source(
+                    member, stream, group, source_paths, tracker, results
+                )
+            except _AlwaysStopExtractionError:
+                raise
+            except (ArchiveyError, OSError) as exc:
+                for orphan in group:
+                    results[orphan.result_index] = ExtractionResult(
+                        orphan.original, None, ExtractionStatus.FAILED, exc
+                    )
+                if self._on_error is OnError.STOP:
+                    raise
+                logger.warning(
+                    "Skipping orphaned hardlink source %r: %s", member.name, exc
+                )
+            finally:
+                self._close(stream)
+            needed.discard(member.member_id)
+
+        # Any orphan whose source never reappeared (should not happen for a re-readable
+        # source) is a per-member failure.
+        for source_id in needed:
+            err = ExtractionError(
+                "Hardlink source was not found on the second pass"
+            )
+            for orphan in orphans_by_source[source_id]:
+                results[orphan.result_index] = ExtractionResult(
+                    orphan.original, None, ExtractionStatus.FAILED, err
+                )
+            if self._on_error is OnError.STOP:
+                raise err
+
+    def _materialize_orphan_source(
+        self,
+        source_member: ArchiveMember,
+        stream: BinaryIO | None,
+        group: list[_Orphan],
+        source_paths: dict[int, list[Path]],
+        tracker: BombTracker,
+        results: list[ExtractionResult],
+    ) -> None:
+        # Count the recovered source bytes toward the cumulative/ratio guards too.
+        tracker.start_member(source_member)
+        first = group[0]
+        # The excluded source is written to the first selected link's destination path,
+        # never to its own name.
+        if self._prepare_destination(first.original, first.dest_path):
+            os.makedirs(first.dest_path.parent, exist_ok=True)
+            self._copy_stream_to(stream, first.dest_path, tracker)
+            source_paths.setdefault(source_member.member_id, []).append(first.dest_path)
+            results[first.result_index] = ExtractionResult(
+                first.original, first.dest_path, ExtractionStatus.EXTRACTED, None
+            )
+        else:
+            results[first.result_index] = ExtractionResult(
+                first.original, None, ExtractionStatus.SKIPPED, None
+            )
+
+        for orphan in group[1:]:
+            if not self._prepare_destination(orphan.original, orphan.dest_path):
+                results[orphan.result_index] = ExtractionResult(
+                    orphan.original, None, ExtractionStatus.SKIPPED, None
+                )
+                continue
+            os.makedirs(orphan.dest_path.parent, exist_ok=True)
+            self._place_link(
+                source_paths, source_member.member_id, orphan.dest_path, orphan.original
+            )
+            results[orphan.result_index] = ExtractionResult(
+                orphan.original, orphan.dest_path, ExtractionStatus.EXTRACTED, None
+            )
+
+    # --- filesystem helpers --------------------------------------------------------
+
+    def _prepare_destination(self, member: ArchiveMember, dest_path: Path) -> bool:
+        """Apply the OverwritePolicy. Returns True to proceed with creation, False to
+        skip (SKIP over an existing entry). Raises ExtractionError under ERROR when the
+        entry exists. Uses lstat semantics so a dangling symlink counts as existing."""
+        exists = os.path.lexists(dest_path)
+        if not exists:
+            return True
+
+        # A real directory being (re)created as a directory is fine under any policy.
+        if (
+            member.type == MemberType.DIRECTORY
+            and dest_path.is_dir()
+            and not dest_path.is_symlink()
+        ):
+            return True
+
+        if self._overwrite is OverwritePolicy.ERROR:
+            raise ExtractionError(
+                f"Destination already exists: {dest_path}", member_name=member.name
+            )
+        if self._overwrite is OverwritePolicy.SKIP:
+            return False
+
+        # REPLACE: unlink-then-create, never write-through. Remove a symlink/file with
+        # unlink (so bytes never follow the link to its target); remove a real dir tree.
+        if dest_path.is_symlink() or not dest_path.is_dir():
+            dest_path.unlink()
+        else:
+            shutil.rmtree(dest_path)
+        return True
+
+    def _copy_stream_to(
+        self, stream: BinaryIO | None, path: Path, tracker: BombTracker | None
+    ) -> None:
+        try:
+            with open(path, "wb") as dst:
+                if stream is not None:
+                    while True:
+                        chunk = stream.read(_CHUNK)
+                        if not chunk:
+                            break
+                        if tracker is not None:
+                            tracker.count(len(chunk))
+                        dst.write(chunk)
+        except BaseException:
+            # Remove this member's partial output on any failure (bomb guard, write
+            # error, KeyboardInterrupt) before re-raising.
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
+            raise
+
+    def _place_link(
+        self,
+        source_paths: dict[int, list[Path]],
+        source_id: int,
+        new_path: Path,
+        member: ArchiveMember,
+    ) -> None:
+        """Create ``new_path`` as a hardlink to the source's content, trying each recorded
+        on-disk path in turn; on all-cross-device (EXDEV), copy from an existing path.
+        Appends ``new_path`` so a later same-device link can reuse it."""
+        existing = source_paths[source_id]
+        copied = False
+        for candidate in existing:
+            try:
+                os.link(candidate, new_path)
+                break
+            except OSError as exc:
+                if exc.errno == errno.EXDEV:
+                    continue
+                raise
+        else:
+            # Every recorded path is cross-device: fall back to a copy from the first.
+            shutil.copy2(existing[0], new_path)
+            copied = True
+        existing.append(new_path)
+        if copied:
+            self._apply_metadata(new_path, member)
+
+    def _apply_metadata(self, path: Path, member: ArchiveMember) -> None:
+        """Best-effort mode / mtime / ownership. Failures are swallowed (best-effort)."""
+        if member.mode is not None:
+            try:
+                os.chmod(path, member.mode)
+            except OSError:
+                pass
+        if member.modified is not None:
+            try:
+                ts = member.modified.timestamp()
+                os.utime(path, (ts, ts))
+            except (OSError, ValueError, OverflowError):
+                pass
+        # Ownership only under TRUSTED as root (STRICT/STANDARD never chown).
+        if (
+            self._policy is ExtractionPolicy.TRUSTED
+            and member.uid is not None
+            and member.gid is not None
+            and hasattr(os, "geteuid")
+            and os.geteuid() == 0
+        ):
+            try:
+                os.chown(path, member.uid, member.gid)
+            except OSError:
+                pass
+
+    # --- progress / misc -----------------------------------------------------------
+
+    def _estimate_total_bytes(
+        self, all_members: list[ArchiveMember] | None
+    ) -> int | None:
+        if all_members is None:
+            return None
+        if any(m.is_file and m.size is None for m in all_members):
+            return None
+        return sum(m.size or 0 for m in all_members if m.is_file)
+
+    def _report_progress(
+        self,
+        member: ArchiveMember,
+        tracker: BombTracker,
+        total_estimate: int | None,
+        members_done: int,
+        members_total: int | None,
+    ) -> None:
+        if self._on_progress is None:
+            return
+        self._on_progress(
+            ExtractionProgress(
+                member=member,
+                bytes_written=tracker.total_bytes,
+                total_bytes_estimated=total_estimate,
+                members_done=members_done,
+                members_total=members_total,
+            )
+        )
+
+    @staticmethod
+    def _close(stream: BinaryIO | None) -> None:
+        if stream is not None:
+            try:
+                stream.close()
+            except Exception:  # noqa: BLE001 - best-effort close; nothing left to do
+                pass

--- a/src/archivey/internal/extraction.py
+++ b/src/archivey/internal/extraction.py
@@ -35,8 +35,7 @@ from archivey.exceptions import (
     LinkTargetNotFoundError,
     SymlinkEscapeError,
 )
-from archivey.internal.filters import POLICY_TRANSFORMS, check_universal
-from archivey.internal.progress import (
+from archivey.internal.extraction_types import (
     ExtractionPolicy,
     ExtractionProgress,
     ExtractionResult,
@@ -46,6 +45,7 @@ from archivey.internal.progress import (
     OnError,
     OverwritePolicy,
 )
+from archivey.internal.filters import POLICY_TRANSFORMS, check_universal
 from archivey.types import ArchiveMember, MemberType
 
 if TYPE_CHECKING:
@@ -392,9 +392,23 @@ class ExtractionCoordinator:
         # a per-member OnError failure; no copy-the-target fallback.
         os.symlink(target, dest_path)
 
-        # Post-creation re-resolution (defense-in-depth layer 3): the created link's
-        # resolved target must stay within dest, catching chained-symlink TOCTOU. An
-        # unresolvable link (ELOOP / RuntimeError) is treated as an escape.
+        # Re-validate the symlink target AFTER creating it, resolving through the real
+        # filesystem. check_universal already rejected an absolute or escaping target at
+        # planning time, but that check resolves the target lexically against the tree as it
+        # looked *then*. The authoritative question — where does this link actually point? —
+        # can only be answered against the filesystem as it is now, because an *earlier*
+        # extracted member may have planted a symlink on one of this target's path
+        # components that redirects it outside dest (a "chained symlink": e.g. member 1 is
+        # `sub -> /tmp/evil`, member 2 is `sub/link -> x`, so `sub/link` resolves to
+        # `/tmp/evil/x`). Path.resolve() follows those on-disk links, so it catches the
+        # escape the planning check cannot see. We can't do this "just before" creating the
+        # link because there is no link to resolve until it exists; and resolving the *bare
+        # target string* would only repeat check_universal. So: create, resolve, and unlink
+        # if it escaped. A cyclic/adversarial link makes resolve() raise ELOOP/RuntimeError,
+        # which we also treat as an escape (fail safe rather than crash). This is the third
+        # of the three defense-in-depth layers named in the `safe-extraction` spec
+        # ("Symlink Escape Re-Validated at Extraction Time"); layers 1-2 are in
+        # check_universal.
         try:
             resolved = (dest_path.parent / target).resolve()
             escaped = not (resolved == dest_root or resolved.is_relative_to(dest_root))
@@ -594,7 +608,11 @@ class ExtractionCoordinator:
                         dst.write(chunk)
         except BaseException:
             # Remove this member's partial output on any failure (bomb guard, write
-            # error, KeyboardInterrupt) before re-raising.
+            # error, KeyboardInterrupt) and re-raise. No log here on purpose: the failure
+            # propagates to run()'s per-member handler, which under OnError.CONTINUE emits
+            # the WARNING and records the FAILED result, and under OnError.STOP re-raises
+            # for the caller — logging here would either duplicate that or fire on a
+            # deliberate STOP.
             try:
                 os.unlink(path)
             except OSError:

--- a/src/archivey/internal/extraction.py
+++ b/src/archivey/internal/extraction.py
@@ -534,10 +534,11 @@ class ExtractionCoordinator:
         tracker.start_member(source_member)
         first = group[0]
         # The excluded source is written to the first selected link's destination path,
-        # never to its own name.
-        if self._prepare_destination(first.original, first.dest_path):
+        # never to its own name — atomically (temp + os.replace), same as a normal FILE, so a
+        # failure while re-reading the source doesn't clobber an existing entry there.
+        if self._prepare_destination(first.original, first.dest_path, atomic=True):
             os.makedirs(first.dest_path.parent, exist_ok=True)
-            self._copy_stream_to(stream, first.dest_path, tracker)
+            self._write_file_atomic(stream, first.dest_path, None, tracker)
             source_paths.setdefault(source_member.member_id, []).append(first.dest_path)
             results[first.result_index] = ExtractionResult(
                 first.original, first.dest_path, ExtractionStatus.EXTRACTED, None
@@ -610,21 +611,24 @@ class ExtractionCoordinator:
         self,
         stream: BinaryIO | None,
         dest_path: Path,
-        member: ArchiveMember,
+        member: ArchiveMember | None,
         tracker: BombTracker | None,
     ) -> None:
-        """Write a FILE by streaming into a temp sibling, applying metadata, then
-        ``os.replace()``-ing it onto ``dest_path`` — atomic, so a mid-stream failure never
-        truncates or removes an existing destination (only the temp is discarded), and the
-        target name never appears half-written. The temp lives in the destination directory
-        so the rename stays on one filesystem."""
+        """Write a FILE by streaming into a temp sibling, applying ``member``'s metadata
+        (when given), then ``os.replace()``-ing it onto ``dest_path`` — atomic, so a
+        mid-stream failure never truncates or removes an existing destination (only the temp
+        is discarded), and the target name never appears half-written. The temp lives in the
+        destination directory so the rename stays on one filesystem. ``member`` is ``None``
+        when materializing an orphaned hardlink source's content (it applies no metadata; the
+        links each carry their own)."""
         # mkstemp hands back an already-open fd; write straight into it (no close+reopen).
         fd, tmp_name = tempfile.mkstemp(dir=dest_path.parent, prefix=".archivey-tmp-")
         tmp = Path(tmp_name)
         try:
             with os.fdopen(fd, "wb") as dst:
                 self._copy_to_fileobj(stream, dst, tracker)
-            self._apply_metadata(tmp, member)
+            if member is not None:
+                self._apply_metadata(tmp, member)
             os.replace(tmp, dest_path)
         except BaseException:
             # os.replace consumes the temp on success; on any earlier failure remove it so
@@ -648,25 +652,6 @@ class ExtractionCoordinator:
             if tracker is not None:
                 tracker.count(len(chunk))
             dst.write(chunk)
-
-    def _copy_stream_to(
-        self, stream: BinaryIO | None, path: Path, tracker: BombTracker | None
-    ) -> None:
-        try:
-            with open(path, "wb") as dst:
-                self._copy_to_fileobj(stream, dst, tracker)
-        except BaseException:
-            # Remove this member's partial output on any failure (bomb guard, write
-            # error, KeyboardInterrupt) and re-raise. No log here on purpose: the failure
-            # propagates to run()'s per-member handler, which under OnError.CONTINUE emits
-            # the WARNING and records the FAILED result, and under OnError.STOP re-raises
-            # for the caller — logging here would either duplicate that or fire on a
-            # deliberate STOP.
-            try:
-                os.unlink(path)
-            except OSError:
-                pass
-            raise
 
     def _place_link(
         self,

--- a/src/archivey/internal/extraction_types.py
+++ b/src/archivey/internal/extraction_types.py
@@ -1,4 +1,6 @@
-"""Public extraction value types: policies, per-member results, progress.
+"""Public extraction value types: the ``ExtractionPolicy`` / ``OverwritePolicy`` /
+``OnError`` / ``ExtractionStatus`` enums, the ``ExtractionProgress`` / ``ExtractionResult``
+dataclasses, and the ``members`` / ``filter`` type aliases.
 
 These types are part of the public API (re-exported from ``archivey``), but they live
 under ``internal/`` so the public ``reader.py`` / ``core.py`` surface and the internal
@@ -46,10 +48,16 @@ class ExtractionPolicy(Enum):
 
 
 class OverwritePolicy(Enum):
-    """What to do when a destination entry already exists where a member would be written."""
+    """What to do when a destination entry already exists where a member would be written.
 
-    ERROR = "error"  # raise ExtractionError if a destination entry exists
-    SKIP = "skip"  # silently skip existing entries
+    ``ERROR`` raises an ``ExtractionError`` for the member, which is then a per-member
+    failure governed by the ``OnError`` policy — ``OnError.STOP`` re-raises and halts,
+    ``OnError.CONTINUE`` records a ``FAILED`` ``ExtractionResult`` and proceeds. ``SKIP``
+    is not an error: it records a ``SKIPPED`` result regardless of ``OnError``.
+    """
+
+    ERROR = "error"  # existing entry -> ExtractionError (then handled per OnError)
+    SKIP = "skip"  # silently skip existing entries (records SKIPPED)
     REPLACE = "replace"  # unlink the existing entry, then create fresh (never write-through)
 
 

--- a/src/archivey/internal/filters.py
+++ b/src/archivey/internal/filters.py
@@ -23,7 +23,7 @@ from archivey.exceptions import (
     SpecialFileError,
     SymlinkEscapeError,
 )
-from archivey.internal.progress import ExtractionPolicy
+from archivey.internal.extraction_types import ExtractionPolicy
 from archivey.types import ArchiveMember, MemberType
 
 # Split a member name into path components on either separator; a ".." component after

--- a/src/archivey/internal/filters.py
+++ b/src/archivey/internal/filters.py
@@ -1,0 +1,165 @@
+"""Universal path-safety checks and policy permission transforms for extraction.
+
+Two independent stages sit in front of every on-disk write (see ``safe-extraction``):
+
+* :func:`check_universal` — the non-bypassable path/link/special-file constraints,
+  enforced under **every** :class:`ExtractionPolicy` (including ``TRUSTED``). Run on the
+  **original** member before any transform.
+* the policy transforms in :data:`POLICY_TRANSFORMS` — permission/ownership normalization
+  applied to a transient copy of the member, selected by the active policy.
+
+The post-``os.symlink`` re-resolution check (the third defense-in-depth layer) lives in
+the coordinator, next to the ``os.symlink`` call it guards.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Callable
+
+from archivey.exceptions import (
+    PathTraversalError,
+    SpecialFileError,
+    SymlinkEscapeError,
+)
+from archivey.internal.progress import ExtractionPolicy
+from archivey.types import ArchiveMember, MemberType
+
+# Split a member name into path components on either separator; a ".." component after
+# this split is a traversal attempt regardless of which separator the archive used.
+_SEP_SPLIT = re.compile(r"[\\/]")
+
+
+def _is_absolute(name: str) -> bool:
+    """Whether ``name`` is an absolute path: a POSIX root, a UNC share, or a drive letter."""
+    if name.startswith("/") or name.startswith("\\"):
+        return True  # POSIX root or UNC / rooted-backslash
+    # Drive letter: a single ASCII letter followed by ':' (e.g. "C:\\", "C:foo").
+    return len(name) >= 2 and name[0].isalpha() and name[1] == ":"
+
+
+def _within(path: Path, root: Path) -> bool:
+    return path == root or path.is_relative_to(root)
+
+
+def check_universal(member: ArchiveMember, dest: Path) -> None:
+    """Enforce the non-bypassable universal path-safety constraints on ``member``.
+
+    ``dest`` is the extraction root. Raises a :class:`FilterRejectionError` subclass
+    (``PathTraversalError`` / ``SymlinkEscapeError`` / ``SpecialFileError``) on the first
+    violation; returns ``None`` when the member is safe to extract. Applied to the
+    original member, before any policy transform, regardless of the active policy.
+    """
+    name = member.name
+
+    # (1) String checks on member.name. Names are faithful (meaning-preserving
+    # normalization keeps a leading "/" and every ".."), so the danger is visible directly
+    # on member.name — no separate raw_name inspection is needed. Any ".." component is
+    # rejected (escaping and internal alike): a well-formed archive has no reason to carry
+    # one. (A future opt-in SANITIZE policy may re-root such names instead of rejecting.)
+    if "\x00" in name:
+        raise PathTraversalError(
+            f"Null byte in member name: {name!r}", member_name=name
+        )
+    if _is_absolute(name):
+        raise PathTraversalError(
+            f"Absolute path not allowed: {name!r}", member_name=name
+        )
+    if ".." in _SEP_SPLIT.split(name):
+        raise PathTraversalError(
+            f"Path traversal ('..') in member name: {name!r}", member_name=name
+        )
+
+    if member.type == MemberType.OTHER:
+        raise SpecialFileError(
+            f"Special file (device/FIFO/socket) not allowed: {name!r}",
+            member_name=name,
+        )
+
+    # Pre-extraction path computation: the destination's PARENT directory must resolve
+    # within the root. We resolve the parent, not the full path — the final component may
+    # be a pre-existing (possibly hostile) symlink that the OverwritePolicy will unlink
+    # rather than follow, so following it here would wrongly reject a REPLACE. Combined
+    # with the no-".." name check above, a parent inside the root guarantees the member
+    # lands inside the root. A symlinked *parent* that escapes is still caught.
+    dest_root = dest.resolve()
+    rel = name.rstrip("/")
+    if rel not in ("", "."):  # "" / "." is the root dir member itself
+        parent = (dest_root / rel).parent.resolve()
+        if not _within(parent, dest_root):
+            raise PathTraversalError(
+                f"Member {name!r} resolves outside the destination root",
+                member_name=name,
+            )
+
+    # Link-target escape at planning time (the authoritative symlink check is re-run
+    # post-creation in the coordinator). A symlink target is relative to the link's own
+    # directory; a hardlink target is archive-root relative. An absolute target makes the
+    # join absolute, so it resolves outside dest and is caught here too.
+    if member.link_target is not None:
+        if member.type == MemberType.SYMLINK:
+            link_parent = (dest_root / name).parent
+            resolved_target = (link_parent / member.link_target).resolve()
+            if not _within(resolved_target, dest_root):
+                raise SymlinkEscapeError(
+                    f"Symlink target escapes destination: "
+                    f"{name!r} -> {member.link_target!r}",
+                    member_name=name,
+                )
+        elif member.type == MemberType.HARDLINK:
+            resolved_target = (dest_root / member.link_target).resolve()
+            if not _within(resolved_target, dest_root):
+                raise SymlinkEscapeError(
+                    f"Hardlink target escapes destination: "
+                    f"{name!r} -> {member.link_target!r}",
+                    member_name=name,
+                )
+
+
+# --- Policy permission transforms (applied to a transient copy) ---------------------
+
+_HIGH_BITS = 0o7000  # setuid | setgid | sticky
+_EXEC_BITS = 0o111
+
+
+def transform_strict(member: ArchiveMember) -> ArchiveMember:
+    """STRICT: drop ownership, strip high/execute bits, normalize to 644/755."""
+    new: dict[str, object] = {
+        "uid": None,
+        "gid": None,
+        "uname": None,
+        "gname": None,
+    }
+    if member.is_dir:
+        new["mode"] = 0o755
+    elif member.is_file:
+        mode = member.mode
+        if mode is None:
+            new["mode"] = 0o644
+        else:
+            mode = (mode & ~_HIGH_BITS) & ~_EXEC_BITS
+            new["mode"] = min(mode & 0o666, 0o644)
+    return member.replace(**new)
+
+
+def transform_standard(member: ArchiveMember) -> ArchiveMember:
+    """STANDARD: strip setuid/setgid/sticky, keep execute and ownership."""
+    new: dict[str, object] = {}
+    if member.is_dir:
+        new["mode"] = 0o755 if member.mode is None else (member.mode & ~_HIGH_BITS)
+    elif member.is_file:
+        new["mode"] = 0o644 if member.mode is None else (member.mode & ~_HIGH_BITS)
+    return member.replace(**new)
+
+
+def transform_trusted(member: ArchiveMember) -> ArchiveMember:
+    """TRUSTED: apply stored metadata as-is (a fresh copy, no changes)."""
+    return member.replace()
+
+
+POLICY_TRANSFORMS: dict[ExtractionPolicy, Callable[[ArchiveMember], ArchiveMember]] = {
+    ExtractionPolicy.STRICT: transform_strict,
+    ExtractionPolicy.STANDARD: transform_standard,
+    ExtractionPolicy.TRUSTED: transform_trusted,
+}

--- a/src/archivey/internal/progress.py
+++ b/src/archivey/internal/progress.py
@@ -1,0 +1,92 @@
+"""Public extraction value types: policies, per-member results, progress.
+
+These types are part of the public API (re-exported from ``archivey``), but they live
+under ``internal/`` so the public ``reader.py`` / ``core.py`` surface and the internal
+``ExtractionCoordinator`` can share them without an import cycle. They carry no behavior
+beyond being enums / dataclasses; the extraction logic lives in
+``internal/extraction.py`` and ``internal/filters.py``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Callable, Collection
+
+from archivey.exceptions import ArchiveyError
+from archivey.types import ArchiveMember
+
+# Shared selector / filter aliases, defined in this leaf module so both the public
+# reader.py signature and the internal coordinator can import them without a cycle.
+#
+# ``MemberSelectorArg`` — which members to extract: a collection of names / ArchiveMembers,
+# a predicate, or ``None`` (= all). The collection form is normalized to a predicate by the
+# coordinator; the public ``stream_members`` selector stays predicate-only (its
+# duplicate-name semantics are deferred to Phase 5 — see reader.py).
+MemberSelectorArg = (
+    Collection["str | ArchiveMember"] | Callable[[ArchiveMember], bool] | None
+)
+# ``MemberFilter`` — a per-member sanitize/rename hook run after the safety checks and
+# policy transform; returns a ``.replace()``d copy, or ``None`` to skip the member.
+MemberFilter = Callable[[ArchiveMember], "ArchiveMember | None"]
+
+
+class ExtractionPolicy(Enum):
+    """How much of an archive member's stored permission/ownership metadata to trust.
+
+    The universal path/symlink/special-file safety checks are enforced under **all**
+    policies (see ``safe-extraction``); the policy only governs the permission/ownership
+    transform applied to a member before it is written.
+    """
+
+    STRICT = "strict"  # default; untrusted archives
+    STANDARD = "standard"  # moderate trust; e.g. your own older archives
+    TRUSTED = "trusted"  # apply stored mode (and uid/gid as root); path safety still enforced
+
+
+class OverwritePolicy(Enum):
+    """What to do when a destination entry already exists where a member would be written."""
+
+    ERROR = "error"  # raise ExtractionError if a destination entry exists
+    SKIP = "skip"  # silently skip existing entries
+    REPLACE = "replace"  # unlink the existing entry, then create fresh (never write-through)
+
+
+class OnError(Enum):
+    """What to do when an individual member cannot be extracted."""
+
+    STOP = "stop"  # default: raise the first failure and halt
+    CONTINUE = "continue"  # record the failure, clean up, proceed to the next member
+
+
+class ExtractionStatus(Enum):
+    """The outcome recorded for a single member in its :class:`ExtractionResult`."""
+
+    EXTRACTED = "extracted"
+    SKIPPED = "skipped"  # pre-existing destination under OverwritePolicy.SKIP
+    REJECTED = "rejected"  # blocked by a safety filter (universal or policy check)
+    FAILED = "failed"  # error while extracting (corrupt data, ratio bomb, write error)
+
+
+@dataclass
+class ExtractionProgress:
+    """Reported once per member through the ``on_progress`` callback."""
+
+    member: ArchiveMember
+    bytes_written: int  # cumulative bytes written across the whole call so far
+    total_bytes_estimated: int | None  # None if the archive carries no size info
+    members_done: int
+    members_total: int | None  # None when the count would require a full scan
+
+
+@dataclass
+class ExtractionResult:
+    """One entry per member processed, returned from ``extract()`` / ``extract_all()``."""
+
+    member: ArchiveMember
+    path: Path | None  # the written path, or None if the member was not written
+    status: ExtractionStatus
+    # The failure, for FAILED/REJECTED under OnError.CONTINUE; an OSError when the failure
+    # is a filesystem read/write error on this member (not translated to an ArchiveyError).
+    error: ArchiveyError | OSError | None = None

--- a/src/archivey/reader.py
+++ b/src/archivey/reader.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import BinaryIO, Callable, Iterator
 
 from archivey.cost import CostReceipt
-from archivey.internal.progress import (
+from archivey.internal.extraction_types import (
     ExtractionPolicy,
     ExtractionProgress,
     ExtractionResult,

--- a/src/archivey/reader.py
+++ b/src/archivey/reader.py
@@ -7,6 +7,15 @@ from pathlib import Path
 from typing import BinaryIO, Callable, Iterator
 
 from archivey.cost import CostReceipt
+from archivey.internal.progress import (
+    ExtractionPolicy,
+    ExtractionProgress,
+    ExtractionResult,
+    MemberFilter,
+    MemberSelectorArg,
+    OnError,
+    OverwritePolicy,
+)
 from archivey.types import ArchiveFormat, ArchiveInfo, ArchiveMember
 
 # Type alias for the member selector passed to stream_members(). Only the predicate form
@@ -108,8 +117,29 @@ class ArchiveReader(ABC):
         ...
 
     @abstractmethod
-    def extract_all(self, dest: str | Path) -> None:
-        """Extract all members to ``dest`` (safe-by-default; see ``safe-extraction``)."""
+    def extract_all(
+        self,
+        dest: str | Path,
+        *,
+        members: MemberSelectorArg = None,
+        filter: MemberFilter | None = None,
+        policy: ExtractionPolicy = ExtractionPolicy.STRICT,
+        overwrite: OverwritePolicy = OverwritePolicy.ERROR,
+        on_error: OnError = OnError.STOP,
+        on_progress: Callable[[ExtractionProgress], None] | None = None,
+        max_extracted_bytes: int = 2 * 2**30,
+        max_ratio: float = 1000.0,
+        ratio_activation_threshold: int = 5 * 2**20,
+        max_entries: int = 1_048_576,
+    ) -> list[ExtractionResult]:
+        """Extract members to ``dest`` (safe-by-default; see ``safe-extraction``).
+
+        ``members`` selects which members to extract (names/``ArchiveMember``s, or a
+        predicate; ``None`` = all). ``filter`` runs after the universal safety checks and
+        the ``policy`` transform, and may rename/sanitize a member (return a
+        ``.replace()``d copy) or skip it (return ``None``). Returns one
+        :class:`~archivey.ExtractionResult` per member processed.
+        """
         ...
 
     @abstractmethod

--- a/tests/test_directory.py
+++ b/tests/test_directory.py
@@ -414,16 +414,20 @@ def test_deep_nested_read(deep_dir: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# extract_all stub
+# extract_all — basic smoke test via the ExtractionCoordinator
 # ---------------------------------------------------------------------------
 
 
-def test_extract_all_raises_not_implemented(simple_dir: Path, tmp_path: Path) -> None:
+def test_extract_all_writes_members(simple_dir: Path, tmp_path: Path) -> None:
+    from archivey import ExtractionStatus
+
     dest = tmp_path / "out"
-    dest.mkdir()
     with open_archive(simple_dir) as reader:
-        with pytest.raises(NotImplementedError):
-            reader.extract_all(dest)
+        results = reader.extract_all(dest)
+    assert (dest / "a.txt").read_bytes() == b"hello"
+    assert (dest / "b.txt").read_bytes() == b"world"
+    assert (dest / "sub" / "c.txt").read_bytes() == b"nested"
+    assert all(r.status is ExtractionStatus.EXTRACTED for r in results)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -1,0 +1,633 @@
+"""Safe-extraction tests: universal filters, policy transforms, BombTracker, and the
+ExtractionCoordinator across ZIP / TAR / directory backends.
+
+Covers the ``safe-extraction`` capability and the ``testing-contract`` adversarial
+scenarios (path traversal, symlink escape, zip bomb, entry-count bomb).
+"""
+
+from __future__ import annotations
+
+import errno
+import io
+import os
+import tarfile
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from archivey import (
+    ExtractionPolicy,
+    ExtractionStatus,
+    OnError,
+    OverwritePolicy,
+    extract,
+    open_archive,
+)
+from archivey.exceptions import (
+    ExtractionError,
+    PathTraversalError,
+    SpecialFileError,
+    SymlinkEscapeError,
+)
+from archivey.internal.extraction import BombTracker, _AlwaysStopExtractionError
+from archivey.internal.filters import (
+    POLICY_TRANSFORMS,
+    check_universal,
+    transform_standard,
+    transform_strict,
+)
+from archivey.types import ArchiveMember, MemberType
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+
+def _member(
+    name: str,
+    *,
+    raw: bytes | None = None,
+    type: MemberType = MemberType.FILE,
+    mode: int | None = None,
+    link_target: str | None = None,
+    uid: int | None = None,
+    gid: int | None = None,
+) -> ArchiveMember:
+    return ArchiveMember(
+        type=type,
+        name=name,
+        raw_name=raw if raw is not None else name.encode(),
+        mode=mode,
+        link_target=link_target,
+        uid=uid,
+        gid=gid,
+    )
+
+
+def _tar_bytes(specs: list[tuple], *, mode: str = "w") -> bytes:
+    """Build a tar from (kind, name, payload) specs.
+
+    kind: "file" (payload=bytes), "sym"/"hard" (payload=linkname), "dir" (payload=None).
+    """
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode=mode) as t:
+        for kind, name, payload in specs:
+            if kind == "file":
+                info = tarfile.TarInfo(name)
+                info.size = len(payload)
+                info.mode = 0o644
+                t.addfile(info, io.BytesIO(payload))
+            elif kind == "dir":
+                info = tarfile.TarInfo(name)
+                info.type = tarfile.DIRTYPE
+                info.mode = 0o755
+                t.addfile(info)
+            elif kind == "sym":
+                info = tarfile.TarInfo(name)
+                info.type = tarfile.SYMTYPE
+                info.linkname = payload
+                t.addfile(info)
+            elif kind == "hard":
+                info = tarfile.TarInfo(name)
+                info.type = tarfile.LNKTYPE
+                info.linkname = payload
+                t.addfile(info)
+    return buf.getvalue()
+
+
+def _write_zip(path: Path, entries: dict[str, bytes], mode: int | None = None) -> None:
+    with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as z:
+        for name, data in entries.items():
+            if mode is not None:
+                info = zipfile.ZipInfo(name)
+                info.create_system = 3  # Unix
+                info.external_attr = mode << 16
+                z.writestr(info, data)
+            else:
+                z.writestr(name, data)
+
+
+# ---------------------------------------------------------------------------
+# check_universal — universal path-safety (task 1.4 / testing-contract)
+# ---------------------------------------------------------------------------
+
+
+# Names are faithful now (normalization keeps a leading "/" and every ".."), so the
+# check runs on member.name directly.
+@pytest.mark.parametrize(
+    "name",
+    [
+        "../evil",  # escaping traversal
+        "../../etc/passwd",
+        "foo/../bar",  # internal traversal is also rejected under the default RAISE
+        "/etc/x",  # absolute
+    ],
+)
+def test_check_universal_rejects_traversal(tmp_path: Path, name: str) -> None:
+    with pytest.raises(PathTraversalError):
+        check_universal(_member(name), tmp_path)
+
+
+def test_check_universal_rejects_null_byte(tmp_path: Path) -> None:
+    with pytest.raises(PathTraversalError):
+        check_universal(_member("a\x00b"), tmp_path)
+
+
+def test_check_universal_rejects_special_file(tmp_path: Path) -> None:
+    with pytest.raises(SpecialFileError):
+        check_universal(_member("dev", type=MemberType.OTHER), tmp_path)
+
+
+def test_check_universal_rejects_symlink_escape(tmp_path: Path) -> None:
+    m = _member("link", type=MemberType.SYMLINK, link_target="../../etc/passwd")
+    with pytest.raises(SymlinkEscapeError):
+        check_universal(m, tmp_path)
+
+
+def test_check_universal_allows_internal_symlink(tmp_path: Path) -> None:
+    m = _member("sub/link", type=MemberType.SYMLINK, link_target="../file.txt")
+    check_universal(m, tmp_path)  # resolves to <dest>/file.txt, inside root
+
+
+def test_check_universal_enforced_under_trusted(tmp_path: Path) -> None:
+    # Universal checks are non-bypassable, even under TRUSTED.
+    with pytest.raises(PathTraversalError):
+        check_universal(_member("../evil"), tmp_path)
+    # ...and TRUSTED's transform itself is identity (path safety is separate).
+    m = _member("ok", mode=0o777)
+    assert POLICY_TRANSFORMS[ExtractionPolicy.TRUSTED](m).mode == 0o777
+
+
+# ---------------------------------------------------------------------------
+# Policy transforms (task 1.4)
+# ---------------------------------------------------------------------------
+
+
+def test_strict_strips_execute_and_normalizes() -> None:
+    out = transform_strict(_member("f", mode=0o755))
+    assert out.mode == 0o644  # execute stripped, normalized
+    assert out.uid is None and out.gid is None
+
+
+def test_strict_dir_normalized_to_755() -> None:
+    out = transform_strict(_member("d/", type=MemberType.DIRECTORY, mode=0o777))
+    assert out.mode == 0o755
+
+
+def test_strict_strips_setuid() -> None:
+    out = transform_strict(_member("f", mode=0o4755))
+    assert out.mode & 0o7000 == 0
+    assert out.mode == 0o644
+
+
+def test_standard_preserves_execute() -> None:
+    out = transform_standard(_member("f", mode=0o755))
+    assert out.mode == 0o755  # execute kept
+    out2 = transform_standard(_member("f", mode=0o4755))
+    assert out2.mode == 0o755  # only setuid stripped
+
+
+def test_strict_mode_none_defaults() -> None:
+    assert transform_strict(_member("f")).mode == 0o644
+    assert transform_strict(_member("d/", type=MemberType.DIRECTORY)).mode == 0o755
+
+
+# ---------------------------------------------------------------------------
+# BombTracker (task 2.3)
+# ---------------------------------------------------------------------------
+
+
+def test_cumulative_byte_limit() -> None:
+    t = BombTracker(max_bytes=100, max_ratio=1e9)
+    t.start_member(_member("f"))
+    t.count(60)
+    with pytest.raises(_AlwaysStopExtractionError):
+        t.count(50)  # crosses 100
+
+
+def test_per_member_ratio() -> None:
+    t = BombTracker(max_bytes=10**12, max_ratio=2.0, ratio_activation_threshold=10)
+    t.start_member(_member("f").replace(compressed_size=1))
+    with pytest.raises(ExtractionError) as ei:
+        t.count(20)  # member_bytes 20 > floor 10, ratio 20:1 > 2
+    assert not isinstance(ei.value, _AlwaysStopExtractionError)  # skippable
+
+
+def test_ratio_activation_threshold_false_positive_guard() -> None:
+    t = BombTracker(max_bytes=10**12, max_ratio=2.0, ratio_activation_threshold=100)
+    t.start_member(_member("f").replace(compressed_size=1))
+    t.count(50)  # below floor 100 -> no trip despite 50:1
+
+
+def test_archive_wide_ratio() -> None:
+    t = BombTracker(
+        max_bytes=10**12,
+        max_ratio=2.0,
+        ratio_activation_threshold=10,
+        compressed_source_size=10,
+    )
+    t.start_member(_member("f"))  # no per-member compressed_size
+    with pytest.raises(_AlwaysStopExtractionError):
+        t.count(30)  # total 30 > floor 10, 30/10 = 3 > 2
+
+
+def test_ratio_skipped_when_denominators_unknown() -> None:
+    t = BombTracker(max_bytes=10**12, max_ratio=2.0, ratio_activation_threshold=1)
+    t.start_member(_member("f"))  # compressed_size None, no source size
+    t.count(10_000)  # no ratio applies; cumulative under limit
+
+
+def test_max_entries_guard() -> None:
+    t = BombTracker(max_bytes=10**12, max_ratio=1e9, max_entries=2)
+    t.start_member(_member("a"))
+    t.start_member(_member("b"))
+    with pytest.raises(_AlwaysStopExtractionError):
+        t.start_member(_member("c"))
+
+
+def test_entry_count_independent_of_bytes() -> None:
+    t = BombTracker(max_bytes=10**12, max_ratio=1e9, max_entries=1)
+    t.start_member(_member("a"))
+    with pytest.raises(_AlwaysStopExtractionError):
+        t.start_member(_member("b"))  # trips on count, not bytes
+
+
+# ---------------------------------------------------------------------------
+# Coordinator — ZIP vertical slice (tasks 3.x, 5.x)
+# ---------------------------------------------------------------------------
+
+
+def test_extract_zip_basic(tmp_path: Path) -> None:
+    src = tmp_path / "a.zip"
+    _write_zip(src, {"hello.txt": b"hi", "dir/nested.txt": b"deep"})
+    dest = tmp_path / "out"
+    results = extract(src, dest)
+    assert (dest / "hello.txt").read_bytes() == b"hi"
+    assert (dest / "dir" / "nested.txt").read_bytes() == b"deep"
+    assert {r.status for r in results} == {ExtractionStatus.EXTRACTED}
+
+
+def test_extract_zip_strict_normalizes_mode(tmp_path: Path) -> None:
+    src = tmp_path / "m.zip"
+    _write_zip(src, {"x.sh": b"#!/bin/sh"}, mode=0o777)
+    dest = tmp_path / "out"
+    extract(src, dest, policy=ExtractionPolicy.STRICT)
+    assert (dest / "x.sh").stat().st_mode & 0o777 == 0o644
+
+
+def test_extract_zip_standard_keeps_execute(tmp_path: Path) -> None:
+    src = tmp_path / "m.zip"
+    _write_zip(src, {"x.sh": b"#!/bin/sh"}, mode=0o755)
+    dest = tmp_path / "out"
+    extract(src, dest, policy=ExtractionPolicy.STANDARD)
+    assert (dest / "x.sh").stat().st_mode & 0o111  # execute preserved
+
+
+def test_subset_selection(tmp_path: Path) -> None:
+    src = tmp_path / "a.zip"
+    _write_zip(src, {"a.txt": b"a", "b.txt": b"b", "c.txt": b"c"})
+    dest = tmp_path / "out"
+    with open_archive(src) as r:
+        results = r.extract_all(dest, members=["a.txt", "c.txt"])
+    assert (dest / "a.txt").exists() and (dest / "c.txt").exists()
+    assert not (dest / "b.txt").exists()
+    assert len(results) == 2
+
+
+def test_user_filter_rename(tmp_path: Path) -> None:
+    src = tmp_path / "a.zip"
+    _write_zip(src, {"a.txt": b"a"})
+    dest = tmp_path / "out"
+
+    def rename(m: ArchiveMember) -> ArchiveMember:
+        return m.replace(name="renamed.txt")
+
+    with open_archive(src) as r:
+        r.extract_all(dest, filter=rename)
+    assert (dest / "renamed.txt").read_bytes() == b"a"
+
+
+def test_user_filter_skip(tmp_path: Path) -> None:
+    src = tmp_path / "a.zip"
+    _write_zip(src, {"a.txt": b"a", "b.txt": b"b"})
+    dest = tmp_path / "out"
+
+    def skip_b(m: ArchiveMember) -> ArchiveMember | None:
+        return None if m.name == "b.txt" else m
+
+    with open_archive(src) as r:
+        r.extract_all(dest, filter=skip_b)
+    assert (dest / "a.txt").exists()
+    assert not (dest / "b.txt").exists()
+
+
+# ---------------------------------------------------------------------------
+# Overwrite policy (task 3.x)
+# ---------------------------------------------------------------------------
+
+
+def test_overwrite_error(tmp_path: Path) -> None:
+    src = tmp_path / "a.zip"
+    _write_zip(src, {"a.txt": b"new"})
+    dest = tmp_path / "out"
+    dest.mkdir()
+    (dest / "a.txt").write_bytes(b"old")
+    with pytest.raises(ExtractionError):
+        extract(src, dest, overwrite=OverwritePolicy.ERROR)
+    assert (dest / "a.txt").read_bytes() == b"old"  # untouched
+
+
+def test_overwrite_skip(tmp_path: Path) -> None:
+    src = tmp_path / "a.zip"
+    _write_zip(src, {"a.txt": b"new"})
+    dest = tmp_path / "out"
+    dest.mkdir()
+    (dest / "a.txt").write_bytes(b"old")
+    results = extract(src, dest, overwrite=OverwritePolicy.SKIP)
+    assert (dest / "a.txt").read_bytes() == b"old"
+    assert results[0].status is ExtractionStatus.SKIPPED
+
+
+def test_overwrite_replace(tmp_path: Path) -> None:
+    src = tmp_path / "a.zip"
+    _write_zip(src, {"a.txt": b"new"})
+    dest = tmp_path / "out"
+    dest.mkdir()
+    (dest / "a.txt").write_bytes(b"old")
+    extract(src, dest, overwrite=OverwritePolicy.REPLACE)
+    assert (dest / "a.txt").read_bytes() == b"new"
+
+
+def test_replace_symlink_no_write_through(tmp_path: Path) -> None:
+    # A planted symlink at the destination path must be unlinked, not written through.
+    src = tmp_path / "a.zip"
+    _write_zip(src, {"a.txt": b"new"})
+    dest = tmp_path / "out"
+    dest.mkdir()
+    outside = tmp_path / "outside.txt"
+    outside.write_bytes(b"secret")
+    os.symlink(outside, dest / "a.txt")
+    extract(src, dest, overwrite=OverwritePolicy.REPLACE)
+    assert (dest / "a.txt").read_bytes() == b"new"
+    assert not (dest / "a.txt").is_symlink()
+    assert outside.read_bytes() == b"secret"  # target never written through
+
+
+def test_dangling_symlink_counts_as_existing(tmp_path: Path) -> None:
+    src = tmp_path / "a.zip"
+    _write_zip(src, {"a.txt": b"new"})
+    dest = tmp_path / "out"
+    dest.mkdir()
+    os.symlink(tmp_path / "does-not-exist", dest / "a.txt")  # dangling
+    with pytest.raises(ExtractionError):
+        extract(src, dest, overwrite=OverwritePolicy.ERROR)
+
+
+# ---------------------------------------------------------------------------
+# OnError policy (task 3.5)
+# ---------------------------------------------------------------------------
+
+
+def test_on_error_continue_records_rejected(tmp_path: Path) -> None:
+    # A member with a hostile stored name is rejected; CONTINUE keeps going.
+    src = tmp_path / "a.zip"
+    with zipfile.ZipFile(src, "w") as z:
+        z.writestr("../evil.txt", b"bad")
+        z.writestr("good.txt", b"good")
+    dest = tmp_path / "out"
+    results = extract(src, dest, on_error=OnError.CONTINUE)
+    statuses = {r.member.name: r.status for r in results}
+    assert ExtractionStatus.REJECTED in statuses.values()
+    assert (dest / "good.txt").read_bytes() == b"good"
+
+
+def test_on_error_stop_raises(tmp_path: Path) -> None:
+    src = tmp_path / "a.zip"
+    with zipfile.ZipFile(src, "w") as z:
+        z.writestr("../evil.txt", b"bad")
+    dest = tmp_path / "out"
+    with pytest.raises(PathTraversalError):
+        extract(src, dest, on_error=OnError.STOP)
+
+
+# ---------------------------------------------------------------------------
+# Bomb limits end-to-end (task 6.2)
+# ---------------------------------------------------------------------------
+
+
+def test_cumulative_bomb_halts_even_under_continue(tmp_path: Path) -> None:
+    src = tmp_path / "big.zip"
+    _write_zip(src, {"a.txt": b"x" * 5000, "b.txt": b"y" * 5000})
+    dest = tmp_path / "out"
+    with pytest.raises(ExtractionError):
+        extract(src, dest, max_extracted_bytes=6000, on_error=OnError.CONTINUE)
+
+
+def test_zip_bomb_per_member_ratio(tmp_path: Path) -> None:
+    # Highly compressible payload above the activation threshold trips the ratio.
+    src = tmp_path / "bomb.zip"
+    payload = b"\x00" * (8 * 1024 * 1024)  # 8 MiB of zeros -> tiny compressed
+    _write_zip(src, {"bomb.bin": payload})
+    dest = tmp_path / "out"
+    with pytest.raises(ExtractionError):
+        extract(src, dest, max_ratio=10.0, ratio_activation_threshold=1024)
+
+
+def test_entry_count_bomb(tmp_path: Path) -> None:
+    src = tmp_path / "many.zip"
+    _write_zip(src, {f"f{i}.txt": b"" for i in range(50)})
+    dest = tmp_path / "out"
+    with pytest.raises(ExtractionError):
+        extract(src, dest, max_entries=10, on_error=OnError.CONTINUE)
+
+
+# ---------------------------------------------------------------------------
+# Progress callback
+# ---------------------------------------------------------------------------
+
+
+def test_on_progress_called_per_member(tmp_path: Path) -> None:
+    src = tmp_path / "a.zip"
+    _write_zip(src, {"a.txt": b"a", "b.txt": b"b"})
+    dest = tmp_path / "out"
+    seen: list[str] = []
+    extract(src, dest, on_progress=lambda p: seen.append(p.member.name))
+    assert set(seen) == {"a.txt", "b.txt"}
+
+
+# ---------------------------------------------------------------------------
+# TAR symlinks (tasks 3.4, 4.5)
+# ---------------------------------------------------------------------------
+
+
+def test_tar_symlink_created(tmp_path: Path) -> None:
+    src = tmp_path / "a.tar"
+    src.write_bytes(_tar_bytes([("file", "file.txt", b"data"), ("sym", "link", "file.txt")]))
+    dest = tmp_path / "out"
+    extract(src, dest)
+    link = dest / "link"
+    assert link.is_symlink()
+    assert os.readlink(link) == "file.txt"
+    assert link.read_bytes() == b"data"
+
+
+def test_tar_symlink_dangling_to_filtered_target(tmp_path: Path) -> None:
+    # A symlink is target-independent: it is created even when its target is excluded,
+    # and may dangle. No copy, no error.
+    src = tmp_path / "a.tar"
+    src.write_bytes(_tar_bytes([("file", "file.txt", b"data"), ("sym", "link", "file.txt")]))
+    dest = tmp_path / "out"
+    with open_archive(src) as r:
+        r.extract_all(dest, members=["link"])  # exclude file.txt
+    link = dest / "link"
+    assert link.is_symlink()
+    assert not (dest / "file.txt").exists()
+    assert not link.exists()  # dangles (target excluded)
+
+
+def test_tar_symlink_escape_rejected(tmp_path: Path) -> None:
+    src = tmp_path / "a.tar"
+    src.write_bytes(_tar_bytes([("sym", "evil", "../../etc/passwd")]))
+    dest = tmp_path / "out"
+    with pytest.raises(SymlinkEscapeError):
+        extract(src, dest)
+    assert not (dest / "evil").exists()
+
+
+def test_tar_symlink_escape_continue_records_rejected(tmp_path: Path) -> None:
+    src = tmp_path / "a.tar"
+    src.write_bytes(
+        _tar_bytes([("sym", "evil", "../../etc/passwd"), ("file", "ok.txt", b"ok")])
+    )
+    dest = tmp_path / "out"
+    results = extract(src, dest, on_error=OnError.CONTINUE)
+    statuses = {r.member.name: r.status for r in results}
+    assert statuses["evil"] is ExtractionStatus.REJECTED
+    assert (dest / "ok.txt").read_bytes() == b"ok"
+
+
+# ---------------------------------------------------------------------------
+# TAR hardlinks (tasks 4.1, 4.3)
+# ---------------------------------------------------------------------------
+
+
+def test_tar_hardlink_shares_inode(tmp_path: Path) -> None:
+    src = tmp_path / "a.tar"
+    src.write_bytes(
+        _tar_bytes([("file", "file.txt", b"data"), ("hard", "hard.txt", "file.txt")])
+    )
+    dest = tmp_path / "out"
+    extract(src, dest)
+    assert (dest / "file.txt").read_bytes() == b"data"
+    assert (dest / "hard.txt").read_bytes() == b"data"
+    assert os.path.samefile(dest / "file.txt", dest / "hard.txt")
+
+
+def test_tar_hardlink_orphan_recovered_seekable(tmp_path: Path) -> None:
+    # A filter excludes the source but keeps the link; a seekable source recovers the
+    # content in a second pass, writing it to the link path (source name never created).
+    src = tmp_path / "a.tar"
+    src.write_bytes(
+        _tar_bytes([("file", "file.txt", b"data"), ("hard", "hard.txt", "file.txt")])
+    )
+    dest = tmp_path / "out"
+
+    def drop_source(m: ArchiveMember) -> ArchiveMember | None:
+        return None if m.name == "file.txt" else m
+
+    with open_archive(src) as r:
+        results = r.extract_all(dest, filter=drop_source)
+    assert (dest / "hard.txt").read_bytes() == b"data"
+    assert not (dest / "file.txt").exists()
+    assert [r.status for r in results] == [ExtractionStatus.EXTRACTED]
+
+
+def test_tar_hardlink_orphan_forward_only_onerror(tmp_path: Path) -> None:
+    from tests.streams_util import NonSeekableBytesIO
+
+    raw = _tar_bytes([("file", "file.txt", b"data"), ("hard", "hard.txt", "file.txt")])
+
+    def drop_source(m: ArchiveMember) -> ArchiveMember | None:
+        return None if m.name == "file.txt" else m
+
+    # STOP: raises on the unrecoverable orphan.
+    dest = tmp_path / "out_stop"
+    with open_archive(NonSeekableBytesIO(raw), streaming=True) as r:
+        with pytest.raises(ExtractionError):
+            r.extract_all(dest, filter=drop_source)
+
+    # CONTINUE: records FAILED, does not raise.
+    dest2 = tmp_path / "out_continue"
+    with open_archive(NonSeekableBytesIO(raw), streaming=True) as r:
+        results = r.extract_all(dest2, filter=drop_source, on_error=OnError.CONTINUE)
+    statuses = {r.member.name: r.status for r in results}
+    assert statuses["hard.txt"] is ExtractionStatus.FAILED
+    assert not (dest2 / "hard.txt").exists()
+
+
+# ---------------------------------------------------------------------------
+# Seekable + non-seekable compressed TAR (tasks 5.3, 6.3)
+# ---------------------------------------------------------------------------
+
+
+def test_seekable_targz_extract(tmp_path: Path) -> None:
+    src = tmp_path / "a.tar.gz"
+    src.write_bytes(_tar_bytes([("file", "a.txt", b"hello"), ("dir", "d", None)], mode="w:gz"))
+    dest = tmp_path / "out"
+    extract(src, dest)
+    assert (dest / "a.txt").read_bytes() == b"hello"
+    assert (dest / "d").is_dir()
+
+
+def test_seekable_targz_archive_wide_ratio(tmp_path: Path) -> None:
+    # A small .tar.gz whose decompressed output far exceeds max_ratio * file_size trips
+    # the archive-wide ratio (member compressed_size is unknown for TAR).
+    src = tmp_path / "bomb.tar.gz"
+    payload = b"\x00" * (4 * 1024 * 1024)
+    src.write_bytes(_tar_bytes([("file", "z.bin", payload)], mode="w:gz"))
+    dest = tmp_path / "out"
+    with pytest.raises(ExtractionError):
+        extract(src, dest, max_ratio=5.0, ratio_activation_threshold=1024)
+
+
+def test_non_seekable_targz_extract(tmp_path: Path) -> None:
+    from tests.streams_util import NonSeekableBytesIO
+
+    raw = _tar_bytes([("file", "a.txt", b"hello"), ("file", "b.txt", b"world")], mode="w:gz")
+    dest = tmp_path / "out"
+    with open_archive(NonSeekableBytesIO(raw), streaming=True) as r:
+        r.extract_all(dest)
+    assert (dest / "a.txt").read_bytes() == b"hello"
+    assert (dest / "b.txt").read_bytes() == b"world"
+
+
+def test_cross_device_hardlink_reuses_sibling(tmp_path: Path, monkeypatch) -> None:
+    # B->A lands "cross-device" (os.link against A fails EXDEV -> copy). A later C->A on
+    # the same device as B is created with os.link(B, C), reusing the sibling copy.
+    src = tmp_path / "a.tar"
+    src.write_bytes(
+        _tar_bytes(
+            [
+                ("file", "A.txt", b"payload"),
+                ("hard", "B.txt", "A.txt"),
+                ("hard", "C.txt", "A.txt"),
+            ]
+        )
+    )
+    dest = tmp_path / "out"
+    real_link = os.link
+
+    def fake_link(source, target, *a, **k):
+        # Every attempt against A's own copy is "cross-device"; links to B's copy work.
+        if os.fspath(source).endswith("A.txt"):
+            raise OSError(errno.EXDEV, "cross-device")
+        return real_link(source, target, *a, **k)
+
+    monkeypatch.setattr(os, "link", fake_link)
+    extract(src, dest)
+
+    assert (dest / "B.txt").read_bytes() == b"payload"
+    assert (dest / "C.txt").read_bytes() == b"payload"
+    assert os.path.samefile(dest / "B.txt", dest / "C.txt")  # C linked to B's copy
+    assert not os.path.samefile(dest / "A.txt", dest / "B.txt")  # B is a separate copy

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -268,6 +268,15 @@ def test_extract_zip_basic(tmp_path: Path) -> None:
     assert {r.status for r in results} == {ExtractionStatus.EXTRACTED}
 
 
+# Windows has no Unix permission bits — os.chmod there can only toggle the read-only
+# flag, so a regular file always reads back ~0o666 with no execute/group/other bits. The
+# permission-normalization behavior is a POSIX concept, so assert it only on POSIX.
+_posix_perms = pytest.mark.skipif(
+    os.name != "posix", reason="Unix permission bits (chmod) are a no-op on Windows"
+)
+
+
+@_posix_perms
 def test_extract_zip_strict_normalizes_mode(tmp_path: Path) -> None:
     src = tmp_path / "m.zip"
     _write_zip(src, {"x.sh": b"#!/bin/sh"}, mode=0o777)
@@ -276,6 +285,7 @@ def test_extract_zip_strict_normalizes_mode(tmp_path: Path) -> None:
     assert (dest / "x.sh").stat().st_mode & 0o777 == 0o644
 
 
+@_posix_perms
 def test_extract_zip_standard_keeps_execute(tmp_path: Path) -> None:
     src = tmp_path / "m.zip"
     _write_zip(src, {"x.sh": b"#!/bin/sh"}, mode=0o755)

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -394,6 +394,30 @@ def test_dangling_symlink_counts_as_existing(tmp_path: Path) -> None:
         extract(src, dest, overwrite=OverwritePolicy.ERROR)
 
 
+def test_replace_failure_preserves_existing_file(tmp_path: Path) -> None:
+    # A mid-extraction failure under REPLACE must not clobber the existing file: FILE writes
+    # land via a temp + os.replace, so the old data survives and no temp is left behind.
+    src = tmp_path / "big.zip"
+    _write_zip(src, {"a.txt": b"x" * 100_000})
+    dest = tmp_path / "out"
+    dest.mkdir()
+    (dest / "a.txt").write_bytes(b"OLD DATA")
+    with pytest.raises(ExtractionError):
+        extract(
+            src, dest, overwrite=OverwritePolicy.REPLACE, max_extracted_bytes=1000
+        )
+    assert (dest / "a.txt").read_bytes() == b"OLD DATA"  # untouched
+    assert not list(dest.glob(".archivey-tmp-*"))  # temp cleaned up
+
+
+def test_no_temp_files_after_success(tmp_path: Path) -> None:
+    src = tmp_path / "a.zip"
+    _write_zip(src, {"a.txt": b"hi", "dir/b.txt": b"bye"})
+    dest = tmp_path / "out"
+    extract(src, dest)
+    assert not list(dest.rglob(".archivey-tmp-*"))
+
+
 # ---------------------------------------------------------------------------
 # OnError policy (task 3.5)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Implements the **`safe-extraction`** capability (openspec change `phase-4-safe-extraction`): members are written to disk safely behind path-safety filters, policy transforms, and decompression-bomb limits.

## What's here

**New internal modules**
- `internal/progress.py` — `ExtractionPolicy` / `OverwritePolicy` / `OnError` / `ExtractionStatus` enums, `ExtractionProgress` / `ExtractionResult` dataclasses, shared selector/filter aliases.
- `internal/filters.py` — `check_universal()` (path traversal, absolute paths, null bytes, symlink/hardlink escape, special files) + `STRICT`/`STANDARD`/`TRUSTED` policy transforms.
- `internal/extraction.py` — `BombTracker` (cumulative bytes, per-member ratio, archive-wide ratio, entry count) and `ExtractionCoordinator`, a **pull-based sink** (no push-model `ExtractionHelper`): FILE/DIR/SYMLINK/HARDLINK writes, overwrite policy with lstat + unlink-then-create symlink safety, `OnError`, and the core hardlink algorithm (single forward pass + conditional seekable second pass + cross-device sibling linking).

**Wiring**
- `ArchiveReader.extract_all(...)` full signature (was a `NotImplementedError` stub) → delegates to the coordinator.
- Top-level `archivey.extract(...)` one-shot API.
- New public extraction types exported from `archivey`.

## Decisions & deviations (please review)

- **Interim path-traversal handling.** Read-time `normalize_member_name` *silently collapses* traversal (`../evil` → `evil`), so `check_universal` can't see the escape on `member.name`. As a stopgap it also inspects `member.raw_name` and rejects a hostile **stored** name, satisfying `testing-contract` today. The principled fix — minimal, meaning-preserving normalization so `member.name` stays truthful and the check runs on it alone — is proposed as a **separate change** (`minimal-name-normalization`, also in this PR's openspec dir) per maintainer direction to keep this change scoped.
- **Archive-wide ratio = always-stop.** The spec explicitly classifies cumulative bytes + entry-count as always-stop and the per-member ratio as skippable, but leaves the archive-wide ratio unclassified. Treated as always-stop (implemented via a private `ExtractionError` subclass so `except ExtractionError` still catches it).
- **STANDARD keeps uid/gid** (per the transforms table + DEV's `tar` filter; the prose bullet's "remove uid/gid" is the outlier). No on-disk effect — the coordinator only `chown`s under `TRUSTED` as root.
- **`members=[...]` collection selector** is normalized to a predicate inside the coordinator, leaving `stream_members`' Phase-5 duplicate-name deferral untouched.
- **Deferred (task 4.2):** the optional planned-single-pass optimization. The core algorithm handles every case correctly and the current TAR backend rarely exposes a free member list, so it's left for a follow-up.

## Tests

`tests/test_extraction.py` (50 tests): universal filters + policy transforms, `BombTracker` guards, ZIP/TAR/directory extraction, overwrite policies (incl. planted-symlink no-write-through, dangling-symlink-as-existing), `OnError` STOP/CONTINUE, symlink escape + dangling-to-filtered-target, hardlink inode sharing + seekable orphan recovery + forward-only `OnError` + cross-device chained linking, seekable/non-seekable `tar.gz`, and the `testing-contract` adversarial scenarios (path traversal, zip bomb, entry-count bomb).

Full suite: **680 passed, 15 skipped**. `pyrefly` + `ty` + `ruff` clean. `openspec validate phase-4-safe-extraction --strict` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FqR2Cxqm8k4aRhnKfkErty

---
_Generated by [Claude Code](https://claude.ai/code/session_01FqR2Cxqm8k4aRhnKfkErty)_