### PR TITLE
fix(zip): translate open-time errors (overlap zip-bomb guard, bad password) to ArchiveyError

### DIFF
--- a/src/archivey/internal/backends/zip_reader.py
+++ b/src/archivey/internal/backends/zip_reader.py
@@ -344,10 +344,23 @@ class ZipReader(BaseArchiveReader):
         # — and a duplicate member name can't resolve to the wrong entry.
         info = member._raw
         assert isinstance(info, zipfile.ZipInfo), "ZIP member is missing its ZipInfo handle"
-        raw = cast(
-            "BinaryIO",
-            self._archive.open(info, pwd=self._password),
-        )
+        # zipfile validates the local header when opening a member — the "Overlapped
+        # entries" zip-bomb guard, the name-mismatch check, a missing-password
+        # RuntimeError, and unsupported-compression NotImplementedError all fire here,
+        # before any byte flows through the ArchiveStream translator. Translate them at
+        # the source so callers only ever see ArchiveyErrors (a genuine OSError from the
+        # underlying source is not in the caught set, so it propagates unchanged).
+        try:
+            raw = cast(
+                "BinaryIO",
+                self._archive.open(info, pwd=self._password),
+            )
+        except (zipfile.BadZipFile, RuntimeError, io.UnsupportedOperation) as exc:
+            translated = self._translate_exception(exc)
+            if translated is not None:
+                self._stamp_error_context(translated, member.name)
+                raise translated from exc
+            raise
         return self._wrap_member_stream(raw, member.name, size=member.size)
 
     def _get_archive_info(self) -> ArchiveInfo:

--- a/tests/test_zip.py
+++ b/tests/test_zip.py
@@ -383,6 +383,66 @@ def test_corrupt_member_data_raises_corruption_on_read() -> None:
             ar.read("data.txt")
 
 
+def _overlapping_entries_zip() -> bytes:
+    """A Fifield-style overlap bomb: many central-directory entries whose data spans
+    overlap a single shared compressed kernel (https://www.bamsoftware.com/hacks/zipbomb/).
+
+    stdlib zipfile's "Overlapped entries (possible zip bomb)" guard fires when a member is
+    opened — before any byte flows through archivey's read-time translator — so this pins
+    that the *open-time* stdlib exception is translated to a CorruptionError like every
+    other backend error, rather than leaking as a raw zipfile.BadZipFile.
+    """
+    import zlib
+
+    n = 8
+    raw = b"\x00" * (1024 * 1024)
+    comp = zlib.compressobj(9, zlib.DEFLATED, -15)
+    blob = comp.compress(raw) + comp.flush()
+    crc, csize, usize = zlib.crc32(raw) & 0xFFFFFFFF, len(blob), len(raw)
+
+    buf = io.BytesIO()
+    names = [f"f{i}".encode() for i in range(n)]
+    offsets = []
+    for nm in names:  # adjacent local headers, each claiming the shared csize
+        offsets.append(buf.tell())
+        buf.write(
+            struct.pack(
+                "<IHHHHHIIIHH", 0x04034B50, 20, 0, 8, 0, 0, crc, csize, usize, len(nm), 0
+            )
+        )
+        buf.write(nm)
+    buf.write(blob)  # one shared kernel; every entry's data span overruns the next header
+
+    cd_start = buf.tell()
+    for nm, off in zip(names, offsets):
+        buf.write(
+            struct.pack(
+                "<IHHHHHHIIIHHHHHII",
+                0x02014B50, 20, 20, 0, 8, 0, 0, crc, csize, usize,
+                len(nm), 0, 0, 0, 0, 0, off,
+            )
+        )
+        buf.write(nm)
+    cd_size = buf.tell() - cd_start
+    buf.write(struct.pack("<IHHHHIIH", 0x06054B50, 0, 0, n, n, cd_size, cd_start, 0))
+    return buf.getvalue()
+
+
+def test_overlapping_entries_bomb_translated_to_corruption() -> None:
+    # The overlap guard is an open-time check, not a read-time one, so it exercises a path
+    # distinct from the CRC check above. Every overlapping member must surface as a
+    # translated CorruptionError carrying the stdlib BadZipFile as its cause.
+    data = _overlapping_entries_zip()
+    with open_archive(io.BytesIO(data)) as ar:
+        overlapping = [m for m in ar.members() if m.name != "f7"]  # last entry is valid
+        assert overlapping, "expected the crafted archive to list overlapping members"
+        for member in overlapping:
+            with pytest.raises(CorruptionError) as excinfo:
+                ar.read(member)
+            assert "Overlapped entries" in str(excinfo.value)
+            assert isinstance(excinfo.value.__cause__, zipfile.BadZipFile)
+
+
 # ---------------------------------------------------------------------------
 # Encrypted symlink targets and explicit metadata encoding
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What & why

While reviewing the library's zip-bomb resistance against Fifield's overlapping-entries construction (https://www.bamsoftware.com/hacks/zipbomb/), I found that the ZIP backend was the **only** reader that called its underlying library's `open()` without the translate+stamp wrapper every other backend (tar/iso/single-file) uses.

stdlib `zipfile.ZipFile.open()` validates the local file header **at open time** — before any byte flows through archivey's read-time `ArchiveStream` translator. That means several stdlib exceptions were leaking to callers as raw, untranslated exceptions instead of `ArchiveyError`s, breaking the exception-translation contract:

- **`BadZipFile("Overlapped entries ... (possible zip bomb)")`** — CPython's overlap guard, the direct defense against the paper's bomb. Leaked as a raw `zipfile.BadZipFile` from `open()`/`extract()`.
- `BadZipFile("File name in directory ... differ")` — the name-mismatch check.
- `RuntimeError("... password required ...")` / `"Bad password"` — encrypted member opened without / wrong password.
- `NotImplementedError("... compression method ...")` — unsupported compression.

## The fix

`zip_reader._open_member` now wraps `self._archive.open(...)` in the same translate+stamp path the other backends use, catching `(zipfile.BadZipFile, RuntimeError, io.UnsupportedOperation)` and routing them through the existing `_translate_exception` (which already maps these to `CorruptionError` / `EncryptionError` / `UnsupportedFeatureError` / `StreamNotSeekableError`). A genuine `OSError` from the underlying source is deliberately **not** in the caught set, so it still propagates unchanged.

Now an overlap bomb surfaces as a `CorruptionError` stamped with `archive=/member=/format=` context, from both `open()` and `extract()`.

## Note on defense-in-depth

The overlap guard itself lives in stdlib (present in all supported CPython ≥ 3.11); this change is about surfacing its verdict as a proper typed error. The **format-agnostic** backstop — the extraction `BombTracker` (per-member ratio, archive-wide static/live ratio, cumulative `max_extracted_bytes`) — remains the primary defense and already stops a plain non-overlapping deep-ratio bomb regardless of format.

## Tests

`tests/test_zip.py` gains `test_overlapping_entries_bomb_translated_to_corruption`, which crafts a Fifield-style overlap archive (adjacent tiny local headers over one shared compressed kernel) and asserts every overlapping member raises a translated `CorruptionError` carrying the stdlib `BadZipFile` as its `__cause__`. It runs in the zero-dep core leg too (stdlib `zipfile` only).

Green in all three dependency configurations (`[all]`, `[all-lowest]`, `[core-only]`); Pyrefly, ty, and ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hQi3WhKr3LnvViH9smD3j

---
_Generated by [Claude Code](https://claude.ai/code/session_018hQi3WhKr3LnvViH9smD3j)_