### PR TITLE
Finalization sweep + maintainer decisions (Phase 5 stage 6)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -683,17 +683,29 @@ This three-layer approach catches:
 ```python
 class BombTracker:
     def __init__(self, max_bytes: int, max_ratio: float,
-                 ratio_activation_threshold: int = 5 * 2**20):  # 5 MiB
+                 ratio_activation_threshold: int = 5 * 2**20,  # 5 MiB
+                 max_entries: int | None = DEFAULT_MAX_ENTRIES):
         self._max_bytes = max_bytes
         self._max_ratio = max_ratio
         self._ratio_floor = ratio_activation_threshold
+        self._max_entries = max_entries
+        self._entry_count = 0          # members actually written so far
         self._total_bytes = 0          # cumulative across all members
         self._member_bytes = 0         # output of the current member
         self._member = None            # the ORIGINAL member (not a filter copy)
 
     def start_member(self, member: ArchiveMember) -> None:
+        # The coordinator calls this only AFTER the selector and filter accept a member and
+        # the universal check passes — i.e. once for each member that will be written — so
+        # skipped/rejected members create nothing on disk and never count. Like the
+        # cumulative byte guard, the entry-count guard halts even under OnError.CONTINUE.
         self._member = member
         self._member_bytes = 0
+        self._entry_count += 1
+        if self._max_entries is not None and self._entry_count > self._max_entries:
+            raise ExtractionError(
+                f"Entry-count limit reached: {self._entry_count} > {self._max_entries}"
+            )
 
     def count(self, chunk_bytes: int) -> None:
         self._total_bytes += chunk_bytes
@@ -785,7 +797,10 @@ A future `archivey.asyncio` module using async generators is a clean add-on.
 `max_extracted_bytes=2 GiB`, `max_ratio=1000`:
 - 2 GiB is enough for most legitimate use cases and prevents gigabyte-class bombs.
 - 1000:1 is extremely generous (typical DEFLATE is 3:1 to 10:1; text compresses to maybe 20:1). Even 42.zip's outer layer reaches ~391:1. This catches pathological ratios while not triggering on legitimate very-compressible data.
-- Both are caller-configurable via `extract(..., max_extracted_bytes=..., max_ratio=...)`.
+- The limits live on the `ExtractionLimits` dataclass (`max_extracted_bytes`, `max_ratio`,
+  `ratio_activation_threshold`, `max_entries`), configured via `extract(..., limits=ExtractionLimits(...))`
+  or `config.extraction_limits`; the four loose bomb-limit kwargs no longer exist.
+  `ExtractionLimits.UNLIMITED` disables the guards for trusted archives.
 
 ### 5.6 Native streaming 7z reader vs py7zr wrapper
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -35,8 +35,9 @@ archivey.open_archive(
     *,
     format: ArchiveFormat | None = None,  # override detection
     streaming: bool = False,              # False = random access; True = forward-only, one pass
-    password: str | bytes | None = None,
+    password: str | bytes | Sequence[str | bytes] | PasswordProvider | None = None,
     encoding: str | None = None,         # None = auto-detect member-name encoding
+    config: ArchiveyConfig | None = None,  # tuning knobs; None = DEFAULT_ARCHIVEY_CONFIG
 ) -> ArchiveReader
 
 # Create a new archive for writing
@@ -55,15 +56,18 @@ archivey.create(
 # reopen it here (an anti-pattern). Selective extraction is done on an already-open
 # reader via `reader.extract_all(members=..., filter=...)`.
 archivey.extract(
-    source: str | Path | BinaryIO,
+    source: str | Path | BinaryIO | Sequence[str | Path | BinaryIO],
     dest: str | Path,
     *,
     policy: ExtractionPolicy = ExtractionPolicy.STRICT,
     overwrite: OverwritePolicy = OverwritePolicy.ERROR,   # pre-existing files
     on_error: OnError = OnError.STOP,                     # member extraction failures
     format: ArchiveFormat | None = None,
-    password: str | bytes | None = None,
+    password: str | bytes | Sequence[str | bytes] | PasswordProvider | None = None,
+    encoding: str | None = None,         # member-name encoding for TAR/ZIP
     on_progress: Callable[[ExtractionProgress], None] | None = None,
+    config: ArchiveyConfig | None = None,     # tuning knobs; None = DEFAULT_ARCHIVEY_CONFIG
+    limits: ExtractionLimits | None = None,   # per-call bomb-limit override; None = config's
 ) -> list[ExtractionResult]
 
 # Detect format without opening
@@ -136,6 +140,8 @@ class ArchiveReader:
         overwrite: OverwritePolicy = OverwritePolicy.ERROR,
         on_error: OnError = OnError.STOP,
         on_progress: Callable[[ExtractionProgress], None] | None = None,
+        config: ArchiveyConfig | None = None,     # overrides the reader's config for this call
+        limits: ExtractionLimits | None = None,   # per-call bomb-limit override
     ) -> list[ExtractionResult]: ...
 
     # --- Context manager ---
@@ -718,9 +724,18 @@ Applied **after** universal checks pass:
 
 ### 7.3 Decompression bomb detection
 
+The four limits below live on the `ExtractionLimits` frozen dataclass. It is supplied per
+call via `extract(..., limits=)` / `extract_all(..., limits=)`, or as the app-wide default
+via `config.extraction_limits`; precedence is per-call `limits` > `config.extraction_limits`
+> the library default. `ExtractionLimits.UNLIMITED` disables all four guards for explicitly
+trusted archives.
+
 All extraction paths must track bytes written and raise `ExtractionError` when:
 - **Cumulative** bytes written across all members exceeds `max_extracted_bytes` (default: 2 GiB; caller-configurable).
 - A **single member's** output / `compressed_size` exceeds `max_ratio` (default: 1000:1; caller-configurable) — computed against that member's own output, not the cumulative total.
+- The number of members **actually written** exceeds `max_entries`. Only written members
+  count: members excluded by the `members` selector, skipped by the `filter`, or rejected
+  by the universal safety check create nothing on disk and do not consume the budget.
 
 **Ratio activation floor.** The ratio check is evaluated **only after** a member's output
 exceeds a `ratio_activation_threshold` (default: 5 MiB; caller-configurable). This prevents

--- a/openspec/changes/phase-5-public-api/tasks.md
+++ b/openspec/changes/phase-5-public-api/tasks.md
@@ -98,15 +98,15 @@
 
 ## 6. Finalization sweep
 
-- [ ] 6.1 Per-format `CostReceipt` value assertions (zip/tar/all-compressed-tar/
+- [x] 6.1 Per-format `CostReceipt` value assertions (zip/tar/all-compressed-tar/
       single-file/iso/directory) in one parametrized contract test.
-- [ ] 6.2 Error-context stamping verified end-to-end for every backend (archive_name/
+- [x] 6.2 Error-context stamping verified end-to-end for every backend (archive_name/
       member_name/format present on translated errors).
-- [ ] 6.3 Remaining `archive-reading` / `archive-data-model` scenarios audited against
+- [x] 6.3 Remaining `archive-reading` / `archive-data-model` scenarios audited against
       the test suite; add the missing ones.
-- [ ] 6.4 `SPEC.md` §2 signature blocks + `ARCHITECTURE.md` sketches updated to the
+- [x] 6.4 `SPEC.md` §2 signature blocks + `ARCHITECTURE.md` sketches updated to the
       final signatures; `openspec validate --strict` clean for the touched specs.
-- [ ] 6.5 Implement the two maintainer decisions recorded in proposal.md
+- [x] 6.5 Implement the two maintainer decisions recorded in proposal.md
       (`max_entries`: count only written members — move `start_member` after selector +
       filter; ZIP `format_availability`: always PARTIAL until Phase 7 codec bypass).
       Spec deltas landed; code + tests still pending.

--- a/src/archivey/internal/extraction.py
+++ b/src/archivey/internal/extraction.py
@@ -253,11 +253,16 @@ class ExtractionCoordinator:
                 if selector is not None and not selector(original):
                     continue
 
-                tracker.start_member(original)  # entry-count guard + ratio bookkeeping
-
                 transformed = self._transform(original, dest_root)
                 if transformed is None:
                     continue  # user filter skipped this member (deliberate exclusion)
+
+                # Entry-count guard + ratio bookkeeping. Counted only once the selector and
+                # user filter have accepted the member (and the universal check inside
+                # _transform has passed), immediately before writing begins — so
+                # selector-skipped, filter-skipped, and rejected members create nothing on
+                # disk and do not count toward max_entries (resolved 2026-07 decision).
+                tracker.start_member(original)
 
                 result_index = len(results)
                 results.append(

--- a/src/archivey/internal/registry.py
+++ b/src/archivey/internal/registry.py
@@ -199,6 +199,15 @@ class BackendRegistry:
                 assert requirement is not None  # an optional codec always declares one
                 missing.append(requirement)
 
+        # ZIP exception (until Phase 7): member *data* still decodes via stdlib zipfile,
+        # which cannot use the optional codecs (deflate64/PPMd/zstd) even when installed,
+        # so ZIP never reports FULL — it is PARTIAL regardless of codec installation. The
+        # `missing` list still names absent packages, and is empty when all are present
+        # (the read-time gap is implementation stage, not a missing install). See the
+        # `backend-registry` / `format-zip` Phase 5 deltas.
+        if fmt.container == ContainerFormat.ZIP:
+            return FormatAvailability(fmt, FormatSupport.PARTIAL, tuple(missing))
+
         if not missing:
             return FormatAvailability(fmt, FormatSupport.FULL, ())
         return FormatAvailability(fmt, FormatSupport.PARTIAL, tuple(missing))

--- a/tests/test_cost_receipt.py
+++ b/tests/test_cost_receipt.py
@@ -1,0 +1,170 @@
+"""Per-format ``CostReceipt`` contract (phase-5 task 6.1).
+
+One parametrized test that opens a small archive of every backend from a seekable path
+source and asserts the full cost receipt — the three orthogonal axes (listing / access /
+stream capability) plus ``solid_block_count`` and ``notes``. The per-format test modules
+each assert their own cost in passing; this is the single authoritative table that pins
+the values side by side so a backend can't silently drift from the ``access-mode-and-cost``
+model.
+"""
+
+from __future__ import annotations
+
+import bz2
+import gzip
+import io
+import lzma
+import tarfile
+import zipfile
+from pathlib import Path
+from typing import Callable
+
+import pytest
+
+from archivey import open_archive
+from archivey.cost import AccessCost, CostReceipt, ListingCost, StreamCapability
+
+try:
+    import pycdlib  # noqa: F401
+
+    _HAVE_PYCDLIB = True
+except ImportError:
+    _HAVE_PYCDLIB = False
+
+
+def _zip(tmp: Path) -> Path:
+    p = tmp / "a.zip"
+    with zipfile.ZipFile(p, "w", zipfile.ZIP_DEFLATED) as z:
+        z.writestr("a.txt", b"hello")
+        z.writestr("dir/b.txt", b"world")
+    return p
+
+
+def _directory(tmp: Path) -> Path:
+    d = tmp / "srcdir"
+    (d / "dir").mkdir(parents=True)
+    (d / "a.txt").write_bytes(b"hello")
+    (d / "dir" / "b.txt").write_bytes(b"world")
+    return d
+
+
+def _tar_writer(mode: str, ext: str) -> Callable[[Path], Path]:
+    def build(tmp: Path) -> Path:
+        p = tmp / f"a{ext}"
+        with tarfile.open(p, mode=mode) as t:
+            info = tarfile.TarInfo("a.txt")
+            data = b"hello"
+            info.size = len(data)
+            t.addfile(info, io.BytesIO(data))
+        return p
+
+    return build
+
+
+def _single_file_writer(
+    compress: Callable[[bytes], bytes], ext: str
+) -> Callable[[Path], Path]:
+    def build(tmp: Path) -> Path:
+        p = tmp / f"a{ext}"
+        p.write_bytes(compress(b"hello world"))
+        return p
+
+    return build
+
+
+# id -> (builder, expected CostReceipt). The receipt is asserted in full (every field),
+# including notes, which no current backend sets.
+_CASES: dict[str, tuple[Callable[[Path], Path], CostReceipt]] = {
+    "zip": (
+        _zip,
+        CostReceipt(ListingCost.INDEXED, AccessCost.DIRECT, StreamCapability.SEEKABLE),
+    ),
+    "directory": (
+        _directory,
+        CostReceipt(ListingCost.INDEXED, AccessCost.DIRECT, StreamCapability.SEEKABLE),
+    ),
+    "tar": (
+        _tar_writer("w", ".tar"),
+        CostReceipt(
+            ListingCost.REQUIRES_SCANNING, AccessCost.DIRECT, StreamCapability.SEEKABLE
+        ),
+    ),
+    "tar.gz": (
+        _tar_writer("w:gz", ".tar.gz"),
+        CostReceipt(
+            ListingCost.REQUIRES_DECOMPRESSION,
+            AccessCost.SOLID,
+            StreamCapability.SEEKABLE,
+            solid_block_count=1,
+        ),
+    ),
+    "tar.bz2": (
+        _tar_writer("w:bz2", ".tar.bz2"),
+        CostReceipt(
+            ListingCost.REQUIRES_DECOMPRESSION,
+            AccessCost.SOLID,
+            StreamCapability.SEEKABLE,
+            solid_block_count=1,
+        ),
+    ),
+    "tar.xz": (
+        _tar_writer("w:xz", ".tar.xz"),
+        CostReceipt(
+            ListingCost.REQUIRES_DECOMPRESSION,
+            AccessCost.SOLID,
+            StreamCapability.SEEKABLE,
+            solid_block_count=1,
+        ),
+    ),
+    "single-file.gz": (
+        _single_file_writer(gzip.compress, ".gz"),
+        CostReceipt(ListingCost.INDEXED, AccessCost.DIRECT, StreamCapability.SEEKABLE),
+    ),
+    "single-file.bz2": (
+        _single_file_writer(bz2.compress, ".bz2"),
+        CostReceipt(ListingCost.INDEXED, AccessCost.DIRECT, StreamCapability.SEEKABLE),
+    ),
+    "single-file.xz": (
+        _single_file_writer(lzma.compress, ".xz"),
+        CostReceipt(ListingCost.INDEXED, AccessCost.DIRECT, StreamCapability.SEEKABLE),
+    ),
+}
+
+
+def _iso(tmp: Path) -> Path:
+    import pycdlib
+
+    iso = pycdlib.PyCdlib()
+    iso.new(interchange_level=3, rock_ridge="1.09")
+    iso.add_fp(io.BytesIO(b"hello"), 5, "/A.TXT;1", rr_name="a.txt")
+    p = tmp / "a.iso"
+    iso.write(str(p))
+    iso.close()
+    return p
+
+
+_PARAMS = [pytest.param(builder, expected, id=name) for name, (builder, expected) in _CASES.items()]
+_PARAMS.append(
+    pytest.param(
+        _iso,
+        CostReceipt(ListingCost.INDEXED, AccessCost.DIRECT, StreamCapability.SEEKABLE),
+        id="iso",
+        marks=pytest.mark.skipif(not _HAVE_PYCDLIB, reason="pycdlib not installed"),
+    )
+)
+
+
+@pytest.mark.parametrize(("builder", "expected"), _PARAMS)
+def test_cost_receipt_per_format(
+    tmp_path: Path,
+    builder: Callable[[Path], Path],
+    expected: CostReceipt,
+) -> None:
+    source = builder(tmp_path)
+    with open_archive(source) as ar:
+        cost = ar.cost
+    assert cost.listing_cost == expected.listing_cost
+    assert cost.access_cost == expected.access_cost
+    assert cost.stream_capability == expected.stream_capability
+    assert cost.solid_block_count == expected.solid_block_count
+    assert cost.notes == expected.notes

--- a/tests/test_data_model.py
+++ b/tests/test_data_model.py
@@ -1,0 +1,124 @@
+"""Archive-data-model contract tests (phase-5 task 6.3 audit).
+
+Pure data-type behaviours required by ``archive-data-model`` that the per-format tests
+don't exercise directly: ``ArchiveFormat`` identity (compositional round-trip, on-demand
+construction of uncommon container×codec pairs, ``file_extension``) and the
+``ArchiveMember`` value-object contract (unhashable, copy-on-edit via ``replace``,
+``None`` defaults, equality excluding hashes/extra, and the type helpers).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from archivey.types import (
+    EXTRA_IS_JUNCTION,
+    ArchiveFormat,
+    ArchiveMember,
+    CompressionAlgorithm,
+    CompressionMethod,
+    ContainerFormat,
+    MemberType,
+    StreamFormat,
+)
+
+# ---------------------------------------------------------------------------
+# ArchiveFormat identity (compositional (container, stream) model)
+# ---------------------------------------------------------------------------
+
+
+def test_format_identity_round_trips_through_pair() -> None:
+    assert ArchiveFormat(ContainerFormat.TAR, StreamFormat.GZIP) == ArchiveFormat.TAR_GZ
+
+
+def test_standalone_lzip_has_named_format() -> None:
+    assert ArchiveFormat.LZIP.container == ContainerFormat.RAW_STREAM
+    assert ArchiveFormat.LZIP.stream == StreamFormat.LZIP
+
+
+def test_uncommon_container_codec_built_on_demand() -> None:
+    # tar.lz has no predefined TAR_LZIP constant, but is constructed on demand and compares
+    # equal to any other instance with the same (container, stream) pair.
+    fmt = ArchiveFormat(ContainerFormat.TAR, StreamFormat.LZIP)
+    assert fmt == ArchiveFormat(ContainerFormat.TAR, StreamFormat.LZIP)
+    assert fmt.file_extension() == "tar.lz"
+
+
+def test_file_extension_examples() -> None:
+    assert ArchiveFormat.ZIP.file_extension() == "zip"
+    assert ArchiveFormat.TAR_GZ.file_extension() == "tar.gz"
+    assert ArchiveFormat.GZ.file_extension() == "gz"
+    # Formats with no on-disk file representation return "".
+    assert ArchiveFormat.DIRECTORY.file_extension() == ""
+    assert ArchiveFormat.UNKNOWN.file_extension() == ""
+
+
+# ---------------------------------------------------------------------------
+# ArchiveMember value-object contract
+# ---------------------------------------------------------------------------
+
+
+def test_member_is_unhashable() -> None:
+    m = ArchiveMember(type=MemberType.FILE, name="a.txt")
+    with pytest.raises(TypeError):
+        hash(m)
+    with pytest.raises(TypeError):
+        _ = {m}  # set membership needs hashing → unhashable
+
+
+def test_replace_returns_copy_without_mutating_original() -> None:
+    m = ArchiveMember(type=MemberType.FILE, name="a.txt", mode=0o644)
+    copy = m.replace(name="b.txt")
+    assert copy is not m
+    assert copy.name == "b.txt"
+    assert copy.mode == 0o644  # untouched fields carried over
+    assert m.name == "a.txt"  # original never mutated
+
+
+def test_unavailable_fields_default_to_none() -> None:
+    # The library must not substitute silent defaults for fields a format cannot provide.
+    m = ArchiveMember(type=MemberType.FILE, name="a.txt")
+    assert m.size is None
+    assert m.compressed_size is None
+    assert m.mode is None
+    assert m.modified is None
+    assert m.link_target is None
+    assert m.link_target_member is None
+    assert m.compression == ()
+
+
+def test_equality_excludes_hashes_and_extra() -> None:
+    # hashes vary by format and extra is format-specific overflow; neither affects logical
+    # identity, so both are excluded from __eq__.
+    a = ArchiveMember(
+        type=MemberType.FILE, name="a.txt", hashes={"crc32": 1}, extra={"x": 1}
+    )
+    b = ArchiveMember(
+        type=MemberType.FILE, name="a.txt", hashes={"crc32": 2}, extra={"y": 2}
+    )
+    assert a == b
+
+
+def test_single_codec_member_compression_shape() -> None:
+    m = ArchiveMember(
+        type=MemberType.FILE,
+        name="a",
+        compression=(CompressionMethod(CompressionAlgorithm.DEFLATE),),
+    )
+    assert m.compression == (CompressionMethod(algo=CompressionAlgorithm.DEFLATE),)
+
+
+def test_type_helpers() -> None:
+    assert ArchiveMember(type=MemberType.FILE, name="f").is_file
+    assert ArchiveMember(type=MemberType.DIRECTORY, name="d/").is_dir
+    assert ArchiveMember(type=MemberType.SYMLINK, name="s").is_link
+    assert ArchiveMember(type=MemberType.HARDLINK, name="h").is_link
+    assert ArchiveMember(type=MemberType.OTHER, name="o").is_other
+
+
+def test_junction_helper() -> None:
+    junction = ArchiveMember(
+        type=MemberType.SYMLINK, name="j", extra={EXTRA_IS_JUNCTION: True}
+    )
+    assert junction.is_junction
+    assert not ArchiveMember(type=MemberType.SYMLINK, name="s").is_junction

--- a/tests/test_error_context.py
+++ b/tests/test_error_context.py
@@ -1,0 +1,163 @@
+"""End-to-end error-context stamping across the real backends (phase-5 task 6.2).
+
+``test_error_translation`` unit-tests the stamping *mechanism* on a synthetic reader;
+this module verifies it end-to-end on each shipped backend: a translated
+``ArchiveyError`` raised while opening/scanning/reading a real archive opened from a
+**named path** must carry the format and archive-name context, and — when the failure is
+attributable to a specific member — the member name too (see ``error-handling``).
+"""
+
+from __future__ import annotations
+
+import gzip
+import io
+import tarfile
+import zipfile
+from pathlib import Path
+from typing import Callable
+
+import pytest
+
+from archivey import ArchiveReader, open_archive
+from archivey.exceptions import ArchiveyError
+from archivey.types import ArchiveFormat
+
+try:
+    import pycdlib  # noqa: F401
+
+    _HAVE_PYCDLIB = True
+except ImportError:
+    _HAVE_PYCDLIB = False
+
+
+# ---------------------------------------------------------------------------
+# Member-attributable read errors: format + archive_name + member_name present
+# ---------------------------------------------------------------------------
+
+
+def _corrupt_zip_member(tmp: Path) -> tuple[Path, str]:
+    # A structurally valid ZIP whose STORED payload was flipped: listing works, the read
+    # trips the CRC check inside stdlib zipfile -> translated CorruptionError on the member.
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_STORED) as z:
+        z.writestr("data.txt", b"A" * 200)
+    raw = bytearray(buf.getvalue())
+    raw[50] ^= 0xFF  # STORED payload starts after the 30-byte header + 8-byte name
+    p = tmp / "corrupt.zip"
+    p.write_bytes(bytes(raw))
+    return p, "data.txt"
+
+
+def _corrupt_gzip_member(tmp: Path) -> tuple[Path, str]:
+    # A bare .gz whose deflate body is clobbered: the single member read surfaces the codec
+    # layer's CorruptionError, stamped with that member's name by the single-file backend.
+    data = bytearray(gzip.compress(b"payload" * 100))
+    data[15:35] = b"\x00" * 20  # past the 10-byte gzip header
+    p = tmp / "corrupt.txt.gz"
+    p.write_bytes(bytes(data))
+    return p, "corrupt.txt"
+
+
+@pytest.mark.parametrize(
+    ("builder", "expected_format"),
+    [
+        pytest.param(_corrupt_zip_member, ArchiveFormat.ZIP, id="zip"),
+        pytest.param(_corrupt_gzip_member, ArchiveFormat.GZ, id="single-file-gz"),
+    ],
+)
+def test_member_read_error_stamps_full_context(
+    tmp_path: Path,
+    builder: Callable[[Path], tuple[Path, str]],
+    expected_format: ArchiveFormat,
+) -> None:
+    source, member_name = builder(tmp_path)
+    with open_archive(source) as ar:
+        target = next(m for m in ar.members() if m.name == member_name)
+        with pytest.raises(ArchiveyError) as excinfo:
+            ar.read(target)
+    err = excinfo.value
+    assert err.source_format is expected_format
+    assert err.archive_name is not None and source.name in err.archive_name
+    assert err.member_name == member_name
+
+
+# ---------------------------------------------------------------------------
+# Archive-level (scan / codec) errors: format + archive_name present. These are not
+# attributable to one member (a corrupt tar header aborts the scan; a mangled deflate
+# body fails in the shared compression stream), so member_name may legitimately be None.
+# ---------------------------------------------------------------------------
+
+
+def _build_tar(mode: str = "w") -> bytes:
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode=mode) as t:
+        info = tarfile.TarInfo("a.txt")
+        info.size = 5
+        t.addfile(info, io.BytesIO(b"hello"))
+    return buf.getvalue()
+
+
+def _corrupt_tar_header(tmp: Path) -> tuple[Path, Callable[[ArchiveReader], None]]:
+    raw = bytearray(_build_tar())
+    raw[148:156] = b"\xff" * 8  # clobber the header checksum field
+    p = tmp / "corrupt.tar"
+    p.write_bytes(bytes(raw))
+    return p, lambda ar: ar.members()
+
+
+def _corrupt_targz_body(tmp: Path) -> tuple[Path, Callable[[ArchiveReader], None]]:
+    raw = bytearray(_build_tar("w:gz"))
+    raw[len(raw) // 2] ^= 0xFF  # flip a byte inside the deflate stream
+    p = tmp / "corrupt.tar.gz"
+    p.write_bytes(bytes(raw))
+
+    def trigger(ar: ArchiveReader) -> None:
+        for _member, stream in ar.stream_members():
+            if stream is not None:
+                stream.read()
+
+    return p, trigger
+
+
+def _corrupt_iso(tmp: Path) -> tuple[Path, Callable[[ArchiveReader], None]]:
+    iso = pycdlib.PyCdlib()
+    iso.new(interchange_level=3, rock_ridge="1.09")
+    iso.add_fp(io.BytesIO(b"hello"), 5, "/A.TXT;1", rr_name="a.txt")
+    buf = io.BytesIO()
+    iso.write_fp(buf)
+    iso.close()
+    raw = bytearray(buf.getvalue())
+    # Clobber the primary volume descriptor region so pycdlib rejects the image at open.
+    raw[32769:32800] = b"\x00" * 31
+    p = tmp / "corrupt.iso"
+    p.write_bytes(bytes(raw))
+    return p, lambda ar: ar.members()
+
+
+_ARCHIVE_LEVEL = [
+    pytest.param(_corrupt_tar_header, id="tar"),
+    pytest.param(_corrupt_targz_body, id="tar.gz"),
+    pytest.param(
+        _corrupt_iso,
+        id="iso",
+        marks=pytest.mark.skipif(not _HAVE_PYCDLIB, reason="pycdlib not installed"),
+    ),
+]
+
+
+@pytest.mark.parametrize("builder", _ARCHIVE_LEVEL)
+def test_archive_error_stamps_format_and_archive(
+    tmp_path: Path,
+    builder: Callable[[Path], tuple[Path, Callable[[ArchiveReader], None]]],
+) -> None:
+    source, trigger = builder(tmp_path)
+    # The corruption may surface at open (ISO/tar header) or while reading (tar.gz); either
+    # way the raised ArchiveyError must carry the format and archive-name context. The exact
+    # format is not over-constrained: a codec-layer failure (tar.gz) is stamped with the
+    # codec's own format rather than the outer container, which is a valid attribution.
+    with pytest.raises(ArchiveyError) as excinfo:
+        with open_archive(source) as ar:
+            trigger(ar)
+    err = excinfo.value
+    assert err.source_format is not None
+    assert err.archive_name is not None and source.name in err.archive_name

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -505,6 +505,60 @@ def test_entry_count_bomb(tmp_path: Path) -> None:
         extract(src, dest, limits=ExtractionLimits(max_entries=10), on_error=OnError.CONTINUE)
 
 
+def test_selector_skips_do_not_count_toward_max_entries(tmp_path: Path) -> None:
+    # Only members actually written count toward max_entries (resolved 2026-07 decision):
+    # a member excluded by the selector creates nothing on disk, so a tiny cap survives a
+    # huge archive when only one member is selected.
+    src = tmp_path / "many.zip"
+    _write_zip(src, {f"f{i}.txt": b"x" for i in range(20)})
+    dest = tmp_path / "out"
+    with open_archive(src) as r:
+        results = r.extract_all(
+            dest, members=["f0.txt"], limits=ExtractionLimits(max_entries=1)
+        )
+    assert (dest / "f0.txt").read_bytes() == b"x"
+    assert len(results) == 1
+
+
+def test_filter_skips_do_not_count_toward_max_entries(tmp_path: Path) -> None:
+    # A member the user filter drops (returns None) likewise creates nothing on disk and
+    # must not consume the entry-count budget.
+    src = tmp_path / "many.zip"
+    _write_zip(src, {f"f{i}.txt": b"x" for i in range(20)})
+    dest = tmp_path / "out"
+
+    def keep_one(m: ArchiveMember) -> ArchiveMember | None:
+        return m if m.name == "f0.txt" else None
+
+    with open_archive(src) as r:
+        results = r.extract_all(
+            dest, filter=keep_one, limits=ExtractionLimits(max_entries=1)
+        )
+    assert (dest / "f0.txt").read_bytes() == b"x"
+    assert [res.status for res in results] == [ExtractionStatus.EXTRACTED]
+
+
+def test_rejected_members_do_not_count_toward_max_entries(tmp_path: Path) -> None:
+    # A member rejected by the universal safety check writes nothing, so it must not
+    # consume the entry-count budget either: two good files + one hostile member with
+    # max_entries=2 completes under CONTINUE (before the fix the rejected member counted
+    # and tripped the guard on the second good file).
+    src = tmp_path / "a.zip"
+    with zipfile.ZipFile(src, "w") as z:
+        z.writestr("good1.txt", b"a")
+        z.writestr("../evil.txt", b"bad")
+        z.writestr("good2.txt", b"b")
+    dest = tmp_path / "out"
+    with open_archive(src) as r:
+        results = r.extract_all(
+            dest, limits=ExtractionLimits(max_entries=2), on_error=OnError.CONTINUE
+        )
+    statuses = {res.member.name: res.status for res in results}
+    assert statuses["good1.txt"] is ExtractionStatus.EXTRACTED
+    assert statuses["good2.txt"] is ExtractionStatus.EXTRACTED
+    assert ExtractionStatus.REJECTED in statuses.values()
+
+
 # ---------------------------------------------------------------------------
 # Progress callback
 # ---------------------------------------------------------------------------

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -148,16 +148,20 @@ def test_zip_partial_when_optional_codecs_missing(
     assert ArchiveFormat.ZIP in list_supported_formats()
 
 
-def test_zip_full_when_codecs_present(monkeypatch: pytest.MonkeyPatch) -> None:
-    # Force ZIP's optional member codecs present so FULL is asserted deterministically,
-    # regardless of which extras the test environment installed (the core-only CI legs
-    # have none). The PARTIAL direction is covered by
-    # test_zip_partial_when_optional_codecs_missing.
+def test_zip_partial_even_when_codecs_present(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Resolved 2026-07 decision (see the phase-5 proposal): ZIP member *data* still decodes
+    # via stdlib zipfile, which cannot use the optional codecs even when installed, so ZIP
+    # reports PARTIAL (never FULL) until Phase 7 wires the codec layer into ZIP reads.
+    # `missing` is empty when every optional codec is present (the gap is implementation
+    # stage, not a missing install). Force them present so this holds regardless of which
+    # extras the test environment installed (the core-only CI legs have none).
     for sentinel in ("_inflate64", "_zstd", "_pyppmd"):
         monkeypatch.setattr(codecs_module, sentinel, object())
     avail = format_availability(ArchiveFormat.ZIP)
-    assert avail.support is FormatSupport.FULL
+    assert avail.support is FormatSupport.PARTIAL
     assert avail.missing == ()
+    # PARTIAL formats are still "supported" (readable for their common members).
+    assert ArchiveFormat.ZIP in list_supported_formats()
 
 
 def test_single_codec_format_none_when_codec_missing(


### PR DESCRIPTION
Stage 6 of Phase 5, stacked on #40 (`phase5-stage5`). Completes the finalization sweep and the two resolved maintainer decisions.

## Summary

**6.5 — behavioral (the two resolved maintainer decisions):**
- `max_entries` now counts **only members actually written**. `BombTracker.start_member()` moved after the `members` selector *and* user `filter` accept a member (and the universal check passes), so selector-skipped, filter-skipped, and rejected members create nothing on disk and don't consume the entry budget.
- ZIP `format_availability` always reports **PARTIAL** until the Phase 7 codec bypass — never FULL, even with every optional codec installed (member data still decodes via stdlib `zipfile`). `missing` still lists absent packages, empty when all present.

**6.1–6.3 — verification:**
- `tests/test_cost_receipt.py`: one parametrized per-format `CostReceipt` contract (zip/tar/tar.gz/bz2/xz/single-file/iso/directory) pinning all four axes.
- `tests/test_error_context.py`: end-to-end error-context stamping per backend — full format+archive+member for member-attributable read errors (ZIP, single-file), format+archive for archive-level/codec errors (tar, tar.gz, iso).
- `tests/test_data_model.py`: archive-data-model audit filling untested pure-model contracts (ArchiveFormat identity round-trip / on-demand construction / `file_extension`; ArchiveMember unhashable / `replace` copy semantics / `None` defaults / equality excluding hashes+extra / type helpers).

**6.4 — docs:**
- `SPEC.md` §3 signatures updated (`open_archive`/`extract`/`extract_all`: `config=`, `limits=`, `encoding`, widened `source`, multi-candidate `password`); §7.3 bomb-limits rewritten around `ExtractionLimits` incl. `max_entries` semantics.
- `ARCHITECTURE.md` `BombTracker` sketch + §5.5 updated to the `ExtractionLimits` model.

## Test plan

- [x] `pyrefly check` + `ty check` clean
- [x] Full suite: 792 passed, 7 skipped
- [x] `ruff check` on changed files clean
- [x] `openspec validate --strict phase-5-public-api` valid

Made with [Cursor](https://cursor.com)