### PR TITLE
ci: stop running the full matrix twice per PR commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,20 @@
 name: CI
 
+# Run on PRs (covers every branch that has one) and on pushes to main (post-merge
+# and direct pushes). Scoping push to main — rather than "**" — avoids running the
+# whole matrix twice for branches with an open PR, where both `push` and
+# `pull_request` would otherwise fire on each commit. No coverage is lost: PR
+# branches are validated by `pull_request`, main by `push`.
 on:
   push:
-    branches: ["**"]
+    branches: [main]
   pull_request:
+
+# Cancel an in-progress run when a newer commit arrives for the same PR/branch, so
+# rapid pushes don't pile up redundant full-matrix runs.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   # Lint + type-check once (these are environment-independent). No continue-on-error:


### PR DESCRIPTION
## Problem

CI (`.github/workflows/ci.yml`) triggers on both `push` to **every** branch (`branches: ["**"]`) and `pull_request`. For any branch with an open PR, each commit fires *both* events, so the entire test matrix (lint, docs, and ~11 test legs across OSes/Pythons) runs twice — e.g. PR #28.

## Fix

- Scope the `push` trigger to `main` only. `pull_request` already validates every PR branch, and `push: [main]` covers post-merge and direct pushes to the default branch.
- Add a `concurrency` group keyed on the PR number / ref with `cancel-in-progress: true`, so rapid successive pushes cancel the superseded in-progress run instead of piling up full-matrix runs.

## Coverage

No coverage is lost:

| Case | Before | After |
|------|--------|-------|
| Branch with an open PR | runs twice (push + PR) | runs once (PR) |
| `main` after merge / direct push | push | push |
| Fork PRs | pull_request (fork pushes never triggered the base repo's `push`) | pull_request |

The only behavioural change: a branch with **no** open PR won't run CI until a PR is opened — which is exactly when validation is wanted in a PR-based workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NEueSJSg4h27UTvZdzjQXY

---
_Generated by [Claude Code](https://claude.ai/code/session_01NEueSJSg4h27UTvZdzjQXY)_