### PR TITLE
openspec: fold 2026-07 pre-Phase-5 review outcomes into the phase-5 change

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -197,7 +197,10 @@ resolve to an **earlier** member (the TAR model), so they resolve in a single fo
 def open(self, member: str | ArchiveMember,
          _seen: frozenset[int] = frozenset()) -> BinaryIO:
     if isinstance(member, str):
-        member = self[member]
+        found = self.get(member)  # name lookup — there is no __getitem__ on the reader
+        if found is None:
+            raise KeyError(f"Member {member!r} not found")
+        member = found
     if member.type in (MemberType.SYMLINK, MemberType.HARDLINK) and member.link_target:
         if member.member_id in _seen:
             raise ReadError(f"Link cycle detected at '{member.name}'")

--- a/openspec/changes/phase-5-public-api/design.md
+++ b/openspec/changes/phase-5-public-api/design.md
@@ -34,17 +34,34 @@ them.
 ### 1. Password: single value | sequence | provider callable
 
 `password: str | bytes | Sequence[str | bytes] | PasswordProvider | None` where
-`PasswordProvider = Callable[[ArchiveMember | None], str | bytes | None]`.
+
+```python
+@dataclass(frozen=True)
+class PasswordRequest:
+    member: ArchiveMember | None  # the member being decrypted; None for archive-level
+                                  # (header) decryption, where no member exists yet
+    attempt: int                  # 1 on the first ask for this unit; increments when a
+                                  # previously returned password failed for it
+
+PasswordProvider = Callable[[PasswordRequest], str | bytes | None]
+```
 
 - **Per encrypted unit** (a 7z folder, a RAR/ZIP member, an encrypted header), the
   reader tries the per-archive **known-good list** first (passwords that already
   succeeded, most-recent first), then remaining sequence candidates, then — if a
-  provider was given — calls it, passing the `ArchiveMember` being decrypted (`None`
-  for archive-level/header decryption, where no member exists yet) so interactive UIs
-  can show what is being asked about. A provider may be called repeatedly for the same
-  unit until it returns `None` (= give up → `EncryptionError`). Every success is
-  appended to the known-good list for the rest of the operation, so a provider is asked
-  once per *new* password, not once per member.
+  provider was given — calls it with a `PasswordRequest` so interactive UIs can show
+  what is being asked about *and* whether this is a retry. A provider may be called
+  repeatedly for the same unit (with `attempt` incrementing) until it returns `None`
+  (= give up → `EncryptionError`). Every success is appended to the known-good list for
+  the rest of the operation, so a provider is asked once per *new* password, not once
+  per member.
+- **Why a context object, not a bare member:** a callable's signature cannot be widened
+  compatibly after the freeze — every future need (attempt count, the prior error, the
+  encryption algorithm) would be a breaking change. The frozen dataclass costs one
+  import now and makes those additions non-breaking. The `attempt` field exists from
+  day one because "may be called repeatedly until it returns `None`" *invites* retry
+  loops, and a UI that cannot distinguish first-ask from wrong-password is broken in an
+  obvious, immediately-visible way.
 - **Why not per-call `open(member, password=...)`:** it forces random access — a
   streaming pass over a multi-password 7z could not supply the second password without
   aborting the pass. The candidate list + provider covers both random and streaming
@@ -81,10 +98,13 @@ them.
 ```python
 @dataclass(frozen=True)
 class ExtractionLimits:
-    max_extracted_bytes: int = 2 * 2**30
-    max_ratio: float = 1000.0
+    # None disables that guard; the UNLIMITED preset is all-None.
+    max_extracted_bytes: int | None = 2 * 2**30
+    max_ratio: float | None = 1000.0
     ratio_activation_threshold: int = 5 * 2**20
-    max_entries: int = 1_048_576
+    max_entries: int | None = 1_048_576
+
+    UNLIMITED: ClassVar["ExtractionLimits"]  # every guard disabled (trusted archives)
 
 @dataclass(frozen=True)
 class ArchiveyConfig:
@@ -97,6 +117,25 @@ class ArchiveyConfig:
 - Passed explicitly: `open_archive(..., config=None)` (None → module default constant),
   `extract(..., config=None)`. The reader carries its config; `extract_all()` inherits
   the reader's unless overridden.
+- **Per-call limits override:** `extract()` and `extract_all()` additionally accept
+  `limits: ExtractionLimits | None = None`. Precedence: per-call `limits` >
+  `config.extraction_limits` > library default. Rationale: the bomb limits are the one
+  config field callers legitimately vary *per call* ("tighter cap for this untrusted
+  upload, defaults for our own archives"); forcing a `replace()`d config per call would
+  make the security-relevant knob the least ergonomic one. This replaces the four loose
+  Phase-4b kwargs (`max_extracted_bytes`/`max_ratio`/`ratio_activation_threshold`/
+  `max_entries`) — one structured type, two supply points, no parallel surface.
+- **Presets:** `ExtractionLimits()` (the defaults) is the untrusted posture —
+  safe-by-default already serves that case — and `ExtractionLimits.UNLIMITED` disables
+  all four guards for explicitly trusted archives. Presets are deliberately **not**
+  named by trust (`TRUSTED`/`UNTRUSTED`) and **not** coupled to `ExtractionPolicy`:
+  policy governs metadata/permission semantics, limits govern resource bounds, and an
+  implicit coupling (e.g. `policy=TRUSTED` silently lifting bomb guards) would be a
+  footgun in the dangerous direction. The trusted-archive recipe is two explicit
+  decisions — `extract(src, dest, policy=ExtractionPolicy.TRUSTED,
+  limits=ExtractionLimits.UNLIMITED)` — documented in SPEC.md rather than encoded. A
+  `SecurityConfig` sub-config / umbrella `trust=` convenience was considered and
+  deferred post-v1: a convenience can be added compatibly, unbundling one cannot.
 - **Why not contextvars (DEV's approach):** ambient config makes behavior depend on
   call-site-invisible state — hard to trace in applications embedding archivey, and
   interacts confusingly with threads/executors (a worker thread silently misses the
@@ -138,6 +177,55 @@ garbage later; TAR is just the first implementation.)
   a selector answers "should this member be included", and silently dropping earlier
   duplicates would surprise both streaming consumers and extraction, where writing all
   duplicates is what sequential extraction does anyway.)
+
+### 6. Link resolution: positional hardlinks, last-wins symlinks, member-id cycles
+
+The two access modes currently disagree on duplicate names. Streaming
+(`_register_progressively`) resolves links against an *incremental* name map — a
+hardlink finds the latest **earlier** occurrence. Random access (`_resolve_link`)
+resolves against one *last-wins* map built from all members — a hardlink can resolve
+**forward**, and with duplicate names resolves to the **last occurrence overall**.
+Concretely, for `[A.txt(content1), hardlink L→A.txt, A.txt(content2)]`: real tar
+extraction gives `L` content1 (it links against what is on disk when `L` is written);
+v2 streaming agrees; v2 random access returns content2 from `read(L)` and links `L`
+against the content2 inode. Same archive, different answers by mode.
+
+Decided semantics (both modes, one story):
+
+- **Hardlinks resolve positionally**: the latest occurrence **strictly before** the
+  link (filesystem-faithful — every real tar writer stores the data-bearing entry
+  before its link entries, since hardlinks are detected by inode during archiving;
+  RAR5's redirect model is the same). Implementation: `_resolve_link` walks members in
+  order with an incremental map, as the streaming path already does.
+- **Forward fallback kept in random-access mode**: when no earlier occurrence exists
+  (a crafted / reordered archive), fall back to a later member rather than failing —
+  extraction's orphan second pass already recovers this case gracefully (links against
+  the source once written, bytes bomb-counted once; PR #33's regression test), and
+  that behavior depends on `link_target_member` being set. Strictly-backward-only
+  would regress it. Streaming inherently cannot resolve forward and already fails per
+  `OnError` — an acceptable, documented asymmetry.
+- **Symlinks keep last-wins overall** (random access): a symlink is a *name* resolved
+  at use time, and the final extracted state of a duplicated name is the last
+  occurrence — so the full-map resolution is already correct. Streaming resolves to
+  the latest earlier occurrence because a single pass cannot see forward; documented,
+  not fought.
+- **Cycle detection tracks member ids**, not names, in both `_resolve_link` and
+  `_open_with_link_follow`: name-based visited-sets false-positive on chains passing
+  through distinct same-named members. The raised error's message must say "cycle"
+  (today's `LinkTargetNotFoundError` subclasses `ReadError`, so the spec scenario is
+  technically met, but the message misleads).
+- **Spec wording softened** (`archive-reading`): "hardlinks SHALL always resolve to an
+  earlier member" becomes "resolve to the most recent earlier member; an archive where
+  the source appears only later is malformed but tolerated — random access falls back
+  to the later member, streaming fails per `OnError`."
+
+## Open questions (maintainer decisions, tracked in proposal.md)
+
+1. `max_entries` counting semantics — selector-skips don't count today, filter-skips
+   do; recommendation: count only members actually written.
+2. ZIP `format_availability` reports the intended post-Phase-7 composition, not
+   current read capability; recommendation: report current truth (`PARTIAL` + note)
+   until the Phase 7 codec bypass lands.
 
 ## Risks / Trade-offs
 

--- a/openspec/changes/phase-5-public-api/proposal.md
+++ b/openspec/changes/phase-5-public-api/proposal.md
@@ -15,13 +15,16 @@ per the maintainer decisions from the 2026-07 whole-codebase review.
 
 - **Passwords become multi-candidate** (`archive-reading`): `password` accepts a single
   value, a **sequence** of candidates, or a **provider callable**
-  (`Callable[[ArchiveMember | None], str | bytes | None]`) that is invoked per encrypted
-  unit — receiving the member so a UI can show what is being asked about, or `None` for
-  archive-level (header) decryption. Candidates that succeed join a per-archive
-  known-good list tried first for later units, keeping single-pass streaming viable for
-  archives whose folders/members use different passwords (7z has no cheap password
-  check, so candidate order matters; RAR5/ZIP validate cheaply). Provider returning
-  `None` → `EncryptionError`.
+  (`Callable[[PasswordRequest], str | bytes | None]`) invoked per encrypted unit.
+  `PasswordRequest` is a small frozen context object carrying the `ArchiveMember` being
+  decrypted (`None` for archive-level/header decryption) and the `attempt` count for the
+  unit, so an interactive UI can distinguish a first ask from a wrong-password retry —
+  and the shape can grow (e.g. a `prior_error` field) without breaking the callable
+  signature, which a bare-member parameter could not. Candidates that succeed join a
+  per-archive known-good list tried first for later units, keeping single-pass streaming
+  viable for archives whose folders/members use different passwords (7z has no cheap
+  password check, so candidate order matters; RAR5/ZIP validate cheaply). Provider
+  returning `None` → `EncryptionError`.
 - **Multi-source input is implemented** (`archive-reading`, already specced):
   `open_archive()` accepts `Sequence[str | Path | BinaryIO]` as the explicit ordered
   volume list, and single-path volume-set **auto-discovery** (a path matching a volume
@@ -41,10 +44,36 @@ per the maintainer decisions from the 2026-07 whole-codebase review.
   tuning/policy knobs that rarely vary per call. No contextvars and no mutable global in
   v1 (decided: DEV's ambient-config approach traded traceability for convenience);
   a process-wide default stays possible to add later without breaking.
+- **Extraction limits get a per-call override** (`safe-extraction`): the four loose
+  bomb-limit kwargs on `extract()` / `extract_all()` are **removed**, replaced by a
+  single structured `limits: ExtractionLimits | None = None` keyword. Precedence:
+  per-call `limits` > `config.extraction_limits` > library default — the config is the
+  app-wide home, the kwarg the per-call escape hatch ("tighter cap for this untrusted
+  upload"), mirroring the existing "extract_all inherits the reader's config unless
+  overridden" rule. An `ExtractionLimits.UNLIMITED` preset disables all four guards
+  for explicitly trusted archives. Presets are deliberately **not** named by trust and
+  **not** coupled to `ExtractionPolicy` (see design.md).
 - **`strict_eof` moves into the config** (default **False** — see design.md for the
   rationale) and is renamed `strict_archive_eof` (format-agnostic: TAR trailer today,
   applicable to ZIP trailing-junk / gzip trailing-garbage checks later). **BREAKING**
   for the Phase 4 stopgap keyword (pre-1.0; the bare `strict_eof=` kwarg is removed).
+  A `format-tar` delta renames the spec's `strict_eof` references accordingly.
+- **`extract()` reaches parity with `open_archive()`** (`safe-extraction`): its
+  `source` union widens to the same `Sequence[...]` multi-volume form (it merely
+  delegates to `open_archive`, so a divergent signature would be an arbitrary freeze),
+  and it gains the `encoding` keyword (needed for one-shot extraction of TAR/ZIP with
+  non-UTF-8 member names).
+- **Link resolution is made positional** (`archive-reading`): hardlinks resolve to the
+  **latest occurrence at or before the link** (falling back to a later member only when
+  no earlier one exists — the crafted/reordered-archive case extraction already
+  recovers); symlinks keep resolving to the **last occurrence overall** (the final
+  on-disk state). This makes streaming and random-access modes agree on duplicate
+  names. Link-chain cycle detection tracks **member ids**, not names (name-based
+  tracking false-positives on chains through distinct same-named members).
+- **Public exports finalized**: `ArchiveyConfig`, `ExtractionLimits`, `PasswordRequest`
+  / `PasswordProvider`, and the callback aliases used in public signatures
+  (`MemberSelector`, `MemberFilter`) are exported from the top-level `archivey`
+  namespace.
 - **`MemberSelector` collection form is implemented** (`archive-reading`): a
   `Collection[str | ArchiveMember]` selects by **name match — every duplicate with that
   name — or by member identity** for `ArchiveMember` entries (matched via
@@ -62,14 +91,19 @@ _None — this change finalizes existing capabilities._
 
 ### Modified Capabilities
 
-- `archive-reading`: password sequence/provider model; multi-source
+- `archive-reading`: password sequence/provider model (`PasswordRequest`); multi-source
   discovery/rejection details; `ArchiveyConfig` / `ExtractionLimits` definition and the
   `config=` parameter; `MemberSelector` collection semantics; `strict_eof` →
-  `config.strict_archive_eof`.
-- `safe-extraction`: `extract()`/`extract_all()` gain `config=`; the bomb-limit
-  requirements reference `ExtractionLimits` (defaults unchanged); results-list
-  accumulation documented as unconditional for v1 (a no-tracking mode interacts with
-  the readers' internal member caching and is deferred — see design.md).
+  `config.strict_archive_eof`; positional link resolution + member-id cycle detection
+  (the "Transparent link following" requirement is modified).
+- `safe-extraction`: `extract()`/`extract_all()` gain `config=` and the per-call
+  `limits=` override (the four loose bomb-limit kwargs are removed); `extract()`'s
+  `source` union widens and it gains `encoding`; the bomb-limit requirements reference
+  `ExtractionLimits` (defaults unchanged); results-list accumulation documented as
+  unconditional for v1 (a no-tracking mode interacts with the readers' internal member
+  caching and is deferred — see design.md).
+- `format-tar`: the truncation-detection requirement's `strict_eof` references are
+  renamed to `config.strict_archive_eof` (no behavior change beyond the relocation).
 - `format-7z`: the per-call-password phrasing is replaced by the
   candidate-list/provider model (no separate `open(member, password=...)` parameter).
   (`format-rar`'s password wording already fits the model; no delta needed.)
@@ -77,14 +111,41 @@ _None — this change finalizes existing capabilities._
   streams, seekable streams — is implemented and recorded in the in-flight
   `phase-4-safe-extraction` delta, not here.)
 
+## Open decisions (maintainer input needed before the freeze)
+
+Two items surfaced by the 2026-07 pre-Phase-5 reviews are deliberately **not** decided
+by this change; they need an explicit maintainer call (per the pause-and-ask rule):
+
+1. **`max_entries` counting semantics.** Today the count is inconsistent: members
+   excluded by the `members` selector are skipped *before* `BombTracker.start_member()`
+   and never count, while members skipped by the user `filter` count (the tracker runs
+   first). The safe-extraction spec's "every member counts" matches neither exactly.
+   **Recommendation:** count only members that will actually be written (move
+   `start_member` after the filter) — the guard's stated rationale is filesystem/inode
+   exhaustion, and a skipped member creates nothing on disk. Either way the spec and
+   the two exclusion paths must be made to agree.
+2. **ZIP `format_availability` vs. actual read capability.** The availability table
+   describes the intended post-Phase-7 composition (`registry.py` documents this):
+   with the deflate64/ppmd packages installed ZIP reports `FULL`, yet member reads
+   still go through stdlib `zipfile` and fail with `UnsupportedFeatureError`; without
+   them, `PARTIAL`'s install hint suggests an extra that does not actually unlock the
+   reads until Phase 7. Options: report `PARTIAL` (with a note) until the Phase 7
+   codec bypass lands, add read-capability granularity, or keep the forward-looking
+   report and document the gap. **Recommendation:** report current truth (`PARTIAL` +
+   spec note), but this is a judgment call on how availability should be defined.
+
 ## Impact
 
 - `archivey.open_archive()` / `archivey.extract()` signatures (password type widens;
-  `config=` added; `strict_eof=` removed; `source` union widens).
+  `config=` added; `strict_eof=` removed; `source` union widens on **both**;
+  `extract()` gains `encoding`; `extract()`/`extract_all()` gain `limits=` and lose
+  the four loose bomb-limit kwargs).
 - `archivey/internal/config.py`: `StreamConfig` folds into the public `ArchiveyConfig`
   (internal plumbing keeps a derived view).
 - `BaseArchiveReader`: selector normalization for the collection form; password
-  candidate/known-good bookkeeping helper for Phase 7 backends.
+  candidate/known-good bookkeeping helper for Phase 7 backends; `_resolve_link` /
+  `_open_with_link_follow` reworked for positional hardlink resolution and member-id
+  cycle detection (`__init__.py` exports grow accordingly).
 - Phase 7 consumes: multi-volume entry paths, the password model, and (already landed)
   the generalized `compressed_source_size`.
 - Docs: `SPEC.md` §2 signature blocks updated to match.

--- a/openspec/changes/phase-5-public-api/specs/archive-reading/spec.md
+++ b/openspec/changes/phase-5-public-api/specs/archive-reading/spec.md
@@ -49,6 +49,119 @@ Phase 4 `strict_eof` keyword is removed — end-of-archive strictness lives at
 - **WHEN** `archivey.open_archive(source, password="secret")` is called
 - **THEN** the returned `ArchiveReader` uses the provided password for encrypted members
 
+### Requirement: Transparent link following
+
+The system SHALL transparently follow symlinks and hardlinks in `open()` and `read()`. If `member.type` is `SYMLINK` or `HARDLINK`, the call is redirected to the target member. This behavior is format-independent and is implemented once in the `ArchiveReader` ABC. The resolved target, when known, is also exposed as `member.link_target_member`.
+
+**Hardlinks resolve positionally**: the target is the most recent occurrence of the
+target name **strictly before** the link in archive order (this is the TAR model — every
+real tar writer stores the data-bearing entry before the link entries that reference it,
+because hardlinks are detected by inode during archiving; RAR5's redirect model is the
+same). With duplicate names this matches what a sequential extraction would link
+against on disk at the moment the link is written. An archive whose hardlink source
+appears **only later** in archive order is malformed but tolerated: in random-access
+mode resolution falls back to the later member (and extraction recovers it — see
+`format-tar`'s orphan second pass); in streaming mode a forward-pointing hardlink
+cannot be resolved in a single pass and fails per `OnError`.
+
+**Symlinks resolve to the last occurrence overall** of the target name (random-access
+mode): a symlink is a *name*, resolved at use time, and the final on-disk state of a
+duplicated name after sequential extraction is its last occurrence. In streaming mode a
+symlink can only resolve to the latest occurrence seen so far; a forward-pointing
+symlink stays unresolved (`link_target_member` is `None`). The two modes SHALL agree on
+hardlink resolution for the same archive; the symlink forward-visibility difference is
+inherent to a single pass and is documented.
+
+**Target-name resolution.** The stored target string is resolved to an archive-namespace
+member name before lookup, because the two link kinds store targets in different
+namespaces: a **hardlink** target is archive-relative from the root (the linkname is the
+source member's own stored path) and is normalized as-is, while a **symlink** target is
+a filesystem path relative to the link's *own directory* (`dir/link -> file` means
+`dir/file`) and is joined to that directory first. An absolute symlink target, or one
+that `..`-escapes the archive root, cannot name a member — it stays unresolved
+(`link_target_member` is `None`; opening through it raises `LinkTargetNotFoundError`).
+Directory members carry a trailing `/` in their normalized names, so target lookup tries
+both the bare and the `/`-suffixed form.
+
+If the link target is not present in the archive, `LinkTargetNotFoundError` (a
+`ReadError`/member error) SHALL be raised. Chains SHALL be followed recursively with
+**cycle detection** — the set of **member ids** already visited on the current chain is
+tracked, and if a member is revisited the library raises a `ReadError` whose message
+reports the cycle. Tracking is by member id, never by name: a chain passing through two
+*distinct* members that share a name is not a cycle, and a name-based visited set would
+falsely report one. There is no fixed depth limit; an acyclic chain of any length
+resolves, and only an actual cycle (or a missing target) fails.
+
+```python
+# ABC implementation (ARCHITECTURE.md §2.3)
+def open(self, member: str | ArchiveMember, _seen: frozenset[int] = frozenset()) -> BinaryIO:
+    if isinstance(member, str):
+        found = self.get(member)  # name lookup — there is no __getitem__ on the reader
+        if found is None:
+            raise KeyError(f"Member {member!r} not found")
+        member = found
+    if member.type in (MemberType.SYMLINK, MemberType.HARDLINK) and member.link_target:
+        if member.member_id in _seen:
+            raise ReadError(f"Link cycle detected at '{member.name}'")
+        target = member.link_target_member or self.get(member.link_target)
+        if target is None:
+            raise LinkTargetNotFoundError(f"Link target '{member.link_target}' not in archive")
+        return self.open(target, _seen=_seen | {member.member_id})
+    return self._open_member(member)
+```
+
+This does not rely on format-level link resolution; format-level resolution (e.g. a RAR5 reader following hardlinks internally) happens at a lower level.
+
+#### Scenario: reading via a symlink member
+
+- **WHEN** `ar.read("data/latest")` is called and `"data/latest"` is a `SYMLINK` pointing to `"data/v1.0/report.txt"`
+- **THEN** the content of `"data/v1.0/report.txt"` is returned transparently
+
+#### Scenario: relative symlink target resolves against the link's directory
+
+- **WHEN** member `"dir/link"` is a `SYMLINK` whose stored target is `"file"` and the archive contains both `"dir/file"` and a root-level `"file"`
+- **THEN** `ar.read("dir/link")` returns the content of `"dir/file"` (not the root-level `"file"`), and `member.link_target_member` points at `"dir/file"`
+
+#### Scenario: absolute symlink target stays unresolved
+
+- **WHEN** a `SYMLINK` member's stored target is absolute (e.g. `"/etc/passwd"`)
+- **THEN** `member.link_target_member` is `None` and `ar.open()` on it raises `LinkTargetNotFoundError`
+
+#### Scenario: hardlink resolves to an earlier member
+
+- **WHEN** a `HARDLINK` member is read and its target is an earlier member in archive order
+- **THEN** the earlier member's content is returned, resolved in a single forward pass
+
+#### Scenario: duplicate names — hardlink links to the latest earlier occurrence
+
+- **WHEN** an archive contains `A.txt` (content1), then a `HARDLINK` `L → A.txt`, then a second `A.txt` (content2)
+- **THEN** `ar.read("L")` returns content1 in **both** access modes, and extraction links `L` against the content1 inode — matching what a sequential extraction leaves on disk
+
+#### Scenario: duplicate names — symlink resolves to the last occurrence
+
+- **WHEN** an archive contains `A.txt` (content1), a `SYMLINK` `S → A.txt`, then a second `A.txt` (content2), opened in random-access mode
+- **THEN** `S.link_target_member` points at the second `A.txt` (the final on-disk state of that name)
+
+#### Scenario: hardlink source only appears later (malformed archive)
+
+- **WHEN** a `HARDLINK` precedes its source in archive order and the archive is opened in random-access mode
+- **THEN** the link resolves to the later member and `ar.read()` on it returns that content; in streaming mode the same link fails per `OnError` (a single pass cannot see forward)
+
+#### Scenario: link target not in archive
+
+- **WHEN** `ar.open(link_member)` is called and `link_member.link_target` is absent from the archive
+- **THEN** `LinkTargetNotFoundError` is raised
+
+#### Scenario: link cycle detected
+
+- **WHEN** following a link chain revisits a member (by member id) already seen on that chain
+- **THEN** `ReadError` is raised with a message reporting the cycle (no fixed depth limit is used; only genuine cycles fail)
+
+#### Scenario: same-named members on one chain are not a false cycle
+
+- **WHEN** a link chain passes through two distinct members that share a normalized name
+- **THEN** the chain resolves normally — cycle detection tracks member ids, so the shared name does not trigger a spurious cycle error
+
 ## ADDED Requirements
 
 ### Requirement: Password candidates and provider
@@ -56,21 +169,34 @@ Phase 4 `strict_eof` keyword is removed — end-of-archive strictness lives at
 `password` SHALL accept, besides a single `str | bytes` value:
 
 - an **ordered sequence** of candidate values, and/or
-- a **provider callable** `PasswordProvider = Callable[[ArchiveMember | None], str | bytes | None]`.
+- a **provider callable** `PasswordProvider = Callable[[PasswordRequest], str | bytes | None]`, where
+
+```python
+@dataclass(frozen=True)
+class PasswordRequest:
+    member: ArchiveMember | None  # the member being decrypted; None for archive-level
+                                  # (header) decryption, where no member exists yet
+    attempt: int                  # 1 on the first ask for this unit; increments when a
+                                  # previously returned password failed for it
+```
 
 For each encrypted unit (an encrypted member, a 7z folder, or an encrypted archive
 header), the reader SHALL try, in order: the per-archive **known-good list** (passwords
 that already succeeded during this open, most recent first), then the remaining sequence
 candidates, then — when a provider is given — the provider, repeatedly, until it returns
-`None`. The provider receives the `ArchiveMember` being decrypted so an interactive
-caller can present which entry is being asked about, or `None` when decryption is
-archive-level (a header-encrypted 7z/RAR5, where no member exists yet). Every password
-that succeeds SHALL be added to the known-good list for the remainder of the operation,
-so a provider is consulted once per *new* password rather than once per member, and a
-single forward streaming pass stays viable on archives whose members use different
-passwords. When all candidates are exhausted (or the provider returns `None`) for a unit
-that needs one, the reader SHALL raise `EncryptionError`. There is no per-call password
-parameter on `open()`/`read()` — the candidate model subsumes it.
+`None`. The provider receives a `PasswordRequest` carrying the `ArchiveMember` being
+decrypted (so an interactive caller can present which entry is being asked about, or
+`None` for archive-level decryption — a header-encrypted 7z/RAR5, where no member exists
+yet) and the `attempt` count for the unit (so a retry after a wrong password is
+distinguishable from a first ask). The context object exists so future fields (e.g. the
+prior error) can be added without breaking provider implementations — a bare callable
+parameter could not be widened compatibly. Every password that succeeds SHALL be added
+to the known-good list for the remainder of the operation, so a provider is consulted
+once per *new* password rather than once per member, and a single forward streaming pass
+stays viable on archives whose members use different passwords. When all candidates are
+exhausted (or the provider returns `None`) for a unit that needs one, the reader SHALL
+raise `EncryptionError`. There is no per-call password parameter on `open()`/`read()` —
+the candidate model subsumes it.
 
 #### Scenario: sequence of candidates across differently-encrypted members
 
@@ -80,17 +206,22 @@ parameter on `open()`/`read()` — the candidate model subsumes it.
 #### Scenario: provider is consulted and its answer is reused
 
 - **WHEN** a provider callable is given and a member needs a password not yet known
-- **THEN** the provider is called with that `ArchiveMember`; a returned password that succeeds is added to the known-good list and later members encrypted with it do not trigger further provider calls
+- **THEN** the provider is called with a `PasswordRequest` carrying that `ArchiveMember`; a returned password that succeeds is added to the known-good list and later members encrypted with it do not trigger further provider calls
+
+#### Scenario: provider sees the retry count
+
+- **WHEN** a provider's returned password fails to decrypt the unit and the provider is consulted again
+- **THEN** the new `PasswordRequest` carries an incremented `attempt`, so an interactive caller can display "wrong password, try again"
 
 #### Scenario: provider gives up
 
 - **WHEN** the provider returns `None` for a unit no known candidate decrypts
 - **THEN** `EncryptionError` is raised for that unit
 
-#### Scenario: header decryption passes None to the provider
+#### Scenario: header decryption passes a memberless request
 
 - **WHEN** a header-encrypted archive is opened with only a provider and the header must be decrypted to list members
-- **THEN** the provider is called with `None` (no member exists yet)
+- **THEN** the provider is called with a `PasswordRequest` whose `member` is `None` (no member exists yet)
 
 ### Requirement: Explicit configuration object
 
@@ -101,10 +232,13 @@ tuning/policy knobs, passed explicitly as `config=` to `open_archive()` and
 ```python
 @dataclass(frozen=True)
 class ExtractionLimits:
-    max_extracted_bytes: int = 2 * 2**30
-    max_ratio: float = 1000.0
+    # None disables that guard; the UNLIMITED preset is all-None.
+    max_extracted_bytes: int | None = 2 * 2**30
+    max_ratio: float | None = 1000.0
     ratio_activation_threshold: int = 5 * 2**20
-    max_entries: int = 1_048_576
+    max_entries: int | None = 1_048_576
+
+    UNLIMITED: ClassVar["ExtractionLimits"]  # every guard disabled (trusted archives)
 
 @dataclass(frozen=True)
 class ArchiveyConfig:
@@ -115,7 +249,11 @@ class ArchiveyConfig:
 ```
 
 A reader carries the config it was opened with; `extract_all()` uses the reader's
-config unless the call overrides it. Configuration is **explicit only**: the library
+config unless the call overrides it. The extraction limits are additionally overridable
+per call via `limits: ExtractionLimits | None` on `extract()`/`extract_all()`
+(precedence: per-call `limits` > `config.extraction_limits` > library default; the
+`ExtractionLimits.UNLIMITED` preset disables all four guards — see `safe-extraction`).
+Configuration is **explicit only**: the library
 SHALL NOT read ambient state (no context variables, no mutable global default) to
 resolve configuration. Per-call operational arguments — `format`, `streaming`,
 `password`, `encoding`, and extraction's `members`/`filter`/`policy`/`overwrite`/

--- a/openspec/changes/phase-5-public-api/specs/format-tar/spec.md
+++ b/openspec/changes/phase-5-public-api/specs/format-tar/spec.md
@@ -1,0 +1,32 @@
+# format-tar — Phase 5 deltas
+
+## MODIFIED Requirements
+
+### Requirement: Detect truncated TAR archives
+
+The system SHALL verify archive integrity at the end of iteration by checking for valid end-of-archive markers.
+
+After iterating all members, the system verifies that the final 512-byte block(s) are null-filled end-of-archive markers. Strictness is configured by `ArchiveyConfig.strict_archive_eof` (see `archive-reading`; the Phase 4 `open_archive(strict_eof=)` keyword is removed). If the markers are absent:
+
+- By default (`config.strict_archive_eof=False`): emit a `logging.WARNING` via the `archivey.backends.*` logger.
+- When `config.strict_archive_eof=True`: raise `TruncatedError`.
+
+#### Scenario: Valid TAR end-of-archive markers present
+
+- **WHEN** all TAR members have been iterated
+- **AND** the archive ends with null-filled 512-byte end-of-archive block(s)
+- **THEN** no warning or error is emitted
+
+#### Scenario: Missing end-of-archive markers, default mode
+
+- **WHEN** all TAR members have been iterated
+- **AND** the archive does not end with valid null-filled end-of-archive block(s)
+- **AND** `config.strict_archive_eof` is `False` (the default)
+- **THEN** the system emits a `logging.WARNING` indicating the archive may be truncated
+
+#### Scenario: Missing end-of-archive markers, strict mode
+
+- **WHEN** all TAR members have been iterated
+- **AND** the archive does not end with valid null-filled end-of-archive block(s)
+- **AND** `config.strict_archive_eof` is `True`
+- **THEN** the system raises `TruncatedError`

--- a/openspec/changes/phase-5-public-api/specs/safe-extraction/spec.md
+++ b/openspec/changes/phase-5-public-api/specs/safe-extraction/spec.md
@@ -1,5 +1,103 @@
 # safe-extraction — Phase 5 deltas
 
+## MODIFIED Requirements
+
+### Requirement: One-Shot Extraction API
+
+The system SHALL expose a top-level `archivey.extract()` function that opens an archive, applies safety checks, and writes **all** members to a destination directory in a single call. It deliberately has **no** member-selection parameter: selecting a subset requires the member list, which would force the caller to open the archive first and reopen it here — an anti-pattern. Subset extraction is done through `ArchiveReader.extract_all(members=..., filter=...)` on an already-open reader.
+
+```python
+archivey.extract(
+    source: str | Path | BinaryIO | Sequence[str | Path | BinaryIO],
+    dest: str | Path,
+    *,
+    policy: ExtractionPolicy = ExtractionPolicy.STRICT,
+    overwrite: OverwritePolicy = OverwritePolicy.ERROR,
+    on_error: OnError = OnError.STOP,
+    format: ArchiveFormat | None = None,
+    password: str | bytes | Sequence[str | bytes] | PasswordProvider | None = None,
+    encoding: str | None = None,
+    on_progress: Callable[[ExtractionProgress], None] | None = None,
+    config: ArchiveyConfig | None = None,
+    limits: ExtractionLimits | None = None,
+) -> list[ExtractionResult]
+```
+
+The function delegates to `open_archive()`, so its `source`, `password`, and `encoding`
+parameters carry exactly the `open_archive()` semantics (see `archive-reading`): `source`
+MAY be an ordered sequence forming a multi-volume archive, `password` accepts the
+candidate/provider model, and `encoding` overrides member-name decoding for formats that
+record none. The four loose bomb-limit keywords of the Phase 4b signature
+(`max_extracted_bytes`, `max_ratio`, `ratio_activation_threshold`, `max_entries`) are
+**removed**; the limits travel in `config.extraction_limits` or the per-call `limits`
+override (see the configuration requirement below).
+
+The default policy is `ExtractionPolicy.STRICT` and the default overwrite behaviour is `OverwritePolicy.ERROR`.
+
+#### Scenario: extract all members from an untrusted archive
+
+- **WHEN** `archivey.extract("untrusted.zip", "/safe/output/")` is called with no other arguments
+- **THEN** all members are extracted to `/safe/output/` under `ExtractionPolicy.STRICT` and `OverwritePolicy.ERROR`
+- **AND** a `list[ExtractionResult]` describing each member's outcome is returned
+
+#### Scenario: subset extraction goes through an open reader
+
+- **WHEN** a caller wants only some members
+- **THEN** they open the archive and call `reader.extract_all(dest, members=...)` rather than passing members to the top-level function (which would require reopening)
+
+#### Scenario: one-shot extraction of a non-UTF-8-named archive
+
+- **WHEN** `archivey.extract(src, dest, encoding="cp932")` is called on a TAR whose member names are CP932-encoded
+- **THEN** the members land on disk under their correctly decoded names, identical to `open_archive(src, encoding="cp932")` + `extract_all(dest)`
+
+### Requirement: Per-Reader Extract-All Helper
+
+The system SHALL provide a single `extract_all()` instance method on `ArchiveReader` that delegates to the same extraction internals as `archivey.extract()`. There is **no** single-member `reader.extract()`: extracting one file is expressed as `extract_all(members=[name])`, which is also strictly better for solid archives (selecting a set of files costs one pass, whereas one-at-a-time extraction would re-decompress per file).
+
+```python
+class ArchiveReader:
+    def extract_all(
+        self,
+        dest: str | Path,
+        *,
+        members: MemberSelector | None = None,  # names/members or predicate; None = all
+        filter: MemberFilter | None = None,      # per-member sanitize/rename; None to skip a member
+        policy: ExtractionPolicy = ExtractionPolicy.STRICT,
+        overwrite: OverwritePolicy = OverwritePolicy.ERROR,
+        on_error: OnError = OnError.STOP,
+        on_progress: Callable[[ExtractionProgress], None] | None = None,
+        config: ArchiveyConfig | None = None,    # None = the reader's own config
+        limits: ExtractionLimits | None = None,  # per-call bomb-limit override
+    ) -> list[ExtractionResult]: ...
+```
+
+`members` selects which members to extract (a collection of names/`ArchiveMember`s, or a
+`Callable[[ArchiveMember], bool]` predicate); `None` extracts all. In the collection form a
+`str` entry matches **every** member with that name (duplicates included), while an
+`ArchiveMember` entry matches only that exact member, by object identity — so with duplicate
+names the caller can select one specific occurrence (the same semantics the Phase 5
+`MemberSelector` collection form specifies). `filter` runs **after**
+the universal safety checks and the `policy` transform, letting the caller rename or
+further sanitize each member (returning a `.replace()`d copy) or skip it (returning
+`None`). `policy` and `overwrite` carry the same meaning as on the top-level function.
+`config` defaults to the config the reader was opened with; `limits` overrides its
+`extraction_limits` for this call only (see the configuration requirement below).
+
+#### Scenario: extract all via reader
+
+- **WHEN** `reader.extract_all(dest)` is called
+- **THEN** all members are extracted and a `list[ExtractionResult]` is returned, with the same safety guarantees as `archivey.extract()`
+
+#### Scenario: extract a selected subset in one pass
+
+- **WHEN** `reader.extract_all(dest, members=["a.txt", "b.txt"])` is called on a solid archive
+- **THEN** only those members are extracted, in a single decompression pass over the archive
+
+#### Scenario: single-file extraction via selector
+
+- **WHEN** a caller wants just one file
+- **THEN** they call `reader.extract_all(dest, members=[name])`; there is no separate single-member `extract()` method
+
 ## ADDED Requirements
 
 ### Requirement: Extraction reads limits and strictness from the configuration object
@@ -8,11 +106,20 @@
 `config: ArchiveyConfig | None` (see `archive-reading`), whose `extraction_limits`
 field (an `ExtractionLimits` of `max_extracted_bytes`, `max_ratio`,
 `ratio_activation_threshold`, `max_entries` — defaults unchanged from the individual
-requirements) supplies the decompression-bomb limits. `extract_all()` SHALL default to
+requirements) supplies the decompression-bomb limits, **and** a per-call
+`limits: ExtractionLimits | None` override. Precedence: per-call `limits` >
+`config.extraction_limits` > library default. `extract_all()` SHALL default to
 the config the reader was opened with; `archivey.extract()` SHALL default to the
 library default config. Per-call operational parameters (`members`, `filter`,
 `policy`, `overwrite`, `on_error`, `on_progress`, `password`) remain keyword
 arguments and are not part of the config object.
+
+`ExtractionLimits.UNLIMITED` SHALL be provided as a preset that disables all four
+guards, for archives the caller explicitly trusts. Presets are not named by trust and
+are independent of `ExtractionPolicy`: policy governs metadata/permission semantics,
+limits govern resource bounds, and neither implies the other (the documented
+trusted-archive recipe is the explicit pair `policy=ExtractionPolicy.TRUSTED,
+limits=ExtractionLimits.UNLIMITED`).
 
 The returned `list[ExtractionResult]` is accumulated unconditionally in v1: a
 no-tracking mode would not bound memory on its own (readers cache the member list
@@ -23,6 +130,16 @@ phase-5 design document).
 
 - **WHEN** `archivey.extract(src, dest, config=ArchiveyConfig(extraction_limits=ExtractionLimits(max_extracted_bytes=10 * 2**30)))` is called
 - **THEN** the cumulative byte limit enforced is 10 GiB
+
+#### Scenario: per-call limits override the config
+
+- **WHEN** a reader opened with a custom `config` runs `extract_all(dest, limits=ExtractionLimits(max_extracted_bytes=50 * 2**20))`
+- **THEN** the 50 MiB per-call cap governs that run, overriding `config.extraction_limits`; a later `extract_all()` without `limits` reverts to the reader's config
+
+#### Scenario: UNLIMITED preset disables the guards
+
+- **WHEN** `archivey.extract(src, dest, limits=ExtractionLimits.UNLIMITED)` is called on an archive that would trip the default byte or ratio limits
+- **THEN** extraction completes with no bomb-guard error
 
 #### Scenario: extract_all inherits the reader's config
 

--- a/openspec/changes/phase-5-public-api/tasks.md
+++ b/openspec/changes/phase-5-public-api/tasks.md
@@ -2,7 +2,8 @@
 
 > Order matters: the config object (1) unblocks strict_eof relocation (its tests) and
 > extraction limits; the password model (2) and multi-source (3) are independent of each
-> other; the sweep (5) runs last.
+> other; the link-resolution sweep (5) is independent of 1–4; the finalization sweep (6)
+> and sync (7) run last.
 
 ## 1. ArchiveyConfig / ExtractionLimits
 
@@ -17,21 +18,31 @@
 - [ ] 1.4 Tests: default config equivalence; accelerator modes honored via config
       (monkeypatched sentinels); `strict_archive_eof=True` raises / default warns;
       frozen-ness (`dataclasses.FrozenInstanceError` on mutation).
+- [ ] 1.5 Per-call `limits: ExtractionLimits | None = None` on `extract()` /
+      `extract_all()`; **remove** the four loose bomb-limit kwargs; precedence
+      per-call > `config.extraction_limits` > default; `ExtractionLimits.UNLIMITED`
+      preset. Tests: override tightens/loosens one call; reader-config limits apply
+      when no per-call override; UNLIMITED disables all four guards.
+- [ ] 1.6 `format-tar` spec references updated via the new delta (`strict_eof` →
+      `config.strict_archive_eof`); `SPEC.md` §"truncation detection" wording follows.
 
 ## 2. Password candidates and provider
 
 - [ ] 2.1 Widen `password` typing on `open_archive` (`str | bytes | Sequence[str |
-      bytes] | PasswordProvider | None`); normalize once into an internal
-      `_PasswordCandidates` helper on `BaseArchiveReader` (known-good list +
-      remaining candidates + optional provider; `provider(member_or_none)`).
+      bytes] | PasswordProvider | None`); define the frozen `PasswordRequest`
+      dataclass (`member: ArchiveMember | None`, `attempt: int`); normalize once into
+      an internal `_PasswordCandidates` helper on `BaseArchiveReader` (known-good list
+      + remaining candidates + optional provider; `provider(PasswordRequest(...))`).
 - [ ] 2.2 Wire the ZIP backend (the only current consumer) through the helper: try
       known-good → candidates → provider per encrypted member; successful password
       appended to known-good; exhaustion → `EncryptionError`. Encrypted-symlink
       listing path uses the same resolution.
 - [ ] 2.3 Tests: sequence across two differently-encrypted members in one pass;
-      provider called once per *new* password (call-count assertion) and receives the
-      member; provider `None` → `EncryptionError`; header-level call passes `None`
-      (unit-test the helper; the real header-encrypted case lands with Phase 7).
+      provider called once per *new* password (call-count assertion) and receives a
+      `PasswordRequest` carrying the member; `attempt` increments on a wrong-password
+      retry for the same unit; provider `None` → `EncryptionError`; header-level
+      request carries `member=None` (unit-test the helper; the real header-encrypted
+      case lands with Phase 7).
 - [ ] 2.4 Docs: candidate-order note ("most likely password first" — 7z key derivation
       is deliberately expensive) in the open_archive docstring.
 
@@ -47,6 +58,9 @@
       `UnsupportedFeatureError` with a format-appropriate message (7z/RAR: "lands in
       Phase 7"; others: "not a multi-volume format"). Tests for both messages and
       for discovery ordering (fixture files, no real volume parsing).
+- [ ] 3.4 `extract()` parity: widen its `source` union to the same `Sequence[...]`
+      form (it delegates to `open_archive`) and add the `encoding` keyword; test a
+      one-shot extract of a non-UTF-8-named TAR with an explicit `encoding`.
 
 ## 4. MemberSelector collection form
 
@@ -58,18 +72,45 @@
       "Phase 5 pending" note); tests: duplicate-name tar selects both; member-entry
       selects only its identity; mixed collection.
 
-## 5. Finalization sweep
+## 5. Link-resolution sweep & safety test gaps
 
-- [ ] 5.1 Per-format `CostReceipt` value assertions (zip/tar/all-compressed-tar/
+- [ ] 5a.1 Positional hardlink resolution in `_get_members_registered` /
+      `_resolve_link`: walk members in order with an incremental map (latest earlier
+      occurrence wins); fall back to a later member only when no earlier one exists;
+      symlinks keep resolving against the full last-wins map. Streaming and
+      random-access modes must agree on the duplicate-name cases.
+- [ ] 5a.2 Cycle detection by member id (not name) in `_resolve_link` and
+      `_open_with_link_follow`; error message reports a cycle (not "target not
+      found"). Tests: cyclic symlink pair (`a → b`, `b → a`) raises on `open()`;
+      a chain through two distinct same-named members does NOT false-positive.
+- [ ] 5a.3 Duplicate-name positional test: `[A(content1), hardlink L→A, A(content2)]`
+      — `read(L)` returns content1 and extraction links `L` to the content1 inode, in
+      both access modes (the regression the last-wins map caused).
+- [ ] 5a.4 Port the chained-symlink attack test from `_dev_oracle` into the v2 suite
+      (member 1 plants `sub → /outside`, member 2 writes through `sub/...`; both the
+      SYMLINK-payload and FILE-payload variants must be rejected).
+- [ ] 5a.5 Defensive raise in `_copy_to_fileobj`/`_write_file` when a FILE member
+      arrives with `stream=None` (today it silently creates an empty file, masking a
+      backend bug; a zero-byte FILE gets a real empty stream, so raising is safe).
+- [ ] 5a.6 Export `MemberSelector`, `MemberFilter`, `ArchiveyConfig`,
+      `ExtractionLimits`, `PasswordRequest`, `PasswordProvider` from `archivey`
+      (`__all__` + test_public_api assertions).
+
+## 6. Finalization sweep
+
+- [ ] 6.1 Per-format `CostReceipt` value assertions (zip/tar/all-compressed-tar/
       single-file/iso/directory) in one parametrized contract test.
-- [ ] 5.2 Error-context stamping verified end-to-end for every backend (archive_name/
+- [ ] 6.2 Error-context stamping verified end-to-end for every backend (archive_name/
       member_name/format present on translated errors).
-- [ ] 5.3 Remaining `archive-reading` / `archive-data-model` scenarios audited against
+- [ ] 6.3 Remaining `archive-reading` / `archive-data-model` scenarios audited against
       the test suite; add the missing ones.
-- [ ] 5.4 `SPEC.md` §2 signature blocks + `ARCHITECTURE.md` sketches updated to the
+- [ ] 6.4 `SPEC.md` §2 signature blocks + `ARCHITECTURE.md` sketches updated to the
       final signatures; `openspec validate --strict` clean for the touched specs.
+- [ ] 6.5 Resolve the two open maintainer decisions recorded in proposal.md
+      (`max_entries` counting semantics; ZIP `format_availability` truthfulness) and
+      spec the outcomes.
 
-## 6. Sync
+## 7. Sync
 
-- [ ] 6.1 Sync delta specs to `openspec/specs/` (archive-reading, safe-extraction,
-      format-7z) and archive the change.
+- [ ] 7.1 Sync delta specs to `openspec/specs/` (archive-reading, safe-extraction,
+      format-7z, format-tar) and archive the change.

--- a/openspec/specs/archive-reading/spec.md
+++ b/openspec/specs/archive-reading/spec.md
@@ -344,7 +344,10 @@ an actual cycle (or a missing target) fails.
 # ABC implementation (ARCHITECTURE.md §2.3)
 def open(self, member: str | ArchiveMember, _seen: frozenset[int] = frozenset()) -> BinaryIO:
     if isinstance(member, str):
-        member = self[member]
+        found = self.get(member)  # name lookup — there is no __getitem__ on the reader
+        if found is None:
+            raise KeyError(f"Member {member!r} not found")
+        member = found
     if member.type in (MemberType.SYMLINK, MemberType.HARDLINK) and member.link_target:
         if member.member_id in _seen:
             raise ReadError(f"Link cycle detected at '{member.name}'")

--- a/openspec/specs/backend-registry/spec.md
+++ b/openspec/specs/backend-registry/spec.md
@@ -142,15 +142,17 @@ class MagicSignature(NamedTuple):
     offset: int
     magic: bytes
     format: ArchiveFormat
-    weak: bool = False   # a too-short/unspecific signal (zlib's 2-byte header): the
-                         # detector confirms it with a content probe before accepting it
+    # No "weak" flag: a match is accepted on the byte comparison alone. A format whose
+    # signature is too short/unspecific to trust (zlib's 2-byte header) or that has no
+    # signature at all (Brotli) is recognized by a CONTENT_PROBES entry instead.
 
 class ReadBackend(ABC):
     FORMATS: tuple[ArchiveFormat, ...]                   # formats this backend reads
     EXTENSIONS: Mapping[str, ArchiveFormat] = {}         # ".gz" -> ArchiveFormat.GZ
-    MAGIC: tuple[MagicSignature, ...] = ()               # magic signals declared as data
-    CONTENT_PROBE_FORMATS: tuple[ArchiveFormat, ...] = ()  # magic-less formats (Brotli)
-                         # the detector confirms by decoding a bounded prefix through the codec
+    MAGIC: tuple[MagicSignature, ...] = ()               # exact magic signals as data
+    CONTENT_PROBES: tuple[tuple[ArchiveFormat, Callable[[bytes], bool]], ...] = ()
+                         # (format, probe) pairs for formats with no trustworthy exact
+                         # magic; the probe inspects a peeked prefix (see format-detection)
     REQUIRES_SEEK: bool = False                          # if True, non-seekable sources rejected
     OPTIONAL_DEPENDENCY: str | None = None               # e.g. "pycdlib"
 

--- a/openspec/specs/format-7z/spec.md
+++ b/openspec/specs/format-7z/spec.md
@@ -245,19 +245,20 @@ in the Phase 7 change proposal.
 
 ### Requirement: Report solid block metadata in CostReceipt
 
-The system SHALL populate `CostReceipt` from the natively parsed header:
-`solid_block_count` is the number of folders, and `is_solid` is `True` when any
-folder packs more than one file.
+The system SHALL populate the solidity signals from the natively parsed header:
+`CostReceipt.solid_block_count` is the number of folders, and `ArchiveInfo.is_solid`
+is `True` when any folder packs more than one file (`is_solid` lives on `ArchiveInfo`,
+not on `CostReceipt` — see `access-mode-and-cost`).
 
 #### Scenario: reporting cost for a solid 7z archive
 
 - **WHEN** a 7-Zip archive contains folders that pack multiple files
-- **THEN** `CostReceipt.is_solid` is `True` and `CostReceipt.solid_block_count` reflects the folder count from the header
+- **THEN** `ArchiveInfo.is_solid` is `True` and `CostReceipt.solid_block_count` reflects the folder count from the header
 
 #### Scenario: reporting cost for a non-solid 7z archive
 
 - **WHEN** every folder packs exactly one file
-- **THEN** `CostReceipt.is_solid` is `False` and `CostReceipt.access_cost` is `DIRECT`
+- **THEN** `ArchiveInfo.is_solid` is `False` and `CostReceipt.access_cost` is `DIRECT`
 
 ---
 

--- a/openspec/specs/format-rar/spec.md
+++ b/openspec/specs/format-rar/spec.md
@@ -159,7 +159,7 @@ archives.
 #### Scenario: CostReceipt for a solid RAR
 
 - **WHEN** a solid RAR archive is opened
-- **THEN** `CostReceipt.is_solid` is `True` and `CostReceipt.solid_block_count` is `None`
+- **THEN** `ArchiveInfo.is_solid` is `True` and `CostReceipt.solid_block_count` is `None` (`is_solid` lives on `ArchiveInfo` — see `access-mode-and-cost`)
 
 ---
 

--- a/openspec/specs/safe-extraction/spec.md
+++ b/openspec/specs/safe-extraction/spec.md
@@ -96,9 +96,10 @@ Because `member.name` is now a **faithful** representation of the stored path (s
 verbatim `raw_name` (the interim mechanism introduced while normalization still collapsed
 traversal is removed).
 
-This is the default (`RAISE`) path-safety behavior. A future opt-in `SANITIZE` policy (phase 5)
-re-roots/collapses an unsafe name to a safe in-`dest` path instead of rejecting it; there is no
-path-safety "trust" bypass. The constraints below describe `RAISE`.
+This is the default (`RAISE`) path-safety behavior. A future opt-in `SANITIZE` policy
+(**post-v1** — deliberately not part of the Phase 5 API freeze) would re-root/collapse an
+unsafe name to a safe in-`dest` path instead of rejecting it; there is no path-safety
+"trust" bypass. The constraints below describe `RAISE`.
 
 Three independent enforcement layers provide defense in depth:
 
@@ -137,8 +138,8 @@ The individual universal constraints are:
 #### Scenario: internal traversal is also rejected
 
 - **WHEN** a member's `name` is `"foo/../bar"` (a `..` that would resolve within the root)
-- **THEN** `PathTraversalError` is raised under the default `RAISE`; extracting it requires the
-  opt-in `SANITIZE` policy (phase 5)
+- **THEN** `PathTraversalError` is raised under the default `RAISE`; extracting it would
+  require the future opt-in `SANITIZE` policy (post-v1, not yet available)
 
 #### Scenario: absolute path in member name
 

--- a/openspec/specs/testing-contract/spec.md
+++ b/openspec/specs/testing-contract/spec.md
@@ -99,12 +99,12 @@ codec" error rather than diverging silently from the oracle.
 
 ### Requirement: Non-seekable stream coverage for every streaming backend
 
-The system SHALL test every backend that supports streaming with a `FakeNonSeekable` wrapper that raises `io.UnsupportedOperation` on all `seek` and `tell` calls. The test verifies that the backend reads and iterates correctly when the source stream cannot be repositioned.
+The system SHALL test every backend that supports streaming with a `FakeNonSeekable` wrapper that raises `io.UnsupportedOperation` on all `seek` and `tell` calls. The test verifies that the backend reads and iterates correctly when the source stream cannot be repositioned. A backend that **requires** a seekable source (ZIP, ISO — see `access-mode-and-cost` and the format specs) SHALL instead be tested to **fail fast** at open time with `StreamNotSeekableError`, never buffering the stream implicitly.
 
-#### Scenario: non-seekable ZIP source
+#### Scenario: non-seekable ZIP source fails fast
 
 - **WHEN** a ZIP archive is opened through a `FakeNonSeekable` wrapper
-- **THEN** the backend reads all members correctly without calling `seek` or `tell` on the underlying stream
+- **THEN** `open_archive` raises `StreamNotSeekableError` at open time (ZIP requires a seekable source; the library never implicitly buffers), and no member data is read
 
 #### Scenario: non-seekable TAR.GZ source
 


### PR DESCRIPTION
Folds the accepted outcomes of the 2026-07 pre-Phase-5 model reviews into the `phase-5-public-api` change, plus five mechanical corrections to main specs that contradicted each other or the implementation. Docs/spec-only — no code changes.

## Phase-5 change (`openspec/changes/phase-5-public-api/`)

- **Per-call limits override**: `extract()` / `extract_all()` gain `limits: ExtractionLimits | None = None` (precedence: per-call > `config.extraction_limits` > default), replacing the four loose Phase-4b bomb-limit kwargs. `ExtractionLimits.UNLIMITED` preset (fields widen to `| None`; `None` disables a guard). Presets are deliberately not trust-named and not coupled to `ExtractionPolicy` — rationale in design.md. This resolves the reviewer conflict ("one knob location" vs. "per-call override for the security knob") with one structured type and two supply points.
- **`PasswordRequest` context object**: the provider callable becomes `Callable[[PasswordRequest], str | bytes | None]` with `member: ArchiveMember | None` and `attempt: int`, so an interactive UI can distinguish a first ask from a wrong-password retry, and the shape can grow without breaking a bare callable signature.
- **`extract()` parity with `open_archive()`**: `source` widens to the multi-volume `Sequence[...]` form and `encoding` is added (MODIFIED "One-Shot Extraction API" delta).
- **Link-resolution sweep** (MODIFIED "Transparent link following" delta): hardlinks resolve positionally (latest occurrence strictly before the link; forward fallback only for malformed link-before-source archives, which extraction's orphan second pass already recovers); symlinks keep last-wins-overall; cycle detection tracks member ids, not names; streaming and random-access modes must agree on duplicate names. Includes the concrete duplicate-name scenarios.
- **New `format-tar` delta**: the truncation requirement's `strict_eof` references become `config.strict_archive_eof` (the rename previously had no format-tar delta).
- **Tasks added**: per-call limits wiring/tests, `PasswordRequest` attempt-count tests, positional-resolution + false-cycle tests, porting the chained-symlink attack test from `_dev_oracle`, a cyclic-symlink `open()` test, a defensive raise for FILE members with `stream=None`, and top-level exports (`MemberSelector`, `MemberFilter`, `ArchiveyConfig`, `ExtractionLimits`, `PasswordRequest`, `PasswordProvider`).
- **Two open maintainer decisions recorded** in proposal.md rather than silently resolved:
  1. `max_entries` counting semantics — selector-skipped members don't count today while filter-skipped ones do; recommendation: count only members actually written.
  2. ZIP `format_availability` reports the intended post-Phase-7 composition, not current read capability (deflate64/PPMd fail at read even when installed); recommendation: report current truth (`PARTIAL` + note) until the Phase 7 codec bypass.

## Main-spec corrections (stale/contradictory text; no behavior change)

- `testing-contract`: the non-seekable ZIP scenario expected a successful read, contradicting `format-zip` / `access-mode-and-cost`; it now expects the `StreamNotSeekableError` fail-fast, and seek-requiring backends are explicitly tested to fail fast.
- `format-7z` / `format-rar`: `is_solid` attributed to `ArchiveInfo`, not `CostReceipt` (matches `access-mode-and-cost` and `cost.py`).
- `archive-reading` + `ARCHITECTURE.md`: link-following pseudocode drops the nonexistent `self[member]` indexing in favor of `get()` (there is deliberately no `__getitem__`).
- `safe-extraction`: the `SANITIZE` policy is relabeled post-v1 (Phase 5 explicitly defers it).
- `backend-registry`: `MagicSignature.weak` removed (content probes replaced weak magic); `CONTENT_PROBES` aligned with the implemented `(format, probe)` shape.

## Validation

`openspec validate --all`: 17 passed / 9 failed — the identical 9 pre-existing failures as on `main` (verified by stashing; they're missing-SHALL issues in requirements untouched here). `change/phase-5-public-api` and every spec edited in this PR validate clean. Markdown-only diff, so the three-configuration test matrix does not apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013uqPYhAnGMi6XoovksoLNT

---
_Generated by [Claude Code](https://claude.ai/code/session_013uqPYhAnGMi6XoovksoLNT)_