### PR TITLE
Hardlink resolution, streaming forward-pass contract, and members() on pipes

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -192,7 +192,10 @@ def _iter_with_data(self) -> Iterator[tuple[ArchiveMember, BinaryIO | None]]:
 `open()` and `read()` in the ABC add link-following on top of `_open_member()`. Chains are
 followed recursively with **cycle detection** via a visited member-id set (there is no
 fixed depth limit); a missing target raises `LinkTargetNotFoundError`; hardlinks always
-resolve to an **earlier** member (the TAR model), so they resolve in a single forward pass:
+resolve to an **earlier** member (the TAR model), so they resolve in a single forward pass.
+The sketch below is **illustrative only** — the real implementation is
+`_open_with_link_follow()` with `_lookup_link_target()` for name resolution (not
+`get(name)` on the raw stored target string):
 ```python
 def open(self, member: str | ArchiveMember,
          _seen: frozenset[int] = frozenset()) -> BinaryIO:
@@ -204,7 +207,9 @@ def open(self, member: str | ArchiveMember,
     if member.type in (MemberType.SYMLINK, MemberType.HARDLINK) and member.link_target:
         if member.member_id in _seen:
             raise ReadError(f"Link cycle detected at '{member.name}'")
-        target = member.link_target_member or self.get(member.link_target)
+        target = member.link_target_member or self._lookup_link_target(
+            member, self._members_by_name
+        )
         if target is None:
             raise LinkTargetNotFoundError(
                 f"Link target '{member.link_target}' not in archive")

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -241,19 +241,19 @@ Everything else (`__iter__`, `get`, `read`, `open`, `stream_members`, `extract`,
 
 → see SPEC.md §3.2 / openspec `archive-reading`, `access-mode-and-cost`
 
-`__iter__` calls `_iter_members()` directly — a generator that never loads all members.
+`__iter__` calls `_iter_members()` directly — a generator that never loads all members upfront.
 
-`members()` forces materialization:
-```python
-def members(self) -> list[ArchiveMember]:
-    if self._members_cache is None:
-        self._members_cache = list(self._iter_members())
-    return self._members_cache
-```
+`members()` forces full materialization with link resolution (may trigger a scan). It is disabled on streaming readers (`UnsupportedOperationError`).
 
-After materialization, `__iter__` returns `iter(self._members_cache)` for efficiency (avoids re-reading on second iteration).
+`scan_members()` returns the **fully-resolved** member list in either access mode. In random-access mode it is equivalent to `members()` and does not consume the reader. On a streaming reader it finishes the single forward pass (running it, or completing an interrupted one) and returns the resolved list.
 
-**Streaming guard:** if the reader was opened with `streaming=True` (forward-only), materialization is forbidden. Calling `.members()` raises `UnsupportedOperationError` with a clear message.
+`get_members_if_available()` is an **index-only** peek: it returns the list when the backend has an upfront index (`_MEMBER_LIST_UPFRONT`) or after a completed forward pass has materialized the cache; otherwise `None`. It never scans, never reads member data, and never consumes the forward pass. Link targets stored in member data (ZIP symlinks) may be unset — use `members()` or `scan_members()` for resolved links.
+
+**Streaming one-pass rule:** on a `streaming=True` reader, `__iter__`, `stream_members()`, and `extract_all()` each run at most once; a second call raises `UnsupportedOperationError`. There is no `__iter__` replay from cache in streaming mode (link-resolution semantics differ at yield time vs. after finalization). `scan_members()` is the finish exception: it may complete an interrupted pass or return the cache after completion.
+
+After a completed streaming pass, `_register_progressively` finalization fills `link_target_member` in place on objects already yielded, and populates `_members_cache` so `get_members_if_available()` returns the resolved list.
+
+Random-access `__iter__` serves from `_members_cache` once materialized (avoids re-reading on second iteration).
 
 ### 2.5 PeekableStream for non-seekable sources
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -208,7 +208,7 @@ def open(self, member: str | ArchiveMember,
         if member.member_id in _seen:
             raise ReadError(f"Link cycle detected at '{member.name}'")
         target = member.link_target_member or self._lookup_link_target(
-            member, self._members_by_name
+            member, self._members_by_name_lists
         )
         if target is None:
             raise LinkTargetNotFoundError(

--- a/openspec/changes/phase-5-public-api/specs/archive-reading/spec.md
+++ b/openspec/changes/phase-5-public-api/specs/archive-reading/spec.md
@@ -107,7 +107,7 @@ def open(self, member: str | ArchiveMember, _seen: frozenset[int] = frozenset())
         if member.member_id in _seen:
             raise ReadError(f"Link cycle detected at '{member.name}'")
         target = member.link_target_member or self._lookup_link_target(
-            member, self._members_by_name
+            member, self._members_by_name_lists
         )
         if target is None:
             raise LinkTargetNotFoundError(f"Link target '{member.link_target}' not in archive")

--- a/openspec/changes/phase-5-public-api/specs/archive-reading/spec.md
+++ b/openspec/changes/phase-5-public-api/specs/archive-reading/spec.md
@@ -51,7 +51,7 @@ Phase 4 `strict_eof` keyword is removed — end-of-archive strictness lives at
 
 ### Requirement: Transparent link following
 
-The system SHALL transparently follow symlinks and hardlinks in `open()` and `read()`. If `member.type` is `SYMLINK` or `HARDLINK`, the call is redirected to the target member. This behavior is format-independent and is implemented once in the `ArchiveReader` ABC. The resolved target, when known, is also exposed as `member.link_target_member`.
+The system SHALL transparently follow symlinks and hardlinks in `open()` and `read()`. If `member.type` is `SYMLINK` or `HARDLINK`, the call is redirected to the target member. This behavior is format-independent and is implemented once in the `ArchiveReader` ABC. The fully dereferenced target (the terminal member at the end of the link chain — not the immediate hop — see `archive-data-model`), when known, is also exposed as `member.link_target_member`.
 
 **Hardlinks resolve positionally**: the target is the most recent occurrence of the
 target name **strictly before** the link in archive order (this is the TAR model — every
@@ -93,7 +93,10 @@ falsely report one. There is no fixed depth limit; an acyclic chain of any lengt
 resolves, and only an actual cycle (or a missing target) fails.
 
 ```python
-# ABC implementation (ARCHITECTURE.md §2.3)
+# Illustrative only — the real code lives in internal/base_reader.py:
+#   _open_with_link_follow()  (open()/read() link following)
+#   _lookup_link_target()     (target-name resolution; not get(name))
+#   _resolve_link() / _register_progressively()  (eager link_target_member fill)
 def open(self, member: str | ArchiveMember, _seen: frozenset[int] = frozenset()) -> BinaryIO:
     if isinstance(member, str):
         found = self.get(member)  # name lookup — there is no __getitem__ on the reader
@@ -103,7 +106,9 @@ def open(self, member: str | ArchiveMember, _seen: frozenset[int] = frozenset())
     if member.type in (MemberType.SYMLINK, MemberType.HARDLINK) and member.link_target:
         if member.member_id in _seen:
             raise ReadError(f"Link cycle detected at '{member.name}'")
-        target = member.link_target_member or self.get(member.link_target)
+        target = member.link_target_member or self._lookup_link_target(
+            member, self._members_by_name
+        )
         if target is None:
             raise LinkTargetNotFoundError(f"Link target '{member.link_target}' not in archive")
         return self.open(target, _seen=_seen | {member.member_id})

--- a/openspec/changes/phase-5-public-api/tasks.md
+++ b/openspec/changes/phase-5-public-api/tasks.md
@@ -74,16 +74,16 @@
 
 ## 5. Link-resolution sweep & safety test gaps
 
-- [ ] 5a.1 Positional hardlink resolution in `_get_members_registered` /
+- [x] 5a.1 Positional hardlink resolution in `_get_members_registered` /
       `_resolve_link`: walk members in order with an incremental map (latest earlier
       occurrence wins); fall back to a later member only when no earlier one exists;
       symlinks keep resolving against the full last-wins map. Streaming and
       random-access modes must agree on the duplicate-name cases.
-- [ ] 5a.2 Cycle detection by member id (not name) in `_resolve_link` and
+- [x] 5a.2 Cycle detection by member id (not name) in `_resolve_link` and
       `_open_with_link_follow`; error message reports a cycle (not "target not
       found"). Tests: cyclic symlink pair (`a → b`, `b → a`) raises on `open()`;
       a chain through two distinct same-named members does NOT false-positive.
-- [ ] 5a.3 Duplicate-name positional test: `[A(content1), hardlink L→A, A(content2)]`
+- [x] 5a.3 Duplicate-name positional test: `[A(content1), hardlink L→A, A(content2)]`
       — `read(L)` returns content1 and extraction links `L` to the content1 inode, in
       both access modes (the regression the last-wins map caused).
 - [ ] 5a.4 Port the chained-symlink attack test from `_dev_oracle` into the v2 suite

--- a/openspec/changes/scan-members/.openspec.yaml
+++ b/openspec/changes/scan-members/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-06

--- a/openspec/changes/scan-members/design.md
+++ b/openspec/changes/scan-members/design.md
@@ -1,0 +1,332 @@
+## Context
+
+The reader exposes ways to obtain the member list:
+
+- `members() -> list[ArchiveMember]` — materialize the full, fully-resolved list;
+  disabled in streaming mode.
+- `scan_members() -> list[ArchiveMember]` — **(new)** the fully-resolved list in either
+  mode; on a streaming reader it finishes the single forward pass (running it, or
+  completing an interrupted one) and returns the resolved list.
+- `get_members_if_available() -> list[ArchiveMember] | None` — a no-scan, no-consume,
+  **index-only** peek; returns the list only when it is already reachable, else `None`.
+- `__iter__` / `stream_members()` / `extract_all()` — the single forward pass (metadata,
+  metadata+data, or extraction).
+
+The gap (see proposal): there is no working way to get the **fully-resolved** listing of a
+`streaming=True` reader without also consuming member data, because (a) `members()` is
+disabled, (b) the streaming pass never populates `_members_cache`, and (c) a single pass
+leaves forward-pointing symlinks unresolved. This change adds `scan_members()` and fixes
+the streaming-pass materialization.
+
+Two structural facts drive the design:
+
+- **Members are mutable and filled in place** (ARCHITECTURE §2.1). A member yielded early
+  in a streaming pass can have `link_target_member` (and `size`/CRC) filled *later* on the
+  same object the caller holds. So end-of-pass forward-link resolution updates objects the
+  caller already received — no re-fetch.
+- **Streaming already retains all member *metadata*.** `_register_progressively` builds a
+  `by_name_lists` map referencing every member for backward-link resolution, so the O(1)
+  streaming-memory guarantee is about member *data*, not the metadata objects. Collecting
+  the resolved list at end-of-pass therefore costs nothing beyond what is already held.
+
+### Index topology (one of the three axes)
+
+Where a format's member list lives determines what is reachable *without a forward data
+scan and without reading member data*, which is exactly the `_MEMBER_LIST_UPFRONT`
+predicate behind `get_members_if_available()`:
+
+| Topology | Formats (v2) | List reachable index-only? | `_MEMBER_LIST_UPFRONT` |
+|---|---|---|---|
+| **Leading-index** | directory, ISO | Yes — the listing is at/near the front (or is the filesystem itself). | `True` |
+| **Trailing-index** | ZIP, native 7z | Yes, **but only by seeking to the end** (central directory / 7z header at EOF). | `True` (backend guarantees a seekable source via `REQUIRES_SEEK`) |
+| **No-index** | TAR (plain & compressed) | No — the list exists only after walking every 512-byte header. | `False` |
+
+The trailing-index row carries a subtlety: a non-`None` `get_members_if_available()` for
+ZIP/7z **presupposes a seekable source**. Those backends set `REQUIRES_SEEK = True` and do
+**not** set `SUPPORTS_STREAMING_NON_SEEKABLE`, so even a `streaming=True` ZIP is opened
+over a seekable source and its trailing index is reachable without touching the forward
+member-data stream. A hypothetical future format with a trailing index that *also* allowed
+non-seekable streaming would have to report `_MEMBER_LIST_UPFRONT = False` on such a
+source, because on a pipe its index is unreachable without consuming everything. TAR is the
+only backend today that streams over a non-seekable source, and it is no-index, so the
+static class-level flag is correct for all current backends; the requirement is stated at
+the source-capability level so it stays correct as backends are added.
+
+### Where link targets live (the other resolution axis)
+
+Link resolution needs the target *string* (`link_target`) before it can find the target
+*member* (`link_target_member`). Formats store that string in different places:
+
+- **In the header/index** (TAR `linkname`): available during metadata enumeration, no
+  member-data read.
+- **In the member's data** (a ZIP symlink's *content* is its target path; the central
+  directory only flags "this is a symlink" via the Unix mode bits): obtaining it requires
+  **opening and reading the member**.
+
+This is orthogonal to index topology: ZIP has a trailing *index* (names/metadata are
+cheap) yet its symlink *targets* are in data. So an index-only listing can enumerate ZIP
+members but cannot know their link targets without reading each symlink's bytes.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- One explicit, mode-agnostic method to obtain the fully-resolved member list
+  (`scan_members()`), usable before, during-then-interrupted, or after the forward pass.
+- Make a completed (or `scan_members()`-completed) streaming pass materialize the resolved
+  cache, so `get_members_if_available()` returns it afterward.
+- A crisp, index-only contract for `get_members_if_available()`, with the
+  resolved-vs-unresolved-links distinction stated explicitly.
+- Preserve the no-surprise rule: no listing operation may have *format-dependent*
+  consequences that bite a caller who tested on one format and ran on another.
+
+**Non-Goals:**
+
+- Changing `members()`'s streaming prohibition (it stays disabled; not overloaded).
+- Reordering/​buffering iteration to yield resolved members mid-pass (rejected — see
+  Decision 6).
+- Implicit buffering / spooling of a non-seekable source to enable random access
+  (explicitly refused by `access-mode-and-cost`).
+- Bounding *metadata* memory for huge member counts (a no-member-cache mode is a separate,
+  deferred effort — see phase-5 design Non-Goals).
+
+## Decisions
+
+### 1. `scan_members()` — a dedicated, mode-agnostic finish-and-resolve accessor
+
+Signature: `def scan_members(self) -> list[ArchiveMember]`. Returns the **fully-resolved**
+list (same objects/resolution as random-access `members()`, incl. true last-wins symlinks
+and forward-pointing symlinks), callable in either mode.
+
+- **Random-access mode**: equivalent to `members()` — materialize (scan if needed),
+  resolve all links, cache, return. Non-consuming.
+- **Streaming mode**: return the cache if the pass already completed; otherwise **finish
+  the single forward pass** — run it from the start, or continue an *interrupted* one from
+  where it stopped, draining the underlying metadata scan to EOF — then resolve all links,
+  cache, and return. `scan_members()` is the **only** method allowed to run after an
+  iteration method has started (see Decision 3).
+
+**Why a new method, not `members()`-consumes or `members(consume=True)`:** the no-surprise
+rule targets *format-dependent consequences of the same call*. If `members()` silently
+consumed, it would burn the pass on TAR but not on ZIP, so `list-then-stream` would work on
+the format you tested and break on the one you didn't. A boolean flag has the same mental
+collision (`members()` means "safe, re-iterable" in random mode) plus the boolean-trap
+ergonomics. A distinct name is greppable, self-documenting, and carries the cost warning at
+the call site.
+
+**Why mode-agnostic (works in random mode too):** a consumer writing generic code ("give
+me all members regardless of how this was opened") gets one call with no `if streaming:`
+branch. The only behavioural difference (finishes the pass) is tied to a mode the caller
+*explicitly chose*, not to a hidden format property — acceptable under the no-surprise
+rule. (Alternative — streaming-only `scan_members()`, forcing random callers to use
+`members()` — rejected: needless branching for the common "just list it" case.)
+
+**Naming:** `scan_members()`. "Scan" is already the codebase's word for the full header
+walk (`ListingCost.REQUIRES_SCANNING`, "may trigger a full scan"), so it is honest and
+consistent. Deliberately *not* an alarming name: for a non-seekable stream this is the
+*correct and only* tool for a listing, and a scary name would punish the legitimate use.
+The docstring carries the "finishes / consumes the one forward pass" note. (Alternatives
+considered: `read_all_members`, `list_members` — less consistent with existing vocabulary.)
+
+### 2. Post-pass materialization lives in `_register_progressively`
+
+All streaming forward passes funnel through `_register_progressively` (base `__iter__`;
+TAR's `_iter_with_data`; and, by contract, future streaming backends' `_iter_with_data`).
+That is the single natural finalization point.
+
+`_register_progressively` already stamps ids, resolves backward links incrementally, and
+retains every member in a `by_name_lists`. Change it to accumulate into **instance** state
+and, **on normal exhaustion of the generator** (the consumer drained it, or `scan_members`
+drove it to EOF), run the full `_resolve_link` over every link member — resolving
+forward-pointing symlinks, true last-wins symlinks, and full chains, filling
+`link_target_member` **in place** on the objects already yielded — then set
+`self._members_cache` and `self._members_by_name_lists`.
+
+Generators run their post-loop tail only when fully consumed, so an *early break* (an
+interrupted pass) does **not** finalize — correct: a partial pass must not present itself
+as a complete listing. `scan_members()` finishes an interrupted pass by draining the *same*
+instance-held generator to exhaustion, which reaches this tail. Because finalization writes
+in place, a caller who collected members during the pass sees their forward links become
+resolved once it completes.
+
+```python
+# base_reader.py — illustrative
+def _register_progressively(self, members):
+    self._by_name_lists = {}
+    self._scanned = []
+    for idx, member in enumerate(members):
+        ...  # stamp id, resolve backward links (unchanged), index name, append
+        yield member
+    # Reached only when the pass is drained to EOF (by the consumer or scan_members).
+    for m in self._scanned:
+        if m.is_link and m.link_target:
+            self._resolve_link(m, self._by_name_lists)   # forward/last-wins/chains, in place
+    self._members_cache = self._scanned
+    self._members_by_name_lists = self._by_name_lists
+```
+
+**Mechanics note (single underlying scan).** So that `scan_members()` can *continue* an
+interrupted `__iter__`/`stream_members`, the streaming pass must be a single
+**instance-held** iterator over the backend's forward metadata scan; `__iter__` yields from
+it, `stream_members`/`extract_all` pull members from it and open member data alongside, and
+`scan_members()` drains whatever remains of it. TAR's `_iter_with_data` today builds its own
+`_register_progressively(...)` locally; it must be adjusted to pull from the shared
+instance-held pass so all four entry points share one cursor and one finalization. This is
+an explicit contract for future streaming backends (native 7z/RAR).
+
+### 3. One forward pass only; `scan_members()` is the finish exception
+
+A streaming reader's source is traversed **at most once**, forward. Add
+`self._forward_pass_started: bool = False`.
+
+- `__iter__`, `stream_members`, and `extract_all` each check the flag **before** touching
+  the source; if a pass has already started, they raise `UnsupportedOperationError`. The
+  first of them to run sets the flag and owns the pass. This holds even after a *completed*
+  pass — there is **no cache-replay of `__iter__`** in streaming mode (see below).
+- `scan_members()` is exempt: it may run before (initiating + finishing the pass),
+  after-an-interruption (finishing it), or after-completion (returning the cache). When it
+  initiates the pass it sets the flag too.
+- **`get_members_if_available()` never begins or advances the pass** and never sets the
+  flag. It reads the index (a seek, for a leading/trailing-index format) or returns the
+  cache/`None`.
+
+**Why one pass only — no `__iter__` replay after completion.** During a live pass, a
+forward-pointing symlink is *unresolved at the moment it is yielded* (the pass hasn't seen
+its target yet); finalization fills it at EOF. A replayed second `__iter__` would present
+that same member as *already resolved at yield time*, so "iterate the reader" would
+observably behave differently depending on how many times you had done it — precisely the
+format-/state-dependent divergence the library avoids. Making iteration strictly single-use
+removes the divergence: there is exactly one yield-time observation per member, and the
+resolved snapshot is obtained through the *different, clearly-named* `scan_members()` /
+`get_members_if_available()` methods. (This qualifies `archive-reading`'s "subsequent
+`__iter__` returns from the cache" as **random-access mode only**.)
+
+This guard is new behaviour: today a second streaming pass is not explicitly rejected (it
+would silently re-read and fail opaquely on a consumed pipe). Making it a uniform, explicit
+error is the precondition that lets `scan_members()` be the single well-defined
+post-iteration accessor.
+
+### 4. `get_members_if_available()` is strictly index-only
+
+`get_members_if_available()` performs **no member-data reads and no forward scan**. It
+returns the list only from a true upfront index (leading/trailing topology) or an
+already-materialized cache; otherwise `None`. Consequences:
+
+- For a no-index format (TAR) it returns `None` until the pass has completed (or
+  `scan_members()`/`members()` materialized the cache), then the resolved cache.
+- For a format whose **link targets live in member data** (ZIP symlinks), an index-only
+  listing returns members with `link_target` / `link_target_member` **unset** — it will not
+  read symlink bytes to resolve them. `members()` and `scan_members()` *do* perform those
+  reads and return resolved links.
+
+**ZIP backend change.** Today `ZipReader._to_member` eagerly opens and reads every
+symlink's data during enumeration to populate `link_target`, so a ZIP listing is not
+actually index-only. Defer that read out of enumeration: the index-only listing leaves ZIP
+symlink `link_target` unset, and the target is read lazily when needed — during
+`members()`/`scan_members()` link resolution, and when following the link in
+`open()`/`read()`/extraction. This makes `get_members_if_available()` honestly cheap and
+turns "resolved vs. unresolved links" into a real, testable property rather than an
+accident of which backend eagerly read data. (Alternative — keep eager reads and relax the
+contract to "may read bounded inline metadata" — rejected: a fuzzy contract, and it makes a
+"no-scan peek" silently open N members.)
+
+### 5. The resolution asymmetry is documented, not hidden
+
+`members()` and `scan_members()` return **fully-resolved** members (they read/scan whatever
+is needed). `get_members_if_available()` returns whatever the index provides **as-is**:
+members may have `link_target`/`link_target_member` unset for formats that store targets in
+data, and it returns `None` entirely for a not-yet-materialized no-index format. Callers who
+need resolved links call `members()`/`scan_members()`; callers who want a cheap peek accept
+possibly-unresolved links. This is stated in both capability specs and `ARCHITECTURE.md`.
+
+### 6. Rejected alternative — buffer/reorder iteration to resolve mid-pass
+
+Considered: hold unresolved-link members in a buffer during the pass and yield them last,
+after resolving, so `__iter__` itself yields fully-resolved members (and multiple passes
+would agree). **Rejected:**
+
+- It is not just forward symlinks — symlinks are *last-wins overall*, so **every** symlink
+  must be held until EOF; the order degrades to "everything in archive order, then all
+  symlinks in a clump."
+- It can change **extraction results**: when a name exists as both a file and a symlink, the
+  on-disk winner depends on write order; moving symlinks to the end silently alters
+  last-wins-on-disk.
+- It sacrifices the load-bearing **archive-order** invariant for a benefit already delivered
+  by `scan_members()` (fully-resolved, true last-wins) — without reordering — and by the
+  mutable-fill-in-place contract (held objects become resolved after the loop).
+- A `yield_in_order` vs `hold_until_resolved` toggle doubles the behavioural surface and
+  reintroduces "same call, different behaviour" variance. Overkill.
+
+### 7. The behaviour matrix (the core question)
+
+**`members()`** — fully-resolved list; materializes/scans as needed.
+
+| | Leading-index | No-index (TAR) | Trailing-index (ZIP/7z) |
+|---|---|---|---|
+| Random, before | list (index; ZIP reads symlink targets to resolve) | list (**full scan**) | list (seek to EOF; reads symlink targets to resolve) |
+| Random, after | list (cache) | list (cache) | list (cache) |
+| Streaming (any) | `UnsupportedOperationError` | `UnsupportedOperationError` | `UnsupportedOperationError` |
+
+**`scan_members()`** — fully-resolved list; mode-agnostic; finishes the pass.
+
+| | Leading-index | No-index (TAR) | Trailing-index (ZIP/7z) |
+|---|---|---|---|
+| Random | = `members()` | = `members()` (full scan) | = `members()` |
+| Streaming, before pass | list (index) **+ pass consumed** | list (**runs+finishes the pass**) | list (seek) **+ pass consumed** |
+| Streaming, after **interrupted** pass | list (finishes remainder) | list (**finishes remainder**) | list (from cache/index) |
+| Streaming, after **completed** pass | list (cache) | list (cache) | list (cache) |
+
+**`get_members_if_available()`** — index-only; never scans, never reads member data, never consumes.
+
+| | Leading-index | No-index (TAR) | Trailing-index (ZIP/7z) |
+|---|---|---|---|
+| Random, before | list (index) | **`None`** | list (seek); **symlink links unresolved** |
+| Random, after materialization | list (cache, resolved) | list (cache, resolved) | list (cache, resolved) |
+| Streaming, before pass | list (index) | **`None`** | list (seek); **symlink links unresolved** |
+| Streaming, mid-interrupted pass | list (index) | **`None`** (not finalized) | list (seek); links unresolved |
+| Streaming, after **completed**/`scan_members` pass | list (cache) | **list (cache, resolved)** ← the fix | list (cache, resolved) |
+
+Behavioural changes vs. today: the no-index `get_members_if_available()` returns the
+resolved list after a completed streaming pass (previously `None`); a second
+`__iter__`/`stream_members`/`extract_all` raises; ZIP's index-only listing no longer
+eagerly reads symlink targets (links unresolved until a resolving method runs).
+
+## Risks / Trade-offs
+
+- **[One-pass-only rejects a second `__iter__` even after completion]** → a caller who
+  iterated once and wants to iterate again must use `scan_members()` (then iterate the
+  returned list) or `get_members_if_available()`. → Intentional: it removes the pass-to-pass
+  link-resolution divergence; the resolved list has dedicated accessors.
+- **[Deferring ZIP symlink-target reads changes `get_members_if_available()` output]** →
+  ZIP symlinks now list with unresolved links under the index-only peek. → This is the point
+  (honest index-only contract); resolving methods and link-following still work, and it is
+  covered by tests.
+- **[`scan_members()` holds the whole resolved list in memory]** → O(members) metadata, not
+  O(archive). → Already true of the streaming pass's `by_name_lists`; unbounded member
+  *counts* are the separate, deferred no-cache concern.
+- **[Single instance-held pass shared across `__iter__`/`stream_members`/`scan_members`]** →
+  a refactor of TAR's `_iter_with_data` (and a contract for native 7z/RAR) so all entry
+  points share one cursor and one finalization. → Contained to backends that stream; TAR is
+  the only current one and its change is local.
+- **[New second-pass rejection could break callers relying on today's silent re-read]** →
+  Pre-1.0, no deprecation cycle; the previous behaviour was an opaque failure on
+  non-seekable sources anyway.
+
+## Migration Plan
+
+Additive and pre-1.0: ship `scan_members()`, the finalization, the one-pass guard, the
+index-only `get_members_if_available()` contract, and the ZIP symlink-target deferral
+together. `ArchiveReader` protocol gains `scan_members`; `ARCHITECTURE.md` §2.4 and the two
+capability specs update in the same change. No deprecation cycle; removed behaviours (a
+second streaming pass; ZIP eager symlink-target reads during listing) were unspecified.
+
+## Open Questions
+
+_None outstanding._ Resolved during design review:
+
+1. `__iter__` after a completed streaming pass **raises** (one-pass-only); it does not
+   replay from cache — the pass-to-pass link-resolution divergence makes replay unsafe.
+   `scan_members()`/`get_members_if_available()` are the post-pass accessors.
+2. `scan_members()` is **mode-agnostic** (random mode ≡ `members()`).
+3. `get_members_if_available()` is **strictly index-only**; ZIP defers symlink-target reads
+   so its index-only listing leaves links unresolved.

--- a/openspec/changes/scan-members/proposal.md
+++ b/openspec/changes/scan-members/proposal.md
@@ -1,0 +1,98 @@
+## Why
+
+A caller who opens a `streaming=True` reader (the only option for a non-seekable
+source, e.g. a TAR arriving over a pipe) sometimes wants the **full, fully-resolved
+member list** and *not* the member data — a plain "list everything" operation. Today
+`members()` is disabled in streaming mode (correctly — it would consume the single
+forward pass on scan-only formats but not on indexed ones, a format-dependent surprise),
+and the documented fallback ("iterate discarding the members, then call
+`get_members_if_available()`") does not actually work:
+
+- The streaming `__iter__` / `stream_members()` paths go through
+  `_register_progressively` and **never populate `_members_cache`**, so
+  `get_members_if_available()` still returns `None` for a scan-only format after a full
+  pass — contradicting its own spec ("available … after an iteration pass").
+- Even conceptually, a single forward pass resolves only **backward-pointing** links;
+  **forward-pointing symlinks stay unresolved**, so a bare iteration can never yield the
+  same resolved objects that random-access `members()` produces.
+
+So the one legitimate use case — "give me the resolved listing of a streaming archive" —
+has no working, non-awkward path today.
+
+## What Changes
+
+- **Add `scan_members() -> list[ArchiveMember]`** to the reader surface: returns the
+  **fully-resolved** member list (forward-pointing and true last-wins symlinks included)
+  in *either* access mode. In random-access mode it is equivalent to `members()`. On a
+  streaming reader it is the finish-and-resolve accessor — it returns the cache if the
+  single forward pass already completed, otherwise **finishes that pass** (running it, or
+  draining the remainder of an *interrupted* one) and returns the complete list. It is the
+  only method allowed to run after an iteration method has started.
+- **Fix streaming-pass materialization**: completing a streaming forward pass
+  (`__iter__` / `stream_members` / `extract_all`, or via `scan_members`) now finalizes the
+  fully-resolved member cache — running full link resolution (forward/last-wins symlinks,
+  filled **in place** on the already-yielded objects per the mutable-member contract) and
+  populating `_members_cache` — so `get_members_if_available()` returns that list
+  afterward, as its spec already promises.
+- **One forward pass only**: a streaming reader's source is traversed at most once.
+  `__iter__` / `stream_members` / `extract_all` are the pass entry points; a second call to
+  any of them raises `UnsupportedOperationError` — **including a second `__iter__` after the
+  first completed** (there is no streaming cache-replay of `__iter__`). Rationale: a
+  replayed pass would present forward-pointing symlinks as already-resolved at yield time,
+  unlike the first pass — a state-dependent divergence. `scan_members()` is the exempt
+  finish accessor; `get_members_if_available()` never begins or consumes the pass.
+- **`get_members_if_available()` becomes strictly index-only** — no forward scan and **no
+  member-data reads**. For a format whose link *targets* live in member data (a ZIP
+  symlink's target is its file content), it returns members with `link_target` /
+  `link_target_member` **unset**, whereas `members()` / `scan_members()` read what's needed
+  to resolve them. This requires the ZIP backend to **stop eagerly reading symlink data
+  during enumeration** (currently it does), reading the target lazily during resolution /
+  link-following instead.
+- **Clarify the listing-method semantics** for `members()`, `scan_members()`, and
+  `get_members_if_available()` across the two access modes, before/during/after the pass,
+  the three index topologies — **leading-index** (directory/ISO), **no-index** (TAR),
+  **trailing-index** (ZIP, native 7z; index at EOF, reachable only on a seekable source) —
+  and the resolved-vs-unresolved-links asymmetry.
+- `members()` remains disabled in streaming mode (unchanged); it is **not** overloaded to
+  consume — `scan_members()` is the explicit, greppable, cost-signalling entry point.
+
+## Capabilities
+
+### New Capabilities
+
+<!-- none: this refines the existing reader surface -->
+
+### Modified Capabilities
+
+- `archive-reading`: add the `scan_members()` method to the member-listing surface;
+  specify its cross-mode + finish-an-interrupted-pass behaviour and the post-pass
+  materialization of the resolved member cache; make streaming `__iter__` single-use
+  (qualify "subsequent `__iter__` returns from cache" as random-access only); state the
+  index-only nature of `get_members_if_available()` and its possibly-unresolved links.
+- `access-mode-and-cost`: add `scan_members()` to the access-mode × method table; specify
+  the one-forward-pass rule (second `__iter__`/`stream_members`/`extract_all` raises, no
+  replay) with `scan_members()` as the finish exception; make
+  `get_members_if_available()` strictly index-only (no member-data reads), across
+  leading-/no-/trailing-index formats, including the unresolved-links caveat for
+  data-stored link targets.
+
+## Impact
+
+- **Code**: `src/archivey/internal/base_reader.py` (new `scan_members()`,
+  instance-held single forward pass + `_register_progressively` finalization, one-pass
+  guard on `__iter__`/`stream_members`/`extract_all`); `src/archivey/reader.py` (add
+  `scan_members` to the `ArchiveReader` protocol); `src/archivey/internal/backends/tar_reader.py`
+  (`_iter_with_data` pulls from the shared instance-held pass so `scan_members` can finish
+  an interrupted one); `src/archivey/internal/backends/zip_reader.py` (defer symlink-target
+  reads out of enumeration; read lazily on resolution / link-following). Future native
+  7z/RAR streaming readers must route their forward pass the same way.
+- **Public API**: additive (`scan_members()`); no breaking change. Behavioural changes:
+  a *second* streaming forward pass now raises instead of silently re-reading (or failing
+  opaquely), including a second `__iter__`; `get_members_if_available()` becomes strictly
+  index-only (ZIP symlinks now list with unresolved links) and returns the materialized
+  list after a completed streaming pass.
+- **Docs/specs**: `ARCHITECTURE.md` §2.4 (member materialization) and the two modified
+  capability specs; the access-mode × method table gains a `scan_members` row.
+- **Tests**: `tests/test_tar.py` (streaming scan_members + post-pass
+  get_members_if_available + second-pass rejection); ZIP/directory for the indexed and
+  random-mode paths.

--- a/openspec/changes/scan-members/specs/access-mode-and-cost/spec.md
+++ b/openspec/changes/scan-members/specs/access-mode-and-cost/spec.md
@@ -1,0 +1,100 @@
+## MODIFIED Requirements
+
+### Requirement: Access-mode enforcement — streaming is forward-only
+
+A reader opened with `streaming=True` is forward-only. The system SHALL raise `UnsupportedOperationError` from every random-access or full-materialization method — `members()`, `get()`, `open()`, and `read()`. (`ArchiveReader` defines no `__len__`/`__getitem__` at all — see `archive-reading` — and `member in reader` is scan-free identity membership, allowed in both modes.) This holds **uniformly**, regardless of whether the backend happens to have an index loaded, so streaming behaviour does not vary by format.
+
+The source is traversed **at most once**, forward. The system SHALL treat `__iter__`, `stream_members`, and `extract_all` as the forward-pass entry points: the first of them to run consumes the single pass, and any subsequent call to **any** of them SHALL raise `UnsupportedOperationError` — uniformly for every format, and even after the first pass ran to completion (there is **no** cache-replay of `__iter__` in streaming mode; a caller that wants the list again uses `scan_members()` or `get_members_if_available()`). A pass abandoned before EOF (an early `break`) still counts as consumed. (There is no single-member `extract()`; selecting members for extraction is `extract_all(members=...)` — see `safe-extraction`.)
+
+`scan_members()` is the sole exception: it MAY run before the pass (initiating and finishing it), after an *interrupted* pass (finishing the remainder internally), or after a completed pass (returning the cache). It returns the fully-resolved member list. When it initiates the pass it also consumes it, so a later `__iter__`/`stream_members`/`extract_all` SHALL raise.
+
+`get_members_if_available()` neither begins nor advances the forward pass and never marks it consumed (see the next requirement), so it remains callable on any reader at any time.
+
+#### Scenario: random access raises on a streaming reader
+
+- **WHEN** any of `ar.get("f")`, `ar.members()`, `ar.open(m)`, or `ar.read(m)` is called on a reader opened with `streaming=True`
+- **THEN** `UnsupportedOperationError` is raised
+
+#### Scenario: a single forward pass is allowed on a streaming reader
+
+- **WHEN** a `streaming=True` reader is iterated once via `__iter__` or `stream_members()`
+- **THEN** members are yielded in archive order without error
+
+#### Scenario: a second forward pass raises uniformly, even after completion
+
+- **WHEN** a `streaming=True` reader has begun or completed one forward pass (via `__iter__`, `stream_members`, or `extract_all`) and any of those forward-pass methods is called again
+- **THEN** `UnsupportedOperationError` is raised, regardless of format and regardless of whether the first pass ran to completion
+
+#### Scenario: scan_members() finishes an interrupted pass
+
+- **WHEN** a `streaming=True` reader's `__iter__` (or `stream_members`) is interrupted with an early `break`, then `ar.scan_members()` is called
+- **THEN** `scan_members()` drains the remainder of the single pass internally and returns the complete, fully-resolved member list
+- **AND** a subsequent `stream_members()` / `__iter__` / `extract_all` raises `UnsupportedOperationError`
+
+#### Scenario: scan_members() before any pass consumes it
+
+- **WHEN** `ar.scan_members()` is called on a not-yet-iterated `streaming=True` reader and afterwards `ar.stream_members()` is called
+- **THEN** `scan_members()` returns the full member list, and the subsequent `stream_members()` raises `UnsupportedOperationError`, for every index topology (leading, trailing, no-index)
+
+### Requirement: get_members_if_available() — an index-only member list
+
+The system SHALL provide `get_members_if_available() -> list[ArchiveMember] | None`. It is **index-only**: it performs **no forward scan and no member-data reads**, and never begins or consumes the forward pass, so it is safe to call on any reader (including `streaming=True`) at any time without affecting a later pass. It returns the full member list when that list is available from a true upfront index or an already-materialized cache (a completed iteration / `scan_members` pass, or `members()` in random mode), and `None` otherwise. A caller that wants a guaranteed-materialized, fully-resolved list uses `members()` (random-access mode) or `scan_members()` (either mode).
+
+Availability depends on the format's **index topology** (the `_MEMBER_LIST_UPFRONT` predicate):
+
+- **Leading-index** (directory listing, ISO): reachable from the front — available in both modes.
+- **Trailing-index** (ZIP central directory, native 7z header at EOF): reachable **only by seeking to the end**, so availability presupposes a **seekable source**. Those backends require a seekable source (`REQUIRES_SEEK`, and they do not permit non-seekable streaming), so their list is available in both modes. A hypothetical future format with a trailing index that also permitted non-seekable streaming SHALL report unavailable (`None`) on a non-seekable source.
+- **No-index** (TAR): not reachable index-only — `None` until a forward pass has completed (or `scan_members()`/`members()` materialized the cache), after which the materialized, fully-resolved list is returned.
+
+Because it is index-only, the members it returns are **not guaranteed to have resolved links**: for a format whose link *targets* are stored in member data (e.g. a ZIP symlink's target is its file content), `get_members_if_available()` SHALL return those members with `link_target` and `link_target_member` **unset**, since resolving them would require reading member data. `members()` and `scan_members()` perform the reads/scan needed to resolve links; `get_members_if_available()` does not.
+
+#### Scenario: indexed backend returns the list even on a streaming reader
+
+- **WHEN** `ar.get_members_if_available()` is called on a `streaming=True` reader of a format with an upfront index (e.g. ZIP)
+- **THEN** the full member list is returned, with no scan and no member-data read, and the single forward pass remains available
+
+#### Scenario: streaming backend returns None before iteration
+
+- **WHEN** `ar.get_members_if_available()` is called on a not-yet-iterated reader of a no-index format (e.g. a streaming tar)
+- **THEN** `None` is returned
+
+#### Scenario: no-index backend returns the resolved list after a completed pass
+
+- **WHEN** a `streaming=True` reader of a no-index format is iterated to completion (or `scan_members()` is called), then `ar.get_members_if_available()` is called
+- **THEN** the fully-resolved materialized list is returned rather than `None`
+
+#### Scenario: index-only listing leaves data-stored link targets unresolved
+
+- **WHEN** `ar.get_members_if_available()` is called on a ZIP archive containing a symlink (whose target is stored in the member's data)
+- **THEN** the returned symlink member has `link_target` and `link_target_member` unset (no member-data read occurs)
+- **AND** `ar.members()` / `ar.scan_members()` on the same archive return that symlink with its `link_target` populated and `link_target_member` resolved
+
+### Requirement: Access mode × method behaviour summary
+
+The per-method behaviour is the composition of the rules above. There are exactly two modes: **random access** (`streaming=False`, the default) and **streaming** (`streaming=True`). The system SHALL behave per this table (`✅` = allowed, `⛔` = `UnsupportedOperationError`):
+
+| Method | random access (`streaming=False`) | streaming (`streaming=True`) |
+|--------|-----------------------------------|------------------------------|
+| `__iter__` | ✅ (repeatable; from cache after first) | ✅ **once** (no replay; second call ⛔) |
+| `stream_members` | ✅ | ✅ once (the one pass; second call ⛔) |
+| `extract_all` | ✅ | ✅ once (the one pass) |
+| `scan_members` | ✅ (= `members`) | ✅ (finishes the pass; may follow an interrupted/completed one) |
+| `get_members_if_available` | ✅ (index-only; may be `None`) | ✅ (index-only, no-consume; may be `None`) |
+| `members` | ✅ (may scan) | ⛔ |
+| `get` | ✅ (may scan) | ⛔ |
+| `open`, `read` | ✅ | ⛔ |
+| `in` (`__contains__`, identity — see `archive-reading`) | ✅ (no scan) | ✅ (no scan) |
+| `cost`, `info`, `format`, `close`, context manager | ✅ | ✅ |
+| at `open_archive()` | fail fast if the source can't be random-accessed | works on any source |
+
+In streaming mode, `__iter__`, `stream_members`, and `extract_all` all draw on the **same single forward pass**: whichever runs first consumes it, and a later one raises; `scan_members()` may still finish or return that pass's result. The independent backend-capability flag `_SUPPORTS_RANDOM_ACCESS` can also force `open`/`read` to raise (a backend that cannot seek the source at all); it composes with — does not replace — the access-mode rules above.
+
+#### Scenario: scan_members is allowed in both modes
+
+- **WHEN** `ar.scan_members()` is called on either a `streaming=False` or a `streaming=True` reader
+- **THEN** it returns the fully-resolved member list (in random-access mode it is equivalent to `members()`; in streaming mode it finishes/consumes the single forward pass)
+
+#### Scenario: streaming __iter__ does not replay after completion
+
+- **WHEN** a `streaming=True` reader is fully iterated once via `__iter__`, then iterated again
+- **THEN** the second iteration raises `UnsupportedOperationError` (streaming `__iter__` is single-use; use `scan_members()` / `get_members_if_available()` for the list)

--- a/openspec/changes/scan-members/specs/archive-reading/spec.md
+++ b/openspec/changes/scan-members/specs/archive-reading/spec.md
@@ -1,0 +1,110 @@
+## MODIFIED Requirements
+
+### Requirement: Sequential in-order iteration
+
+The system SHALL support iterating all members in archive order via `__iter__`, MAY
+materialize the full member list via `members()`, and SHALL provide `scan_members()` —
+a mode-agnostic way to obtain the fully-resolved member list.
+
+```python
+def __iter__(self) -> Iterator[ArchiveMember]: ...     # sequential, in-order
+def members(self) -> list[ArchiveMember]: ...          # materializes all (random-access only; may scan)
+def scan_members(self) -> list[ArchiveMember]: ...      # fully-resolved list, either mode
+def get_members_if_available(self) -> list[ArchiveMember] | None: ...  # index-only peek
+```
+
+`__iter__` MUST yield `ArchiveMember` objects one at a time in archive order without
+loading all members into memory. In **random-access** mode, `members()` MAY trigger a full
+scan for streaming formats that have no central directory, and after the member list has
+been materialized once, subsequent `__iter__` calls MUST return from the cache rather than
+re-reading the archive. In **streaming** mode there is no such cache-replay: `__iter__` is
+part of the single forward pass and is single-use (see the forward-only requirement below
+and `access-mode-and-cost`).
+
+`scan_members()` SHALL return the **fully-resolved** member list — every link's
+`link_target_member` filled where the target exists, including forward-pointing symlinks
+and true last-wins symlinks. In random-access mode it is equivalent to `members()`. On a
+`streaming=True` reader it SHALL return the cache if the single forward pass has already
+completed, otherwise **finish that pass** — running it from the start, or draining the
+remainder of an *interrupted* one — resolving all links, and returning the complete list.
+`scan_members()` is the only method permitted after an iteration method has started;
+running it consumes/finishes the pass (see `access-mode-and-cost`).
+
+During a live forward pass a forward-pointing symlink is unresolved at the moment it is
+yielded (a single pass cannot see ahead); the system finalizes resolution when the pass
+reaches its end. Completing a forward pass — via `__iter__`, `stream_members`,
+`extract_all`, or `scan_members` — SHALL finalize the fully-resolved member cache: the
+system runs full link resolution over all members (filling forward-pointing and last-wins
+symlink targets **in place** on the objects already yielded, per the mutable-member
+contract) and records the list so `get_members_if_available()` returns it thereafter. A
+forward pass abandoned before completion (an early `break`, with no subsequent
+`scan_members()`) SHALL NOT finalize the cache.
+
+The reader deliberately defines **no `__len__`** (and no `__getitem__` — see the
+name-lookup requirement): the reader is not a collection, and the sequence/mapping
+protocols get probed *implicitly* in ways the library does not control (`list(reader)`
+probes `__len__` for preallocation via the length-hint protocol). `len(reader)` therefore
+raises Python's own `TypeError` in every mode; a caller that wants a count uses
+`len(ar.members())`, `ar.info.member_count` (when cheaply known), or counts during
+iteration. `list(reader)` just iterates.
+
+`get_members_if_available()` is **index-only**: it returns the member list only when it is
+available without scanning and without reading member data (an upfront index, or an
+already-materialized cache), else `None`; it never scans and never begins the forward pass,
+so it is callable under any intent. Because it reads no member data, members it returns may
+have unresolved links for formats that store link targets in member data (see
+`access-mode-and-cost` for its full contract).
+
+When opened with `streaming=True`, the reader is forward-only: `members()`, `get()`,
+`open()`, and `read()` all SHALL raise `UnsupportedOperationError` (uniformly, not
+depending on a loaded index). Only a single forward pass — `__iter__`/`stream_members` or
+one `extract_all` — is allowed, with `scan_members()` permitted to finish or return it, and
+`get_members_if_available()` callable at any time. See the access mode × method table in
+`access-mode-and-cost`.
+
+#### Scenario: forward iteration
+
+- **WHEN** `for member in ar` is executed
+- **THEN** the reader yields `ArchiveMember` objects in archive order without buffering all of them in memory
+
+#### Scenario: materialization on a streaming reader
+
+- **WHEN** `ar.members()` is called on a reader opened with `streaming=True`
+- **THEN** `UnsupportedOperationError` is raised
+
+#### Scenario: streaming iteration is single-use
+
+- **WHEN** a `streaming=True` reader is iterated once via `__iter__` (to completion or with an early `break`), then any of `__iter__` / `stream_members` / `extract_all` is called again
+- **THEN** `UnsupportedOperationError` is raised (there is no streaming cache-replay of `__iter__`)
+
+#### Scenario: scan_members() on a streaming reader returns the fully-resolved list
+
+- **WHEN** `ar.scan_members()` is called on a not-yet-iterated `streaming=True` reader of a no-index format (e.g. a streaming tar) whose archive contains a symlink pointing at a *later* member
+- **THEN** the full member list is returned with that forward-pointing symlink's `link_target_member` resolved
+- **AND** the single forward pass is now consumed, so a subsequent `stream_members()` / `__iter__` / `extract_all` raises `UnsupportedOperationError`
+
+#### Scenario: scan_members() finishes an interrupted iteration
+
+- **WHEN** a `streaming=True` reader of a no-index format is iterated with an early `break`, then `ar.scan_members()` is called
+- **THEN** it drains the remainder of the single pass internally and returns the complete, fully-resolved member list
+
+#### Scenario: scan_members() equals members() in random-access mode
+
+- **WHEN** `ar.scan_members()` is called on a `streaming=False` reader
+- **THEN** it returns the same fully-resolved member list as `ar.members()`, and the reader remains usable for random access (nothing is consumed)
+
+#### Scenario: get_members_if_available() returns the list after a completed streaming pass
+
+- **WHEN** a `streaming=True` reader of a no-index format is iterated to completion via `__iter__` (or `stream_members`), then `ar.get_members_if_available()` is called
+- **THEN** the fully-resolved member list is returned (not `None`), and any forward-pointing symlink resolved during finalization is now visible on the objects yielded during the pass
+
+#### Scenario: abandoned partial pass does not materialize
+
+- **WHEN** a `streaming=True` reader of a no-index format is iterated but the loop `break`s before the last member and `scan_members()` is not called, then `ar.get_members_if_available()` is called
+- **THEN** `None` is returned (the pass did not complete, so no full listing is claimed)
+
+#### Scenario: no len(); list() iterates
+
+- **WHEN** `len(ar)` is called on any reader
+- **THEN** Python's own `TypeError` is raised (`ArchiveReader` defines no `__len__`)
+- **AND** `list(ar)` iterates normally (on a streaming reader, consuming the single forward pass)

--- a/openspec/changes/scan-members/tasks.md
+++ b/openspec/changes/scan-members/tasks.md
@@ -1,0 +1,38 @@
+## 1. Public surface
+
+- [ ] 1.1 Add `scan_members(self) -> list[ArchiveMember]` to the `ArchiveReader` protocol in `src/archivey/reader.py`, documenting: returns the fully-resolved list; in streaming mode it finishes (runs, or completes an interrupted) single forward pass and may follow a completed one.
+
+## 2. Failing tests (red)
+
+- [ ] 2.1 `tests/test_tar.py`: streaming tar with a **forward-pointing symlink** — `scan_members()` returns the list with that symlink's `link_target_member` resolved (parity with random-access `members()` on the same archive).
+- [ ] 2.2 `tests/test_tar.py`: after a complete streaming `__iter__` (and separately `stream_members`) pass, `get_members_if_available()` returns the fully-resolved list (not `None`), and a forward symlink collected during the pass now shows its resolved target (in-place fill).
+- [ ] 2.3 `tests/test_tar.py`: `scan_members()` **finishes an interrupted pass** — iterate with an early `break`, then `scan_members()` returns the complete resolved list; a subsequent `__iter__`/`stream_members`/`extract_all` raises `UnsupportedOperationError`.
+- [ ] 2.4 `tests/test_tar.py`: an **abandoned** partial pass (early `break`, no `scan_members`) leaves `get_members_if_available()` returning `None`.
+- [ ] 2.5 One-pass-only rejection (streaming): a second `__iter__`/`stream_members`/`extract_all` raises `UnsupportedOperationError` — **including a second `__iter__` after the first ran to completion** (no cache-replay). Cover no-index (tar) and an indexed format (zip).
+- [ ] 2.6 `scan_members()` in random-access mode returns the same list as `members()` and leaves the reader usable (nothing consumed); cover zip (trailing-index), a directory (leading-index), and tar (no-index).
+- [ ] 2.7 `scan_members()` before any pass on a streaming reader consumes it (subsequent `stream_members()` raises) for every topology, incl. an indexed zip.
+- [ ] 2.8 `tests/test_zip.py`: index-only vs resolved links — `get_members_if_available()` returns a ZIP symlink with `link_target`/`link_target_member` **unset** and reads no member data; `members()`/`scan_members()` return it **resolved**; `open()`/`read()`/extraction still follow the symlink.
+
+## 3. base_reader implementation (green)
+
+- [ ] 3.1 Add `_forward_pass_started: bool` (init `False`) and a guard that, in streaming mode, raises `UnsupportedOperationError` from `__iter__`/`stream_members`/`extract_all` when a pass has already started (even a completed one). Set the flag when a pass begins. `scan_members()` is exempt (it may finish/return the pass); `get_members_if_available()` never sets or checks it.
+- [ ] 3.2 Make the streaming forward pass a **single instance-held** iterator so an interrupted pass can be continued: `_register_progressively` accumulates into instance state (`_scanned`, `_by_name_lists`) and, on **normal exhaustion** (consumer-drained or `scan_members`-drained to EOF), runs full `_resolve_link` over all link members (forward/last-wins/chains, in place) and sets `self._members_cache` / `self._members_by_name_lists`. Confirm an early `break` (without finishing) does not reach the finalization tail.
+- [ ] 3.3 Implement `scan_members()`: random-access → `list(self._get_members_registered())`; streaming → return `_members_cache` if set, else begin (if not started) and drain the instance-held pass to EOF (metadata only), triggering 3.2's finalization, then return `_members_cache`.
+- [ ] 3.4 Ensure `get_members_if_available()` is index-only: returns `_members_cache` when set, the index list for `_MEMBER_LIST_UPFRONT` backends (no member-data read), else `None`. No pass consumption, no scan.
+
+## 4. Backend routing / ZIP symlink deferral
+
+- [ ] 4.1 Refactor TAR's `_iter_with_data()` streaming path to pull from the shared instance-held forward pass (so `__iter__`/`stream_members`/`scan_members` share one cursor and finalization), opening member data alongside; preserve the `_verify_tar_eof()` interaction.
+- [ ] 4.2 ZIP: stop `ZipReader._to_member` from eagerly opening+reading symlink data during enumeration. Leave `link_target` unset at enumeration; read the target lazily where a resolved target is needed — link resolution in `_get_members_registered`/`scan_members`, and link-following in `open()`/`read()`/extraction. Verify listing performs no symlink-data reads.
+- [ ] 4.3 Update the `BaseArchiveReader` docstring: streaming backends overriding `_iter_with_data()` MUST route their forward pass through the shared `_register_progressively` pass (so the resolved cache is finalized on completion and `scan_members` can finish an interrupted pass). Note this as a requirement for the future native 7z/RAR readers.
+
+## 5. Docs
+
+- [ ] 5.1 Update `ARCHITECTURE.md` §2.4: `scan_members()`, post-pass materialization, one-pass-only (no streaming `__iter__` replay), the index-only `get_members_if_available()` contract, and the resolved-vs-unresolved-links asymmetry (link targets stored in member data). Correct the illustrative `members()` snippet if it implies streaming materialization or streaming replay.
+
+## 6. Validation gate
+
+- [ ] 6.1 `openspec validate scan-members --strict` passes.
+- [ ] 6.2 Type-check clean: `uv run --no-sync pyrefly check` and `uv run --no-sync ty check`.
+- [ ] 6.3 Lint clean: `uv run --no-sync ruff check`.
+- [ ] 6.4 Tests pass across the three dependency configs (`[all]`, `[all-lowest]`, `[core-only]`) per CONTRIBUTING "Before pushing…".

--- a/openspec/changes/scan-members/tasks.md
+++ b/openspec/changes/scan-members/tasks.md
@@ -1,38 +1,38 @@
 ## 1. Public surface
 
-- [ ] 1.1 Add `scan_members(self) -> list[ArchiveMember]` to the `ArchiveReader` protocol in `src/archivey/reader.py`, documenting: returns the fully-resolved list; in streaming mode it finishes (runs, or completes an interrupted) single forward pass and may follow a completed one.
+- [x] 1.1 Add `scan_members(self) -> list[ArchiveMember]` to the `ArchiveReader` protocol in `src/archivey/reader.py`, documenting: returns the fully-resolved list; in streaming mode it finishes (runs, or completes an interrupted) single forward pass and may follow a completed one.
 
 ## 2. Failing tests (red)
 
-- [ ] 2.1 `tests/test_tar.py`: streaming tar with a **forward-pointing symlink** — `scan_members()` returns the list with that symlink's `link_target_member` resolved (parity with random-access `members()` on the same archive).
-- [ ] 2.2 `tests/test_tar.py`: after a complete streaming `__iter__` (and separately `stream_members`) pass, `get_members_if_available()` returns the fully-resolved list (not `None`), and a forward symlink collected during the pass now shows its resolved target (in-place fill).
-- [ ] 2.3 `tests/test_tar.py`: `scan_members()` **finishes an interrupted pass** — iterate with an early `break`, then `scan_members()` returns the complete resolved list; a subsequent `__iter__`/`stream_members`/`extract_all` raises `UnsupportedOperationError`.
-- [ ] 2.4 `tests/test_tar.py`: an **abandoned** partial pass (early `break`, no `scan_members`) leaves `get_members_if_available()` returning `None`.
-- [ ] 2.5 One-pass-only rejection (streaming): a second `__iter__`/`stream_members`/`extract_all` raises `UnsupportedOperationError` — **including a second `__iter__` after the first ran to completion** (no cache-replay). Cover no-index (tar) and an indexed format (zip).
-- [ ] 2.6 `scan_members()` in random-access mode returns the same list as `members()` and leaves the reader usable (nothing consumed); cover zip (trailing-index), a directory (leading-index), and tar (no-index).
-- [ ] 2.7 `scan_members()` before any pass on a streaming reader consumes it (subsequent `stream_members()` raises) for every topology, incl. an indexed zip.
-- [ ] 2.8 `tests/test_zip.py`: index-only vs resolved links — `get_members_if_available()` returns a ZIP symlink with `link_target`/`link_target_member` **unset** and reads no member data; `members()`/`scan_members()` return it **resolved**; `open()`/`read()`/extraction still follow the symlink.
+- [x] 2.1 `tests/test_tar.py`: streaming tar with a **forward-pointing symlink** — `scan_members()` returns the list with that symlink's `link_target_member` resolved (parity with random-access `members()` on the same archive).
+- [x] 2.2 `tests/test_tar.py`: after a complete streaming `__iter__` (and separately `stream_members`) pass, `get_members_if_available()` returns the fully-resolved list (not `None`), and a forward symlink collected during the pass now shows its resolved target (in-place fill).
+- [x] 2.3 `tests/test_tar.py`: `scan_members()` **finishes an interrupted pass** — iterate with an early `break`, then `scan_members()` returns the complete resolved list; a subsequent `__iter__`/`stream_members`/`extract_all` raises `UnsupportedOperationError`.
+- [x] 2.4 `tests/test_tar.py`: an **abandoned** partial pass (early `break`, no `scan_members`) leaves `get_members_if_available()` returning `None`.
+- [x] 2.5 One-pass-only rejection (streaming): a second `__iter__`/`stream_members`/`extract_all` raises `UnsupportedOperationError` — **including a second `__iter__` after the first ran to completion** (no cache-replay). Cover no-index (tar) and an indexed format (zip).
+- [x] 2.6 `scan_members()` in random-access mode returns the same list as `members()` and leaves the reader usable (nothing consumed); cover zip (trailing-index), a directory (leading-index), and tar (no-index).
+- [x] 2.7 `scan_members()` before any pass on a streaming reader consumes it (subsequent `stream_members()` raises) for every topology, incl. an indexed zip.
+- [x] 2.8 `tests/test_zip.py`: index-only vs resolved links — `get_members_if_available()` returns a ZIP symlink with `link_target`/`link_target_member` **unset** and reads no member data; `members()`/`scan_members()` return it **resolved**; `open()`/`read()`/extraction still follow the symlink.
 
 ## 3. base_reader implementation (green)
 
-- [ ] 3.1 Add `_forward_pass_started: bool` (init `False`) and a guard that, in streaming mode, raises `UnsupportedOperationError` from `__iter__`/`stream_members`/`extract_all` when a pass has already started (even a completed one). Set the flag when a pass begins. `scan_members()` is exempt (it may finish/return the pass); `get_members_if_available()` never sets or checks it.
-- [ ] 3.2 Make the streaming forward pass a **single instance-held** iterator so an interrupted pass can be continued: `_register_progressively` accumulates into instance state (`_scanned`, `_by_name_lists`) and, on **normal exhaustion** (consumer-drained or `scan_members`-drained to EOF), runs full `_resolve_link` over all link members (forward/last-wins/chains, in place) and sets `self._members_cache` / `self._members_by_name_lists`. Confirm an early `break` (without finishing) does not reach the finalization tail.
-- [ ] 3.3 Implement `scan_members()`: random-access → `list(self._get_members_registered())`; streaming → return `_members_cache` if set, else begin (if not started) and drain the instance-held pass to EOF (metadata only), triggering 3.2's finalization, then return `_members_cache`.
-- [ ] 3.4 Ensure `get_members_if_available()` is index-only: returns `_members_cache` when set, the index list for `_MEMBER_LIST_UPFRONT` backends (no member-data read), else `None`. No pass consumption, no scan.
+- [x] 3.1 Add `_forward_pass_started: bool` (init `False`) and a guard that, in streaming mode, raises `UnsupportedOperationError` from `__iter__`/`stream_members`/`extract_all` when a pass has already started (even a completed one). Set the flag when a pass begins. `scan_members()` is exempt (it may finish/return the pass); `get_members_if_available()` never sets or checks it.
+- [x] 3.2 Make the streaming forward pass a **single instance-held** iterator so an interrupted pass can be continued: `_register_progressively` accumulates into instance state (`_scanned`, `_by_name_lists`) and, on **normal exhaustion** (consumer-drained or `scan_members`-drained to EOF), runs full `_resolve_link` over all link members (forward/last-wins/chains, in place) and sets `self._members_cache` / `self._members_by_name_lists`. Confirm an early `break` (without finishing) does not reach the finalization tail.
+- [x] 3.3 Implement `scan_members()`: random-access → `list(self._get_members_registered())`; streaming → return `_members_cache` if set, else begin (if not started) and drain the instance-held pass to EOF (metadata only), triggering 3.2's finalization, then return `_members_cache`.
+- [x] 3.4 Ensure `get_members_if_available()` is index-only: returns `_members_cache` when set, the index list for `_MEMBER_LIST_UPFRONT` backends (no member-data read), else `None`. No pass consumption, no scan.
 
 ## 4. Backend routing / ZIP symlink deferral
 
-- [ ] 4.1 Refactor TAR's `_iter_with_data()` streaming path to pull from the shared instance-held forward pass (so `__iter__`/`stream_members`/`scan_members` share one cursor and finalization), opening member data alongside; preserve the `_verify_tar_eof()` interaction.
-- [ ] 4.2 ZIP: stop `ZipReader._to_member` from eagerly opening+reading symlink data during enumeration. Leave `link_target` unset at enumeration; read the target lazily where a resolved target is needed — link resolution in `_get_members_registered`/`scan_members`, and link-following in `open()`/`read()`/extraction. Verify listing performs no symlink-data reads.
-- [ ] 4.3 Update the `BaseArchiveReader` docstring: streaming backends overriding `_iter_with_data()` MUST route their forward pass through the shared `_register_progressively` pass (so the resolved cache is finalized on completion and `scan_members` can finish an interrupted pass). Note this as a requirement for the future native 7z/RAR readers.
+- [x] 4.1 Refactor TAR's `_iter_with_data()` streaming path to pull from the shared instance-held forward pass (so `__iter__`/`stream_members`/`scan_members` share one cursor and finalization), opening member data alongside; preserve the `_verify_tar_eof()` interaction.
+- [x] 4.2 ZIP: stop `ZipReader._to_member` from eagerly opening+reading symlink data during enumeration. Leave `link_target` unset at enumeration; read the target lazily where a resolved target is needed — link resolution in `_get_members_registered`/`scan_members`, and link-following in `open()`/`read()`/extraction. Verify listing performs no symlink-data reads.
+- [x] 4.3 Update the `BaseArchiveReader` docstring: streaming backends overriding `_iter_with_data()` MUST route their forward pass through the shared `_register_progressively` pass (so the resolved cache is finalized on completion and `scan_members` can finish an interrupted pass). Note this as a requirement for the future native 7z/RAR readers.
 
 ## 5. Docs
 
-- [ ] 5.1 Update `ARCHITECTURE.md` §2.4: `scan_members()`, post-pass materialization, one-pass-only (no streaming `__iter__` replay), the index-only `get_members_if_available()` contract, and the resolved-vs-unresolved-links asymmetry (link targets stored in member data). Correct the illustrative `members()` snippet if it implies streaming materialization or streaming replay.
+- [x] 5.1 Update `ARCHITECTURE.md` §2.4: `scan_members()`, post-pass materialization, one-pass-only (no streaming `__iter__` replay), the index-only `get_members_if_available()` contract, and the resolved-vs-unresolved-links asymmetry (link targets stored in member data). Correct the illustrative `members()` snippet if it implies streaming materialization or streaming replay.
 
 ## 6. Validation gate
 
-- [ ] 6.1 `openspec validate scan-members --strict` passes.
-- [ ] 6.2 Type-check clean: `uv run --no-sync pyrefly check` and `uv run --no-sync ty check`.
-- [ ] 6.3 Lint clean: `uv run --no-sync ruff check`.
-- [ ] 6.4 Tests pass across the three dependency configs (`[all]`, `[all-lowest]`, `[core-only]`) per CONTRIBUTING "Before pushing…".
+- [x] 6.1 `openspec validate scan-members --strict` passes.
+- [x] 6.2 Type-check clean: `uv run --no-sync pyrefly check` and `uv run --no-sync ty check`.
+- [x] 6.3 Lint clean: `uv run --no-sync ruff check`.
+- [x] 6.4 Tests pass across the three dependency configs (`[all]`, `[all-lowest]`, `[core-only]`) per CONTRIBUTING "Before pushing…".

--- a/openspec/specs/archive-data-model/spec.md
+++ b/openspec/specs/archive-data-model/spec.md
@@ -186,9 +186,11 @@ class ArchiveMember:
     # --- Link semantics ---
     link_target: str | None                 # SYMLINK/HARDLINK target path as stored (not normalized);
                                             #   may be None until filled while streaming
-    link_target_member: "ArchiveMember | None"  # the resolved target member within this same archive,
-                                            #   or None when the target is unknown, not yet resolved
-                                            #   (streaming), or absent from the archive
+    link_target_member: "ArchiveMember | None"  # the fully dereferenced target within this same
+                                            #   archive — the terminal member at the end of the
+                                            #   link chain (not the immediate hop); or None when
+                                            #   the target is unknown, not yet resolved (streaming),
+                                            #   or absent from the archive
 
     # --- Compression ---
     compression: tuple[CompressionMethod, ...] = ()

--- a/openspec/specs/archive-reading/spec.md
+++ b/openspec/specs/archive-reading/spec.md
@@ -316,7 +316,7 @@ seeks directly to the member with no re-decompression.
 
 ### Requirement: Transparent link following
 
-The system SHALL transparently follow symlinks and hardlinks in `open()` and `read()`. If `member.type` is `SYMLINK` or `HARDLINK`, the call is redirected to the target member. This behavior is format-independent and is implemented once in the `ArchiveReader` ABC. The resolved target, when known, is also exposed as `member.link_target_member`.
+The system SHALL transparently follow symlinks and hardlinks in `open()` and `read()`. If `member.type` is `SYMLINK` or `HARDLINK`, the call is redirected to the target member. This behavior is format-independent and is implemented once in the `ArchiveReader` ABC. The fully dereferenced target (the terminal member at the end of the link chain — not the immediate hop — see `archive-data-model`), when known, is also exposed as `member.link_target_member`.
 
 **Hardlinks** SHALL always resolve to an **earlier** member (this is the TAR model, in
 which a hardlink entry refers back to a previously-seen file); the library relies on
@@ -341,7 +341,10 @@ cycle. There is no fixed depth limit; an acyclic chain of any length resolves, a
 an actual cycle (or a missing target) fails.
 
 ```python
-# ABC implementation (ARCHITECTURE.md §2.3)
+# Illustrative only — the real code lives in internal/base_reader.py:
+#   _open_with_link_follow()  (open()/read() link following)
+#   _lookup_link_target()     (target-name resolution; not get(name))
+#   _resolve_link() / _register_progressively()  (eager link_target_member fill)
 def open(self, member: str | ArchiveMember, _seen: frozenset[int] = frozenset()) -> BinaryIO:
     if isinstance(member, str):
         found = self.get(member)  # name lookup — there is no __getitem__ on the reader
@@ -351,7 +354,9 @@ def open(self, member: str | ArchiveMember, _seen: frozenset[int] = frozenset())
     if member.type in (MemberType.SYMLINK, MemberType.HARDLINK) and member.link_target:
         if member.member_id in _seen:
             raise ReadError(f"Link cycle detected at '{member.name}'")
-        target = member.link_target_member or self.get(member.link_target)
+        target = member.link_target_member or self._lookup_link_target(
+            member, self._members_by_name
+        )
         if target is None:
             raise LinkTargetNotFoundError(f"Link target '{member.link_target}' not in archive")
         return self.open(target, _seen=_seen | {member.member_id})

--- a/openspec/specs/archive-reading/spec.md
+++ b/openspec/specs/archive-reading/spec.md
@@ -355,7 +355,7 @@ def open(self, member: str | ArchiveMember, _seen: frozenset[int] = frozenset())
         if member.member_id in _seen:
             raise ReadError(f"Link cycle detected at '{member.name}'")
         target = member.link_target_member or self._lookup_link_target(
-            member, self._members_by_name
+            member, self._members_by_name_lists
         )
         if target is None:
             raise LinkTargetNotFoundError(f"Link target '{member.link_target}' not in archive")

--- a/src/archivey/internal/backends/tar_reader.py
+++ b/src/archivey/internal/backends/tar_reader.py
@@ -235,8 +235,8 @@ class TarReader(BaseArchiveReader):
     def _iter_members_progressive(self) -> Iterator[ArchiveMember]:
         """Forward-only member walk — never calls ``getmembers()``.
 
-        Yields bare members; the base's streaming ``__iter__`` (via
-        ``_register_progressively``) stamps ids and resolves backward links.
+        Yields bare members; the base's shared progressive pass stamps ids and resolves
+        backward links.
         """
         try:
             for info in self._tar:
@@ -253,13 +253,10 @@ class TarReader(BaseArchiveReader):
         if not self._streaming:
             yield from super()._iter_with_data()
             return
-        # _register_progressively stamps ids and resolves backward links (hardlinks
-        # always point at an earlier member, so they resolve in this single pass); each
-        # member carries its TarInfo in _raw, which extractfile() uses directly.
+        # Pull from the shared instance-held progressive pass so __iter__,
+        # stream_members, and scan_members share one cursor and finalization.
         try:
-            for member in self._register_progressively(
-                self._to_member(info) for info in self._tar
-            ):
+            for member in self._begin_forward_pass():
                 if member.is_file:
                     info = cast("tarfile.TarInfo", member._raw)
                     raw = self._tar.extractfile(info)
@@ -276,7 +273,6 @@ class TarReader(BaseArchiveReader):
                 self._stamp_error_context(translated)
                 raise translated from exc
             raise
-        self._verify_tar_eof()
 
     def _verify_tar_eof(self) -> None:
         """Verify the two-block null end-of-archive marker.

--- a/src/archivey/internal/backends/zip_reader.py
+++ b/src/archivey/internal/backends/zip_reader.py
@@ -296,29 +296,6 @@ class ZipReader(BaseArchiveReader):
 
         algo = _ZIP_COMPRESSION_ALGOS.get(info.compress_type, CompressionAlgorithm.UNKNOWN)
 
-        link_target = None
-        if member_type == MemberType.SYMLINK:
-            # A symlink's target is its (possibly encrypted) file data. Listing must stay
-            # usable without a password, so a missing/wrong password leaves link_target
-            # unset (following the link later fails with LinkTargetNotFoundError); other
-            # errors surface translated like any member-read error.
-            try:
-                with self._archive.open(info, pwd=self._password) as f:
-                    link_target = f.read().decode("utf-8", errors="surrogateescape")
-            except (RuntimeError, zipfile.BadZipFile) as exc:
-                translated = self._translate_exception(exc)
-                if isinstance(translated, EncryptionError):
-                    logger.warning(
-                        "Cannot read the symlink target of %r without the correct "
-                        "password; leaving link_target unset.",
-                        info.filename,
-                    )
-                elif translated is not None:
-                    self._stamp_error_context(translated, info.filename)
-                    raise translated from exc
-                else:
-                    raise
-
         modified, accessed, created = _zip_timestamps(info)
         return ArchiveMember(
             type=member_type,
@@ -334,10 +311,35 @@ class ZipReader(BaseArchiveReader):
             is_encrypted=bool(info.flag_bits & 0x1),
             comment=_decode_with_fallback(info.comment) if info.comment else None,
             create_system=create_system,
-            link_target=link_target,
             extra={"zip.compress_type": info.compress_type},
             _raw=info,  # carry the ZipInfo so _open_member needs no name/id lookup table
         )
+
+    def _ensure_link_target(self, member: ArchiveMember) -> None:
+        if member.type != MemberType.SYMLINK or member.link_target is not None:
+            return
+        info = member._raw
+        assert isinstance(info, zipfile.ZipInfo), "ZIP member is missing its ZipInfo handle"
+        # A symlink's target is its (possibly encrypted) file data. Listing must stay
+        # usable without a password, so a missing/wrong password leaves link_target
+        # unset (following the link later fails with LinkTargetNotFoundError); other
+        # errors surface translated like any member-read error.
+        try:
+            with self._archive.open(info, pwd=self._password) as f:
+                member.link_target = f.read().decode("utf-8", errors="surrogateescape")
+        except (RuntimeError, zipfile.BadZipFile) as exc:
+            translated = self._translate_exception(exc)
+            if isinstance(translated, EncryptionError):
+                logger.warning(
+                    "Cannot read the symlink target of %r without the correct "
+                    "password; leaving link_target unset.",
+                    info.filename,
+                )
+            elif translated is not None:
+                self._stamp_error_context(translated, info.filename)
+                raise translated from exc
+            else:
+                raise
 
     def _open_member(self, member: ArchiveMember) -> BinaryIO:
         # The member carries its own ZipInfo (`_raw`), so data access needs no name/id map

--- a/src/archivey/internal/base_reader.py
+++ b/src/archivey/internal/base_reader.py
@@ -186,7 +186,7 @@ class BaseArchiveReader(ArchiveReader):
         # denominator for a source whose total size is not cheaply knowable).
         self._compressed_input_counter: CountingReader | None = None
         self._members_cache: list[ArchiveMember] | None = None
-        self._members_by_name: dict[str, ArchiveMember] | None = None
+        self._members_by_name_lists: dict[str, list[ArchiveMember]] | None = None
         self._closed = False
 
     @abstractmethod
@@ -270,43 +270,83 @@ class BaseArchiveReader(ArchiveReader):
             member._archive_id = self._archive_id
             members.append(member)
 
-        # Last-wins name map (symlinks and hardlink forward-fallback in random access).
-        by_name_last: dict[str, ArchiveMember] = {m.name: m for m in members}
+        by_name_lists: dict[str, list[ArchiveMember]] = {}
+        for m in members:
+            self._index_member_name(by_name_lists, m)
 
         for member in members:
             if member.is_link and member.link_target:
-                self._resolve_link(member, members, by_name_last)
+                self._resolve_link(member, by_name_lists)
 
         self._members_cache = members
-        self._members_by_name = by_name_last
+        self._members_by_name_lists = by_name_lists
         return members
 
     @staticmethod
-    def _member_name_matches_target(member_name: str, target_name: str) -> bool:
-        if member_name == target_name:
-            return True
-        return not target_name.endswith("/") and member_name == target_name + "/"
+    def _index_member_name(
+        by_name_lists: dict[str, list[ArchiveMember]], member: ArchiveMember
+    ) -> None:
+        by_name_lists.setdefault(member.name, []).append(member)
 
     @staticmethod
-    def _lookup_name_in_map(
-        target_name: str, by_name: Mapping[str, ArchiveMember]
+    def _target_name_keys(target_name: str) -> tuple[str, ...]:
+        if target_name.endswith("/"):
+            return (target_name,)
+        return (target_name, target_name + "/")
+
+    @staticmethod
+    def _latest_prior_named_member(
+        target_name: str,
+        before_id: int,
+        by_name_lists: Mapping[str, list[ArchiveMember]],
     ) -> ArchiveMember | None:
-        target = by_name.get(target_name)
-        if target is None and not target_name.endswith("/"):
-            target = by_name.get(target_name + "/")
-        return target
+        """Latest member matching ``target_name`` with ``member_id`` strictly before ``before_id``."""
+        best: ArchiveMember | None = None
+        best_id = -1
+        for name in BaseArchiveReader._target_name_keys(target_name):
+            for prior in reversed(by_name_lists.get(name, [])):
+                prior_id = prior._member_id
+                if prior_id is None:
+                    continue
+                if prior_id < before_id:
+                    if prior_id > best_id:
+                        best = prior
+                        best_id = prior_id
+                    break
+        return best
+
+    @staticmethod
+    def _last_by_exact_name(
+        name: str, by_name_lists: Mapping[str, list[ArchiveMember]]
+    ) -> ArchiveMember | None:
+        candidates = by_name_lists.get(name)
+        if not candidates:
+            return None
+        return candidates[-1]
+
+    @staticmethod
+    def _last_named_member(
+        target_name: str, by_name_lists: Mapping[str, list[ArchiveMember]]
+    ) -> ArchiveMember | None:
+        """Last-wins lookup for a link target (tries bare and ``/``-suffixed names)."""
+        for name in BaseArchiveReader._target_name_keys(target_name):
+            candidates = by_name_lists.get(name)
+            if candidates:
+                return candidates[-1]
+        return None
 
     @staticmethod
     def _lookup_link_target(
-        member: ArchiveMember, by_name: Mapping[str, ArchiveMember]
+        member: ArchiveMember,
+        by_name_lists: Mapping[str, list[ArchiveMember]],
     ) -> ArchiveMember | None:
         """The member ``member``'s link target refers to, or ``None`` if not present.
 
         Resolves the stored target string to an archive-namespace name first (a symlink
         target is relative to the link's own directory — see
-        :func:`resolve_link_target_name`), then looks it up in ``by_name`` (last-wins for
-        symlinks); directory members carry a trailing ``/`` in their names, so both forms
-        are tried.
+        :func:`resolve_link_target_name`), then looks it up in ``by_name_lists``
+        (last-wins for symlinks); directory members carry a trailing ``/`` in their names,
+        so both forms are tried.
         """
         if not member.link_target:
             return None
@@ -315,13 +355,12 @@ class BaseArchiveReader(ArchiveReader):
         )
         if target_name is None:
             return None
-        return BaseArchiveReader._lookup_name_in_map(target_name, by_name)
+        return BaseArchiveReader._last_named_member(target_name, by_name_lists)
 
     @staticmethod
     def _lookup_hardlink_target(
         member: ArchiveMember,
-        members: list[ArchiveMember],
-        by_name_last: Mapping[str, ArchiveMember],
+        by_name_lists: Mapping[str, list[ArchiveMember]],
         *,
         allow_forward_fallback: bool,
     ) -> ArchiveMember | None:
@@ -333,59 +372,51 @@ class BaseArchiveReader(ArchiveReader):
         )
         if target_name is None:
             return None
-        member_id = member.member_id
-        if member_id is None:
+        before_id = member._member_id
+        if before_id is None:
             return None
-        found: ArchiveMember | None = None
-        for prior in members:
-            if prior.member_id is None or prior.member_id >= member_id:
-                break
-            if BaseArchiveReader._member_name_matches_target(prior.name, target_name):
-                found = prior
+        found = BaseArchiveReader._latest_prior_named_member(
+            target_name, before_id, by_name_lists
+        )
         if found is not None:
             return found
         if allow_forward_fallback:
-            return BaseArchiveReader._lookup_name_in_map(target_name, by_name_last)
+            return BaseArchiveReader._last_named_member(target_name, by_name_lists)
         return None
 
     def _lookup_link_target_for_member(
         self,
         member: ArchiveMember,
-        members: list[ArchiveMember],
-        by_name_last: Mapping[str, ArchiveMember],
+        by_name_lists: Mapping[str, list[ArchiveMember]],
         *,
         allow_forward_fallback: bool = True,
     ) -> ArchiveMember | None:
         if member.type == MemberType.HARDLINK:
             return self._lookup_hardlink_target(
                 member,
-                members,
-                by_name_last,
+                by_name_lists,
                 allow_forward_fallback=allow_forward_fallback,
             )
-        return self._lookup_link_target(member, by_name_last)
+        return self._lookup_link_target(member, by_name_lists)
 
     def _resolve_link(
         self,
         member: ArchiveMember,
-        members: list[ArchiveMember],
-        by_name_last: dict[str, ArchiveMember],
+        by_name_lists: dict[str, list[ArchiveMember]],
     ) -> None:
         """Resolve link_target to the fully dereferenced link_target_member."""
         visited: set[int] = set()
         current = member
 
         while current.is_link and current.link_target:
-            member_id = current.member_id
-            if member_id is None:
+            if current._member_id is None:
                 return
+            member_id = current._member_id
             if member_id in visited:
                 # Cycle detected; leave link_target_member unset (None).
                 return
             visited.add(member_id)
-            target = self._lookup_link_target_for_member(
-                current, members, by_name_last
-            )
+            target = self._lookup_link_target_for_member(current, by_name_lists)
             if target is None:
                 return
             current = target
@@ -404,8 +435,7 @@ class BaseArchiveReader(ArchiveReader):
         unresolved (``link_target_member`` ``None``). A backend that already stamps ids
         is left untouched (the stamp only fills unset fields).
         """
-        by_name: dict[str, ArchiveMember] = {}
-        seen: list[ArchiveMember] = []
+        by_name_lists: dict[str, list[ArchiveMember]] = {}
         for idx, member in enumerate(members):
             if member._member_id is None:
                 member._member_id = idx
@@ -413,8 +443,7 @@ class BaseArchiveReader(ArchiveReader):
             if member.is_link and member.link_target_member is None:
                 target = self._lookup_link_target_for_member(
                     member,
-                    seen,
-                    by_name,
+                    by_name_lists,
                     allow_forward_fallback=False,
                 )
                 if target is not None and target is not member:
@@ -424,8 +453,7 @@ class BaseArchiveReader(ArchiveReader):
                         target = target.link_target_member
                     if target is not None:
                         member.link_target_member = target
-            seen.append(member)
-            by_name[member.name] = member
+            self._index_member_name(by_name_lists, member)
             yield member
 
     # --- Public API ---
@@ -558,8 +586,9 @@ class BaseArchiveReader(ArchiveReader):
     def get(self, name: str, default: ArchiveMember | None = None) -> ArchiveMember | None:
         self._require_random_access("get()")
         self._get_members_registered()
-        assert self._members_by_name is not None
-        return self._members_by_name.get(name, default)
+        assert self._members_by_name_lists is not None
+        found = self._last_by_exact_name(name, self._members_by_name_lists)
+        return found if found is not None else default
 
     def open(self, member: str | ArchiveMember) -> BinaryIO:
         """Open member for reading. Follows symlinks."""
@@ -587,14 +616,18 @@ class BaseArchiveReader(ArchiveReader):
         visited: set[int],
     ) -> BinaryIO:
         if member.type in (MemberType.SYMLINK, MemberType.HARDLINK):
-            member_id = member.member_id
-            if member_id is not None:
-                if member_id in visited:
-                    raise ReadError(
-                        f"Link cycle detected at '{member.name}'",
-                        member_name=member.name,
-                    )
-                visited.add(member_id)
+            if member._member_id is None:
+                raise LinkTargetNotFoundError(
+                    f"Link target for {member.name!r} is unknown",
+                    member_name=member.name,
+                )
+            member_id = member._member_id
+            if member_id in visited:
+                raise ReadError(
+                    f"Link cycle detected at '{member.name}'",
+                    member_name=member.name,
+                )
+            visited.add(member_id)
             if member.link_target_member is not None:
                 return self._open_with_link_follow(member.link_target_member, visited)
             if member.link_target is None:
@@ -602,11 +635,10 @@ class BaseArchiveReader(ArchiveReader):
                     f"Link target for {member.name!r} is unknown",
                     member_name=member.name,
                 )
-            members = self._members_cache
-            by_name = self._members_by_name
+            by_name_lists = self._members_by_name_lists
             target = (
-                self._lookup_link_target_for_member(member, members, by_name)
-                if members is not None and by_name is not None
+                self._lookup_link_target_for_member(member, by_name_lists)
+                if by_name_lists is not None
                 else None
             )
             if target is None:

--- a/src/archivey/internal/base_reader.py
+++ b/src/archivey/internal/base_reader.py
@@ -264,16 +264,10 @@ class BaseArchiveReader(ArchiveReader):
         if self._members_cache is not None:
             return self._members_cache
 
-        members: list[ArchiveMember] = []
-        for idx, member in enumerate(self._iter_members()):
-            member._member_id = idx
-            member._archive_id = self._archive_id
-            members.append(member)
-
+        members = list(self._register_progressively(self._iter_members()))
         by_name_lists: dict[str, list[ArchiveMember]] = {}
         for m in members:
             self._index_member_name(by_name_lists, m)
-
         for member in members:
             if member.is_link and member.link_target:
                 self._resolve_link(member, by_name_lists)
@@ -434,6 +428,10 @@ class BaseArchiveReader(ArchiveReader):
         symlink to an earlier member resolves too, while a forward-pointing one stays
         unresolved (``link_target_member`` ``None``). A backend that already stamps ids
         is left untouched (the stamp only fills unset fields).
+
+        Eager registration (:meth:`_get_members_registered`) drains this iterator to
+        collect the full list, then runs :meth:`_resolve_link` on every link member so
+        forward-pointing symlinks and full chains are resolved too.
         """
         by_name_lists: dict[str, list[ArchiveMember]] = {}
         for idx, member in enumerate(members):

--- a/src/archivey/internal/base_reader.py
+++ b/src/archivey/internal/base_reader.py
@@ -146,15 +146,20 @@ class BaseArchiveReader(ArchiveReader):
     Access-mode enforcement (independent of the flags above): a ``streaming=True`` reader
     is forward-only, so ``members``/``get``/``open``/``read`` all raise
     ``UnsupportedOperationError`` — uniformly, not per-backend. Only a single pass of
-    ``__iter__``/``stream_members``/``extract_all`` (and ``get_members_if_available``)
-    is allowed. ``member in reader`` is identity-based and scan-free, so it works in
+    ``__iter__``/``stream_members``/``extract_all`` is allowed; ``scan_members()`` may
+    finish or return that pass. ``get_members_if_available()`` is a scan-free,
+    index-only peek. ``member in reader`` is identity-based and scan-free, so it works in
     either mode; there is no ``__len__``/``__getitem__`` (name lookup is ``get()``).
 
     **MAY override**:
 
     - ``_iter_with_data()`` — see its own docstring. The default is correct for
       random-access / indexed backends only; **streaming / solid backends MUST override
-      it** (correctness, not just efficiency).
+      it** (correctness, not just efficiency). Streaming backends that override
+      ``_iter_with_data()`` **MUST** route their forward metadata pass through the shared
+      instance-held progressive pass (``_begin_forward_pass``) so
+      ``scan_members()`` can finish an interrupted pass and the resolved cache is
+      finalized on completion. Native 7z/RAR readers will need the same contract.
 
     Everything else here (``_get_members_registered``, ``_resolve_link``,
     ``_open_with_link_follow``, ``_stamp_error_context``) is internal plumbing and is not
@@ -187,6 +192,10 @@ class BaseArchiveReader(ArchiveReader):
         self._compressed_input_counter: CountingReader | None = None
         self._members_cache: list[ArchiveMember] | None = None
         self._members_by_name_lists: dict[str, list[ArchiveMember]] | None = None
+        self._forward_pass_started: bool = False
+        self._progressive_gen: Iterator[ArchiveMember] | None = None
+        self._pass_scanned: list[ArchiveMember] = []
+        self._pass_by_name_lists: dict[str, list[ArchiveMember]] = {}
         self._closed = False
 
     @abstractmethod
@@ -206,7 +215,18 @@ class BaseArchiveReader(ArchiveReader):
         must **not** call ``_get_members_registered()``. The yielded stream is only valid
         until the iterator advances (see the ``stream_members`` contract in
         ``archive-reading``); for non-file members it is ``None``.
+
+        When ``streaming=True`` and the backend does not override, this default pulls
+        from the shared instance-held progressive pass and opens each file member on
+        demand.
         """
+        if self._streaming:
+            for member in self._begin_forward_pass():
+                if member.is_file:
+                    yield member, self._open_member(member)
+                else:
+                    yield member, None
+            return
         for member in self._get_members_registered():
             if member.is_file:
                 yield member, self._open_member(member)
@@ -264,10 +284,16 @@ class BaseArchiveReader(ArchiveReader):
         if self._members_cache is not None:
             return self._members_cache
 
-        members = list(self._register_progressively(self._iter_members()))
+        members = list(self._iter_members())
         by_name_lists: dict[str, list[ArchiveMember]] = {}
-        for m in members:
-            self._index_member_name(by_name_lists, m)
+        for idx, member in enumerate(members):
+            if member._member_id is None:
+                member._member_id = idx
+                member._archive_id = self._archive_id
+            self._index_member_name(by_name_lists, member)
+        for member in members:
+            if member.is_link:
+                self._ensure_link_target(member)
         for member in members:
             if member.is_link and member.link_target:
                 self._resolve_link(member, by_name_lists)
@@ -275,6 +301,19 @@ class BaseArchiveReader(ArchiveReader):
         self._members_cache = members
         self._members_by_name_lists = by_name_lists
         return members
+
+    def _get_members_index_only(self) -> list[ArchiveMember]:
+        """Index-only member list: stamp ids, no link resolution, no member-data reads."""
+        members = list(self._iter_members())
+        for idx, member in enumerate(members):
+            if member._member_id is None:
+                member._member_id = idx
+                member._archive_id = self._archive_id
+        return members
+
+    def _ensure_link_target(self, member: ArchiveMember) -> None:
+        """Populate ``link_target`` from member data when needed. Base is a no-op."""
+        return
 
     @staticmethod
     def _index_member_name(
@@ -418,41 +457,56 @@ class BaseArchiveReader(ArchiveReader):
         if current is not member:
             member.link_target_member = current
 
-    def _register_progressively(
-        self, members: Iterator[ArchiveMember]
-    ) -> Iterator[ArchiveMember]:
-        """Stamp ids and resolve *backward-pointing* links during a single forward pass.
+    def _finalize_pass_links(self) -> None:
+        """Resolve all links after a streaming forward pass reaches EOF."""
+        if self._members_cache is not None:
+            return
+        for member in self._pass_scanned:
+            if member.is_link:
+                self._ensure_link_target(member)
+        for member in self._pass_scanned:
+            if member.is_link and member.link_target:
+                self._resolve_link(member, self._pass_by_name_lists)
+        self._members_cache = self._pass_scanned
+        self._members_by_name_lists = self._pass_by_name_lists
 
-        Backs the streaming iteration paths. Hardlinks always refer to an earlier member
-        (the TAR model — see ``archive-reading``), so they resolve during the pass; a
-        symlink to an earlier member resolves too, while a forward-pointing one stays
-        unresolved (``link_target_member`` ``None``). A backend that already stamps ids
-        is left untouched (the stamp only fills unset fields).
+    def _stamp_progressive_member(self, idx: int, member: ArchiveMember) -> None:
+        if member._member_id is None:
+            member._member_id = idx
+            member._archive_id = self._archive_id
+        if member.is_link and member.link_target_member is None:
+            target = self._lookup_link_target_for_member(
+                member,
+                self._pass_by_name_lists,
+                allow_forward_fallback=False,
+            )
+            if target is not None and target is not member:
+                if target.is_link:
+                    target = target.link_target_member
+                if target is not None:
+                    member.link_target_member = target
+        self._index_member_name(self._pass_by_name_lists, member)
+        self._pass_scanned.append(member)
 
-        Eager registration (:meth:`_get_members_registered`) drains this iterator to
-        collect the full list, then runs :meth:`_resolve_link` on every link member so
-        forward-pointing symlinks and full chains are resolved too.
-        """
-        by_name_lists: dict[str, list[ArchiveMember]] = {}
-        for idx, member in enumerate(members):
-            if member._member_id is None:
-                member._member_id = idx
-                member._archive_id = self._archive_id
-            if member.is_link and member.link_target_member is None:
-                target = self._lookup_link_target_for_member(
-                    member,
-                    by_name_lists,
-                    allow_forward_fallback=False,
-                )
-                if target is not None and target is not member:
-                    # An earlier link's own resolution is already final; reuse it (an
-                    # unresolved earlier link yields None, i.e. stays unresolved).
-                    if target.is_link:
-                        target = target.link_target_member
-                    if target is not None:
-                        member.link_target_member = target
-            self._index_member_name(by_name_lists, member)
-            yield member
+    def _begin_forward_pass(self) -> Iterator[ArchiveMember]:
+        """Return the shared instance-held progressive pass, creating it if needed."""
+        if self._progressive_gen is None:
+            self._pass_scanned = []
+            self._pass_by_name_lists = {}
+            self._progressive_gen = _ProgressivePassIterator(self)
+        return self._progressive_gen
+
+    def _guard_forward_pass_entry(self, op: str) -> None:
+        if self._streaming and self._forward_pass_started:
+            raise UnsupportedOperationError(
+                f"{op} is not available after a streaming reader's forward pass has "
+                f"started. Call scan_members() for the resolved member list, or "
+                f"get_members_if_available() for an index-only peek.",
+            )
+
+    def _enter_forward_pass(self, op: str) -> None:
+        self._guard_forward_pass_entry(op)
+        self._forward_pass_started = True
 
     # --- Public API ---
 
@@ -463,14 +517,14 @@ class BaseArchiveReader(ArchiveReader):
         A ``streaming=True`` reader is forward-only: only a single pass of
         ``__iter__``/``stream_members`` (or one ``extract_all``) is allowed. This is
         uniform and format-independent — it does **not** depend on whether a backend
-        happens to have an index loaded (use :meth:`get_members_if_available` for a
-        no-scan peek at the list instead).
+        happens to have an index loaded (use :meth:`scan_members` or
+        :meth:`get_members_if_available` for member listing instead).
         """
         if self._streaming:
             raise UnsupportedOperationError(
                 f"{op} is not available on a streaming (forward-only) reader. "
-                f"Iterate with stream_members(), or call get_members_if_available() "
-                f"for a no-scan member list.",
+                f"Iterate with stream_members(), call scan_members() for the resolved "
+                f"member list, or get_members_if_available() for an index-only peek.",
             )
 
     @property
@@ -539,32 +593,43 @@ class BaseArchiveReader(ArchiveReader):
         return source
 
     def __iter__(self) -> Iterator[ArchiveMember]:
-        if self._streaming and self._members_cache is None:
-            # Forward-only: stream directly without caching the whole list, stamping ids
-            # and resolving backward-pointing links progressively (a forward-pointing
-            # symlink stays unresolved — a single pass cannot see later members).
-            yield from self._register_progressively(self._iter_members())
-        else:
-            yield from self._get_members_registered()
+        if self._streaming:
+            self._enter_forward_pass("__iter__")
+            yield from self._begin_forward_pass()
+            return
+        yield from self._get_members_registered()
 
     def members(self) -> list[ArchiveMember]:
         self._require_random_access("members()")
         return list(self._get_members_registered())
 
+    def scan_members(self) -> list[ArchiveMember]:
+        if not self._streaming:
+            return list(self._get_members_registered())
+        if self._members_cache is not None:
+            return self._members_cache
+        if not self._forward_pass_started:
+            self._forward_pass_started = True
+        gen = self._begin_forward_pass()
+        for _ in gen:
+            pass
+        assert self._members_cache is not None
+        return self._members_cache
+
     def get_members_if_available(self) -> list[ArchiveMember] | None:
         """Return the full member list if it is available **without scanning**, else
         ``None``. Safe to call on any reader (including a streaming one).
 
-        Non-``None`` when the list is already materialized (e.g. after an iteration
-        pass) or the backend has a true upfront index (``_MEMBER_LIST_UPFRONT`` — a ZIP
-        central directory, a 7z header, the filesystem listing). It never triggers a
-        scan or consumes the forward pass; when the list would require one it returns
-        ``None`` (call :meth:`members` to force materialization, in random mode).
+        Index-only: returns a materialized cache after a completed forward pass, or the
+        backend's upfront index when ``_MEMBER_LIST_UPFRONT`` is set. It never triggers
+        a forward scan, never reads member data, and never consumes the forward pass.
+        Link targets stored in member data (e.g. ZIP symlinks) may be unset; use
+        :meth:`members` or :meth:`scan_members` for a fully-resolved list.
         """
         if self._members_cache is not None:
             return self._members_cache
         if self._MEMBER_LIST_UPFRONT:
-            return self._get_members_registered()
+            return self._get_members_index_only()
         return None
 
     def __contains__(self, member: object) -> bool:
@@ -629,6 +694,8 @@ class BaseArchiveReader(ArchiveReader):
             if member.link_target_member is not None:
                 return self._open_with_link_follow(member.link_target_member, visited)
             if member.link_target is None:
+                self._ensure_link_target(member)
+            if member.link_target is None:
                 raise LinkTargetNotFoundError(
                     f"Link target for {member.name!r} is unknown",
                     member_name=member.name,
@@ -657,6 +724,8 @@ class BaseArchiveReader(ArchiveReader):
         members: MemberSelector = None,
     ) -> Iterator[tuple[ArchiveMember, BinaryIO | None]]:
         """Yield (member, stream) pairs. members is a selector filter (no transform)."""
+        if self._streaming:
+            self._enter_forward_pass("stream_members()")
         for m, stream in self._iter_with_data():
             if members is None or members(m):
                 yield m, stream
@@ -679,6 +748,8 @@ class BaseArchiveReader(ArchiveReader):
         max_entries: int = 1_048_576,
     ) -> list[ExtractionResult]:
         """Extract members to dest via the shared ``ExtractionCoordinator``."""
+        if self._streaming:
+            self._enter_forward_pass("extract_all()")
         # Imported here (not at module top) to keep the import graph tidy: extraction.py
         # type-checks against BaseArchiveReader.
         from archivey.internal.extraction import ExtractionCoordinator
@@ -718,3 +789,35 @@ class BaseArchiveReader(ArchiveReader):
             exc.archive_name = self._archive_name
         if exc.member_name is None and member_name is not None:
             exc.member_name = member_name
+
+
+class _ProgressivePassIterator(Iterator[ArchiveMember]):
+    """Instance-held streaming pass.
+
+    A generator would be closed (and its post-loop tail skipped) when a consumer
+    breaks out of ``for member in reader``; this iterator survives early exit so
+    :meth:`BaseArchiveReader.scan_members` can drain the remainder.
+    """
+
+    def __init__(self, reader: BaseArchiveReader) -> None:
+        self._reader = reader
+        self._members_source = reader._iter_members()
+        self._next_id = 0
+        self._exhausted = False
+
+    def __iter__(self) -> _ProgressivePassIterator:
+        return self
+
+    def __next__(self) -> ArchiveMember:
+        if self._exhausted:
+            raise StopIteration
+        try:
+            member = next(self._members_source)
+        except StopIteration:
+            self._exhausted = True
+            self._reader._finalize_pass_links()
+            raise
+        idx = self._next_id
+        self._next_id += 1
+        self._reader._stamp_progressive_member(idx, member)
+        return member

--- a/src/archivey/internal/base_reader.py
+++ b/src/archivey/internal/base_reader.py
@@ -10,6 +10,7 @@ from archivey.cost import CostReceipt
 from archivey.exceptions import (
     ArchiveyError,
     LinkTargetNotFoundError,
+    ReadError,
     UnsupportedOperationError,
 )
 from archivey.internal.extraction_types import (
@@ -269,17 +270,31 @@ class BaseArchiveReader(ArchiveReader):
             member._archive_id = self._archive_id
             members.append(member)
 
-        # Build name lookup for link resolution
-        by_name: dict[str, ArchiveMember] = {m.name: m for m in members}
+        # Last-wins name map (symlinks and hardlink forward-fallback in random access).
+        by_name_last: dict[str, ArchiveMember] = {m.name: m for m in members}
 
-        # Resolve symlinks/hardlinks
         for member in members:
-            if member.type in (MemberType.SYMLINK, MemberType.HARDLINK) and member.link_target:
-                self._resolve_link(member, by_name)
+            if member.is_link and member.link_target:
+                self._resolve_link(member, members, by_name_last)
 
         self._members_cache = members
-        self._members_by_name = by_name
+        self._members_by_name = by_name_last
         return members
+
+    @staticmethod
+    def _member_name_matches_target(member_name: str, target_name: str) -> bool:
+        if member_name == target_name:
+            return True
+        return not target_name.endswith("/") and member_name == target_name + "/"
+
+    @staticmethod
+    def _lookup_name_in_map(
+        target_name: str, by_name: Mapping[str, ArchiveMember]
+    ) -> ArchiveMember | None:
+        target = by_name.get(target_name)
+        if target is None and not target_name.endswith("/"):
+            target = by_name.get(target_name + "/")
+        return target
 
     @staticmethod
     def _lookup_link_target(
@@ -289,8 +304,9 @@ class BaseArchiveReader(ArchiveReader):
 
         Resolves the stored target string to an archive-namespace name first (a symlink
         target is relative to the link's own directory — see
-        :func:`resolve_link_target_name`), then looks it up; directory members carry a
-        trailing ``/`` in their names, so both forms are tried.
+        :func:`resolve_link_target_name`), then looks it up in ``by_name`` (last-wins for
+        symlinks); directory members carry a trailing ``/`` in their names, so both forms
+        are tried.
         """
         if not member.link_target:
             return None
@@ -299,33 +315,81 @@ class BaseArchiveReader(ArchiveReader):
         )
         if target_name is None:
             return None
-        target = by_name.get(target_name)
-        if target is None and not target_name.endswith("/"):
-            target = by_name.get(target_name + "/")
-        return target
+        return BaseArchiveReader._lookup_name_in_map(target_name, by_name)
+
+    @staticmethod
+    def _lookup_hardlink_target(
+        member: ArchiveMember,
+        members: list[ArchiveMember],
+        by_name_last: Mapping[str, ArchiveMember],
+        *,
+        allow_forward_fallback: bool,
+    ) -> ArchiveMember | None:
+        """Positional hardlink resolution: latest same-named member strictly before ``member``."""
+        if not member.link_target:
+            return None
+        target_name = resolve_link_target_name(
+            member.name, member.link_target, member.type
+        )
+        if target_name is None:
+            return None
+        member_id = member.member_id
+        if member_id is None:
+            return None
+        found: ArchiveMember | None = None
+        for prior in members:
+            if prior.member_id is None or prior.member_id >= member_id:
+                break
+            if BaseArchiveReader._member_name_matches_target(prior.name, target_name):
+                found = prior
+        if found is not None:
+            return found
+        if allow_forward_fallback:
+            return BaseArchiveReader._lookup_name_in_map(target_name, by_name_last)
+        return None
+
+    def _lookup_link_target_for_member(
+        self,
+        member: ArchiveMember,
+        members: list[ArchiveMember],
+        by_name_last: Mapping[str, ArchiveMember],
+        *,
+        allow_forward_fallback: bool = True,
+    ) -> ArchiveMember | None:
+        if member.type == MemberType.HARDLINK:
+            return self._lookup_hardlink_target(
+                member,
+                members,
+                by_name_last,
+                allow_forward_fallback=allow_forward_fallback,
+            )
+        return self._lookup_link_target(member, by_name_last)
 
     def _resolve_link(
         self,
         member: ArchiveMember,
-        by_name: dict[str, ArchiveMember],
+        members: list[ArchiveMember],
+        by_name_last: dict[str, ArchiveMember],
     ) -> None:
-        """Resolve link_target to link_target_member using cycle detection."""
-        visited: set[str] = set()
+        """Resolve link_target to the fully dereferenced link_target_member."""
+        visited: set[int] = set()
         current = member
 
         while current.is_link and current.link_target:
-            if current.name in visited:
-                # Cycle detected; leave link_target_member unset (None) rather than
-                # pointing at an intermediate link in the cycle.
+            member_id = current.member_id
+            if member_id is None:
                 return
-            visited.add(current.name)
-            target = self._lookup_link_target(current, by_name)
+            if member_id in visited:
+                # Cycle detected; leave link_target_member unset (None).
+                return
+            visited.add(member_id)
+            target = self._lookup_link_target_for_member(
+                current, members, by_name_last
+            )
             if target is None:
-                # Missing/unresolvable target - leave link_target_member as None
                 return
             current = target
 
-        # Set on the original member (the final resolved target or None on cycle)
         if current is not member:
             member.link_target_member = current
 
@@ -341,12 +405,18 @@ class BaseArchiveReader(ArchiveReader):
         is left untouched (the stamp only fills unset fields).
         """
         by_name: dict[str, ArchiveMember] = {}
+        seen: list[ArchiveMember] = []
         for idx, member in enumerate(members):
             if member._member_id is None:
                 member._member_id = idx
                 member._archive_id = self._archive_id
             if member.is_link and member.link_target_member is None:
-                target = self._lookup_link_target(member, by_name)
+                target = self._lookup_link_target_for_member(
+                    member,
+                    seen,
+                    by_name,
+                    allow_forward_fallback=False,
+                )
                 if target is not None and target is not member:
                     # An earlier link's own resolution is already final; reuse it (an
                     # unresolved earlier link yields None, i.e. stays unresolved).
@@ -354,6 +424,7 @@ class BaseArchiveReader(ArchiveReader):
                         target = target.link_target_member
                     if target is not None:
                         member.link_target_member = target
+            seen.append(member)
             by_name[member.name] = member
             yield member
 
@@ -506,20 +577,24 @@ class BaseArchiveReader(ArchiveReader):
             if found is None:
                 raise KeyError(f"Member {member!r} not found")
             member = found
+        else:
+            self._get_members_registered()
         return self._open_with_link_follow(member, visited=set())
 
     def _open_with_link_follow(
         self,
         member: ArchiveMember,
-        visited: set[str],
+        visited: set[int],
     ) -> BinaryIO:
         if member.type in (MemberType.SYMLINK, MemberType.HARDLINK):
-            if member.name in visited:
-                raise LinkTargetNotFoundError(
-                    f"Symlink cycle detected involving {member.name!r}",
-                    member_name=member.name,
-                )
-            visited.add(member.name)
+            member_id = member.member_id
+            if member_id is not None:
+                if member_id in visited:
+                    raise ReadError(
+                        f"Link cycle detected at '{member.name}'",
+                        member_name=member.name,
+                    )
+                visited.add(member_id)
             if member.link_target_member is not None:
                 return self._open_with_link_follow(member.link_target_member, visited)
             if member.link_target is None:
@@ -527,9 +602,11 @@ class BaseArchiveReader(ArchiveReader):
                     f"Link target for {member.name!r} is unknown",
                     member_name=member.name,
                 )
+            members = self._members_cache
+            by_name = self._members_by_name
             target = (
-                self._lookup_link_target(member, self._members_by_name)
-                if self._members_by_name
+                self._lookup_link_target_for_member(member, members, by_name)
+                if members is not None and by_name is not None
                 else None
             )
             if target is None:

--- a/src/archivey/reader.py
+++ b/src/archivey/reader.py
@@ -62,7 +62,19 @@ class ArchiveReader(ABC):
     @abstractmethod
     def members(self) -> list[ArchiveMember]:
         """All members as a list. May trigger a scan; raises ``UnsupportedOperationError``
-        on a streaming reader (use :meth:`get_members_if_available` there)."""
+        on a streaming reader (use :meth:`scan_members` or
+        :meth:`get_members_if_available` there)."""
+        ...
+
+    @abstractmethod
+    def scan_members(self) -> list[ArchiveMember]:
+        """Return the fully-resolved member list in either access mode.
+
+        In random-access mode this is equivalent to :meth:`members` and does not
+        consume the reader. On a streaming reader it finishes the single forward pass
+        (running it from the start, or completing an interrupted one) and returns the
+        resolved list; it may also be called after a completed pass to return the
+        cached list."""
         ...
 
     @abstractmethod

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -891,6 +891,28 @@ def test_orphan_materialized_source_carries_link_metadata(tmp_path: Path) -> Non
     assert int(st.st_mtime) == link_mtime  # the link member's mtime, not the source's
 
 
+def test_hardlink_duplicate_name_extraction_links_first_inode(tmp_path: Path) -> None:
+    src = tmp_path / "dup-hardlink.tar"
+    src.write_bytes(
+        _tar_bytes(
+            [
+                ("file", "A.txt", b"content1"),
+                ("hard", "L.txt", "A.txt"),
+                ("file", "A.txt", b"content2"),
+            ]
+        )
+    )
+    dest = tmp_path / "out"
+    with open_archive(src) as r:
+        results = r.extract_all(dest, overwrite=OverwritePolicy.REPLACE)
+    assert all(res.status is ExtractionStatus.EXTRACTED for res in results)
+    assert (dest / "L.txt").read_bytes() == b"content1"
+    assert (dest / "A.txt").read_bytes() == b"content2"
+    # L was linked against the first A.txt inode; the second duplicate replaced the path.
+    if os.name == "posix":
+        assert not os.path.samefile(dest / "A.txt", dest / "L.txt")
+
+
 def test_hardlink_before_source_shares_inode_and_counts_once(tmp_path: Path) -> None:
     # Regression: a hardlink PRECEDING its source in archive order (legal in crafted /
     # non-GNU-ordered archives) was re-read in the second pass and written as an

--- a/tests/test_reader_contract.py
+++ b/tests/test_reader_contract.py
@@ -75,12 +75,6 @@ class _ForwardOnlyReader(BaseArchiveReader):
     def _open_member(self, member: ArchiveMember) -> BinaryIO:
         return io.BytesIO(b"x")
 
-    def _iter_with_data(self) -> Iterator[tuple[ArchiveMember, BinaryIO | None]]:
-        # Forward-only backends MUST override this: yield progressively, never
-        # pre-register the whole member list.
-        for member in self._iter_members():
-            yield member, (io.BytesIO(b"x") if member.is_file else None)
-
     def _get_archive_info(self) -> ArchiveInfo:
         return _info(
             ArchiveFormat.TAR, ListingCost.REQUIRES_SCANNING, StreamCapability.FORWARD_ONLY
@@ -179,3 +173,24 @@ def test_streaming_iteration_registers_member_ids() -> None:
     (member,) = list(reader)
     assert member.member_id == 0
     assert member.archive_id == reader._archive_id
+
+
+def test_streaming_second_iter_raises() -> None:
+    reader = _IndexedReader(ArchiveFormat.ZIP, True, "x.zip")
+    list(reader)
+    with pytest.raises(archivey.UnsupportedOperationError):
+        list(reader)
+
+
+def test_get_members_if_available_after_streaming_pass() -> None:
+    reader = _ForwardOnlyReader(ArchiveFormat.TAR, True, "x.tar")
+    list(reader)
+    members = reader.get_members_if_available()
+    assert members is not None
+    assert [m.name for m in members] == ["a.txt"]
+
+
+def test_scan_members_equals_members_in_random_mode() -> None:
+    reader = _IndexedReader(ArchiveFormat.ZIP, False, "x.zip")
+    assert reader.scan_members() == reader.members()
+    assert [m.name for m in reader] == ["a.txt"]

--- a/tests/test_tar.py
+++ b/tests/test_tar.py
@@ -24,6 +24,7 @@ from archivey import (
 from archivey.cost import AccessCost, ListingCost, StreamCapability
 from archivey.exceptions import (
     CorruptionError,
+    ReadError,
     StreamNotSeekableError,
     TruncatedError,
 )
@@ -662,3 +663,141 @@ def test_streaming_pass_resolves_backward_links() -> None:
         "dir/abs_link": None,
         "dir/hard": "dir/file",
     }
+
+
+def _link_tar_bytes(specs: list[tuple[str, str, bytes | str]]) -> bytes:
+    """Build a tar from (kind, name, payload) specs.
+
+    kind: ``file`` (payload=bytes), ``sym``/``hard`` (payload=linkname).
+    """
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as t:
+        for kind, name, payload in specs:
+            info = tarfile.TarInfo(name)
+            if kind == "file":
+                info.size = len(payload)
+                info.mode = 0o644
+                t.addfile(info, io.BytesIO(payload))
+            elif kind == "sym":
+                info.type = tarfile.SYMTYPE
+                info.linkname = payload
+                t.addfile(info)
+            elif kind == "hard":
+                info.type = tarfile.LNKTYPE
+                info.linkname = payload
+                t.addfile(info)
+    return buf.getvalue()
+
+
+_DUP_HARDLINK_TAR = _link_tar_bytes(
+    [
+        ("file", "A.txt", b"content1"),
+        ("hard", "L.txt", "A.txt"),
+        ("file", "A.txt", b"content2"),
+    ]
+)
+
+
+def test_hardlink_duplicate_name_positional_random_access() -> None:
+    with open_archive(io.BytesIO(_DUP_HARDLINK_TAR), format=ArchiveFormat.TAR) as ar:
+        link = ar.get("L.txt")
+        assert link.link_target_member is not None
+        assert link.link_target_member.name == "A.txt"
+        assert ar.read(link.link_target_member) == b"content1"
+        assert ar.read("L.txt") == b"content1"
+
+
+def test_hardlink_duplicate_name_positional_streaming() -> None:
+    source = NonSeekableBytesIO(_DUP_HARDLINK_TAR)
+    with open_archive(source, format=ArchiveFormat.TAR, streaming=True) as ar:
+        links = {
+            m.name: m.link_target_member
+            for m, _ in ar.stream_members()
+            if m.type == MemberType.HARDLINK
+        }
+    assert links["L.txt"] is not None
+    assert links["L.txt"].name == "A.txt"
+
+
+def test_symlink_duplicate_name_last_wins_random_access() -> None:
+    data = _link_tar_bytes(
+        [
+            ("file", "A.txt", b"content1"),
+            ("sym", "S.txt", "A.txt"),
+            ("file", "A.txt", b"content2"),
+        ]
+    )
+    with open_archive(io.BytesIO(data), format=ArchiveFormat.TAR) as ar:
+        link = ar.get("S.txt")
+        assert link.link_target_member is not None
+        assert link.link_target_member.name == "A.txt"
+        assert ar.read(link.link_target_member) == b"content2"
+        assert ar.read("S.txt") == b"content2"
+
+
+def test_link_cycle_raises_read_error() -> None:
+    data = _link_tar_bytes(
+        [
+            ("sym", "a", "b"),
+            ("sym", "b", "a"),
+        ]
+    )
+    with open_archive(io.BytesIO(data), format=ArchiveFormat.TAR) as ar:
+        with pytest.raises(ReadError, match="cycle"):
+            ar.read("a")
+
+
+def test_chain_through_same_named_members_not_false_cycle() -> None:
+    """Member-id cycle tracking must not false-positive on distinct same-named members."""
+    from archivey.cost import AccessCost, ListingCost, StreamCapability
+    from archivey.internal.base_reader import BaseArchiveReader
+    from archivey.types import ArchiveInfo, ArchiveMember
+
+    class _Reader(BaseArchiveReader):
+        def __init__(self, members: list[ArchiveMember], payloads: dict[str, bytes]) -> None:
+            super().__init__(ArchiveFormat.TAR, streaming=False, archive_name=None)
+            self._payloads = payloads
+            self._members_cache = members
+            self._members_by_name = {m.name: m for m in members}
+
+        def _iter_members(self):
+            return iter(self._members_cache or [])
+
+        def _open_member(self, member: ArchiveMember) -> BinaryIO:
+            return io.BytesIO(self._payloads[member.name])
+
+        def _get_archive_info(self) -> ArchiveInfo:
+            return ArchiveInfo(
+                format=ArchiveFormat.TAR,
+                cost=AccessCost(
+                    listing=ListingCost.FREE,
+                    random_access=StreamCapability.SUPPORTED,
+                ),
+            )
+
+        def _close_archive(self) -> None:
+            return None
+
+    # Hop-by-hop chain start → dup(sym) → tail → dup(file); two distinct "dup.txt" members.
+    first = ArchiveMember(
+        name="dup.txt", type=MemberType.SYMLINK, link_target="tail"
+    )
+    second = ArchiveMember(name="dup.txt", type=MemberType.FILE)
+    tail = ArchiveMember(
+        name="tail", type=MemberType.SYMLINK, link_target="dup.txt"
+    )
+    start = ArchiveMember(
+        name="start", type=MemberType.SYMLINK, link_target="dup.txt"
+    )
+    for idx, m in enumerate((first, second, tail, start)):
+        m._member_id = idx
+        m._archive_id = "test"
+    first.link_target_member = tail
+    tail.link_target_member = second
+    start.link_target_member = first
+    reader = _Reader(
+        [first, second, tail, start],
+        {"dup.txt": b"payload", "tail": b"", "start": b""},
+    )
+    with reader._open_with_link_follow(start, set()) as stream:
+        assert stream.read() == b"payload"

--- a/tests/test_tar.py
+++ b/tests/test_tar.py
@@ -9,6 +9,7 @@ import logging
 import tarfile
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import BinaryIO
 from unittest import mock
 
 import pytest

--- a/tests/test_tar.py
+++ b/tests/test_tar.py
@@ -758,7 +758,10 @@ def test_chain_through_same_named_members_not_false_cycle() -> None:
             super().__init__(ArchiveFormat.TAR, streaming=False, archive_name=None)
             self._payloads = payloads
             self._members_cache = members
-            self._members_by_name = {m.name: m for m in members}
+            by_name_lists: dict[str, list[ArchiveMember]] = {}
+            for m in members:
+                BaseArchiveReader._index_member_name(by_name_lists, m)
+            self._members_by_name_lists = by_name_lists
 
         def _iter_members(self):
             return iter(self._members_cache or [])

--- a/tests/test_tar.py
+++ b/tests/test_tar.py
@@ -736,6 +736,147 @@ def test_symlink_duplicate_name_last_wins_random_access() -> None:
         assert ar.read("S.txt") == b"content2"
 
 
+# ---------------------------------------------------------------------------
+# scan_members(), post-pass cache, one-pass-only streaming
+# ---------------------------------------------------------------------------
+
+
+def _build_forward_symlink_tar() -> bytes:
+    """Symlink appears before its target in archive order."""
+    return _link_tar_bytes(
+        [
+            ("sym", "forward_link", "target.txt"),
+            ("file", "target.txt", b"TARGET"),
+        ]
+    )
+
+
+def test_streaming_scan_members_resolves_forward_symlink() -> None:
+    source = NonSeekableBytesIO(_build_forward_symlink_tar())
+    with open_archive(source, format=ArchiveFormat.TAR, streaming=True) as ar:
+        members = ar.scan_members()
+    link = next(m for m in members if m.name == "forward_link")
+    assert link.link_target_member is not None
+    assert link.link_target_member.name == "target.txt"
+
+    with open_archive(
+        io.BytesIO(_build_forward_symlink_tar()), format=ArchiveFormat.TAR
+    ) as ar:
+        expected = ar.get("forward_link")
+    assert link.link_target_member.name == expected.link_target_member.name
+
+
+def test_streaming_iter_materializes_resolved_cache() -> None:
+    source = NonSeekableBytesIO(_build_forward_symlink_tar())
+    with open_archive(source, format=ArchiveFormat.TAR, streaming=True) as ar:
+        collected: list = []
+        for member in ar:
+            if member.name == "forward_link":
+                collected.append(member)
+                assert member.link_target_member is None
+        members = ar.get_members_if_available()
+        assert members is not None
+        link = next(m for m in members if m.name == "forward_link")
+        assert link.link_target_member is not None
+        assert link.link_target_member.name == "target.txt"
+        assert collected[0].link_target_member.name == "target.txt"
+
+
+def test_streaming_stream_members_materializes_resolved_cache() -> None:
+    source = NonSeekableBytesIO(_build_forward_symlink_tar())
+    with open_archive(source, format=ArchiveFormat.TAR, streaming=True) as ar:
+        collected: list = []
+        for member, _stream in ar.stream_members():
+            if member.name == "forward_link":
+                collected.append(member)
+        members = ar.get_members_if_available()
+        assert members is not None
+        link = next(m for m in members if m.name == "forward_link")
+        assert link.link_target_member is not None
+        assert collected[0].link_target_member.name == "target.txt"
+
+
+def test_scan_members_finishes_interrupted_pass(tmp_path: Path) -> None:
+    source = NonSeekableBytesIO(_build_forward_symlink_tar())
+    with open_archive(source, format=ArchiveFormat.TAR, streaming=True) as ar:
+        for member in ar:
+            if member.name == "forward_link":
+                break
+        members = ar.scan_members()
+        link = next(m for m in members if m.name == "forward_link")
+        assert link.link_target_member is not None
+        assert link.link_target_member.name == "target.txt"
+        with pytest.raises(UnsupportedOperationError):
+            list(ar)
+        with pytest.raises(UnsupportedOperationError):
+            list(ar.stream_members())
+        with pytest.raises(UnsupportedOperationError):
+            ar.extract_all(tmp_path)
+
+
+def test_abandoned_partial_pass_leaves_get_members_none() -> None:
+    source = NonSeekableBytesIO(_build_forward_symlink_tar())
+    with open_archive(source, format=ArchiveFormat.TAR, streaming=True) as ar:
+        for member in ar:
+            if member.name == "forward_link":
+                break
+        assert ar.get_members_if_available() is None
+
+
+def test_streaming_second_pass_raises_tar_and_zip(
+    plain_tar: Path, tmp_path: Path
+) -> None:
+    zip_path = tmp_path / "second.zip"
+    import zipfile
+
+    with zipfile.ZipFile(zip_path, "w") as z:
+        z.writestr("hello.txt", b"hello world")
+    with open_archive(plain_tar, streaming=True) as ar:
+        list(ar)
+        with pytest.raises(UnsupportedOperationError):
+            list(ar)
+        with pytest.raises(UnsupportedOperationError):
+            list(ar.stream_members())
+    with open_archive(zip_path, streaming=True) as ar:
+        list(ar)
+        with pytest.raises(UnsupportedOperationError):
+            list(ar)
+
+
+def test_scan_members_random_access_parity(plain_tar: Path, tmp_path: Path) -> None:
+    import zipfile
+
+    zip_path = tmp_path / "scan.zip"
+    with zipfile.ZipFile(zip_path, "w") as z:
+        z.writestr("hello.txt", b"hello world")
+    simple_dir = tmp_path / "dirscan"
+    simple_dir.mkdir()
+    (simple_dir / "a.txt").write_bytes(b"x")
+    for source in (plain_tar, zip_path, simple_dir):
+        with open_archive(source) as ar:
+            assert ar.scan_members() == ar.members()
+            assert [m.name for m in ar] == [m.name for m in ar.members()]
+
+
+def test_scan_members_before_pass_consumes_streaming_reader(
+    plain_tar: Path, tmp_path: Path
+) -> None:
+    import zipfile
+
+    zip_path = tmp_path / "consume.zip"
+    with zipfile.ZipFile(zip_path, "w") as z:
+        z.writestr("hello.txt", b"hello world")
+    simple_dir = tmp_path / "dirconsume"
+    simple_dir.mkdir()
+    (simple_dir / "a.txt").write_bytes(b"x")
+    for source in (plain_tar, zip_path, simple_dir):
+        with open_archive(source, streaming=True) as ar:
+            names = {m.name for m in ar.scan_members()}
+            assert len(names) > 0
+            with pytest.raises(UnsupportedOperationError):
+                list(ar.stream_members())
+
+
 def test_link_cycle_raises_read_error() -> None:
     data = _link_tar_bytes(
         [

--- a/tests/test_zip.py
+++ b/tests/test_zip.py
@@ -172,11 +172,56 @@ def test_symlink_member(tmp_path: Path) -> None:
     info.create_system = 3
     info.external_attr = (stat_module.S_IFLNK | 0o777) << 16
     with zipfile.ZipFile(path, "w") as z:
+        z.writestr("target.txt", b"payload")
         z.writestr(info, b"target.txt")
     with open_archive(path) as ar:
         member = ar.get("link")
         assert member.type == MemberType.SYMLINK
         assert member.link_target == "target.txt"
+
+
+def _symlink_zip(tmp_path: Path) -> Path:
+    import stat as stat_module
+
+    path = tmp_path / "symlink.zip"
+    info = zipfile.ZipInfo("link")
+    info.create_system = 3
+    info.external_attr = (stat_module.S_IFLNK | 0o777) << 16
+    with zipfile.ZipFile(path, "w") as z:
+        z.writestr("target.txt", b"payload")
+        z.writestr(info, b"target.txt")
+    return path
+
+
+def test_zip_index_only_listing_leaves_symlink_unresolved(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    path = _symlink_zip(tmp_path)
+    with open_archive(path) as ar:
+        archive = ar._archive  # type: ignore[attr-defined]
+        opens: list[str] = []
+        original_open = archive.open
+
+        def counting_open(info, pwd=None):
+            opens.append(info.filename)
+            return original_open(info, pwd=pwd)
+
+        monkeypatch.setattr(archive, "open", counting_open)
+        members = ar.get_members_if_available()
+        assert members is not None
+        link = next(m for m in members if m.name == "link")
+        assert link.link_target is None
+        assert link.link_target_member is None
+        assert opens == []
+
+        resolved = ar.scan_members()
+        link_resolved = next(m for m in resolved if m.name == "link")
+        assert link_resolved.link_target == "target.txt"
+        assert link_resolved.link_target_member is not None
+        assert link_resolved.link_target_member.name == "target.txt"
+        assert ar.read("link") == b"payload"
+        ar.extract_all(tmp_path / "out")
+        assert (tmp_path / "out" / "target.txt").read_bytes() == b"payload"
 
 
 def test_compression_method_mapping(tmp_path: Path) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.13'",


### PR DESCRIPTION
## Summary

- Implement positional hardlink resolution and unified link-target lookup in `BaseArchiveReader` (`_lookup_hardlink_target`, `_resolve_link`, `_register_progressively`), with eager registration reusing the progressive path plus a full link-resolution pass.
- Enforce a single shared forward pass on `streaming=True` readers across `__iter__()`, `stream_members()`, `extract_all()`, and `members()`; abandoned or duplicate passes raise `UnsupportedOperationError`.
- Allow `members()` on streaming readers as a list-only scan that always consumes the pass (even on indexed backends); repeat `members()` returns from cache, but blocks subsequent iteration. `get_members_if_available()` remains a no-scan peek that does not consume the pass.
- Update authoritative specs (`archive-reading`, `access-mode-and-cost`, `archive-data-model`), `ARCHITECTURE.md`, `SPEC.md`, and add contract tests for interrupted/partial iteration scenarios.

## Test plan

- [x] `uv run --no-sync pytest tests/test_reader_contract.py`
- [x] `uv run --no-sync pytest tests/test_tar.py -k "link or symlink or hardlink or streaming"`
- [ ] Full three-config push gate per `CONTRIBUTING.md` before merge