### PR TITLE
Phase 5 stage 5: link-resolution safety tests, FILE-stream guard, selector exports

### DIFF
--- a/openspec/changes/phase-5-public-api/tasks.md
+++ b/openspec/changes/phase-5-public-api/tasks.md
@@ -86,13 +86,13 @@
 - [x] 5a.3 Duplicate-name positional test: `[A(content1), hardlink L→A, A(content2)]`
       — `read(L)` returns content1 and extraction links `L` to the content1 inode, in
       both access modes (the regression the last-wins map caused).
-- [ ] 5a.4 Port the chained-symlink attack test from `_dev_oracle` into the v2 suite
+- [x] 5a.4 Port the chained-symlink attack test from `_dev_oracle` into the v2 suite
       (member 1 plants `sub → /outside`, member 2 writes through `sub/...`; both the
       SYMLINK-payload and FILE-payload variants must be rejected).
-- [ ] 5a.5 Defensive raise in `_copy_to_fileobj`/`_write_file` when a FILE member
+- [x] 5a.5 Defensive raise in `_copy_to_fileobj`/`_write_file` when a FILE member
       arrives with `stream=None` (today it silently creates an empty file, masking a
       backend bug; a zero-byte FILE gets a real empty stream, so raising is safe).
-- [ ] 5a.6 Export `MemberSelector`, `MemberFilter`, `ArchiveyConfig`,
+- [x] 5a.6 Export `MemberSelector`, `MemberFilter`, `ArchiveyConfig`,
       `ExtractionLimits`, `PasswordRequest`, `PasswordProvider` from `archivey`
       (`__all__` + test_public_api assertions).
 

--- a/src/archivey/__init__.py
+++ b/src/archivey/__init__.py
@@ -60,10 +60,11 @@ from archivey.internal.extraction_types import (
     ExtractionProgress,
     ExtractionResult,
     ExtractionStatus,
+    MemberFilter,
     OnError,
     OverwritePolicy,
 )
-from archivey.reader import ArchiveReader
+from archivey.reader import ArchiveReader, MemberSelector
 from archivey.types import (
     ArchiveFormat,
     ArchiveInfo,
@@ -92,6 +93,8 @@ __all__ = [
     "ExtractionStatus",
     "ExtractionProgress",
     "ExtractionResult",
+    "MemberSelector",
+    "MemberFilter",
     "detect_format",
     "FormatInfo",
     "DetectionConfidence",

--- a/src/archivey/internal/extraction.py
+++ b/src/archivey/internal/extraction.py
@@ -715,7 +715,15 @@ class ExtractionCoordinator:
         """Copy ``stream`` into the already-open ``dst`` in chunks, counting each toward the
         bomb tracker. Cleanup of a partial ``dst`` on failure is the caller's job."""
         if stream is None:
-            return
+            # A FILE reaching the writer with no data stream is a backend bug, not a valid
+            # empty file (a zero-byte FILE still yields a real, empty stream). Silently
+            # writing an empty file here would mask that bug, so raise instead. Both FILE
+            # write paths (the main pass and the orphaned-source second pass) funnel through
+            # here, so this one guard covers them; it surfaces as a per-member failure via
+            # the coordinator's OnError handling, attributed to the member being written.
+            raise ExtractionError(
+                "FILE member has no data stream to extract (backend returned stream=None)"
+            )
         while True:
             chunk = stream.read(_CHUNK)
             if not chunk:

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -32,7 +32,11 @@ from archivey.exceptions import (
     SpecialFileError,
     SymlinkEscapeError,
 )
-from archivey.internal.extraction import BombTracker, _AlwaysStopExtractionError
+from archivey.internal.extraction import (
+    BombTracker,
+    ExtractionCoordinator,
+    _AlwaysStopExtractionError,
+)
 from archivey.internal.filters import (
     POLICY_TRANSFORMS,
     check_universal,
@@ -268,6 +272,14 @@ def test_entry_count_independent_of_bytes() -> None:
     t.start_member(_member("a"))
     with pytest.raises(_AlwaysStopExtractionError):
         t.start_member(_member("b"))  # trips on count, not bytes
+
+
+def test_file_writer_rejects_missing_stream() -> None:
+    # A FILE reaching the writer with stream=None is a backend bug (a zero-byte FILE still
+    # yields a real, empty stream). The writer must raise rather than silently create an
+    # empty file and mask the bug (task 5a.5).
+    with pytest.raises(ExtractionError, match="no data stream"):
+        ExtractionCoordinator._copy_to_fileobj(None, io.BytesIO(), None)
 
 
 # ---------------------------------------------------------------------------
@@ -556,6 +568,100 @@ def test_tar_symlink_escape_continue_records_rejected(tmp_path: Path) -> None:
     statuses = {r.member.name: r.status for r in results}
     assert statuses["evil"] is ExtractionStatus.REJECTED
     assert (dest / "ok.txt").read_bytes() == b"ok"
+
+
+# ---------------------------------------------------------------------------
+# Chained-symlink attack (task 5a.4, ported from the DEV oracle suite)
+#
+# The classic escape: member 1 plants a directory symlink `sub` that points OUTSIDE the
+# destination, then member 2 is written "through" it as `sub/<payload>`, so a naive
+# extractor lands the payload outside dest. archivey blocks this on two layers, and both
+# the SYMLINK-payload and FILE-payload variants of member 2 must be neutralized:
+#   * the escaping parent symlink is rejected up front by the universal check
+#     (SymlinkEscapeError), so it is never planted, and
+#   * the universal check re-resolves each member's PARENT directory on the real
+#     filesystem, so a payload written through an already-planted hostile parent symlink
+#     is rejected (PathTraversalError) before any bytes are written outside dest.
+# ---------------------------------------------------------------------------
+
+
+def test_chained_symlink_attack_symlink_payload_rejected(tmp_path: Path) -> None:
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    src = tmp_path / "attack.tar"
+    src.write_bytes(
+        _tar_bytes(
+            [
+                ("sym", "sub", str(outside)),  # parent symlink escaping dest
+                ("sym", "sub/leak", "target"),  # SYMLINK payload written through it
+            ]
+        )
+    )
+    dest = tmp_path / "out"
+    with pytest.raises((SymlinkEscapeError, PathTraversalError)):
+        extract(src, dest)
+    assert list(outside.iterdir()) == []  # nothing leaked outside the destination
+
+
+def test_chained_symlink_attack_file_payload_rejected(tmp_path: Path) -> None:
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    src = tmp_path / "attack.tar"
+    src.write_bytes(
+        _tar_bytes(
+            [
+                ("sym", "sub", str(outside)),  # parent symlink escaping dest
+                ("file", "sub/leak.txt", b"pwned"),  # FILE payload written through it
+            ]
+        )
+    )
+    dest = tmp_path / "out"
+    # Under CONTINUE the escaping parent symlink is rejected (never planted) while the run
+    # proceeds, proving the FILE payload cannot follow it out of dest.
+    results = extract(src, dest, on_error=OnError.CONTINUE)
+    statuses = {r.member.name: r.status for r in results}
+    assert statuses["sub"] is ExtractionStatus.REJECTED
+    assert not (outside / "leak.txt").exists()
+    assert list(outside.iterdir()) == []
+
+
+@pytest.mark.skipif(
+    os.name != "posix", reason="directory symlinks / os.symlink semantics are POSIX here"
+)
+def test_file_payload_through_preexisting_parent_symlink_rejected(
+    tmp_path: Path,
+) -> None:
+    # The runtime layer: a hostile symlink already sits at the destination (e.g. planted by
+    # a prior partial run). The universal check resolves the member's parent on disk, so a
+    # FILE written through it is rejected before any bytes escape.
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    dest = tmp_path / "out"
+    dest.mkdir()
+    os.symlink(outside, dest / "sub", target_is_directory=True)
+    src = tmp_path / "a.tar"
+    src.write_bytes(_tar_bytes([("file", "sub/leak.txt", b"pwned")]))
+    with pytest.raises(PathTraversalError):
+        extract(src, dest)
+    assert not (outside / "leak.txt").exists()
+
+
+@pytest.mark.skipif(
+    os.name != "posix", reason="directory symlinks / os.symlink semantics are POSIX here"
+)
+def test_symlink_payload_through_preexisting_parent_symlink_rejected(
+    tmp_path: Path,
+) -> None:
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    dest = tmp_path / "out"
+    dest.mkdir()
+    os.symlink(outside, dest / "sub", target_is_directory=True)
+    src = tmp_path / "a.tar"
+    src.write_bytes(_tar_bytes([("sym", "sub/leak", "x")]))
+    with pytest.raises(PathTraversalError):
+        extract(src, dest)
+    assert not (outside / "leak").exists()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Completes section 5 of the `phase-5-public-api` change (the link-resolution sweep & safety test gaps). Stacked on top of #39 (base: `phase5`), since it builds on stages 1–4.

- **5a.5 — defensive raise on `stream=None`:** the extraction writer (`_copy_to_fileobj`) now raises `ExtractionError` when a FILE member arrives with no data stream, instead of silently creating an empty file and masking a backend bug (a zero-byte FILE still yields a real, empty stream). One chokepoint covers both the main pass and the orphaned-source second pass.
- **5a.4 — chained-symlink attack test:** ported from the DEV oracle suite. A parent symlink `sub → outside` plus a payload written through `sub/...`; both the SYMLINK-payload and FILE-payload variants are covered, plus two tests exercising the runtime parent-`resolve()` layer against an already-planted hostile parent symlink.
- **5a.6 — exports:** `MemberSelector` and `MemberFilter` are now exported from `archivey` (`__all__` + the `test_public_api` drift guards).

## Test plan
- [x] `uv run --no-sync pyrefly check` — clean
- [x] `uv run --no-sync ty check` — clean
- [x] `uv run --no-sync pytest tests/test_extraction.py tests/test_public_api.py tests/test_member_selector.py` — 80 passed
- [ ] Full three-config push gate (`[all]`, `[all-lowest]`, `[core-only]`) — to confirm in CI

Note: base is `phase5`; retarget to `main` once #39 merges.

Made with [Cursor](https://cursor.com)