### PR TITLE
Phase 5 stages 1–4: public API (config, passwords, multi-source, selectors)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,11 @@ Non-obvious gotchas:
   CLI (in addition to `uv sync`), so both are present without manual steps.
 - **`unrar`** (system binary, from the `multiverse` apt component) backs RAR *data*
   tests; without it they skip cleanly rather than fail.
+- **`7z`** (system binary, from `p7zip-full`) is required by some tests that build
+  fixtures by shelling out to it — notably the encrypted-ZIP tests in
+  `tests/test_password.py` and the `tests/_dev_oracle/` oracle. Unlike `unrar`, these
+  currently **fail** (subprocess `FileNotFoundError`) rather than skip when it is absent,
+  so install `p7zip-full` if `which 7z` comes up empty.
 - **`openspec` CLI** lives at `~/.local/bin` (on `PATH`). `CLAUDE.md`'s
   `npm install -g @fission-ai/openspec` fails with `EACCES` here because the global npm
   prefix is not user-writable — the update script instead installs it into a writable,

--- a/SPEC.md
+++ b/SPEC.md
@@ -913,7 +913,7 @@ non-seekable source, `open_read()` raises `StreamNotSeekableError` (a subclass o
 
 **Hardlinks in TAR:** `linkname` field holds the target path. Extraction creates an actual hardlink if the target has already been extracted, or defers to a post-pass if not yet extracted (two-pass extraction). If hardlink creation fails (cross-device), fall back to copying.
 
-**Truncation detection:** After iterating all members, verify that the final 512-byte block(s) are null-filled end-of-archive markers. If not present, emit a `logging.WARNING` and optionally raise `TruncatedError` based on a `strict_eof` parameter (default: warn only).
+**Truncation detection:** After iterating all members, verify that the final 512-byte block(s) are null-filled end-of-archive markers. If not present, emit a `logging.WARNING` and optionally raise `TruncatedError` when `ArchiveyConfig.strict_archive_eof` is `True` (default: warn only; configured via `open_archive(..., config=...)`).
 
 **TAR variants:** compression is detected from the magic of the first bytes and matched to `tarfile` mode strings (`r:gz`, `r:bz2`, `r:xz`, `r:*` for auto).
 

--- a/openspec/changes/phase-5-public-api/tasks.md
+++ b/openspec/changes/phase-5-public-api/tasks.md
@@ -64,11 +64,11 @@
 
 ## 4. MemberSelector collection form
 
-- [ ] 4.1 Normalizer: `Collection[str | ArchiveMember]` → predicate (name set matches
+- [x] 4.1 Normalizer: `Collection[str | ArchiveMember]` → predicate (name set matches
       all duplicates; `ArchiveMember` entries matched by `_archive_id` + `member_id`
       id-set; mixed collections fine); wire into `stream_members` (and the
       `extract_all(members=)` path when 4b lands).
-- [ ] 4.2 Update the `MemberSelector` alias + docstring in `reader.py` (drop the
+- [x] 4.2 Update the `MemberSelector` alias + docstring in `reader.py` (drop the
       "Phase 5 pending" note); tests: duplicate-name tar selects both; member-entry
       selects only its identity; mixed collection.
 

--- a/openspec/changes/phase-5-public-api/tasks.md
+++ b/openspec/changes/phase-5-public-api/tasks.md
@@ -28,22 +28,22 @@
 
 ## 2. Password candidates and provider
 
-- [ ] 2.1 Widen `password` typing on `open_archive` (`str | bytes | Sequence[str |
+- [x] 2.1 Widen `password` typing on `open_archive` (`str | bytes | Sequence[str |
       bytes] | PasswordProvider | None`); define the frozen `PasswordRequest`
       dataclass (`member: ArchiveMember | None`, `attempt: int`); normalize once into
       an internal `_PasswordCandidates` helper on `BaseArchiveReader` (known-good list
       + remaining candidates + optional provider; `provider(PasswordRequest(...))`).
-- [ ] 2.2 Wire the ZIP backend (the only current consumer) through the helper: try
+- [x] 2.2 Wire the ZIP backend (the only current consumer) through the helper: try
       known-good → candidates → provider per encrypted member; successful password
       appended to known-good; exhaustion → `EncryptionError`. Encrypted-symlink
       listing path uses the same resolution.
-- [ ] 2.3 Tests: sequence across two differently-encrypted members in one pass;
+- [x] 2.3 Tests: sequence across two differently-encrypted members in one pass;
       provider called once per *new* password (call-count assertion) and receives a
       `PasswordRequest` carrying the member; `attempt` increments on a wrong-password
       retry for the same unit; provider `None` → `EncryptionError`; header-level
       request carries `member=None` (unit-test the helper; the real header-encrypted
       case lands with Phase 7).
-- [ ] 2.4 Docs: candidate-order note ("most likely password first" — 7z key derivation
+- [x] 2.4 Docs: candidate-order note ("most likely password first" — 7z key derivation
       is deliberately expensive) in the open_archive docstring.
 
 ## 3. Multi-source input

--- a/openspec/changes/phase-5-public-api/tasks.md
+++ b/openspec/changes/phase-5-public-api/tasks.md
@@ -7,23 +7,23 @@
 
 ## 1. ArchiveyConfig / ExtractionLimits
 
-- [ ] 1.1 Define public `ExtractionLimits` and `ArchiveyConfig` frozen dataclasses
+- [x] 1.1 Define public `ExtractionLimits` and `ArchiveyConfig` frozen dataclasses
       (fields per design.md), exported from `archivey`; module default constant.
-- [ ] 1.2 `open_archive(..., config: ArchiveyConfig | None = None)`; the reader stores
+- [x] 1.2 `open_archive(..., config: ArchiveyConfig | None = None)`; the reader stores
       its config; internal `StreamConfig` becomes a view derived from
       `ArchiveyConfig` + the access mode (`streaming` stays derived, not public).
-- [ ] 1.3 Relocate `strict_eof` → `config.strict_archive_eof`; **remove** the
+- [x] 1.3 Relocate `strict_eof` → `config.strict_archive_eof`; **remove** the
       `open_archive(strict_eof=)` keyword and the `ReadBackend.open_read` parameter
       (readers read it from their config). Update TAR backend + tests.
-- [ ] 1.4 Tests: default config equivalence; accelerator modes honored via config
+- [x] 1.4 Tests: default config equivalence; accelerator modes honored via config
       (monkeypatched sentinels); `strict_archive_eof=True` raises / default warns;
       frozen-ness (`dataclasses.FrozenInstanceError` on mutation).
-- [ ] 1.5 Per-call `limits: ExtractionLimits | None = None` on `extract()` /
+- [x] 1.5 Per-call `limits: ExtractionLimits | None = None` on `extract()` /
       `extract_all()`; **remove** the four loose bomb-limit kwargs; precedence
       per-call > `config.extraction_limits` > default; `ExtractionLimits.UNLIMITED`
       preset. Tests: override tightens/loosens one call; reader-config limits apply
       when no per-call override; UNLIMITED disables all four guards.
-- [ ] 1.6 `format-tar` spec references updated via the new delta (`strict_eof` →
+- [x] 1.6 `format-tar` spec references updated via the new delta (`strict_eof` →
       `config.strict_archive_eof`); `SPEC.md` §"truncation detection" wording follows.
 
 ## 2. Password candidates and provider

--- a/openspec/changes/phase-5-public-api/tasks.md
+++ b/openspec/changes/phase-5-public-api/tasks.md
@@ -48,17 +48,17 @@
 
 ## 3. Multi-source input
 
-- [ ] 3.1 Accept `Sequence[str | Path | BinaryIO]` in `open_archive` (length-1 ≡
+- [x] 3.1 Accept `Sequence[str | Path | BinaryIO]` in `open_archive` (length-1 ≡
       single source); detection runs on the first volume; origin-normalize each
       seekable stream.
-- [ ] 3.2 Single-path volume-set discovery: `.7z.NNN` / `.partN.rar` / `.rNN` name
+- [x] 3.2 Single-path volume-set discovery: `.7z.NNN` / `.partN.rar` / `.rNN` name
       patterns → sibling scan in the path's directory, natural order (path sources
       only; a helper the Phase 7 readers reuse).
-- [ ] 3.3 Phase-5 behavior: a resolved multi-source open raises
+- [x] 3.3 Phase-5 behavior: a resolved multi-source open raises
       `UnsupportedFeatureError` with a format-appropriate message (7z/RAR: "lands in
       Phase 7"; others: "not a multi-volume format"). Tests for both messages and
       for discovery ordering (fixture files, no real volume parsing).
-- [ ] 3.4 `extract()` parity: widen its `source` union to the same `Sequence[...]`
+- [x] 3.4 `extract()` parity: widen its `source` union to the same `Sequence[...]`
       form (it delegates to `open_archive`) and add the `encoding` keyword; test a
       one-shot extract of a non-UTF-8-named TAR with an explicit `encoding`.
 

--- a/src/archivey/__init__.py
+++ b/src/archivey/__init__.py
@@ -12,6 +12,8 @@ from archivey.config import (
     AcceleratorMode,
     ArchiveyConfig,
     ExtractionLimits,
+    PasswordProvider,
+    PasswordRequest,
 )
 from archivey.core import (
     DetectionConfidence,
@@ -82,6 +84,8 @@ __all__ = [
     "DEFAULT_ARCHIVEY_CONFIG",
     "ExtractionLimits",
     "AcceleratorMode",
+    "PasswordRequest",
+    "PasswordProvider",
     "ExtractionPolicy",
     "OverwritePolicy",
     "OnError",

--- a/src/archivey/__init__.py
+++ b/src/archivey/__init__.py
@@ -8,9 +8,9 @@ except PackageNotFoundError:
     __version__ = "0.0.0+unknown"
 
 from archivey.config import (
+    DEFAULT_ARCHIVEY_CONFIG,
     AcceleratorMode,
     ArchiveyConfig,
-    DEFAULT_ARCHIVEY_CONFIG,
     ExtractionLimits,
 )
 from archivey.core import (

--- a/src/archivey/__init__.py
+++ b/src/archivey/__init__.py
@@ -7,6 +7,12 @@ try:
 except PackageNotFoundError:
     __version__ = "0.0.0+unknown"
 
+from archivey.config import (
+    AcceleratorMode,
+    ArchiveyConfig,
+    DEFAULT_ARCHIVEY_CONFIG,
+    ExtractionLimits,
+)
 from archivey.core import (
     DetectionConfidence,
     FormatAvailability,
@@ -72,6 +78,10 @@ __all__ = [
     "__version__",
     "open_archive",
     "extract",
+    "ArchiveyConfig",
+    "DEFAULT_ARCHIVEY_CONFIG",
+    "ExtractionLimits",
+    "AcceleratorMode",
     "ExtractionPolicy",
     "OverwritePolicy",
     "OnError",

--- a/src/archivey/config.py
+++ b/src/archivey/config.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from enum import Enum
-from typing import ClassVar
+from typing import TYPE_CHECKING, ClassVar
+
+if TYPE_CHECKING:
+    from archivey.types import ArchiveMember
 
 
 class AcceleratorMode(Enum):
@@ -77,3 +81,20 @@ class ArchiveyConfig:
 
 
 DEFAULT_ARCHIVEY_CONFIG = ArchiveyConfig()
+
+
+@dataclass(frozen=True)
+class PasswordRequest:
+    """Context passed to a :data:`PasswordProvider` when a password is needed."""
+
+    member: ArchiveMember | None
+    """The member being decrypted, or ``None`` for archive-level (header) decryption."""
+
+    attempt: int
+    """1 on the first ask for this unit; increments after a wrong-password retry."""
+
+
+PasswordProvider = Callable[[PasswordRequest], str | bytes | None]
+"""Callable consulted when static password candidates fail for an encrypted unit."""
+
+PasswordInput = str | bytes | Sequence[str | bytes] | PasswordProvider | None

--- a/src/archivey/config.py
+++ b/src/archivey/config.py
@@ -1,0 +1,79 @@
+"""Public configuration types for archivey."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import ClassVar
+
+
+class AcceleratorMode(Enum):
+    """Tri-state control for an optional random-access accelerator backend.
+
+    - ``ON``  — always use the accelerator (raise ``PackageNotInstalledError`` if its
+      package is absent: the caller asked for it explicitly).
+    - ``OFF`` — never use it; the stream stays sequential-only.
+    - ``AUTO`` — use it only when random access is actually wanted, i.e. the archive was
+      opened for random access (``streaming=False``). Under ``streaming=True`` a forward
+      pass needs no seeking, so AUTO leaves the cheaper sequential backend in place. When
+      AUTO would enable the accelerator but its package is absent, fall back to sequential
+      silently (it is an enhancement, not a requirement).
+    """
+
+    AUTO = "auto"
+    ON = "on"
+    OFF = "off"
+
+    def enabled_for(self, *, streaming: bool, available: bool) -> bool:
+        """Resolve the tri-state to "use the accelerator?".
+
+        ``ON`` always returns ``True`` (the caller checks availability and raises
+        ``PackageNotInstalledError`` if the package is missing — the user asked for it
+        explicitly). ``AUTO`` enables it only for random access and only when available, so
+        a missing package falls back silently to the sequential backend.
+        """
+        if self is AcceleratorMode.OFF:
+            return False
+        if self is AcceleratorMode.ON:
+            return True
+        # AUTO: random access wants seeking; a forward-only pass does not.
+        return available and not streaming
+
+
+@dataclass(frozen=True)
+class ExtractionLimits:
+    """Decompression-bomb limits for :func:`archivey.extract` / :meth:`extract_all`.
+
+    ``None`` on a guard field disables that guard. :attr:`UNLIMITED` disables all four.
+    """
+
+    max_extracted_bytes: int | None = 2 * 2**30
+    max_ratio: float | None = 1000.0
+    ratio_activation_threshold: int = 5 * 2**20
+    max_entries: int | None = 1_048_576
+
+    UNLIMITED: ClassVar[ExtractionLimits]
+
+
+ExtractionLimits.UNLIMITED = ExtractionLimits(
+    max_extracted_bytes=None,
+    max_ratio=None,
+    max_entries=None,
+)
+
+
+@dataclass(frozen=True)
+class ArchiveyConfig:
+    """Library tuning knobs passed explicitly as ``config=`` to :func:`open_archive` / :func:`extract`.
+
+    Per-call operationals (``format``, ``streaming``, ``password``, extraction's
+    ``members``/``filter``/``policy``/…) stay keyword arguments — not part of this object.
+    """
+
+    use_rapidgzip: AcceleratorMode = AcceleratorMode.AUTO
+    use_indexed_bzip2: AcceleratorMode = AcceleratorMode.AUTO
+    strict_archive_eof: bool = False
+    extraction_limits: ExtractionLimits = ExtractionLimits()
+
+
+DEFAULT_ARCHIVEY_CONFIG = ArchiveyConfig()

--- a/src/archivey/core.py
+++ b/src/archivey/core.py
@@ -231,12 +231,13 @@ def extract(
         encoding=encoding,
         config=config,
     ) as reader:
+        # The reader already carries `config` (passed to open_archive above), so
+        # extract_all falls back to it — no need to forward `config` a second time.
         return reader.extract_all(
             dest,
             policy=policy,
             overwrite=overwrite,
             on_error=on_error,
             on_progress=on_progress,
-            config=config,
             limits=limits,
         )

--- a/src/archivey/core.py
+++ b/src/archivey/core.py
@@ -5,6 +5,12 @@ from __future__ import annotations
 from pathlib import Path
 from typing import BinaryIO, Callable
 
+from archivey.config import (
+    AcceleratorMode,
+    ArchiveyConfig,
+    DEFAULT_ARCHIVEY_CONFIG,
+    ExtractionLimits,
+)
 from archivey.exceptions import StreamNotSeekableError, UnsupportedOperationError
 from archivey.internal.detection import DetectionConfidence, FormatInfo, detect_format
 from archivey.internal.extraction_types import (
@@ -39,6 +45,10 @@ __all__ = [
     "FormatInfo",
     "FormatSupport",
     "MissingComponent",
+    "ArchiveyConfig",
+    "ExtractionLimits",
+    "AcceleratorMode",
+    "DEFAULT_ARCHIVEY_CONFIG",
     "detect_format",
     "extract",
     "format_availability",
@@ -56,7 +66,7 @@ def open_archive(
     streaming: bool = False,
     password: bytes | str | None = None,
     encoding: str | None = None,
-    strict_eof: bool = False,
+    config: ArchiveyConfig | None = None,
 ) -> ArchiveReader:
     """Open an archive for reading.
 
@@ -64,11 +74,9 @@ def open_archive(
     time on a non-seekable source. ``streaming=True`` promises forward-only, single-pass
     access (works on any source, but disables random-access methods).
 
-    ``strict_eof`` controls TAR end-of-archive verification: after all members are read,
-    the TAR backend checks for two null-filled 512-byte EOF blocks. When the check
-    fails, ``strict_eof=False`` (the default) emits a warning; ``strict_eof=True``
-    raises :class:`~archivey.TruncatedError`. This keyword is a Phase 4 stopgap — Phase 5
-    task 4 (``PLAN.md``) folds it into the finalized public config surface.
+    ``config`` supplies library tuning knobs (accelerator modes, TAR end-of-archive
+    strictness via ``strict_archive_eof``, default extraction limits). ``None`` selects
+    the module default :data:`~archivey.DEFAULT_ARCHIVEY_CONFIG`.
 
     The format is auto-detected from the source's magic bytes (then its extension) unless
     ``format=`` is passed explicitly. A directory path opens as a directory pseudo-archive.
@@ -87,6 +95,7 @@ def open_archive(
     if isinstance(password, str):
         password = password.encode()
 
+    effective_config = config if config is not None else DEFAULT_ARCHIVEY_CONFIG
     archive_name = source_name(source)
 
     # A path source: normalize str -> Path; a directory short-circuits detection.
@@ -157,7 +166,7 @@ def open_archive(
         password=password,
         encoding=effective_encoding,
         archive_name=archive_name,
-        strict_eof=strict_eof,
+        config=effective_config,
     )
 
 
@@ -171,10 +180,8 @@ def extract(
     format: ArchiveFormat | None = None,
     password: bytes | str | None = None,
     on_progress: Callable[[ExtractionProgress], None] | None = None,
-    max_extracted_bytes: int = 2 * 2**30,
-    max_ratio: float = 1000.0,
-    ratio_activation_threshold: int = 5 * 2**20,
-    max_entries: int = 1_048_576,
+    config: ArchiveyConfig | None = None,
+    limits: ExtractionLimits | None = None,
 ) -> list[ExtractionResult]:
     """Open ``source``, apply safety checks, and write **all** members to ``dest``.
 
@@ -186,15 +193,13 @@ def extract(
 
     Returns one :class:`~archivey.ExtractionResult` per member processed.
     """
-    with open_archive(source, format=format, password=password) as reader:
+    with open_archive(source, format=format, password=password, config=config) as reader:
         return reader.extract_all(
             dest,
             policy=policy,
             overwrite=overwrite,
             on_error=on_error,
             on_progress=on_progress,
-            max_extracted_bytes=max_extracted_bytes,
-            max_ratio=max_ratio,
-            ratio_activation_threshold=ratio_activation_threshold,
-            max_entries=max_entries,
+            config=config,
+            limits=limits,
         )

--- a/src/archivey/core.py
+++ b/src/archivey/core.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import BinaryIO, Callable
+from typing import Callable
 
 from archivey.config import (
     DEFAULT_ARCHIVEY_CONFIG,

--- a/src/archivey/core.py
+++ b/src/archivey/core.py
@@ -10,6 +10,7 @@ from archivey.config import (
     AcceleratorMode,
     ArchiveyConfig,
     ExtractionLimits,
+    PasswordInput,
 )
 from archivey.exceptions import StreamNotSeekableError, UnsupportedOperationError
 from archivey.internal.detection import DetectionConfidence, FormatInfo, detect_format
@@ -20,6 +21,7 @@ from archivey.internal.extraction_types import (
     OnError,
     OverwritePolicy,
 )
+from archivey.internal.password import _PasswordCandidates
 from archivey.internal.registry import (
     FormatAvailability,
     FormatSupport,
@@ -64,7 +66,7 @@ def open_archive(
     *,
     format: ArchiveFormat | None = None,
     streaming: bool = False,
-    password: bytes | str | None = None,
+    password: PasswordInput = None,
     encoding: str | None = None,
     config: ArchiveyConfig | None = None,
 ) -> ArchiveReader:
@@ -88,12 +90,15 @@ def open_archive(
     then wraps a mid-positioned stream in a zero-origin view so every backend sees the
     archive begin at ``tell() == 0`` (an archive embedded mid-file works uniformly,
     without manual slicing).
+
+    ``password`` accepts a single value, an ordered sequence of candidate passwords, or
+    a provider callable. List the most likely password first — especially for 7z, where
+    each wrong candidate pays an expensive key derivation.
     """
     # Import backends to ensure they are registered
     import archivey.internal.backends  # noqa: F401
 
-    if isinstance(password, str):
-        password = password.encode()
+    passwords = _PasswordCandidates.from_input(password)
 
     effective_config = config if config is not None else DEFAULT_ARCHIVEY_CONFIG
     archive_name = source_name(source)
@@ -122,7 +127,7 @@ def open_archive(
 
     # A password for a format that has no encryption is API misuse, rejected centrally
     # (backends declare SUPPORTS_PASSWORD as data and never see the argument otherwise).
-    if password is not None and not backend_cls.SUPPORTS_PASSWORD:
+    if passwords.has_passwords() and not backend_cls.SUPPORTS_PASSWORD:
         raise UnsupportedOperationError(
             f"Format {format!r} does not support passwords (it carries no encryption).",
             source_format=format,
@@ -163,7 +168,7 @@ def open_archive(
         open_source,
         format=format,
         streaming=streaming,
-        password=password,
+        passwords=passwords,
         encoding=effective_encoding,
         archive_name=archive_name,
         config=effective_config,
@@ -178,7 +183,7 @@ def extract(
     overwrite: OverwritePolicy = OverwritePolicy.ERROR,
     on_error: OnError = OnError.STOP,
     format: ArchiveFormat | None = None,
-    password: bytes | str | None = None,
+    password: PasswordInput = None,
     on_progress: Callable[[ExtractionProgress], None] | None = None,
     config: ArchiveyConfig | None = None,
     limits: ExtractionLimits | None = None,

--- a/src/archivey/core.py
+++ b/src/archivey/core.py
@@ -12,7 +12,11 @@ from archivey.config import (
     ExtractionLimits,
     PasswordInput,
 )
-from archivey.exceptions import StreamNotSeekableError, UnsupportedOperationError
+from archivey.exceptions import (
+    StreamNotSeekableError,
+    UnsupportedFeatureError,
+    UnsupportedOperationError,
+)
 from archivey.internal.detection import DetectionConfidence, FormatInfo, detect_format
 from archivey.internal.extraction_types import (
     ExtractionPolicy,
@@ -38,8 +42,9 @@ from archivey.internal.streams.streamtools import (
     is_stream,
     source_name,
 )
+from archivey.internal.volumes import OpenSourceInput, resolve_source
 from archivey.reader import ArchiveReader
-from archivey.types import ArchiveFormat
+from archivey.types import ArchiveFormat, ContainerFormat
 
 __all__ = [
     "DetectionConfidence",
@@ -61,8 +66,25 @@ __all__ = [
 ]
 
 
+def _raise_multi_volume_not_supported(
+    fmt: ArchiveFormat, archive_name: str | None
+) -> None:
+    if fmt.container in (ContainerFormat.SEVEN_Z, ContainerFormat.RAR):
+        raise UnsupportedFeatureError(
+            f"Multi-volume {fmt.container.value} archives are not supported yet "
+            f"(lands in Phase 7).",
+            source_format=fmt,
+            archive_name=archive_name,
+        )
+    raise UnsupportedFeatureError(
+        f"Format {fmt!r} does not support multi-volume archives.",
+        source_format=fmt,
+        archive_name=archive_name,
+    )
+
+
 def open_archive(
-    source: str | Path | BinaryIO,
+    source: OpenSourceInput,
     *,
     format: ArchiveFormat | None = None,
     streaming: bool = False,
@@ -91,6 +113,10 @@ def open_archive(
     archive begin at ``tell() == 0`` (an archive embedded mid-file works uniformly,
     without manual slicing).
 
+    ``source`` may be an ordered sequence of paths or binary streams that together form
+    a multi-volume archive (volume joining lands in Phase 7). A length-1 sequence is
+    treated as a single source.
+
     ``password`` accepts a single value, an ordered sequence of candidate passwords, or
     a provider callable. List the most likely password first — especially for 7z, where
     each wrong candidate pays an expensive key derivation.
@@ -101,26 +127,26 @@ def open_archive(
     passwords = _PasswordCandidates.from_input(password)
 
     effective_config = config if config is not None else DEFAULT_ARCHIVEY_CONFIG
-    archive_name = source_name(source)
+    resolved = resolve_source(source)
+    open_source = resolved.open_source
+    archive_name = resolved.archive_name
 
-    # A path source: normalize str -> Path; a directory short-circuits detection.
-    open_source: Path | BinaryIO
-    if isinstance(source, (str, Path)):
-        path = Path(source)
-        if path.is_dir():
-            format = ArchiveFormat.DIRECTORY
-        open_source = path
-    else:
-        open_source = source
+    # A path source: a directory short-circuits detection.
+    if isinstance(open_source, Path) and open_source.is_dir():
+        format = ArchiveFormat.DIRECTORY
 
     detected: FormatInfo | None = None
     if format is None:
         # Non-seekable streams must be wrapped before detection so the peeked prefix is
         # replayed to the backend; the same wrapper is then handed over.
-        if is_stream(open_source) and not is_seekable(open_source):
-            open_source = PeekableStream(open_source)
-        detected = detect_format(open_source)
+        detect_source: Path | BinaryIO = open_source
+        if is_stream(detect_source) and not is_seekable(detect_source):
+            detect_source = PeekableStream(detect_source)
+        detected = detect_format(detect_source)
         format = detected.format
+
+    if resolved.volume_count > 1:
+        _raise_multi_volume_not_supported(format, archive_name)
 
     registry = get_registry()
     backend_cls = registry.reader_for_format(format)
@@ -176,7 +202,7 @@ def open_archive(
 
 
 def extract(
-    source: str | Path | BinaryIO,
+    source: OpenSourceInput,
     dest: str | Path,
     *,
     policy: ExtractionPolicy = ExtractionPolicy.STRICT,
@@ -184,6 +210,7 @@ def extract(
     on_error: OnError = OnError.STOP,
     format: ArchiveFormat | None = None,
     password: PasswordInput = None,
+    encoding: str | None = None,
     on_progress: Callable[[ExtractionProgress], None] | None = None,
     config: ArchiveyConfig | None = None,
     limits: ExtractionLimits | None = None,
@@ -198,7 +225,13 @@ def extract(
 
     Returns one :class:`~archivey.ExtractionResult` per member processed.
     """
-    with open_archive(source, format=format, password=password, config=config) as reader:
+    with open_archive(
+        source,
+        format=format,
+        password=password,
+        encoding=encoding,
+        config=config,
+    ) as reader:
         return reader.extract_all(
             dest,
             policy=policy,

--- a/src/archivey/core.py
+++ b/src/archivey/core.py
@@ -6,9 +6,9 @@ from pathlib import Path
 from typing import BinaryIO, Callable
 
 from archivey.config import (
+    DEFAULT_ARCHIVEY_CONFIG,
     AcceleratorMode,
     ArchiveyConfig,
-    DEFAULT_ARCHIVEY_CONFIG,
     ExtractionLimits,
 )
 from archivey.exceptions import StreamNotSeekableError, UnsupportedOperationError

--- a/src/archivey/core.py
+++ b/src/archivey/core.py
@@ -139,10 +139,9 @@ def open_archive(
     if format is None:
         # Non-seekable streams must be wrapped before detection so the peeked prefix is
         # replayed to the backend; the same wrapper is then handed over.
-        detect_source: Path | BinaryIO = open_source
-        if is_stream(detect_source) and not is_seekable(detect_source):
-            detect_source = PeekableStream(detect_source)
-        detected = detect_format(detect_source)
+        if is_stream(open_source) and not is_seekable(open_source):
+            open_source = PeekableStream(open_source)
+        detected = detect_format(open_source)
         format = detected.format
 
     if resolved.volume_count > 1:

--- a/src/archivey/internal/backends/directory_reader.py
+++ b/src/archivey/internal/backends/directory_reader.py
@@ -8,6 +8,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import BinaryIO, Iterator, Mapping
 
+from archivey.config import ArchiveyConfig
 from archivey.cost import (
     AccessCost,
     CostReceipt,
@@ -47,8 +48,9 @@ class DirectoryReader(BaseArchiveReader):
         root: Path,
         streaming: bool,
         archive_name: str | None,
+        config: ArchiveyConfig,
     ) -> None:
-        super().__init__(ArchiveFormat.DIRECTORY, streaming, archive_name)
+        super().__init__(ArchiveFormat.DIRECTORY, streaming, archive_name, config)
         self._root = root
         # uid/gid -> name caches: most entries in a tree share an owner/group, and
         # pwd/grp lookups hit the system database (nss) on every call, so we memoize.
@@ -219,13 +221,13 @@ class DirectoryReadBackend(ReadBackend):
         password: bytes | None,
         encoding: str | None,
         archive_name: str | None,
-        strict_eof: bool = False,
+        config: ArchiveyConfig,
     ) -> DirectoryReader:
         # `format` is always DIRECTORY here (single-format backend); accepted for the
         # uniform ReadBackend signature. Password rejection is central (SUPPORTS_PASSWORD).
         if not isinstance(source, Path):
             raise TypeError("Directory backend requires a Path source")
-        return DirectoryReader(source, streaming, archive_name or str(source))
+        return DirectoryReader(source, streaming, archive_name or str(source), config)
 
 
 # Self-register at import time

--- a/src/archivey/internal/backends/directory_reader.py
+++ b/src/archivey/internal/backends/directory_reader.py
@@ -16,6 +16,7 @@ from archivey.cost import (
     StreamCapability,
 )
 from archivey.internal.base_reader import BaseArchiveReader, ReadBackend
+from archivey.internal.password import _PasswordCandidates
 from archivey.internal.registry import register_reader
 from archivey.types import (
     EXTRA_IS_JUNCTION,
@@ -218,7 +219,7 @@ class DirectoryReadBackend(ReadBackend):
         source: Path | BinaryIO,
         format: ArchiveFormat,
         streaming: bool,
-        password: bytes | None,
+        passwords: _PasswordCandidates | None,
         encoding: str | None,
         archive_name: str | None,
         config: ArchiveyConfig,

--- a/src/archivey/internal/backends/iso_reader.py
+++ b/src/archivey/internal/backends/iso_reader.py
@@ -46,6 +46,7 @@ from archivey.exceptions import (
 )
 from archivey.internal.base_reader import BaseArchiveReader, ReadBackend
 from archivey.internal.naming import normalize_member_name
+from archivey.internal.password import _PasswordCandidates
 from archivey.internal.registry import register_reader
 from archivey.internal.streams.streamtools import DelegatingStream
 from archivey.types import (
@@ -142,7 +143,7 @@ class IsoReader(BaseArchiveReader):
         source: Path | BinaryIO,
         format: ArchiveFormat,
         streaming: bool,
-        password: bytes | None,
+        passwords: _PasswordCandidates | None,
         encoding: str | None,
         archive_name: str | None,
         config: ArchiveyConfig,
@@ -373,14 +374,14 @@ class IsoReadBackend(ReadBackend):
         source: Path | BinaryIO,
         format: ArchiveFormat,
         streaming: bool,
-        password: bytes | None,
+        passwords: _PasswordCandidates | None,
         encoding: str | None,
         archive_name: str | None,
         config: ArchiveyConfig,
     ) -> IsoReader:
         # `format` is always ISO here (single-format backend); accepted for the uniform
         # ReadBackend signature.
-        return IsoReader(source, format, streaming, password, encoding, archive_name, config)
+        return IsoReader(source, format, streaming, passwords, encoding, archive_name, config)
 
 
 register_reader(IsoReadBackend)

--- a/src/archivey/internal/backends/iso_reader.py
+++ b/src/archivey/internal/backends/iso_reader.py
@@ -32,6 +32,7 @@ from typing import TYPE_CHECKING, Any, BinaryIO, Iterator, Mapping, cast
 if TYPE_CHECKING:
     from pycdlib.pycdlibio import PyCdlibIO
 
+from archivey.config import ArchiveyConfig
 from archivey.cost import (
     AccessCost,
     CostReceipt,
@@ -144,9 +145,10 @@ class IsoReader(BaseArchiveReader):
         password: bytes | None,
         encoding: str | None,
         archive_name: str | None,
+        config: ArchiveyConfig,
     ) -> None:
         # password rejection is central: open_archive checks ReadBackend.SUPPORTS_PASSWORD.
-        super().__init__(format, streaming, archive_name)
+        super().__init__(format, streaming, archive_name, config)
         self._source = source
         if pycdlib is None:
             raise PackageNotInstalledError(
@@ -374,11 +376,11 @@ class IsoReadBackend(ReadBackend):
         password: bytes | None,
         encoding: str | None,
         archive_name: str | None,
-        strict_eof: bool = False,
+        config: ArchiveyConfig,
     ) -> IsoReader:
         # `format` is always ISO here (single-format backend); accepted for the uniform
         # ReadBackend signature.
-        return IsoReader(source, format, streaming, password, encoding, archive_name)
+        return IsoReader(source, format, streaming, password, encoding, archive_name, config)
 
 
 register_reader(IsoReadBackend)

--- a/src/archivey/internal/backends/single_file_reader.py
+++ b/src/archivey/internal/backends/single_file_reader.py
@@ -19,6 +19,7 @@ import os
 from pathlib import Path
 from typing import BinaryIO, Iterator
 
+from archivey.config import ArchiveyConfig
 from archivey.cost import (
     AccessCost,
     CostReceipt,
@@ -26,7 +27,6 @@ from archivey.cost import (
     StreamCapability,
 )
 from archivey.exceptions import ArchiveyError
-from archivey.config import ArchiveyConfig
 from archivey.internal.base_reader import BaseArchiveReader, ReadBackend
 from archivey.internal.config import stream_config_from_archivey
 from archivey.internal.registry import register_reader

--- a/src/archivey/internal/backends/single_file_reader.py
+++ b/src/archivey/internal/backends/single_file_reader.py
@@ -29,6 +29,7 @@ from archivey.cost import (
 from archivey.exceptions import ArchiveyError
 from archivey.internal.base_reader import BaseArchiveReader, ReadBackend
 from archivey.internal.config import stream_config_from_archivey
+from archivey.internal.password import _PasswordCandidates
 from archivey.internal.registry import register_reader
 from archivey.internal.streams.codecs import (
     SINGLE_FILE_CODECS,
@@ -76,7 +77,7 @@ class SingleFileReader(BaseArchiveReader):
         source: Path | BinaryIO,
         format: ArchiveFormat,
         streaming: bool,
-        password: bytes | None,
+        passwords: _PasswordCandidates | None,
         encoding: str | None,
         archive_name: str | None,
         config: ArchiveyConfig,
@@ -266,7 +267,7 @@ class SingleFileBackend(ReadBackend):
         source: Path | BinaryIO,
         format: ArchiveFormat,
         streaming: bool,
-        password: bytes | None,
+        passwords: _PasswordCandidates | None,
         encoding: str | None,
         archive_name: str | None,
         config: ArchiveyConfig,
@@ -274,7 +275,7 @@ class SingleFileBackend(ReadBackend):
         # `format` is the resolved single-file format (from detection or the caller); its
         # stream codec is exactly what to decompress with — no re-inspection needed.
         return SingleFileReader(
-            source, format, streaming, password, encoding, archive_name, config
+            source, format, streaming, passwords, encoding, archive_name, config
         )
 
 

--- a/src/archivey/internal/backends/single_file_reader.py
+++ b/src/archivey/internal/backends/single_file_reader.py
@@ -26,8 +26,9 @@ from archivey.cost import (
     StreamCapability,
 )
 from archivey.exceptions import ArchiveyError
+from archivey.config import ArchiveyConfig
 from archivey.internal.base_reader import BaseArchiveReader, ReadBackend
-from archivey.internal.config import StreamConfig
+from archivey.internal.config import stream_config_from_archivey
 from archivey.internal.registry import register_reader
 from archivey.internal.streams.codecs import (
     SINGLE_FILE_CODECS,
@@ -78,9 +79,10 @@ class SingleFileReader(BaseArchiveReader):
         password: bytes | None,
         encoding: str | None,
         archive_name: str | None,
+        config: ArchiveyConfig,
     ) -> None:
         # password rejection is central: open_archive checks ReadBackend.SUPPORTS_PASSWORD.
-        super().__init__(format, streaming, archive_name)
+        super().__init__(format, streaming, archive_name, config)
         self._source = source
         self._stream_codec = stream_codec_for_format(format.stream)
         self._codec = self._stream_codec.codec
@@ -91,7 +93,10 @@ class SingleFileReader(BaseArchiveReader):
         # needs either a seekable stream or a real OS fileno, and archivey wraps a non-seekable
         # source in a PeekableStream that has neither (so it raises StreamNotSeekableError).
         # Keep the codec sequential for such a source regardless of the archive's streaming flag.
-        self._codec_config = StreamConfig(streaming=self._streaming or not self._seekable)
+        self._codec_config = stream_config_from_archivey(
+            self._config,
+            streaming=self._streaming or not self._seekable,
+        )
 
         # The compressed-source header, read at most once and cached (only the gzip metadata
         # hook needs it; codecs without header metadata never trigger a read). See _peek_header.
@@ -264,12 +269,12 @@ class SingleFileBackend(ReadBackend):
         password: bytes | None,
         encoding: str | None,
         archive_name: str | None,
-        strict_eof: bool = False,
+        config: ArchiveyConfig,
     ) -> SingleFileReader:
         # `format` is the resolved single-file format (from detection or the caller); its
         # stream codec is exactly what to decompress with — no re-inspection needed.
         return SingleFileReader(
-            source, format, streaming, password, encoding, archive_name
+            source, format, streaming, password, encoding, archive_name, config
         )
 
 

--- a/src/archivey/internal/backends/tar_reader.py
+++ b/src/archivey/internal/backends/tar_reader.py
@@ -17,6 +17,7 @@ from io import BytesIO
 from pathlib import Path
 from typing import BinaryIO, Iterator, Mapping, cast
 
+from archivey.config import ArchiveyConfig
 from archivey.cost import (
     AccessCost,
     CostReceipt,
@@ -29,7 +30,6 @@ from archivey.exceptions import (
     TruncatedError,
 )
 from archivey.internal.base_reader import BaseArchiveReader, ReadBackend
-from archivey.config import ArchiveyConfig
 from archivey.internal.config import stream_config_from_archivey
 from archivey.internal.logs import backends as backends_logger
 from archivey.internal.naming import normalize_member_name

--- a/src/archivey/internal/backends/tar_reader.py
+++ b/src/archivey/internal/backends/tar_reader.py
@@ -33,6 +33,7 @@ from archivey.internal.base_reader import BaseArchiveReader, ReadBackend
 from archivey.internal.config import stream_config_from_archivey
 from archivey.internal.logs import backends as backends_logger
 from archivey.internal.naming import normalize_member_name
+from archivey.internal.password import _PasswordCandidates
 from archivey.internal.registry import register_reader
 from archivey.internal.streams.codecs import (
     SINGLE_FILE_CODECS,
@@ -128,7 +129,7 @@ class TarReader(BaseArchiveReader):
         source: Path | BinaryIO,
         format: ArchiveFormat,
         streaming: bool,
-        password: bytes | None,
+        passwords: _PasswordCandidates | None,
         encoding: str | None,
         archive_name: str | None,
         config: ArchiveyConfig,
@@ -450,7 +451,7 @@ class TarReadBackend(ReadBackend):
         source: Path | BinaryIO,
         format: ArchiveFormat,
         streaming: bool,
-        password: bytes | None,
+        passwords: _PasswordCandidates | None,
         encoding: str | None,
         archive_name: str | None,
         config: ArchiveyConfig,
@@ -458,7 +459,7 @@ class TarReadBackend(ReadBackend):
         # `format` carries the concrete (TAR, <stream>) variant the detector/caller resolved;
         # the backend uses its stream to pick the codec to decompress with.
         return TarReader(
-            source, format, streaming, password, encoding, archive_name, config
+            source, format, streaming, passwords, encoding, archive_name, config
         )
 
 

--- a/src/archivey/internal/backends/tar_reader.py
+++ b/src/archivey/internal/backends/tar_reader.py
@@ -5,7 +5,7 @@ Random-access reading (``streaming=False``) scans 512-byte headers on a seekable
 reading (``streaming=True``) walks the archive in one progressive pass — including on a
 non-seekable source for plain and compressed tars — via ``_iter_with_data()`` /
 ``stream_members()``. End-of-archive truncation is checked after a full scan or streaming
-pass when ``strict_eof`` is configured on open.
+pass when ``config.strict_archive_eof`` is enabled.
 """
 
 from __future__ import annotations
@@ -29,7 +29,8 @@ from archivey.exceptions import (
     TruncatedError,
 )
 from archivey.internal.base_reader import BaseArchiveReader, ReadBackend
-from archivey.internal.config import StreamConfig
+from archivey.config import ArchiveyConfig
+from archivey.internal.config import stream_config_from_archivey
 from archivey.internal.logs import backends as backends_logger
 from archivey.internal.naming import normalize_member_name
 from archivey.internal.registry import register_reader
@@ -130,12 +131,11 @@ class TarReader(BaseArchiveReader):
         password: bytes | None,
         encoding: str | None,
         archive_name: str | None,
-        strict_eof: bool = False,
+        config: ArchiveyConfig,
     ) -> None:
         # password rejection is central: open_archive checks ReadBackend.SUPPORTS_PASSWORD.
-        super().__init__(format, streaming, archive_name)
+        super().__init__(format, streaming, archive_name, config)
         self._encoding = encoding
-        self._strict_eof = strict_eof
         self._source = source
         self._compressed = format.stream != StreamFormat.UNCOMPRESSED
         # A decompression stream we open and therefore must close (compressed tars only);
@@ -165,7 +165,7 @@ class TarReader(BaseArchiveReader):
             stream = open_codec_stream(
                 codec,
                 codec_source,
-                config=StreamConfig(streaming=streaming),
+                config=stream_config_from_archivey(self._config, streaming=streaming),
                 stamp=lambda exc: self._stamp_error_context(exc),
             )
             # tarfile can mis-handle a short read() (fewer bytes than requested) from a
@@ -300,7 +300,7 @@ class TarReader(BaseArchiveReader):
             "TAR archive may be truncated: missing or invalid "
             "end-of-archive marker block(s)"
         )
-        if self._strict_eof:
+        if self._config.strict_archive_eof:
             err = TruncatedError(msg)
             self._stamp_error_context(err)
             raise err
@@ -453,12 +453,12 @@ class TarReadBackend(ReadBackend):
         password: bytes | None,
         encoding: str | None,
         archive_name: str | None,
-        strict_eof: bool = False,
+        config: ArchiveyConfig,
     ) -> TarReader:
         # `format` carries the concrete (TAR, <stream>) variant the detector/caller resolved;
         # the backend uses its stream to pick the codec to decompress with.
         return TarReader(
-            source, format, streaming, password, encoding, archive_name, strict_eof
+            source, format, streaming, password, encoding, archive_name, config
         )
 
 

--- a/src/archivey/internal/backends/zip_reader.py
+++ b/src/archivey/internal/backends/zip_reader.py
@@ -34,6 +34,7 @@ from archivey.exceptions import (
 from archivey.internal.base_reader import BaseArchiveReader, ReadBackend
 from archivey.internal.logs import backends as logger
 from archivey.internal.naming import normalize_member_name
+from archivey.internal.password import _PasswordCandidates
 from archivey.internal.registry import register_reader
 from archivey.internal.streams.streamtools import is_seekable, is_stream
 from archivey.types import (
@@ -192,14 +193,14 @@ class ZipReader(BaseArchiveReader):
         self,
         source: Path | BinaryIO,
         streaming: bool,
-        password: bytes | None,
+        passwords: _PasswordCandidates | None,
         encoding: str | None,
         archive_name: str | None,
         config: ArchiveyConfig,
     ) -> None:
         super().__init__(ArchiveFormat.ZIP, streaming, archive_name, config)
         self._source = source
-        self._password = password
+        self._passwords = passwords or _PasswordCandidates()
         self._encoding = encoding
 
         if is_stream(source) and not is_seekable(source):
@@ -317,6 +318,38 @@ class ZipReader(BaseArchiveReader):
             _raw=info,  # carry the ZipInfo so _open_member needs no name/id lookup table
         )
 
+    def _open_zip_entry(
+        self,
+        info: zipfile.ZipInfo,
+        member: ArchiveMember | None,
+        *,
+        member_name: str,
+    ) -> BinaryIO:
+        encrypted = bool(info.flag_bits & 0x1)
+
+        def decrypt(password: bytes) -> BinaryIO:
+            try:
+                return cast(
+                    "BinaryIO",
+                    self._archive.open(info, pwd=password if encrypted else None),
+                )
+            except (zipfile.BadZipFile, RuntimeError, io.UnsupportedOperation) as exc:
+                translated = self._translate_exception(exc)
+                if translated is not None:
+                    if isinstance(translated, EncryptionError):
+                        raise translated
+                    self._stamp_error_context(translated, member_name)
+                    raise translated from exc
+                raise
+
+        if encrypted:
+            try:
+                return self._passwords.attempt(member, decrypt)
+            except EncryptionError as exc:
+                self._stamp_error_context(exc, member_name)
+                raise
+        return decrypt(b"")
+
     def _ensure_link_target(self, member: ArchiveMember) -> None:
         if member.type != MemberType.SYMLINK or member.link_target is not None:
             return
@@ -327,44 +360,27 @@ class ZipReader(BaseArchiveReader):
         # unset (following the link later fails with LinkTargetNotFoundError); other
         # errors surface translated like any member-read error.
         try:
-            with self._archive.open(info, pwd=self._password) as f:
+            with self._open_zip_entry(info, member, member_name=member.name) as f:
                 member.link_target = f.read().decode("utf-8", errors="surrogateescape")
-        except (RuntimeError, zipfile.BadZipFile) as exc:
+        except EncryptionError:
+            logger.warning(
+                "Cannot read the symlink target of %r without the correct "
+                "password; leaving link_target unset.",
+                info.filename,
+            )
+        except (zipfile.BadZipFile, RuntimeError) as exc:
             translated = self._translate_exception(exc)
-            if isinstance(translated, EncryptionError):
-                logger.warning(
-                    "Cannot read the symlink target of %r without the correct "
-                    "password; leaving link_target unset.",
-                    info.filename,
-                )
-            elif translated is not None:
+            if translated is not None:
                 self._stamp_error_context(translated, info.filename)
                 raise translated from exc
-            else:
-                raise
+            raise
 
     def _open_member(self, member: ArchiveMember) -> BinaryIO:
         # The member carries its own ZipInfo (`_raw`), so data access needs no name/id map
         # — and a duplicate member name can't resolve to the wrong entry.
         info = member._raw
         assert isinstance(info, zipfile.ZipInfo), "ZIP member is missing its ZipInfo handle"
-        # zipfile validates the local header when opening a member — the "Overlapped
-        # entries" zip-bomb guard, the name-mismatch check, a missing-password
-        # RuntimeError, and unsupported-compression NotImplementedError all fire here,
-        # before any byte flows through the ArchiveStream translator. Translate them at
-        # the source so callers only ever see ArchiveyErrors (a genuine OSError from the
-        # underlying source is not in the caught set, so it propagates unchanged).
-        try:
-            raw = cast(
-                "BinaryIO",
-                self._archive.open(info, pwd=self._password),
-            )
-        except (zipfile.BadZipFile, RuntimeError, io.UnsupportedOperation) as exc:
-            translated = self._translate_exception(exc)
-            if translated is not None:
-                self._stamp_error_context(translated, member.name)
-                raise translated from exc
-            raise
+        raw = self._open_zip_entry(info, member, member_name=member.name)
         return self._wrap_member_stream(raw, member.name, size=member.size)
 
     def _get_archive_info(self) -> ArchiveInfo:
@@ -413,14 +429,14 @@ class ZipReadBackend(ReadBackend):
         source: Path | BinaryIO,
         format: ArchiveFormat,
         streaming: bool,
-        password: bytes | None,
+        passwords: _PasswordCandidates | None,
         encoding: str | None,
         archive_name: str | None,
         config: ArchiveyConfig,
     ) -> ZipReader:
         # `format` is always ZIP here (single-format backend); accepted for the uniform
         # ReadBackend signature.
-        return ZipReader(source, streaming, password, encoding, archive_name, config)
+        return ZipReader(source, streaming, passwords, encoding, archive_name, config)
 
 
 register_reader(ZipReadBackend)

--- a/src/archivey/internal/backends/zip_reader.py
+++ b/src/archivey/internal/backends/zip_reader.py
@@ -17,6 +17,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import BinaryIO, Iterator, Mapping, cast
 
+from archivey.config import ArchiveyConfig
 from archivey.cost import (
     AccessCost,
     CostReceipt,
@@ -30,7 +31,6 @@ from archivey.exceptions import (
     StreamNotSeekableError,
     UnsupportedFeatureError,
 )
-from archivey.config import ArchiveyConfig
 from archivey.internal.base_reader import BaseArchiveReader, ReadBackend
 from archivey.internal.logs import backends as logger
 from archivey.internal.naming import normalize_member_name

--- a/src/archivey/internal/backends/zip_reader.py
+++ b/src/archivey/internal/backends/zip_reader.py
@@ -30,6 +30,7 @@ from archivey.exceptions import (
     StreamNotSeekableError,
     UnsupportedFeatureError,
 )
+from archivey.config import ArchiveyConfig
 from archivey.internal.base_reader import BaseArchiveReader, ReadBackend
 from archivey.internal.logs import backends as logger
 from archivey.internal.naming import normalize_member_name
@@ -194,8 +195,9 @@ class ZipReader(BaseArchiveReader):
         password: bytes | None,
         encoding: str | None,
         archive_name: str | None,
+        config: ArchiveyConfig,
     ) -> None:
-        super().__init__(ArchiveFormat.ZIP, streaming, archive_name)
+        super().__init__(ArchiveFormat.ZIP, streaming, archive_name, config)
         self._source = source
         self._password = password
         self._encoding = encoding
@@ -414,11 +416,11 @@ class ZipReadBackend(ReadBackend):
         password: bytes | None,
         encoding: str | None,
         archive_name: str | None,
-        strict_eof: bool = False,
+        config: ArchiveyConfig,
     ) -> ZipReader:
         # `format` is always ZIP here (single-format backend); accepted for the uniform
         # ReadBackend signature.
-        return ZipReader(source, streaming, password, encoding, archive_name)
+        return ZipReader(source, streaming, password, encoding, archive_name, config)
 
 
 register_reader(ZipReadBackend)

--- a/src/archivey/internal/base_reader.py
+++ b/src/archivey/internal/base_reader.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import BinaryIO, Callable, Iterator, Mapping
+from typing import TYPE_CHECKING, BinaryIO, Callable, Iterator, Mapping
+
+if TYPE_CHECKING:
+    from archivey.internal.password import _PasswordCandidates
 
 from archivey.config import DEFAULT_ARCHIVEY_CONFIG, ArchiveyConfig, ExtractionLimits
 from archivey.cost import CostReceipt
@@ -81,7 +84,7 @@ class ReadBackend(ABC):
         source: Path | BinaryIO,
         format: ArchiveFormat,
         streaming: bool,
-        password: bytes | None,
+        passwords: _PasswordCandidates | None,
         encoding: str | None,
         archive_name: str | None,
         config: ArchiveyConfig,

--- a/src/archivey/internal/base_reader.py
+++ b/src/archivey/internal/base_reader.py
@@ -27,6 +27,7 @@ from archivey.internal.extraction_types import (
     OverwritePolicy,
 )
 from archivey.internal.naming import resolve_link_target_name
+from archivey.internal.selection import normalize_member_selector
 from archivey.internal.streams.archive_stream import ArchiveStream
 from archivey.internal.streams.counting import CountingReader
 from archivey.internal.streams.streamtools import (
@@ -730,10 +731,11 @@ class BaseArchiveReader(ArchiveReader):
         members: MemberSelector = None,
     ) -> Iterator[tuple[ArchiveMember, BinaryIO | None]]:
         """Yield (member, stream) pairs. members is a selector filter (no transform)."""
+        selector = normalize_member_selector(members)
         if self._streaming:
             self._enter_forward_pass("stream_members()")
         for m, stream in self._iter_with_data():
-            if members is None or members(m):
+            if selector is None or selector(m):
                 yield m, stream
             elif stream is not None:
                 stream.close()

--- a/src/archivey/internal/base_reader.py
+++ b/src/archivey/internal/base_reader.py
@@ -30,6 +30,7 @@ from archivey.internal.streams.streamtools import (
     is_stream,
     source_byte_size,
 )
+from archivey.config import ArchiveyConfig, DEFAULT_ARCHIVEY_CONFIG, ExtractionLimits
 from archivey.reader import ArchiveReader, MemberSelector
 from archivey.types import (
     ArchiveFormat,
@@ -83,7 +84,7 @@ class ReadBackend(ABC):
         password: bytes | None,
         encoding: str | None,
         archive_name: str | None,
-        strict_eof: bool = False,
+        config: ArchiveyConfig,
     ) -> "BaseArchiveReader":
         """Open ``source`` as ``format`` (the resolved format the registry selected this
         backend for — either detected by ``open_archive`` or supplied by the caller). A
@@ -178,10 +179,12 @@ class BaseArchiveReader(ArchiveReader):
         format: ArchiveFormat,
         streaming: bool,
         archive_name: str | None,
+        config: ArchiveyConfig | None = None,
     ) -> None:
         self._format = format
         self._streaming = streaming
         self._archive_name = archive_name
+        self._config = config if config is not None else DEFAULT_ARCHIVEY_CONFIG
         self._archive_id = str(id(self))
         # The archive's source, recorded by backends that have one (path or stream);
         # backs the generalized compressed_source_size property below.
@@ -742,10 +745,8 @@ class BaseArchiveReader(ArchiveReader):
         overwrite: OverwritePolicy = OverwritePolicy.ERROR,
         on_error: OnError = OnError.STOP,
         on_progress: Callable[[ExtractionProgress], None] | None = None,
-        max_extracted_bytes: int = 2 * 2**30,
-        max_ratio: float = 1000.0,
-        ratio_activation_threshold: int = 5 * 2**20,
-        max_entries: int = 1_048_576,
+        config: ArchiveyConfig | None = None,
+        limits: ExtractionLimits | None = None,
     ) -> list[ExtractionResult]:
         """Extract members to dest via the shared ``ExtractionCoordinator``."""
         if self._streaming:
@@ -754,6 +755,10 @@ class BaseArchiveReader(ArchiveReader):
         # type-checks against BaseArchiveReader.
         from archivey.internal.extraction import ExtractionCoordinator
 
+        effective_config = config if config is not None else self._config
+        effective_limits = (
+            limits if limits is not None else effective_config.extraction_limits
+        )
         coordinator = ExtractionCoordinator(
             policy=policy,
             overwrite=overwrite,
@@ -761,10 +766,7 @@ class BaseArchiveReader(ArchiveReader):
             on_progress=on_progress,
             members=members,
             filter=filter,
-            max_extracted_bytes=max_extracted_bytes,
-            max_ratio=max_ratio,
-            ratio_activation_threshold=ratio_activation_threshold,
-            max_entries=max_entries,
+            limits=effective_limits,
         )
         return coordinator.run(self, dest)
 

--- a/src/archivey/internal/base_reader.py
+++ b/src/archivey/internal/base_reader.py
@@ -6,6 +6,7 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import BinaryIO, Callable, Iterator, Mapping
 
+from archivey.config import DEFAULT_ARCHIVEY_CONFIG, ArchiveyConfig, ExtractionLimits
 from archivey.cost import CostReceipt
 from archivey.exceptions import (
     ArchiveyError,
@@ -30,7 +31,6 @@ from archivey.internal.streams.streamtools import (
     is_stream,
     source_byte_size,
 )
-from archivey.config import ArchiveyConfig, DEFAULT_ARCHIVEY_CONFIG, ExtractionLimits
 from archivey.reader import ArchiveReader, MemberSelector
 from archivey.types import (
     ArchiveFormat,

--- a/src/archivey/internal/config.py
+++ b/src/archivey/internal/config.py
@@ -1,49 +1,23 @@
-"""Internal configuration for the stream layer.
-
-This is **not** part of the public API yet — ``open_archive()`` does not accept a
-``config=`` argument in this phase. It exists so the codec/seekable layer can carry
-the accelerator flags (and future stream options) as a single value instead of a
-growing list of keyword arguments. A public surface is wired in a later phase (see
-``access-mode-and-cost`` / the ``PLAN.md`` Phase-5 finalization).
-"""
+"""Internal stream-layer view derived from :class:`ArchiveyConfig`."""
 
 from __future__ import annotations
 
 from dataclasses import dataclass
-from enum import Enum
 
+from archivey.config import (
+    AcceleratorMode,
+    ArchiveyConfig,
+    DEFAULT_ARCHIVEY_CONFIG,
+)
 
-class AcceleratorMode(Enum):
-    """Tri-state control for an optional random-access accelerator backend.
-
-    - ``ON``  — always use the accelerator (raise ``PackageNotInstalledError`` if its
-      package is absent: the caller asked for it explicitly).
-    - ``OFF`` — never use it; the stream stays sequential-only.
-    - ``AUTO`` — use it only when random access is actually wanted, i.e. the archive was
-      opened for random access (``streaming=False``). Under ``streaming=True`` a forward
-      pass needs no seeking, so AUTO leaves the cheaper sequential backend in place. When
-      AUTO would enable the accelerator but its package is absent, fall back to sequential
-      silently (it is an enhancement, not a requirement).
-    """
-
-    AUTO = "auto"
-    ON = "on"
-    OFF = "off"
-
-    def enabled_for(self, *, streaming: bool, available: bool) -> bool:
-        """Resolve the tri-state to "use the accelerator?".
-
-        ``ON`` always returns ``True`` (the caller checks availability and raises
-        ``PackageNotInstalledError`` if the package is missing — the user asked for it
-        explicitly). ``AUTO`` enables it only for random access and only when available, so
-        a missing package falls back silently to the sequential backend.
-        """
-        if self is AcceleratorMode.OFF:
-            return False
-        if self is AcceleratorMode.ON:
-            return True
-        # AUTO: random access wants seeking; a forward-only pass does not.
-        return available and not streaming
+__all__ = [
+    "AcceleratorMode",
+    "DEFAULT_ARCHIVEY_CONFIG",
+    "DEFAULT_STREAM_CONFIG",
+    "ArchiveyConfig",
+    "StreamConfig",
+    "stream_config_from_archivey",
+]
 
 
 @dataclass(frozen=True)
@@ -59,6 +33,17 @@ class StreamConfig:
     use_indexed_bzip2: AcceleratorMode = AcceleratorMode.AUTO
 
 
-# A shared default used by callers that have no specific configuration (e.g. opening a
-# bare single-file compressed stream in random-access mode).
-DEFAULT_STREAM_CONFIG = StreamConfig()
+def stream_config_from_archivey(
+    config: ArchiveyConfig, *, streaming: bool
+) -> StreamConfig:
+    """Derive the codec-layer view from the public config and access mode."""
+    return StreamConfig(
+        streaming=streaming,
+        use_rapidgzip=config.use_rapidgzip,
+        use_indexed_bzip2=config.use_indexed_bzip2,
+    )
+
+
+DEFAULT_STREAM_CONFIG = stream_config_from_archivey(
+    DEFAULT_ARCHIVEY_CONFIG, streaming=False
+)

--- a/src/archivey/internal/config.py
+++ b/src/archivey/internal/config.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 
 from archivey.config import (
+    DEFAULT_ARCHIVEY_CONFIG,
     AcceleratorMode,
     ArchiveyConfig,
-    DEFAULT_ARCHIVEY_CONFIG,
 )
 
 __all__ = [

--- a/src/archivey/internal/extraction.py
+++ b/src/archivey/internal/extraction.py
@@ -30,6 +30,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, BinaryIO, Callable, Collection, cast
 
+from archivey.config import ExtractionLimits
 from archivey.exceptions import (
     ArchiveyError,
     ExtractionError,
@@ -83,10 +84,10 @@ class BombTracker:
 
     def __init__(
         self,
-        max_bytes: int,
-        max_ratio: float,
+        max_bytes: int | None,
+        max_ratio: float | None,
         ratio_activation_threshold: int = DEFAULT_RATIO_ACTIVATION_THRESHOLD,
-        max_entries: int = DEFAULT_MAX_ENTRIES,
+        max_entries: int | None = DEFAULT_MAX_ENTRIES,
         *,
         source: "BaseArchiveReader | None" = None,
     ) -> None:
@@ -118,7 +119,7 @@ class BombTracker:
         self._member = member
         self._member_bytes = 0
         self._entry_count += 1
-        if self._entry_count > self._max_entries:
+        if self._max_entries is not None and self._entry_count > self._max_entries:
             raise _AlwaysStopExtractionError(
                 f"Entry-count limit reached: {self._entry_count} > {self._max_entries}"
             )
@@ -128,7 +129,7 @@ class BombTracker:
         self._member_bytes += chunk_bytes
 
         # Cumulative byte guard (always-stop).
-        if self._total_bytes > self._max_bytes:
+        if self._max_bytes is not None and self._total_bytes > self._max_bytes:
             raise _AlwaysStopExtractionError(
                 f"Extraction limit reached: {self._total_bytes} bytes > {self._max_bytes}"
             )
@@ -137,7 +138,13 @@ class BombTracker:
         # (skippable under OnError.CONTINUE).
         member = self._member
         cs = member.compressed_size if member is not None else None
-        if member is not None and self._member_bytes > self._ratio_floor and cs and cs > 0:
+        if (
+            self._max_ratio is not None
+            and member is not None
+            and self._member_bytes > self._ratio_floor
+            and cs
+            and cs > 0
+        ):
             ratio = self._member_bytes / cs
             if ratio > self._max_ratio:
                 raise ExtractionError(
@@ -152,7 +159,7 @@ class BombTracker:
         # are mutually exclusive (static when known, live otherwise), so the ratio is never
         # counted twice.
         css = self._compressed_source_size
-        if self._total_bytes > self._ratio_floor:
+        if self._max_ratio is not None and self._total_bytes > self._ratio_floor:
             if css and css > 0:
                 if self._total_bytes / css > self._max_ratio:
                     raise _AlwaysStopExtractionError(
@@ -162,7 +169,11 @@ class BombTracker:
                     )
             elif self._source is not None:
                 consumed = self._source.compressed_bytes_consumed
-                if consumed and consumed > 0 and self._total_bytes / consumed > self._max_ratio:
+                if (
+                    consumed
+                    and consumed > 0
+                    and self._total_bytes / consumed > self._max_ratio
+                ):
                     raise _AlwaysStopExtractionError(
                         f"Live decompression ratio "
                         f"{self._total_bytes / consumed:.0f}:1 exceeds limit "
@@ -198,10 +209,7 @@ class ExtractionCoordinator:
         on_progress: Callable[[ExtractionProgress], None] | None = None,
         members: MemberSelectorArg = None,
         filter: MemberFilter | None = None,
-        max_extracted_bytes: int = DEFAULT_MAX_EXTRACTED_BYTES,
-        max_ratio: float = DEFAULT_MAX_RATIO,
-        ratio_activation_threshold: int = DEFAULT_RATIO_ACTIVATION_THRESHOLD,
-        max_entries: int = DEFAULT_MAX_ENTRIES,
+        limits: ExtractionLimits | None = None,
     ) -> None:
         self._policy = policy
         self._overwrite = overwrite
@@ -209,10 +217,7 @@ class ExtractionCoordinator:
         self._on_progress = on_progress
         self._members = members
         self._filter = filter
-        self._max_extracted_bytes = max_extracted_bytes
-        self._max_ratio = max_ratio
-        self._ratio_floor = ratio_activation_threshold
-        self._max_entries = max_entries
+        self._limits = limits if limits is not None else ExtractionLimits()
 
     # --- entry point ---------------------------------------------------------------
 
@@ -223,10 +228,10 @@ class ExtractionCoordinator:
         forward_only = reader._streaming
 
         tracker = BombTracker(
-            self._max_extracted_bytes,
-            self._max_ratio,
-            self._ratio_floor,
-            self._max_entries,
+            self._limits.max_extracted_bytes,
+            self._limits.max_ratio,
+            self._limits.ratio_activation_threshold,
+            self._limits.max_entries,
             source=reader,
         )
 

--- a/src/archivey/internal/extraction.py
+++ b/src/archivey/internal/extraction.py
@@ -28,7 +28,7 @@ import shutil
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, BinaryIO, Callable, Collection, cast
+from typing import TYPE_CHECKING, BinaryIO, Callable
 
 from archivey.config import ExtractionLimits
 from archivey.exceptions import (
@@ -49,6 +49,7 @@ from archivey.internal.extraction_types import (
     OverwritePolicy,
 )
 from archivey.internal.filters import POLICY_TRANSFORMS, check_universal
+from archivey.internal.selection import normalize_member_selector
 from archivey.types import ArchiveMember, MemberType
 
 if TYPE_CHECKING:
@@ -235,7 +236,7 @@ class ExtractionCoordinator:
             source=reader,
         )
 
-        selector = self._normalize_selector()
+        selector = normalize_member_selector(self._members)
 
         all_members = reader.get_members_if_available()
         members_total = len(all_members) if all_members is not None else None
@@ -309,27 +310,6 @@ class ExtractionCoordinator:
         return results
 
     # --- selection / transform -----------------------------------------------------
-
-    def _normalize_selector(self) -> Callable[[ArchiveMember], bool] | None:
-        members = self._members
-        if members is None:
-            return None
-        # A predicate is callable; a names/members collection is not.
-        if callable(members):
-            return cast("Callable[[ArchiveMember], bool]", members)
-        # Collection form: a str entry matches EVERY member with that name (duplicates
-        # included); an ArchiveMember entry matches only that exact member, by object
-        # identity (id-set — members are deliberately unhashable), so with duplicate
-        # names the caller can select one specific occurrence.
-        collection = cast("Collection[str | ArchiveMember]", members)
-        names: set[str] = set()
-        identities: set[int] = set()
-        for entry in collection:
-            if isinstance(entry, ArchiveMember):
-                identities.add(id(entry))
-            else:
-                names.add(entry)
-        return lambda member: member.name in names or id(member) in identities
 
     def _transform(
         self, original: ArchiveMember, dest_root: Path

--- a/src/archivey/internal/extraction_types.py
+++ b/src/archivey/internal/extraction_types.py
@@ -24,8 +24,7 @@ from archivey.types import ArchiveMember
 #
 # ``MemberSelectorArg`` — which members to extract: a collection of names / ArchiveMembers,
 # a predicate, or ``None`` (= all). The collection form is normalized to a predicate by the
-# coordinator; the public ``stream_members`` selector stays predicate-only (its
-# duplicate-name semantics are deferred to Phase 5 — see reader.py).
+# shared ``normalize_member_selector`` helper (also used by ``stream_members``).
 MemberSelectorArg = (
     Collection["str | ArchiveMember"] | Callable[[ArchiveMember], bool] | None
 )

--- a/src/archivey/internal/password.py
+++ b/src/archivey/internal/password.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Iterator, Sequence as ABCSequence
+from collections.abc import Callable, Iterator
+from collections.abc import Sequence as ABCSequence
 from typing import TypeVar
 
 from archivey.config import PasswordInput, PasswordProvider, PasswordRequest

--- a/src/archivey/internal/password.py
+++ b/src/archivey/internal/password.py
@@ -1,0 +1,107 @@
+"""Internal password candidate resolution for encrypted archive units."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterator, Sequence as ABCSequence
+from typing import TypeVar
+
+from archivey.config import PasswordInput, PasswordProvider, PasswordRequest
+from archivey.exceptions import EncryptionError
+from archivey.types import ArchiveMember
+
+_T = TypeVar("_T")
+
+
+def _to_bytes(password: str | bytes) -> bytes:
+    return password.encode() if isinstance(password, str) else password
+
+
+class _PasswordCandidates:
+    """Per-archive password state: known-good list, remaining candidates, optional provider."""
+
+    __slots__ = ("_candidates", "_known_good", "_provider")
+
+    def __init__(
+        self,
+        *,
+        candidates: ABCSequence[bytes] = (),
+        provider: PasswordProvider | None = None,
+    ) -> None:
+        self._known_good: list[bytes] = []
+        self._candidates: list[bytes] = list(candidates)
+        self._provider = provider
+
+    @classmethod
+    def from_input(cls, password: PasswordInput) -> _PasswordCandidates:
+        if password is None:
+            return cls()
+        if isinstance(password, (str, bytes)):
+            return cls(candidates=[_to_bytes(password)])
+        if isinstance(password, ABCSequence):
+            return cls(candidates=[_to_bytes(p) for p in password])
+        if callable(password):
+            return cls(provider=password)
+        raise TypeError(f"unsupported password type: {type(password)!r}")
+
+    def has_passwords(self) -> bool:
+        return bool(self._known_good or self._candidates or self._provider is not None)
+
+    def record_success(self, password: bytes) -> None:
+        if password in self._known_good:
+            self._known_good.remove(password)
+        self._known_good.insert(0, password)
+
+    def iter_candidates(self, member: ArchiveMember | None) -> Iterator[bytes]:
+        """Yield passwords to try for one encrypted unit (known-good, then candidates)."""
+        seen: set[bytes] = set()
+        for password in self._known_good:
+            if password not in seen:
+                seen.add(password)
+                yield password
+        for password in self._candidates:
+            if password not in seen:
+                seen.add(password)
+                yield password
+
+    def attempt(
+        self,
+        member: ArchiveMember | None,
+        decrypt: Callable[[bytes], _T],
+        *,
+        on_failure: Callable[[bytes, Exception], EncryptionError | None] | None = None,
+    ) -> _T:
+        """Try passwords in order; consult the provider after static candidates fail."""
+        last_error: EncryptionError | None = None
+
+        def try_password(password: bytes) -> _T | None:
+            nonlocal last_error
+            try:
+                result = decrypt(password)
+            except EncryptionError as exc:
+                last_error = exc
+                if on_failure is not None:
+                    mapped = on_failure(password, exc)
+                    if mapped is not None:
+                        last_error = mapped
+                return None
+            self.record_success(password)
+            return result
+
+        for password in self.iter_candidates(member):
+            result = try_password(password)
+            if result is not None:
+                return result
+
+        attempt = 1
+        while self._provider is not None:
+            raw = self._provider(PasswordRequest(member=member, attempt=attempt))
+            if raw is None:
+                break
+            result = try_password(_to_bytes(raw))
+            if result is not None:
+                return result
+            attempt += 1
+
+        if last_error is not None:
+            raise last_error
+        raise EncryptionError("Password required to read this encrypted member")

--- a/src/archivey/internal/password.py
+++ b/src/archivey/internal/password.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Iterator
 from collections.abc import Sequence as ABCSequence
-from typing import TypeVar
+from typing import TypeVar, cast
 
 from archivey.config import PasswordInput, PasswordProvider, PasswordRequest
 from archivey.exceptions import EncryptionError
@@ -38,11 +38,17 @@ class _PasswordCandidates:
             return cls()
         if isinstance(password, (str, bytes)):
             return cls(candidates=[_to_bytes(password)])
-        if isinstance(password, ABCSequence):
-            return cls(candidates=[_to_bytes(p) for p in password])
-        if callable(password):
-            return cls(provider=password)
-        raise TypeError(f"unsupported password type: {type(password)!r}")
+        if isinstance(password, ABCSequence) and not isinstance(password, (str, bytes)):
+            candidates_list: list[bytes] = []
+            for item in password:
+                if not isinstance(item, (str, bytes)):
+                    raise TypeError(
+                        "password sequence items must be str or bytes, "
+                        f"not {type(item)!r}"
+                    )
+                candidates_list.append(_to_bytes(item))
+            return cls(candidates=candidates_list)
+        return cls(provider=cast(PasswordProvider, password))
 
     def has_passwords(self) -> bool:
         return bool(self._known_good or self._candidates or self._provider is not None)

--- a/src/archivey/internal/password.py
+++ b/src/archivey/internal/password.py
@@ -58,14 +58,10 @@ class _PasswordCandidates:
             self._known_good.remove(password)
         self._known_good.insert(0, password)
 
-    def iter_candidates(self, member: ArchiveMember | None) -> Iterator[bytes]:
+    def iter_candidates(self) -> Iterator[bytes]:
         """Yield passwords to try for one encrypted unit (known-good, then candidates)."""
         seen: set[bytes] = set()
-        for password in self._known_good:
-            if password not in seen:
-                seen.add(password)
-                yield password
-        for password in self._candidates:
+        for password in (*self._known_good, *self._candidates):
             if password not in seen:
                 seen.add(password)
                 yield password
@@ -77,11 +73,19 @@ class _PasswordCandidates:
         *,
         on_failure: Callable[[bytes, Exception], EncryptionError | None] | None = None,
     ) -> _T:
-        """Try passwords in order; consult the provider after static candidates fail."""
+        """Try passwords in order; consult the provider after static candidates fail.
+
+        ``decrypt`` must return a non-``None`` value on success: ``attempt`` uses
+        ``None`` as its "wrong password, try the next candidate" sentinel, so a
+        decrypt callable that returned ``None`` for a valid password would be treated
+        as a failure and retried.
+        """
         last_error: EncryptionError | None = None
+        tried: set[bytes] = set()
 
         def try_password(password: bytes) -> _T | None:
             nonlocal last_error
+            tried.add(password)
             try:
                 result = decrypt(password)
             except EncryptionError as exc:
@@ -94,7 +98,7 @@ class _PasswordCandidates:
             self.record_success(password)
             return result
 
-        for password in self.iter_candidates(member):
+        for password in self.iter_candidates():
             result = try_password(password)
             if result is not None:
                 return result
@@ -104,7 +108,13 @@ class _PasswordCandidates:
             raw = self._provider(PasswordRequest(member=member, attempt=attempt))
             if raw is None:
                 break
-            result = try_password(_to_bytes(raw))
+            password = _to_bytes(raw)
+            # A provider that repeats a password we already tried can make no further
+            # progress; stop rather than re-running an expensive decrypt (and, for 7z,
+            # an expensive key derivation) on the same input forever.
+            if password in tried:
+                break
+            result = try_password(password)
             if result is not None:
                 return result
             attempt += 1

--- a/src/archivey/internal/selection.py
+++ b/src/archivey/internal/selection.py
@@ -21,6 +21,9 @@ def normalize_member_selector(
     identities: set[tuple[str, int]] = set()
     for entry in collection:
         if isinstance(entry, ArchiveMember):
+            # Match by (archive_id, member_id) identity. A member that carries no ids
+            # (never registered by a reader — e.g. hand-built) is deliberately dropped:
+            # it can't correspond to any real member, so it silently matches nothing.
             if entry._archive_id is not None and entry._member_id is not None:
                 identities.add((entry._archive_id, entry._member_id))
         else:

--- a/src/archivey/internal/selection.py
+++ b/src/archivey/internal/selection.py
@@ -1,0 +1,36 @@
+"""Member selection normalization shared by streaming and extraction."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Collection
+from typing import cast
+
+from archivey.types import ArchiveMember
+
+
+def normalize_member_selector(
+    members: Collection[str | ArchiveMember] | Callable[[ArchiveMember], bool] | None,
+) -> Callable[[ArchiveMember], bool] | None:
+    """Normalize a collection or predicate selector to a predicate."""
+    if members is None:
+        return None
+    if callable(members):
+        return cast("Callable[[ArchiveMember], bool]", members)
+    collection = cast("Collection[str | ArchiveMember]", members)
+    names: set[str] = set()
+    identities: set[tuple[str, int]] = set()
+    for entry in collection:
+        if isinstance(entry, ArchiveMember):
+            if entry._archive_id is not None and entry._member_id is not None:
+                identities.add((entry._archive_id, entry._member_id))
+        else:
+            names.add(entry)
+
+    def predicate(member: ArchiveMember) -> bool:
+        if member.name in names:
+            return True
+        if member._archive_id is not None and member._member_id is not None:
+            return (member._archive_id, member._member_id) in identities
+        return False
+
+    return predicate

--- a/src/archivey/internal/volumes.py
+++ b/src/archivey/internal/volumes.py
@@ -1,0 +1,156 @@
+"""Multi-volume path discovery (Phase 5 plumbing; joining lands in Phase 7)."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import BinaryIO
+
+from archivey.internal.streams.streamtools import is_stream, source_name
+
+_7Z_VOLUME_RE = re.compile(r"^(?P<base>.+\.7z)\.(?P<part>\d+)$", re.IGNORECASE)
+_RAR_PART_RE = re.compile(r"^(?P<base>.+)\.part(?P<part>\d+)\.rar$", re.IGNORECASE)
+_RAR_RNN_RE = re.compile(r"^(?P<base>.+)\.r(?P<part>\d{2})$", re.IGNORECASE)
+
+
+def _part_number_from_name(name: str, *, part_group: str = "part") -> int:
+    match = re.search(rf"\.{part_group}(\d+)", name, re.IGNORECASE)
+    if match is None:
+        match = re.search(r"\.(\d+)$", name)
+    return int(match.group(1)) if match is not None else 0
+
+
+def _rnn_part_number(name: str) -> int:
+    match = _RAR_RNN_RE.match(name)
+    return int(match.group("part")) if match is not None else 0
+
+
+def discover_volume_siblings(path: Path) -> list[Path] | None:
+    """Return ordered sibling paths when ``path`` is part of a volume set, else ``None``."""
+    if not path.is_file():
+        return None
+    parent = path.parent
+    name = path.name
+
+    match = _7Z_VOLUME_RE.match(name)
+    if match is not None:
+        base = match.group("base")
+        siblings = sorted(
+            (
+                candidate
+                for candidate in parent.iterdir()
+                if candidate.is_file() and _7Z_VOLUME_RE.match(candidate.name)
+                and _7Z_VOLUME_RE.match(candidate.name).group("base").lower() == base.lower()
+            ),
+            key=lambda candidate: _part_number_from_name(candidate.name),
+        )
+        return siblings if len(siblings) > 1 else None
+
+    match = _RAR_PART_RE.match(name)
+    if match is not None:
+        base = match.group("base")
+        siblings = sorted(
+            (
+                candidate
+                for candidate in parent.iterdir()
+                if candidate.is_file()
+                and (part_match := _RAR_PART_RE.match(candidate.name)) is not None
+                and part_match.group("base").lower() == base.lower()
+            ),
+            key=lambda candidate: _part_number_from_name(candidate.name, part_group="part"),
+        )
+        return siblings if len(siblings) > 1 else None
+
+    if name.lower().endswith(".rar") and _RAR_PART_RE.match(name) is None:
+        base = name[:-4]
+        r00 = parent / f"{base}.r00"
+        if r00.is_file():
+            siblings = [path]
+            siblings.extend(
+                sorted(
+                    (
+                        candidate
+                        for candidate in parent.iterdir()
+                        if candidate.is_file()
+                        and (rnn_match := _RAR_RNN_RE.match(candidate.name)) is not None
+                        and rnn_match.group("base").lower() == base.lower()
+                    ),
+                    key=lambda candidate: _rnn_part_number(candidate.name),
+                )
+            )
+            return siblings if len(siblings) > 1 else None
+
+    match = _RAR_RNN_RE.match(name)
+    if match is not None:
+        base = match.group("base")
+        first = parent / f"{base}.rar"
+        siblings: list[Path] = []
+        if first.is_file():
+            siblings.append(first)
+        siblings.extend(
+            sorted(
+                (
+                    candidate
+                    for candidate in parent.iterdir()
+                    if candidate.is_file()
+                    and (rnn_match := _RAR_RNN_RE.match(candidate.name)) is not None
+                    and rnn_match.group("base").lower() == base.lower()
+                ),
+                key=lambda candidate: _rnn_part_number(candidate.name),
+            )
+        )
+        return siblings if len(siblings) > 1 else None
+
+    return None
+
+
+OpenSourceInput = str | Path | BinaryIO | Sequence[str | Path | BinaryIO]
+
+
+@dataclass(frozen=True)
+class ResolvedSource:
+    """Single source to hand to detection/backends plus multi-volume metadata."""
+
+    open_source: Path | BinaryIO
+    archive_name: str | None
+    volume_count: int
+
+
+def _coerce_path_or_stream(item: str | Path | BinaryIO) -> Path | BinaryIO:
+    if isinstance(item, (str, Path)):
+        return Path(item)
+    return item
+
+
+def _is_source_sequence(source: OpenSourceInput) -> bool:
+    if isinstance(source, (str, Path, bytes)):
+        return False
+    if is_stream(source):
+        return False
+    return isinstance(source, Sequence)
+
+
+def resolve_source(source: OpenSourceInput) -> ResolvedSource:
+    """Normalize ``source`` to one open target and record multi-volume detection."""
+    if _is_source_sequence(source):
+        items = [_coerce_path_or_stream(item) for item in source]
+        if not items:
+            raise ValueError("source sequence must not be empty")
+        if len(items) == 1:
+            return _resolve_single(items[0])
+        first = items[0]
+        return ResolvedSource(first, source_name(first), len(items))
+    return _resolve_single(_coerce_path_or_stream(source))
+
+
+def _resolve_single(source: Path | BinaryIO) -> ResolvedSource:
+    if isinstance(source, Path):
+        if source.is_dir():
+            return ResolvedSource(source, str(source), 1)
+        siblings = discover_volume_siblings(source)
+        if siblings is not None:
+            return ResolvedSource(siblings[0], source_name(siblings[0]), len(siblings))
+        return ResolvedSource(source, source_name(source), 1)
+    return ResolvedSource(source, source_name(source), 1)

--- a/src/archivey/internal/volumes.py
+++ b/src/archivey/internal/volumes.py
@@ -6,9 +6,12 @@ import re
 from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
-from typing import BinaryIO
+from typing import BinaryIO, TypeGuard
 
 from archivey.internal.streams.streamtools import is_stream, source_name
+
+SourceItem = str | Path | BinaryIO
+SourceSequence = Sequence[SourceItem]
 
 _7Z_VOLUME_RE = re.compile(r"^(?P<base>.+\.7z)\.(?P<part>\d+)$", re.IGNORECASE)
 _RAR_PART_RE = re.compile(r"^(?P<base>.+)\.part(?P<part>\d+)\.rar$", re.IGNORECASE)
@@ -41,8 +44,9 @@ def discover_volume_siblings(path: Path) -> list[Path] | None:
             (
                 candidate
                 for candidate in parent.iterdir()
-                if candidate.is_file() and _7Z_VOLUME_RE.match(candidate.name)
-                and _7Z_VOLUME_RE.match(candidate.name).group("base").lower() == base.lower()
+                if candidate.is_file()
+                and (vol_match := _7Z_VOLUME_RE.match(candidate.name)) is not None
+                and vol_match.group("base").lower() == base.lower()
             ),
             key=lambda candidate: _part_number_from_name(candidate.name),
         )
@@ -106,7 +110,7 @@ def discover_volume_siblings(path: Path) -> list[Path] | None:
     return None
 
 
-OpenSourceInput = str | Path | BinaryIO | Sequence[str | Path | BinaryIO]
+OpenSourceInput = SourceItem | SourceSequence
 
 
 @dataclass(frozen=True)
@@ -118,13 +122,13 @@ class ResolvedSource:
     volume_count: int
 
 
-def _coerce_path_or_stream(item: str | Path | BinaryIO) -> Path | BinaryIO:
+def _coerce_path_or_stream(item: SourceItem) -> Path | BinaryIO:
     if isinstance(item, (str, Path)):
         return Path(item)
     return item
 
 
-def _is_source_sequence(source: OpenSourceInput) -> bool:
+def _is_source_sequence(source: OpenSourceInput) -> TypeGuard[SourceSequence]:
     if isinstance(source, (str, Path, bytes)):
         return False
     if is_stream(source):
@@ -142,7 +146,13 @@ def resolve_source(source: OpenSourceInput) -> ResolvedSource:
             return _resolve_single(items[0])
         first = items[0]
         return ResolvedSource(first, source_name(first), len(items))
-    return _resolve_single(_coerce_path_or_stream(source))
+    if isinstance(source, str):
+        return _resolve_single(Path(source))
+    if isinstance(source, Path):
+        return _resolve_single(source)
+    if not is_stream(source):
+        raise TypeError(f"unsupported source type: {type(source)!r}")
+    return _resolve_single(source)
 
 
 def _resolve_single(source: Path | BinaryIO) -> ResolvedSource:

--- a/src/archivey/internal/volumes.py
+++ b/src/archivey/internal/volumes.py
@@ -90,9 +90,14 @@ def discover_volume_siblings(path: Path) -> list[Path] | None:
     if match is not None:
         base = match.group("base")
         first = parent / f"{base}.rar"
-        siblings: list[Path] = []
-        if first.is_file():
-            siblings.append(first)
+        # The first volume of an old-scheme set is always `<base>.rar`; the `.rNN`
+        # files are its continuation volumes. Without the first volume present we can't
+        # anchor the set at its head (siblings[0] must be volume 1), so a bare `.rNN`
+        # with no `.rar` is treated as a lone file — mirrors the `.rar` branch above,
+        # which requires `.r00` to exist.
+        if not first.is_file():
+            return None
+        siblings: list[Path] = [first]
         siblings.extend(
             sorted(
                 (

--- a/src/archivey/reader.py
+++ b/src/archivey/reader.py
@@ -6,6 +6,7 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import BinaryIO, Callable, Iterator
 
+from archivey.config import ArchiveyConfig, ExtractionLimits
 from archivey.cost import CostReceipt
 from archivey.internal.extraction_types import (
     ExtractionPolicy,
@@ -139,18 +140,18 @@ class ArchiveReader(ABC):
         overwrite: OverwritePolicy = OverwritePolicy.ERROR,
         on_error: OnError = OnError.STOP,
         on_progress: Callable[[ExtractionProgress], None] | None = None,
-        max_extracted_bytes: int = 2 * 2**30,
-        max_ratio: float = 1000.0,
-        ratio_activation_threshold: int = 5 * 2**20,
-        max_entries: int = 1_048_576,
+        config: ArchiveyConfig | None = None,
+        limits: ExtractionLimits | None = None,
     ) -> list[ExtractionResult]:
         """Extract members to ``dest`` (safe-by-default; see ``safe-extraction``).
 
         ``members`` selects which members to extract (names/``ArchiveMember``s, or a
         predicate; ``None`` = all). ``filter`` runs after the universal safety checks and
         the ``policy`` transform, and may rename/sanitize a member (return a
-        ``.replace()``d copy) or skip it (return ``None``). Returns one
-        :class:`~archivey.ExtractionResult` per member processed.
+        ``.replace()``d copy) or skip it (return ``None``). ``config`` defaults to the
+        config the reader was opened with; ``limits`` overrides its extraction limits for
+        this call only. Returns one :class:`~archivey.ExtractionResult` per member
+        processed.
         """
         ...
 

--- a/src/archivey/reader.py
+++ b/src/archivey/reader.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import BinaryIO, Callable, Iterator
+from typing import BinaryIO, Callable, Collection, Iterator
 
 from archivey.config import ArchiveyConfig, ExtractionLimits
 from archivey.cost import CostReceipt
@@ -19,12 +19,11 @@ from archivey.internal.extraction_types import (
 )
 from archivey.types import ArchiveFormat, ArchiveInfo, ArchiveMember
 
-# Type alias for the member selector passed to stream_members(). Only the predicate form
-# is implemented today. The archive-reading spec also allows a Collection[ArchiveMember |
-# str] form ("yield exactly these names/members"); that lands with the Phase 5 public-API
-# finalization, where its semantics under duplicate member names must be decided (match
-# by name? by identity?) — see PLAN.md Phase 5.
-MemberSelector = Callable[[ArchiveMember], bool] | None
+# Type alias for the member selector passed to stream_members() and extract_all().
+# Accepts a predicate, a collection of names / ArchiveMember objects, or None (all).
+MemberSelector = (
+    Collection[str | ArchiveMember] | Callable[[ArchiveMember], bool] | None
+)
 
 
 class ArchiveReader(ABC):
@@ -125,8 +124,9 @@ class ArchiveReader(ABC):
         self, members: MemberSelector = None
     ) -> Iterator[tuple[ArchiveMember, BinaryIO | None]]:
         """Yield ``(member, stream)`` pairs in archive order with bounded memory.
-        ``members`` is an optional selector predicate (no transform). The yielded stream
-        is valid only until the iterator advances; it is ``None`` for non-file members."""
+        ``members`` is an optional selector (predicate, name/member collection, or
+        ``None`` for all). The yielded stream is valid only until the iterator advances;
+        it is ``None`` for non-file members."""
         ...
 
     @abstractmethod

--- a/tests/test_archivey_config.py
+++ b/tests/test_archivey_config.py
@@ -1,0 +1,164 @@
+"""Tests for the public ArchiveyConfig / ExtractionLimits surface (Phase 5 stage 1)."""
+
+from __future__ import annotations
+
+import dataclasses
+import io
+import logging
+from unittest import mock
+
+import pytest
+
+import archivey
+from archivey import (
+    AcceleratorMode,
+    ArchiveyConfig,
+    DEFAULT_ARCHIVEY_CONFIG,
+    ExtractionLimits,
+    extract,
+    open_archive,
+)
+from archivey.exceptions import ExtractionError, TruncatedError
+from archivey.internal.config import stream_config_from_archivey
+from archivey.types import ArchiveFormat
+
+
+def test_config_types_are_frozen() -> None:
+    cfg = ArchiveyConfig()
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        cfg.strict_archive_eof = True  # type: ignore[misc]
+    limits = ExtractionLimits()
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        limits.max_ratio = 1.0  # type: ignore[misc]
+
+
+def test_default_config_is_module_constant() -> None:
+    assert DEFAULT_ARCHIVEY_CONFIG is archivey.DEFAULT_ARCHIVEY_CONFIG
+    assert DEFAULT_ARCHIVEY_CONFIG.use_rapidgzip is AcceleratorMode.AUTO
+    assert DEFAULT_ARCHIVEY_CONFIG.strict_archive_eof is False
+    assert DEFAULT_ARCHIVEY_CONFIG.extraction_limits == ExtractionLimits()
+
+
+def test_open_archive_without_config_uses_defaults(tmp_path) -> None:
+    (tmp_path / "f.txt").write_bytes(b"x")
+    with open_archive(tmp_path) as ar:
+        assert ar._config == DEFAULT_ARCHIVEY_CONFIG  # type: ignore[attr-defined]
+
+
+def test_stream_config_derived_from_archivey_config() -> None:
+    cfg = ArchiveyConfig(
+        use_rapidgzip=AcceleratorMode.ON,
+        use_indexed_bzip2=AcceleratorMode.OFF,
+    )
+    stream_cfg = stream_config_from_archivey(cfg, streaming=True)
+    assert stream_cfg.streaming is True
+    assert stream_cfg.use_rapidgzip is AcceleratorMode.ON
+    assert stream_cfg.use_indexed_bzip2 is AcceleratorMode.OFF
+
+
+def test_accelerator_modes_honored_via_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import tarfile
+
+    import archivey.internal.backends.tar_reader as tar_reader_module
+
+    captured: list[object] = []
+
+    def _capture_open(codec, source, *, config, stamp=None):
+        captured.append(config)
+        return mock.MagicMock(__enter__=lambda s: s, __exit__=lambda *a: None)
+
+    monkeypatch.setattr(tar_reader_module, "open_codec_stream", _capture_open)
+    cfg = ArchiveyConfig(
+        use_rapidgzip=AcceleratorMode.ON,
+        use_indexed_bzip2=AcceleratorMode.OFF,
+    )
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as t:
+        info = tarfile.TarInfo("a.txt")
+        info.size = 1
+        t.addfile(info, io.BytesIO(b"x"))
+    buf.seek(0)
+    with open_archive(buf, format=ArchiveFormat.TAR_GZ, config=cfg) as ar:
+        ar.members()
+    assert captured
+    assert captured[0].use_rapidgzip is AcceleratorMode.ON
+    assert captured[0].use_indexed_bzip2 is AcceleratorMode.OFF
+
+
+def test_strict_archive_eof_default_warns(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    from tests.test_tar import _tar_missing_eof_block
+
+    data = _tar_missing_eof_block()
+    with caplog.at_level(logging.WARNING, logger="archivey.backends"):
+        with open_archive(io.BytesIO(data), format=ArchiveFormat.TAR) as ar:
+            ar.members()
+    assert any("truncated" in r.getMessage().lower() for r in caplog.records)
+
+
+def test_strict_archive_eof_true_raises() -> None:
+    from tests.test_tar import _tar_missing_eof_block
+
+    data = _tar_missing_eof_block()
+    with pytest.raises(TruncatedError):
+        with open_archive(
+            io.BytesIO(data),
+            format=ArchiveFormat.TAR,
+            config=ArchiveyConfig(strict_archive_eof=True),
+        ) as ar:
+            ar.members()
+
+
+def test_extract_limits_from_config(tmp_path) -> None:
+    import zipfile
+
+    src = tmp_path / "a.zip"
+    with zipfile.ZipFile(src, "w") as z:
+        z.writestr("a.txt", b"x" * 5000)
+    dest = tmp_path / "out"
+    with pytest.raises(ExtractionError):
+        extract(
+            src,
+            dest,
+            config=ArchiveyConfig(
+                extraction_limits=ExtractionLimits(max_extracted_bytes=1000)
+            ),
+        )
+
+
+def test_per_call_limits_override_config(tmp_path) -> None:
+    import zipfile
+
+    src = tmp_path / "a.zip"
+    with zipfile.ZipFile(src, "w") as z:
+        z.writestr("a.txt", b"x" * 5000)
+    dest = tmp_path / "out"
+    tight = ArchiveyConfig(extraction_limits=ExtractionLimits(max_extracted_bytes=100))
+    with open_archive(src, config=tight) as reader:
+        reader.extract_all(dest, limits=ExtractionLimits(max_extracted_bytes=10_000))
+    assert (dest / "a.txt").exists()
+
+
+def test_unlimited_preset_disables_guards(tmp_path) -> None:
+    import zipfile
+
+    src = tmp_path / "a.zip"
+    with zipfile.ZipFile(src, "w") as z:
+        z.writestr("a.txt", b"x" * 5000)
+    dest = tmp_path / "out"
+    extract(src, dest, limits=ExtractionLimits.UNLIMITED)
+    assert (dest / "a.txt").read_bytes() == b"x" * 5000
+
+
+def test_public_api_exports_config_types() -> None:
+    for name in (
+        "ArchiveyConfig",
+        "ExtractionLimits",
+        "AcceleratorMode",
+        "DEFAULT_ARCHIVEY_CONFIG",
+    ):
+        assert name in archivey.__all__
+        assert hasattr(archivey, name)

--- a/tests/test_archivey_config.py
+++ b/tests/test_archivey_config.py
@@ -11,9 +11,9 @@ import pytest
 
 import archivey
 from archivey import (
+    DEFAULT_ARCHIVEY_CONFIG,
     AcceleratorMode,
     ArchiveyConfig,
-    DEFAULT_ARCHIVEY_CONFIG,
     ExtractionLimits,
     extract,
     open_archive,

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -18,7 +18,6 @@ from types import SimpleNamespace
 import pytest
 
 from archivey import (
-    ArchiveyConfig,
     ExtractionLimits,
     ExtractionPolicy,
     ExtractionStatus,

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -18,6 +18,8 @@ from types import SimpleNamespace
 import pytest
 
 from archivey import (
+    ArchiveyConfig,
+    ExtractionLimits,
     ExtractionPolicy,
     ExtractionStatus,
     OnError,
@@ -420,7 +422,7 @@ def test_replace_failure_preserves_existing_file(tmp_path: Path) -> None:
     (dest / "a.txt").write_bytes(b"OLD DATA")
     with pytest.raises(ExtractionError):
         extract(
-            src, dest, overwrite=OverwritePolicy.REPLACE, max_extracted_bytes=1000
+            src, dest, overwrite=OverwritePolicy.REPLACE, limits=ExtractionLimits(max_extracted_bytes=1000)
         )
     assert (dest / "a.txt").read_bytes() == b"OLD DATA"  # untouched
     assert not list(dest.glob(".archivey-tmp-*"))  # temp cleaned up
@@ -471,7 +473,7 @@ def test_cumulative_bomb_halts_even_under_continue(tmp_path: Path) -> None:
     _write_zip(src, {"a.txt": b"x" * 5000, "b.txt": b"y" * 5000})
     dest = tmp_path / "out"
     with pytest.raises(ExtractionError):
-        extract(src, dest, max_extracted_bytes=6000, on_error=OnError.CONTINUE)
+        extract(src, dest, limits=ExtractionLimits(max_extracted_bytes=6000), on_error=OnError.CONTINUE)
 
 
 def test_zip_bomb_per_member_ratio(tmp_path: Path) -> None:
@@ -481,7 +483,7 @@ def test_zip_bomb_per_member_ratio(tmp_path: Path) -> None:
     _write_zip(src, {"bomb.bin": payload})
     dest = tmp_path / "out"
     with pytest.raises(ExtractionError):
-        extract(src, dest, max_ratio=10.0, ratio_activation_threshold=1024)
+        extract(src, dest, limits=ExtractionLimits(max_ratio=10.0, ratio_activation_threshold=1024))
 
 
 def test_entry_count_bomb(tmp_path: Path) -> None:
@@ -489,7 +491,7 @@ def test_entry_count_bomb(tmp_path: Path) -> None:
     _write_zip(src, {f"f{i}.txt": b"" for i in range(50)})
     dest = tmp_path / "out"
     with pytest.raises(ExtractionError):
-        extract(src, dest, max_entries=10, on_error=OnError.CONTINUE)
+        extract(src, dest, limits=ExtractionLimits(max_entries=10), on_error=OnError.CONTINUE)
 
 
 # ---------------------------------------------------------------------------
@@ -638,7 +640,7 @@ def test_seekable_targz_archive_wide_ratio(tmp_path: Path) -> None:
     src.write_bytes(_tar_bytes([("file", "z.bin", payload)], mode="w:gz"))
     dest = tmp_path / "out"
     with pytest.raises(ExtractionError):
-        extract(src, dest, max_ratio=5.0, ratio_activation_threshold=1024)
+        extract(src, dest, limits=ExtractionLimits(max_ratio=5.0, ratio_activation_threshold=1024))
 
 
 def test_non_seekable_targz_extract(tmp_path: Path) -> None:
@@ -725,9 +727,11 @@ def test_streaming_targz_bomb_caught_by_live_ratio(tmp_path: Path) -> None:
         with pytest.raises(ExtractionError):
             r.extract_all(
                 dest,
-                max_ratio=10.0,
-                ratio_activation_threshold=1024,
-                max_extracted_bytes=100 * 2**20,  # high, so the cap is not what trips
+                limits=ExtractionLimits(
+                    max_ratio=10.0,
+                    ratio_activation_threshold=1024,
+                    max_extracted_bytes=100 * 2**20,  # high, so the cap is not what trips
+                ),
             )
 
 
@@ -740,9 +744,11 @@ def test_streaming_live_ratio_halts_under_continue(tmp_path: Path) -> None:
         with pytest.raises(ExtractionError):
             r.extract_all(
                 dest,
-                max_ratio=10.0,
-                ratio_activation_threshold=1024,
-                max_extracted_bytes=100 * 2**20,
+                limits=ExtractionLimits(
+                    max_ratio=10.0,
+                    ratio_activation_threshold=1024,
+                    max_extracted_bytes=100 * 2**20,
+                ),
                 on_error=OnError.CONTINUE,  # global guard halts anyway
             )
 
@@ -755,7 +761,10 @@ def test_streaming_plain_tar_no_live_ratio_trip(tmp_path: Path) -> None:
     dest = tmp_path / "out"
     with open_archive(NonSeekableBytesIO(raw), streaming=True) as r:
         assert r.compressed_bytes_consumed is None  # uncompressed: nothing counted
-        r.extract_all(dest, max_ratio=10.0, ratio_activation_threshold=1024)
+        r.extract_all(
+            dest,
+            limits=ExtractionLimits(max_ratio=10.0, ratio_activation_threshold=1024),
+        )
     assert (dest / "a.bin").read_bytes() == payload
 
 
@@ -783,9 +792,11 @@ def test_streaming_bare_gz_bomb_caught_by_live_ratio(tmp_path: Path) -> None:
         with pytest.raises(ExtractionError):
             r.extract_all(
                 dest,
-                max_ratio=10.0,
-                ratio_activation_threshold=1024,
-                max_extracted_bytes=100 * 2**20,
+                limits=ExtractionLimits(
+                    max_ratio=10.0,
+                    ratio_activation_threshold=1024,
+                    max_extracted_bytes=100 * 2**20,
+                ),
             )
 
 
@@ -979,7 +990,9 @@ def test_opaque_seekable_compressed_source_gets_live_ratio(tmp_path: Path) -> No
         with pytest.raises(ExtractionError):
             r.extract_all(
                 dest,
-                max_ratio=10.0,
-                ratio_activation_threshold=1024,
-                max_extracted_bytes=100 * 2**20,  # high, so the cap is not what trips
+                limits=ExtractionLimits(
+                    max_ratio=10.0,
+                    ratio_activation_threshold=1024,
+                    max_extracted_bytes=100 * 2**20,  # high, so the cap is not what trips
+                ),
             )

--- a/tests/test_member_selector.py
+++ b/tests/test_member_selector.py
@@ -1,0 +1,56 @@
+"""Tests for MemberSelector collection form (Phase 5 stage 4)."""
+
+from __future__ import annotations
+
+import io
+import tarfile
+from pathlib import Path
+
+from archivey import open_archive
+
+
+def _tar_with_duplicate_names() -> bytes:
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as tar:
+        for content in (b"first", b"second"):
+            info = tarfile.TarInfo("dup.txt")
+            info.size = len(content)
+            tar.addfile(info, io.BytesIO(content))
+    return buf.getvalue()
+
+
+def test_stream_members_name_selects_all_duplicates() -> None:
+    with open_archive(io.BytesIO(_tar_with_duplicate_names())) as ar:
+        selected = [
+            (member.name, stream.read() if stream is not None else None)
+            for member, stream in ar.stream_members(members=["dup.txt"])
+        ]
+    assert selected == [("dup.txt", b"first"), ("dup.txt", b"second")]
+
+
+def test_stream_members_member_selects_by_identity() -> None:
+    with open_archive(io.BytesIO(_tar_with_duplicate_names())) as ar:
+        first, second = ar.members()
+        selected = [
+            stream.read() if stream is not None else None
+            for _member, stream in ar.stream_members(members=[first])
+        ]
+    assert selected == [b"first"]
+    assert first is not second
+
+
+def test_stream_members_mixed_collection(tmp_path: Path) -> None:
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as tar:
+        for name, content in (("keep.txt", b"keep"), ("skip.txt", b"skip")):
+            info = tarfile.TarInfo(name)
+            info.size = len(content)
+            tar.addfile(info, io.BytesIO(content))
+    with open_archive(io.BytesIO(buf.getvalue())) as ar:
+        skip = ar.get("skip.txt")
+        assert skip is not None
+        selected = [
+            member.name
+            for member, _stream in ar.stream_members(members=["keep.txt", skip])
+        ]
+    assert selected == ["keep.txt", "skip.txt"]

--- a/tests/test_password.py
+++ b/tests/test_password.py
@@ -14,8 +14,8 @@ from archivey.types import ArchiveMember, MemberType
 
 
 def _make_multi_password_zip(path: Path) -> None:
-    (path.parent / "f1.txt").write_text("secret1\n")
-    (path.parent / "f2.txt").write_text("secret2\n")
+    (path.parent / "f1.txt").write_bytes(b"secret1\n")
+    (path.parent / "f2.txt").write_bytes(b"secret2\n")
     subprocess.run(
         ["7z", "a", "-tzip", str(path), "f1.txt", "-psecret1", "-y"],
         cwd=path.parent,
@@ -117,9 +117,9 @@ def test_multi_password_zip_streaming_pass(tmp_path: Path) -> None:
 
 def test_zip_provider_receives_member(tmp_path: Path) -> None:
     archive = tmp_path / "one.zip"
-    (tmp_path / "only.txt").write_text("hello\n")
+    (tmp_path / "only.txt").write_bytes(b"hello\n")
     subprocess.run(
-        ["zip", "-P", "hunter2", str(archive), "only.txt"],
+        ["7z", "a", "-tzip", str(archive), "only.txt", "-phunter2", "-y"],
         cwd=tmp_path,
         check=True,
         capture_output=True,

--- a/tests/test_password.py
+++ b/tests/test_password.py
@@ -1,0 +1,138 @@
+"""Tests for password candidates and provider (Phase 5 stage 2)."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from archivey import PasswordRequest, open_archive
+from archivey.exceptions import EncryptionError
+from archivey.internal.password import _PasswordCandidates
+from archivey.types import ArchiveMember, MemberType
+
+
+def _make_multi_password_zip(path: Path) -> None:
+    (path.parent / "f1.txt").write_text("secret1\n")
+    (path.parent / "f2.txt").write_text("secret2\n")
+    subprocess.run(
+        ["7z", "a", "-tzip", str(path), "f1.txt", "-psecret1", "-y"],
+        cwd=path.parent,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["7z", "a", "-tzip", str(path), "f2.txt", "-psecret2", "-y"],
+        cwd=path.parent,
+        check=True,
+        capture_output=True,
+    )
+
+
+def test_password_candidates_provider_header_request() -> None:
+    seen: list[PasswordRequest] = []
+
+    def provider(request: PasswordRequest) -> str | None:
+        seen.append(request)
+        return None
+
+    candidates = _PasswordCandidates.from_input(provider)
+    with pytest.raises(EncryptionError):
+        candidates.attempt(
+            None,
+            lambda _pwd: (_ for _ in ()).throw(EncryptionError("wrong")),
+        )
+    assert len(seen) == 1
+    assert seen[0].member is None
+    assert seen[0].attempt == 1
+
+
+def test_password_candidates_provider_attempt_increments() -> None:
+    attempts: list[int] = []
+
+    def provider(request: PasswordRequest) -> str | None:
+        attempts.append(request.attempt)
+        if request.attempt < 3:
+            return "wrong"
+        return None
+
+    candidates = _PasswordCandidates.from_input(provider)
+    with pytest.raises(EncryptionError):
+        candidates.attempt(
+            None,
+            lambda _pwd: (_ for _ in ()).throw(EncryptionError("bad")),
+        )
+    assert attempts == [1, 2, 3]
+
+
+def test_password_candidates_provider_reuses_known_good() -> None:
+    calls = 0
+
+    def provider(request: PasswordRequest) -> str | None:
+        nonlocal calls
+        calls += 1
+        return "from-provider"
+
+    candidates = _PasswordCandidates.from_input(provider)
+
+    def decrypt(password: bytes) -> bytes:
+        if password == b"from-provider":
+            return b"ok"
+        raise EncryptionError("bad")
+
+    first = ArchiveMember(type=MemberType.FILE, name="first")
+    second = ArchiveMember(type=MemberType.FILE, name="second")
+    assert candidates.attempt(first, decrypt) == b"ok"
+    assert candidates.attempt(second, decrypt) == b"ok"
+    assert calls == 1
+
+
+def test_password_candidates_sequence_order() -> None:
+    tried: list[bytes] = []
+
+    def decrypt(password: bytes) -> bytes:
+        tried.append(password)
+        if password == b"second":
+            return b"data"
+        raise EncryptionError("bad")
+
+    candidates = _PasswordCandidates.from_input([b"first", b"second"])
+    assert candidates.attempt(None, decrypt) == b"data"
+    assert tried == [b"first", b"second"]
+
+
+def test_multi_password_zip_streaming_pass(tmp_path: Path) -> None:
+    archive = tmp_path / "mpw.zip"
+    _make_multi_password_zip(archive)
+
+    with open_archive(archive, password=[b"secret1", b"secret2"], streaming=True) as ar:
+        contents = {
+            member.name: stream.read() if stream is not None else None
+            for member, stream in ar.stream_members()
+            if member.type is MemberType.FILE
+        }
+    assert contents == {"f1.txt": b"secret1\n", "f2.txt": b"secret2\n"}
+
+
+def test_zip_provider_receives_member(tmp_path: Path) -> None:
+    archive = tmp_path / "one.zip"
+    (tmp_path / "only.txt").write_text("hello\n")
+    subprocess.run(
+        ["zip", "-P", "hunter2", str(archive), "only.txt"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+    seen: list[PasswordRequest] = []
+
+    def provider(request: PasswordRequest) -> str | None:
+        seen.append(request)
+        return "hunter2"
+
+    with open_archive(archive, password=provider) as ar:
+        assert ar.read("only.txt") == b"hello\n"
+    assert len(seen) == 1
+    assert seen[0].member is not None
+    assert seen[0].member.name == "only.txt"
+    assert seen[0].attempt == 1

--- a/tests/test_password.py
+++ b/tests/test_password.py
@@ -53,8 +53,11 @@ def test_password_candidates_provider_attempt_increments() -> None:
 
     def provider(request: PasswordRequest) -> str | None:
         attempts.append(request.attempt)
+        # Distinct guesses each time: a *repeated* guess is provably useless (decrypt is
+        # deterministic in the password) and terminates the loop early — see
+        # test_password_candidates_provider_repeat_terminates.
         if request.attempt < 3:
-            return "wrong"
+            return f"wrong{request.attempt}"
         return None
 
     candidates = _PasswordCandidates.from_input(provider)
@@ -86,6 +89,49 @@ def test_password_candidates_provider_reuses_known_good() -> None:
     assert candidates.attempt(first, decrypt) == b"ok"
     assert candidates.attempt(second, decrypt) == b"ok"
     assert calls == 1
+
+
+def test_password_candidates_provider_repeat_terminates() -> None:
+    # A provider that keeps returning the same wrong password can make no progress;
+    # attempt() must stop instead of re-running decrypt on it forever.
+    calls = 0
+
+    def provider(request: PasswordRequest) -> str | None:
+        nonlocal calls
+        calls += 1
+        return "same-wrong"
+
+    decrypt_calls = 0
+
+    def decrypt(password: bytes) -> bytes:
+        nonlocal decrypt_calls
+        decrypt_calls += 1
+        raise EncryptionError("bad")
+
+    candidates = _PasswordCandidates.from_input(provider)
+    with pytest.raises(EncryptionError):
+        candidates.attempt(None, decrypt)
+    # The repeated password is tried once; the repeat breaks the loop.
+    assert calls == 2
+    assert decrypt_calls == 1
+
+
+def test_password_candidates_provider_repeat_of_candidate_terminates() -> None:
+    # A provider echoing a static candidate that already failed also makes no progress.
+    decrypt_calls: list[bytes] = []
+
+    def decrypt(password: bytes) -> bytes:
+        decrypt_calls.append(password)
+        raise EncryptionError("bad")
+
+    def provider(request: PasswordRequest) -> str | None:
+        return "cand"
+
+    candidates = _PasswordCandidates(candidates=[b"cand"], provider=provider)
+    with pytest.raises(EncryptionError):
+        candidates.attempt(None, decrypt)
+    # "cand" is tried once as a static candidate; the provider echo doesn't re-run it.
+    assert decrypt_calls == [b"cand"]
 
 
 def test_password_candidates_sequence_order() -> None:

--- a/tests/test_tar.py
+++ b/tests/test_tar.py
@@ -1,6 +1,6 @@
 """TAR backend tests — random-access read, forward-only streaming on non-seekable
 sources, PAX/GNU/ustar member mapping, cost, corrupt/truncated handling, and
-``strict_eof`` end-of-archive verification."""
+``strict_archive_eof`` end-of-archive verification."""
 
 from __future__ import annotations
 
@@ -16,6 +16,7 @@ import pytest
 
 from archivey import (
     ArchiveFormat,
+    ArchiveyConfig,
     CompressionAlgorithm,
     CompressionMethod,
     MemberType,
@@ -401,7 +402,7 @@ def test_compressed_source_size_generalized(plain_tar: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# strict_eof / end-of-archive truncation detection
+# strict_archive_eof / end-of-archive truncation detection
 # ---------------------------------------------------------------------------
 
 
@@ -437,11 +438,13 @@ def test_missing_eof_blocks_warns_by_default(
     assert "truncated" in warnings[0].lower()
 
 
-def test_missing_eof_blocks_strict_eof_raises() -> None:
+def test_missing_eof_blocks_strict_archive_eof_raises() -> None:
     data = _tar_missing_eof_block()
     with pytest.raises(TruncatedError):
         with open_archive(
-            io.BytesIO(data), format=ArchiveFormat.TAR, strict_eof=True
+            io.BytesIO(data),
+            format=ArchiveFormat.TAR,
+            config=ArchiveyConfig(strict_archive_eof=True),
         ) as ar:
             ar.members()
 
@@ -465,7 +468,7 @@ def test_missing_eof_blocks_streaming_strict_raises() -> None:
             NonSeekableBytesIO(data),
             format=ArchiveFormat.TAR,
             streaming=True,
-            strict_eof=True,
+            config=ArchiveyConfig(strict_archive_eof=True),
         ) as ar:
             list(ar.stream_members())
 
@@ -495,17 +498,19 @@ def test_minimal_eof_trailer_streaming_silent(
 
 
 def test_minimal_eof_trailer_strict_does_not_raise() -> None:
-    # strict_eof must accept the minimal valid trailer on both access modes.
+    # strict_archive_eof must accept the minimal valid trailer on both access modes.
     data = _tar_minimal_eof()
     with open_archive(
-        io.BytesIO(data), format=ArchiveFormat.TAR, strict_eof=True
+        io.BytesIO(data),
+        format=ArchiveFormat.TAR,
+        config=ArchiveyConfig(strict_archive_eof=True),
     ) as ar:
         assert [m.name for m in ar.members()]
     with open_archive(
         NonSeekableBytesIO(data),
         format=ArchiveFormat.TAR,
         streaming=True,
-        strict_eof=True,
+        config=ArchiveyConfig(strict_archive_eof=True),
     ) as ar:
         assert [m for m, _ in ar.stream_members()]
 

--- a/tests/test_volumes.py
+++ b/tests/test_volumes.py
@@ -46,6 +46,15 @@ def test_discover_old_rar_rnn_volumes(tmp_path: Path) -> None:
     assert [p.name for p in siblings] == ["archive.rar", "archive.r00", "archive.r01"]
 
 
+def test_discover_rnn_without_first_volume_is_not_a_set(tmp_path: Path) -> None:
+    # The first volume `<base>.rar` is missing, so a bare `.rNN` can't be anchored at
+    # its head — treat it as a lone file rather than a truncated set with the wrong
+    # first element.
+    for name in ("archive.r00", "archive.r01"):
+        (tmp_path / name).write_bytes(b"")
+    assert discover_volume_siblings(tmp_path / "archive.r01") is None
+
+
 def test_multi_volume_7z_raises_phase7_message(tmp_path: Path) -> None:
     for name in ("vol.7z.001", "vol.7z.002"):
         (tmp_path / name).write_bytes(_7Z_MAGIC)

--- a/tests/test_volumes.py
+++ b/tests/test_volumes.py
@@ -1,0 +1,101 @@
+"""Tests for multi-source input and volume discovery (Phase 5 stage 3)."""
+
+from __future__ import annotations
+
+import io
+import tarfile
+from pathlib import Path
+
+import pytest
+
+from archivey import extract, open_archive
+from archivey.exceptions import UnsupportedFeatureError
+from archivey.internal.volumes import discover_volume_siblings
+from archivey.types import ArchiveFormat
+
+_7Z_MAGIC = bytes.fromhex("377abcaf271c")
+_RAR_MAGIC = b"Rar!\x1a\x07\x00"
+
+
+def test_discover_7z_volume_siblings_natural_order(tmp_path: Path) -> None:
+    for name in ("set.7z.010", "set.7z.002", "set.7z.001"):
+        (tmp_path / name).write_bytes(b"")
+    siblings = discover_volume_siblings(tmp_path / "set.7z.002")
+    assert siblings is not None
+    assert [p.name for p in siblings] == ["set.7z.001", "set.7z.002", "set.7z.010"]
+
+
+def test_discover_rar_part_volumes(tmp_path: Path) -> None:
+    for name in ("data.part2.rar", "data.part1.rar", "data.part10.rar"):
+        (tmp_path / name).write_bytes(b"")
+    siblings = discover_volume_siblings(tmp_path / "data.part10.rar")
+    assert siblings is not None
+    assert [p.name for p in siblings] == [
+        "data.part1.rar",
+        "data.part2.rar",
+        "data.part10.rar",
+    ]
+
+
+def test_discover_old_rar_rnn_volumes(tmp_path: Path) -> None:
+    (tmp_path / "archive.rar").write_bytes(b"")
+    for name in ("archive.r01", "archive.r00"):
+        (tmp_path / name).write_bytes(b"")
+    siblings = discover_volume_siblings(tmp_path / "archive.r01")
+    assert siblings is not None
+    assert [p.name for p in siblings] == ["archive.rar", "archive.r00", "archive.r01"]
+
+
+def test_multi_volume_7z_raises_phase7_message(tmp_path: Path) -> None:
+    for name in ("vol.7z.001", "vol.7z.002"):
+        (tmp_path / name).write_bytes(_7Z_MAGIC)
+    with pytest.raises(UnsupportedFeatureError, match="Phase 7"):
+        open_archive(tmp_path / "vol.7z.002", format=ArchiveFormat.SEVEN_Z)
+
+
+def test_multi_volume_rar_raises_phase7_message(tmp_path: Path) -> None:
+    for name in ("set.part1.rar", "set.part2.rar"):
+        (tmp_path / name).write_bytes(_RAR_MAGIC)
+    with pytest.raises(UnsupportedFeatureError, match="Phase 7"):
+        open_archive(tmp_path / "set.part1.rar", format=ArchiveFormat.RAR)
+
+
+def test_explicit_multi_source_tar_raises_not_multivolume(tmp_path: Path) -> None:
+    a = tmp_path / "a.tar"
+    b = tmp_path / "b.tar"
+    for path in (a, b):
+        buf = io.BytesIO()
+        with tarfile.open(fileobj=buf, mode="w") as tar:
+            info = tarfile.TarInfo("x.txt")
+            info.size = 1
+            tar.addfile(info, io.BytesIO(b"x"))
+        path.write_bytes(buf.getvalue())
+    with pytest.raises(UnsupportedFeatureError, match="does not support multi-volume"):
+        open_archive([a, b])
+
+
+def test_extract_non_utf8_tar_with_explicit_encoding(tmp_path: Path) -> None:
+    archive = tmp_path / "names.tar"
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w", encoding="utf-8") as tar:
+        info = tarfile.TarInfo("caf\xe9.txt")
+        info.size = 3
+        tar.addfile(info, io.BytesIO(b"tea"))
+    archive.write_bytes(buf.getvalue())
+
+    dest = tmp_path / "out"
+    extract(archive, dest, encoding="latin-1")
+    assert (dest / "café.txt").read_bytes() == b"tea"
+
+
+def test_single_member_sequence_equivalent_to_scalar(tmp_path: Path) -> None:
+    path = tmp_path / "one.tar"
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as tar:
+        info = tarfile.TarInfo("only.txt")
+        info.size = 2
+        tar.addfile(info, io.BytesIO(b"ok"))
+    path.write_bytes(buf.getvalue())
+
+    with open_archive([path]) as ar:
+        assert ar.read("only.txt") == b"ok"


### PR DESCRIPTION
## Summary

Implements the first four stages of the in-flight `phase-5-public-api` change (tasks 1–4 complete; stages 5–7 still pending on this branch).

**Stage 1 — `ArchiveyConfig` / `ExtractionLimits`**
- Frozen public config types with `DEFAULT_ARCHIVEY_CONFIG` and `ExtractionLimits.UNLIMITED`.
- `config=` on `open_archive()` / `extract()`; readers carry config and derive internal `StreamConfig` from it.
- TAR end-of-archive strictness moved from `strict_eof=` to `config.strict_archive_eof`.
- Bomb limits consolidated into `limits: ExtractionLimits | None` on `extract()` / `extract_all()` (per-call > config > defaults).

**Stage 2 — password candidates and provider**
- `password` accepts a single value, an ordered sequence, or a `PasswordProvider` callable.
- `PasswordRequest` / `PasswordProvider` exported; `_PasswordCandidates` helper with known-good reuse.
- ZIP backend wired through the helper (including encrypted-symlink listing).

**Stage 3 — multi-source input**
- `open_archive()` / `extract()` accept `Sequence[str | Path | BinaryIO]` (length-1 ≡ single source).
- Path-based volume-set discovery (`.7z.NNN`, `.partN.rar`, `.rNN`) in `internal/volumes.py`.
- Multi-volume opens raise `UnsupportedFeatureError` until Phase 7 (format-specific messages).
- `extract(encoding=...)` added for one-shot extraction parity.

**Stage 4 — `MemberSelector` collection form**
- Shared `normalize_member_selector()` for `stream_members()` and extraction.
- String entries match all same-named duplicates; `ArchiveMember` entries match by `archive_id` + `member_id`.

## Test plan

- [x] `uv run --no-sync pytest` (758 passed)
- [x] `uv run --no-sync pyrefly check`
- [x] `uv run --no-sync ty check`
- [x] `uv run --no-sync ruff check`

## Still pending (follow-up on this change)

- Section 5a.4–5a.6 (safety test gaps, full public exports)
- Section 6 (finalization sweep, maintainer decisions in code)
- Section 7 (sync delta specs and archive change)