### PR TITLE
Set up Cursor Cloud dev environment (AGENTS.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,11 +25,13 @@ in place. Run tools with `--no-sync` to avoid a redundant re-resolve, e.g.:
 
 Non-obvious gotchas:
 
-- **`unrar` is preinstalled** (system binary, from the `multiverse` apt component). RAR
-  *data* tests need it; without it they skip cleanly rather than fail.
-- **`openspec` CLI is preinstalled** at `~/.local/bin` (on `PATH`). `CLAUDE.md`'s
+- The startup update script also installs the system `unrar` binary and the `openspec`
+  CLI (in addition to `uv sync`), so both are present without manual steps.
+- **`unrar`** (system binary, from the `multiverse` apt component) backs RAR *data*
+  tests; without it they skip cleanly rather than fail.
+- **`openspec` CLI** lives at `~/.local/bin` (on `PATH`). `CLAUDE.md`'s
   `npm install -g @fission-ai/openspec` fails with `EACCES` here because the global npm
-  prefix is not user-writable — if it ever goes missing, reinstall into a writable,
+  prefix is not user-writable — the update script instead installs it into a writable,
   already-on-`PATH` prefix: `npm install -g --prefix "$HOME/.local" @fission-ai/openspec`.
 - The full push gate runs the suite in **three dependency configs** (`[all]`,
   `[all-lowest]`, `[core-only]`); the exact commands are in `CONTRIBUTING.md`. After a

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,38 @@
+# Agent Guide
+
+For repo orientation, specs, and workflow, see `CLAUDE.md` and `CONTRIBUTING.md`
+(coding/testing standards, the "Before pushing…" three-config test rule).
+
+## Cursor Cloud specific instructions
+
+This repo is a **pure Python library** (`archivey`) — there is no server, web UI, or
+runnable CLI (the `archivey` command in `openspec/specs/cli/spec.md` is planned, not
+implemented). "Running the application" means exercising the library API in Python:
+`archivey.open_archive(path)` / `archivey.extract(path, dest)` plus the detection
+helpers (`detect_format`, `list_supported_formats`). Implemented backends are ZIP, TAR,
+ISO, directory, and single-file-compressed (gz/bz2/xz/lzip/zstd/lz4/.Z); **7z and RAR
+readers are not implemented yet** despite their specs/extras existing.
+
+Environment is managed by `uv` (Python 3.11, pinned in `.python-version`). The startup
+update script runs `uv sync --group dev --extra all`, so the everyday dev env is already
+in place. Run tools with `--no-sync` to avoid a redundant re-resolve, e.g.:
+
+- Tests: `uv run --no-sync pytest`
+- Lint: `uv run --no-sync ruff check`  (note: `ruff format --check` currently reports
+  pre-existing drift in `tests/`; that is unrelated to any single change)
+- Type-check: `uv run --no-sync pyrefly check` and `uv run --no-sync ty check`
+  (both must stay clean; mypy/pyright are intentionally not used)
+
+Non-obvious gotchas:
+
+- **`unrar` is preinstalled** (system binary, from the `multiverse` apt component). RAR
+  *data* tests need it; without it they skip cleanly rather than fail.
+- **`openspec` CLI is preinstalled** at `~/.local/bin` (on `PATH`). `CLAUDE.md`'s
+  `npm install -g @fission-ai/openspec` fails with `EACCES` here because the global npm
+  prefix is not user-writable — if it ever goes missing, reinstall into a writable,
+  already-on-`PATH` prefix: `npm install -g --prefix "$HOME/.local" @fission-ai/openspec`.
+- The full push gate runs the suite in **three dependency configs** (`[all]`,
+  `[all-lowest]`, `[core-only]`); the exact commands are in `CONTRIBUTING.md`. After a
+  `--no-dev` / lowest-resolution leg, restore the everyday env with
+  `uv sync --group dev --extra all`.
+- Docs (optional): `uv run --group docs mkdocs build --strict`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Sets up and documents the development environment for this Cloud Agent VM. The only repo change is a new `AGENTS.md` with a `## Cursor Cloud specific instructions` section; the reusable startup update script is configured separately via the VM environment setup.

## Startup update script

```
sudo apt-get update
sudo apt-get install -y unrar
npm install -g --prefix "$HOME/.local" @fission-ai/openspec
uv sync --group dev --extra all
```

All four steps are idempotent. `openspec` is installed into `~/.local` (on `PATH`) because `CLAUDE.md`'s bare global `npm install -g` fails with `EACCES` here.

## Verification

This is a pure library (no server/UI/CLI), so evidence is terminal output.

- ✅ `uv run --no-sync ruff check` — All checks passed
- ✅ `uv run --no-sync pyrefly check` — 0 errors
- ✅ `uv run --no-sync ty check` — All checks passed
- ✅ `uv run --no-sync pytest` — 711 passed, 7 skipped
- ✅ Hello-world: created a ZIP, detected its format, opened it, listed members, read a member, and safely extracted it via the public `archivey` API.

[hello_world_demo.log](https://cursor.com/agents/bc-43f4459c-00aa-40d7-aa82-107c67e2a8bf/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhello_world_demo.log)
[env_verification.log](https://cursor.com/agents/bc-43f4459c-00aa-40d7-aa82-107c67e2a8bf/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fenv_verification.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-43f4459c-00aa-40d7-aa82-107c67e2a8bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-43f4459c-00aa-40d7-aa82-107c67e2a8bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

