### PR TITLE
Address PR #39 review feedback (password loop, config, selector, volume ordering)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,11 @@ Non-obvious gotchas:
   CLI (in addition to `uv sync`), so both are present without manual steps.
 - **`unrar`** (system binary, from the `multiverse` apt component) backs RAR *data*
   tests; without it they skip cleanly rather than fail.
+- **`7z`** (system binary, from `p7zip-full`) is required by some tests that build
+  fixtures by shelling out to it — notably the encrypted-ZIP tests in
+  `tests/test_password.py` and the `tests/_dev_oracle/` oracle. Unlike `unrar`, these
+  currently **fail** (subprocess `FileNotFoundError`) rather than skip when it is absent,
+  so install `p7zip-full` if `which 7z` comes up empty.
 - **`openspec` CLI** lives at `~/.local/bin` (on `PATH`). `CLAUDE.md`'s
   `npm install -g @fission-ai/openspec` fails with `EACCES` here because the global npm
   prefix is not user-writable — the update script instead installs it into a writable,

--- a/src/archivey/core.py
+++ b/src/archivey/core.py
@@ -231,12 +231,13 @@ def extract(
         encoding=encoding,
         config=config,
     ) as reader:
+        # The reader already carries `config` (passed to open_archive above), so
+        # extract_all falls back to it — no need to forward `config` a second time.
         return reader.extract_all(
             dest,
             policy=policy,
             overwrite=overwrite,
             on_error=on_error,
             on_progress=on_progress,
-            config=config,
             limits=limits,
         )

--- a/src/archivey/internal/password.py
+++ b/src/archivey/internal/password.py
@@ -58,14 +58,10 @@ class _PasswordCandidates:
             self._known_good.remove(password)
         self._known_good.insert(0, password)
 
-    def iter_candidates(self, member: ArchiveMember | None) -> Iterator[bytes]:
+    def iter_candidates(self) -> Iterator[bytes]:
         """Yield passwords to try for one encrypted unit (known-good, then candidates)."""
         seen: set[bytes] = set()
-        for password in self._known_good:
-            if password not in seen:
-                seen.add(password)
-                yield password
-        for password in self._candidates:
+        for password in (*self._known_good, *self._candidates):
             if password not in seen:
                 seen.add(password)
                 yield password
@@ -77,11 +73,19 @@ class _PasswordCandidates:
         *,
         on_failure: Callable[[bytes, Exception], EncryptionError | None] | None = None,
     ) -> _T:
-        """Try passwords in order; consult the provider after static candidates fail."""
+        """Try passwords in order; consult the provider after static candidates fail.
+
+        ``decrypt`` must return a non-``None`` value on success: ``attempt`` uses
+        ``None`` as its "wrong password, try the next candidate" sentinel, so a
+        decrypt callable that returned ``None`` for a valid password would be treated
+        as a failure and retried.
+        """
         last_error: EncryptionError | None = None
+        tried: set[bytes] = set()
 
         def try_password(password: bytes) -> _T | None:
             nonlocal last_error
+            tried.add(password)
             try:
                 result = decrypt(password)
             except EncryptionError as exc:
@@ -94,7 +98,7 @@ class _PasswordCandidates:
             self.record_success(password)
             return result
 
-        for password in self.iter_candidates(member):
+        for password in self.iter_candidates():
             result = try_password(password)
             if result is not None:
                 return result
@@ -104,7 +108,13 @@ class _PasswordCandidates:
             raw = self._provider(PasswordRequest(member=member, attempt=attempt))
             if raw is None:
                 break
-            result = try_password(_to_bytes(raw))
+            password = _to_bytes(raw)
+            # A provider that repeats a password we already tried can make no further
+            # progress; stop rather than re-running an expensive decrypt (and, for 7z,
+            # an expensive key derivation) on the same input forever.
+            if password in tried:
+                break
+            result = try_password(password)
             if result is not None:
                 return result
             attempt += 1

--- a/src/archivey/internal/selection.py
+++ b/src/archivey/internal/selection.py
@@ -21,6 +21,9 @@ def normalize_member_selector(
     identities: set[tuple[str, int]] = set()
     for entry in collection:
         if isinstance(entry, ArchiveMember):
+            # Match by (archive_id, member_id) identity. A member that carries no ids
+            # (never registered by a reader — e.g. hand-built) is deliberately dropped:
+            # it can't correspond to any real member, so it silently matches nothing.
             if entry._archive_id is not None and entry._member_id is not None:
                 identities.add((entry._archive_id, entry._member_id))
         else:

--- a/src/archivey/internal/volumes.py
+++ b/src/archivey/internal/volumes.py
@@ -90,9 +90,14 @@ def discover_volume_siblings(path: Path) -> list[Path] | None:
     if match is not None:
         base = match.group("base")
         first = parent / f"{base}.rar"
-        siblings: list[Path] = []
-        if first.is_file():
-            siblings.append(first)
+        # The first volume of an old-scheme set is always `<base>.rar`; the `.rNN`
+        # files are its continuation volumes. Without the first volume present we can't
+        # anchor the set at its head (siblings[0] must be volume 1), so a bare `.rNN`
+        # with no `.rar` is treated as a lone file — mirrors the `.rar` branch above,
+        # which requires `.r00` to exist.
+        if not first.is_file():
+            return None
+        siblings: list[Path] = [first]
         siblings.extend(
             sorted(
                 (

--- a/tests/test_password.py
+++ b/tests/test_password.py
@@ -53,8 +53,11 @@ def test_password_candidates_provider_attempt_increments() -> None:
 
     def provider(request: PasswordRequest) -> str | None:
         attempts.append(request.attempt)
+        # Distinct guesses each time: a *repeated* guess is provably useless (decrypt is
+        # deterministic in the password) and terminates the loop early — see
+        # test_password_candidates_provider_repeat_terminates.
         if request.attempt < 3:
-            return "wrong"
+            return f"wrong{request.attempt}"
         return None
 
     candidates = _PasswordCandidates.from_input(provider)
@@ -86,6 +89,49 @@ def test_password_candidates_provider_reuses_known_good() -> None:
     assert candidates.attempt(first, decrypt) == b"ok"
     assert candidates.attempt(second, decrypt) == b"ok"
     assert calls == 1
+
+
+def test_password_candidates_provider_repeat_terminates() -> None:
+    # A provider that keeps returning the same wrong password can make no progress;
+    # attempt() must stop instead of re-running decrypt on it forever.
+    calls = 0
+
+    def provider(request: PasswordRequest) -> str | None:
+        nonlocal calls
+        calls += 1
+        return "same-wrong"
+
+    decrypt_calls = 0
+
+    def decrypt(password: bytes) -> bytes:
+        nonlocal decrypt_calls
+        decrypt_calls += 1
+        raise EncryptionError("bad")
+
+    candidates = _PasswordCandidates.from_input(provider)
+    with pytest.raises(EncryptionError):
+        candidates.attempt(None, decrypt)
+    # The repeated password is tried once; the repeat breaks the loop.
+    assert calls == 2
+    assert decrypt_calls == 1
+
+
+def test_password_candidates_provider_repeat_of_candidate_terminates() -> None:
+    # A provider echoing a static candidate that already failed also makes no progress.
+    decrypt_calls: list[bytes] = []
+
+    def decrypt(password: bytes) -> bytes:
+        decrypt_calls.append(password)
+        raise EncryptionError("bad")
+
+    def provider(request: PasswordRequest) -> str | None:
+        return "cand"
+
+    candidates = _PasswordCandidates(candidates=[b"cand"], provider=provider)
+    with pytest.raises(EncryptionError):
+        candidates.attempt(None, decrypt)
+    # "cand" is tried once as a static candidate; the provider echo doesn't re-run it.
+    assert decrypt_calls == [b"cand"]
 
 
 def test_password_candidates_sequence_order() -> None:

--- a/tests/test_volumes.py
+++ b/tests/test_volumes.py
@@ -46,6 +46,15 @@ def test_discover_old_rar_rnn_volumes(tmp_path: Path) -> None:
     assert [p.name for p in siblings] == ["archive.rar", "archive.r00", "archive.r01"]
 
 
+def test_discover_rnn_without_first_volume_is_not_a_set(tmp_path: Path) -> None:
+    # The first volume `<base>.rar` is missing, so a bare `.rNN` can't be anchored at
+    # its head — treat it as a lone file rather than a truncated set with the wrong
+    # first element.
+    for name in ("archive.r00", "archive.r01"):
+        (tmp_path / name).write_bytes(b"")
+    assert discover_volume_siblings(tmp_path / "archive.r01") is None
+
+
 def test_multi_volume_7z_raises_phase7_message(tmp_path: Path) -> None:
     for name in ("vol.7z.001", "vol.7z.002"):
         (tmp_path / name).write_bytes(_7Z_MAGIC)


### PR DESCRIPTION
Follow-up fixes for the review of #39. Targets `phase5` so it can be merged into that branch.

## Changes

**`internal/password.py` — provider loop termination (main fix)**
- The provider consultation loop could spin forever if a `PasswordProvider` kept returning the same wrong password without ever returning `None`, re-running an expensive `decrypt` (7z key derivation) each time. `attempt()` now tracks every password tried across both the static-candidate and provider phases and breaks when the provider repeats one — retrying a deterministic `decrypt` on the same input can't make progress.
- Documented that `decrypt` must return a non-`None` value on success (`None` is the "wrong password, try next" sentinel).
- Dropped the unused `member` parameter from `iter_candidates()`.

**`core.py` — redundant `config` forward**
- `extract()` no longer passes `config` to `extract_all()` a second time; the reader already carries the config from `open_archive()`, so `extract_all` falls back to it.

**`internal/selection.py` — documentation**
- Explained why an `ArchiveMember` selector entry carrying no `(archive_id, member_id)` is dropped from the identity set (it can't correspond to a registered member).

**`internal/volumes.py` — old-scheme `.rNN` ordering**
- Discovery from a bare `.rNN` now requires the first `<base>.rar` volume to exist, guaranteeing `siblings[0]` is volume 1 (mirrors the `.rar` branch, which requires `.r00`). A `.rNN` with no `.rar` is treated as a lone file rather than a set anchored at the wrong element.

**`AGENTS.md`**
- Documented the `7z` (`p7zip-full`) system-binary test dependency next to the existing `unrar` note. Unlike `unrar`, the `7z`-based tests currently hard-fail rather than skip when it's absent.

## Tests
- Added: provider-repeat termination (same password, and echo of a static candidate), and `.rNN`-without-`.rar` is-not-a-set.
- Updated `test_password_candidates_provider_attempt_increments` to use distinct guesses so it still exercises `attempt` incrementing under the new termination guard.
- All three dependency legs green (`[all]`, `[all-lowest]`, `[core-only]`): 761 passed. `pyrefly`, `ty`, `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B9AeVZWBG5MQF6xGbyDnTW

---
_Generated by [Claude Code](https://claude.ai/code/session_01B9AeVZWBG5MQF6xGbyDnTW)_