### PR TITLE
Document vision, threat model, and strategy backlog; resequence roadmap

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,8 +6,13 @@ library: read, stream, and safely extract ZIP / TAR / RAR / 7z / ISO / directory
 
 ## Where things live
 
+- `VISION.md` — the product vision: positioning, priorities, perf budget, adoption
+  strategy; the tie-breaker when trade-offs conflict.
 - `SPEC.md`, `ARCHITECTURE.md`, `COMPARISON.md`, `PLAN.md` — the original prose
-  design docs (reference). `PLAN.md` is the phased implementation roadmap.
+  design docs (reference). `PLAN.md` is the phased implementation roadmap
+  (resequenced 2026-07: native 7z/RAR before CLI before writing).
+- `docs/threat-model.md` — trust boundaries + the open security/compat gap register
+  (each open item becomes an OpenSpec change when tackled).
 - `openspec/specs/<capability>/spec.md` — the authoritative capability specs
   (OpenSpec format: requirements + WHEN/THEN scenarios). The specs are authoritative,
   but when they disagree with the prose docs (or with each other), **pause and surface

--- a/IDEAS.md
+++ b/IDEAS.md
@@ -182,3 +182,58 @@
 
   Note `pyzstd.SeekableZstdFile` is **not** a substitute either: it reads only the *Seekable
   Zstd* container, not plain `.zst`. See `docs/library-analysis.md` (zstd).
+
+## Strategy & adoption (2026-07 review backlog)
+
+> Parked here from the 2026-07 architecture-review discussion so nothing is lost.
+> Security/compat items with a threat angle live in `docs/threat-model.md` (the gap
+> register); the product framing lives in `VISION.md`. These are the rest.
+
+- **Salvage / best-effort read mode** — the founding use case (indexing decades of
+  messy backups) is full of truncated and corrupt archives, and today every backend is
+  all-or-error. A `salvage=True`-style read mode would yield every recoverable member
+  plus per-member/status errors instead of one terminal exception: for ZIP, walk local
+  headers when the central directory is gone; for TAR, resync on the next valid header;
+  for single-file streams, return the decodable prefix with a truncation flag. Nobody
+  does this well; it is both a founding need and a differentiator. Needs its own spec
+  (interacts with error-handling and the equivalence matrix).
+- **Hashes without decompression** — dedupe workflows can often use the digests the
+  archive already stores (`member.hashes`: CRC32, RAR5 BLAKE2sp, …) instead of reading
+  data. Document the recipe; consider a helper that returns "best available digest +
+  provenance (stored vs computed)" so an indexer can choose cheap-but-weak vs
+  costly-but-strong uniformly.
+- **Benchmarks as a CI gate** — suite tracking open/list/read/extract wall time vs
+  stdlib (`zipfile`/`tarfile`) and py7zr/libarchive where comparable, plus
+  **bytes-decompressed and seek counts** (the real bottlenecks — re-decompression and
+  seek storms — hide in wall time on small corpora). Budget per `VISION.md`: ≤1.3×
+  stdlib common paths, ~2× when justified. Stand up before any perf-sensitive claim.
+- **Public backend API** — stabilize/export the `ReadBackend` ABC + registry so rare
+  formats (CAB, CPIO, SquashFS, WIM, XAR, DMG…) can be third-party plugins instead of
+  a solo compatibility treadmill. Decide pre-1.0 (it constrains how freely the backend
+  contract can change afterwards).
+- **fsspec adapter** — expose an opened archive as an fsspec filesystem
+  (`ArchiveFileSystem`); big adoption channel (pandas/dask/HF datasets ecosystems) and
+  a good stress test of the reader contract. Also the natural place for
+  `open_archive("https://…")` stories rather than teaching core about URLs.
+- **Migration guide** — `zipfile`/`tarfile`/`shutil.unpack_archive`/`patool` →
+  archivey, gotcha-by-gotcha ("`tarfile.extractall` without `filter=` does X; here it
+  cannot happen"). Cheap, high-leverage for the "default library" goal.
+- **Warnings-as-data sweep** — audit every `logger.warning` in the library: each should
+  (also) be queryable as data (member/info field, `FormatInfo`, `CostReceipt`,
+  `ExtractionResult`), since most applications never surface logging. See
+  `docs/threat-model.md` C2.
+- **Extraction collision handling + `OverwritePolicy.RENAME`** — deterministic
+  cross-platform handling of casefold/normalization collisions (threat-model O2), plus
+  an opt-in RENAME policy (`name (1)`) for archives with intentional duplicates.
+- **Writing, done properly, later** — writing is deliberately post-reading (possibly
+  post-1.0). When specced, design in from the start: **reproducible output**
+  (`SOURCE_DATE_EPOCH`, stable member ordering, normalized metadata — the build-tool
+  adoption wedge) and the **metadata-fidelity boundary** (xattrs/ACLs — threat-model
+  C3; read-side is additive later, but write-side fidelity must be a day-one decision
+  of the writing spec, since it shapes `add_member` and the round-trip contract).
+- **Free-threading position** (threat-model C4) — parallel extraction / parallel
+  decode under 3.13t; interacts with the existing parallel-extraction idea above.
+- **CLI earlier, as dev tool + demo** — `archivey list/test/extract` was invaluable for
+  eyeballing DEV against real archives and is the ten-second demo of safe extraction
+  ("the unzip that can't be zip-slipped"). Roadmap moves it right after the native
+  readers (see PLAN); a selling point, though not the main one.

--- a/PLAN.md
+++ b/PLAN.md
@@ -26,11 +26,16 @@ are archived to `openspec/changes/archive/`). Phases without a change yet need a
 | 3 | Indexed leaf formats + detection | `format-zip`, `format-tar` (random-access read), `format-single-file-compressors`, `format-iso`, `format-detection`, `backend-registry`, `access-mode-and-cost` | `archive/2026-06-30-phase-3-indexed-leaf-formats` ✓ |
 | 4 | TAR streaming + safe extraction | `format-tar` (forward-only `stream_members`, hardlinks, truncation), `safe-extraction`, `archive-reading` (sequential + `stream_members`), `format-detection` (gzip-wrapped tar regression), `testing-contract` (adversarial + non-seekable `tar.gz`) | `archive/2026-06-30-package-layout-restructure` ✓ → `phase-4-tar-streaming` + `phase-4-safe-extraction` |
 | 5 | Public API finalization & cost | `archive-reading`, `archive-data-model`, `access-mode-and-cost`, `error-handling` | `phase-5-public-api` |
-| 6 | Writing support | `archive-writing`, `format-zip` / `format-tar` (writers) | — |
-| 7 | Native 7z + RAR read | `format-7z`, `format-rar`, `testing-contract` (oracle cross-validation) | — |
-| 8 | Seekable zstd + blocked gzip (rescoped; original zst/lz4 read goals landed in Phases 2–3, `w:zst` moved to Phase 6) | `seekable-decompressor-streams`, `format-single-file-compressors` | `seekable-gzip-and-block-writing` (partial) |
-| 9 | CLI | `cli` | — |
-| 10 | Polish + oracle retirement | `packaging-and-extras` (finalize), `cli`, `testing-contract` (full corpus) | — |
+| 6 | Native 7z + RAR read (was Phase 7; **fuzzing is an entry gate** — see cross-cutting) | `format-7z`, `format-rar`, `testing-contract` (oracle cross-validation) | — |
+| 7 | CLI (was Phase 9; pulled forward as dev tool + the safe-extraction demo, per `VISION.md`) | `cli` | — |
+| 8 | Seekable zstd + blocked gzip (rescoped; original zst/lz4 read goals landed in Phases 2–3, `w:zst` moved to the writing phase) | `seekable-decompressor-streams`, `format-single-file-compressors` | `seekable-gzip-and-block-writing` (partial) |
+| 9 | Writing support (was Phase 6; **not a 1.0 requirement** — may land after; spec must design in reproducible output + the metadata-fidelity decision, see `IDEAS.md`) | `archive-writing`, `format-zip` / `format-tar` (writers) | — |
+| 10 | Polish + release readiness (test-strategy revision per the `retire-dev-oracle` change) | `packaging-and-extras` (finalize), `cli`, `testing-contract` (full corpus) | — |
+
+> **Resequenced (2026-07, per `VISION.md`):** native 7z/RAR reading moved **before**
+> writing — "reads everything" is the reason to adopt, and writing is explicitly not a
+> 1.0 requirement. The CLI moved up next-after (dev tool + demo). The phase sections
+> below are renumbered accordingly; archived changes keep their historical numbering.
 
 **In-flight changes unrelated to a PLAN phase** (do not block Phase 4, but may land
 alongside): `seekable-gzip-and-block-writing`, `rapidgzip-truncation-investigation`.
@@ -69,7 +74,7 @@ Port-vs-rewrite is decided by **layer**, not file-by-file:
 | Backend registry + `Backend` ABC | **Write fresh** |
 | `ExtractionHelper` (pending/deferred state machine) | **Write fresh** as `ExtractionCoordinator` |
 | `io_helpers.py` god-module, `BinaryIOWrapper` method-swap trick | **Write fresh** as the `internal/streams/` package |
-| 7z `py7zr` reader, RAR `rarfile` reader | **Reference only** — not ported (native-first, Phase 7) |
+| 7z `py7zr` reader, RAR `rarfile` reader | **Reference only** — not ported (native-first, the native-reader phase) |
 | DEV `test_*.py` drivers | **Reference only** — not ported (frozen oracle, then deleted) |
 
 ---
@@ -363,46 +368,16 @@ correct for every format implemented so far.
 
 ---
 
-## Phase 6 — Writing support
-
-**Goal:** `ArchiveWriter` ABC, ZIP + TAR writers, streaming conversion.
-
-**Entry criteria:** Phase 5 green.
-
-### Tasks
-`ArchiveWriter` ABC (`add`/`add_bytes`/`add_stream`/`add_member`/`add_members`/
-`close`); `ZipWriter` (`ZipFile.open(name,'w')`, data descriptor for unknown
-size); `TarWriter` (incl. compressed-tar output — `w:zst` and friends, moved here
-from the original Phase 8); `create_archive()`; `CompressionSpec` model.
-
-> **Pending decisions (resolve in this phase's change proposal):**
-> - *Per-entry `compression` on stream-compressed containers* (`tar.gz`/`tar.zst`):
->   the codec is stream-level, so a per-entry override is meaningless — error, or
->   warn-and-ignore? (Leaning: `ValueError` on an explicit per-entry algo; the
->   writer-level `CompressionSpec` selects the outer codec.)
-> - *`password=` on formats whose writer can't encrypt* (stdlib zipfile cannot write
->   encryption): must fail fast at `create()` — decide the error type
->   (`UnsupportedFeatureError` vs `UnsupportedOperationError`) and add a
->   SUPPORTS_PASSWORD-style WriteBackend field to enforce it centrally.
-
-### Tests added
-`archive-writing` scenarios; `testing-contract` ZIP/TAR round-trip; conversion
-(`tar.gz`→`zip`, `zip`→`tar`) with bounded memory verified via `tracemalloc`.
-
-### Acceptance — spec scenarios covered
-All of `archive-writing`; `testing-contract` (*ZIP round-trip*, *TAR round-trip*);
-`format-zip` (*streaming write via data descriptor*).
-**Gates:** Pyrefly + ty + ruff clean; no full-archive buffering during stream conversion.
-
----
-
-## Phase 7 — Native 7z reader + native RAR metadata parser
+## Phase 6 — Native 7z reader + native RAR metadata parser (was Phase 7)
 
 **Goal:** make the 7z and RAR **read** paths native; flip them from `xfail` to
 passing; wire the oracles. See `format-7z/spec.md`, `format-rar/spec.md`,
 `testing-contract/spec.md`.
 
-**Entry criteria:** Phase 6 green; `py7zr`/`rarfile`/`unrar` available as
+**Entry criteria:** Phase 5 green; **the fuzzing scaffold is stood up** (property
+tests + the corpus mutation harness running; Atheris harnesses for the new parsers
+land with them — see cross-cutting concerns and `docs/threat-model.md` O5);
+`py7zr`/`rarfile`/`unrar` available as
 dev-group oracles; the **shared-source stream plumbing** decided/landed — a
 `streamtools` shared-source view (the shape of stdlib `zipfile._SharedFile`: one
 handle + a lock + per-view positions) so the native readers support multiple
@@ -416,7 +391,7 @@ see the parallel-extraction entry in `IDEAS.md`.
    streaming for `stream_members()`, decode-from-folder-start for random `open()`;
    PPMd/Deflate64 via `[7z]`, AES via `[crypto]`; **BCJ2 and unknown method IDs
    rejected explicitly** (never silent fallback). 7z **writing** stays on `py7zr`
-   behind `[7z-write]`; reads import no third-party lib.
+   behind `[7z-write]` (writing phase); reads import no third-party lib.
 2. **Native RAR** RAR4/RAR5 metadata parse (listing without `unrar`); member data
    via a single `unrar p -inul` pipe demultiplexed by header sizes with incremental
    CRC32; header-encrypted RAR5 decrypted via `[crypto]`; multi-volume joining.
@@ -435,12 +410,27 @@ output matches oracles across the corpus; solid `stream_members()` uses one
 
 ---
 
+## Phase 7 — CLI (was Phase 9)
+
+**Goal:** the `archivey` command (`list`/`test`/`extract`, pattern filtering)
+behind `[cli]`.
+
+**Entry criteria:** Phase 6 green. Pulled forward deliberately: the CLI doubles as
+the maintainer's inspection tool against real-world archives (it served that role in
+DEV) and is the ten-second demo of safe extraction (`VISION.md`).
+
+### Tests added & acceptance
+All of `cli` (incl. *CLI installed without the `[cli]` extra*).
+**Gates:** Pyrefly + ty + ruff clean.
+
+---
+
 ## Phase 8 — Seekable zstd & blocked-gzip native readers
 
 > **Rescoped (2026-07):** the original Phase 8 goal — `.zst`/`.tar.zst`/`.tar.lz4`
 > *reading* and `.zst` magic detection — landed early with the Phase 2/3 codec layer
 > (round-trip tests pass today). The remaining write-side piece (`w:zst`) moves to
-> Phase 6 with the other writers. This phase is repurposed for the seekable-stream
+> the writing phase (now Phase 9) with the other writers. This phase is repurposed for the seekable-stream
 > follow-ons that reuse the segmented-decompressor infrastructure.
 
 **Goal:** frame/block-granular random access for zstd (native, no new dependency) and
@@ -468,14 +458,41 @@ once specced via its own change).
 
 ---
 
-## Phase 9 — CLI
+## Phase 9 — Writing support (was Phase 6; possibly post-1.0)
 
-**Goal:** the `archivey` command (`list`/`test`/`extract`, pattern filtering)
-behind `[cli]`.
+**Goal:** `ArchiveWriter` ABC, ZIP + TAR writers, streaming conversion.
 
-### Tests added & acceptance
-All of `cli` (incl. *CLI installed without the `[cli]` extra*).
-**Gates:** Pyrefly + ty + ruff clean.
+**Entry criteria:** decided explicitly **not a 1.0 requirement** (`VISION.md`):
+reading-complete releases first. Before implementation, the writing spec needs a
+thorough exploration pass covering **reproducible output** (`SOURCE_DATE_EPOCH`,
+stable ordering, normalized metadata) and the **metadata-fidelity boundary**
+(xattrs/ACLs round-trip — see `IDEAS.md`), both of which shape the writer API and
+are costly to retrofit.
+
+### Tasks
+`ArchiveWriter` ABC (`add`/`add_bytes`/`add_stream`/`add_member`/`add_members`/
+`close`); `ZipWriter` (`ZipFile.open(name,'w')`, data descriptor for unknown
+size); `TarWriter` (incl. compressed-tar output — `w:zst` and friends, moved here
+from the original Phase 8); `create_archive()`; `CompressionSpec` model.
+
+> **Pending decisions (resolve in this phase's change proposal):**
+> - *Per-entry `compression` on stream-compressed containers* (`tar.gz`/`tar.zst`):
+>   the codec is stream-level, so a per-entry override is meaningless — error, or
+>   warn-and-ignore? (Leaning: `ValueError` on an explicit per-entry algo; the
+>   writer-level `CompressionSpec` selects the outer codec.)
+> - *`password=` on formats whose writer can't encrypt* (stdlib zipfile cannot write
+>   encryption): must fail fast at `create()` — decide the error type
+>   (`UnsupportedFeatureError` vs `UnsupportedOperationError`) and add a
+>   SUPPORTS_PASSWORD-style WriteBackend field to enforce it centrally.
+
+### Tests added
+`archive-writing` scenarios; `testing-contract` ZIP/TAR round-trip; conversion
+(`tar.gz`→`zip`, `zip`→`tar`) with bounded memory verified via `tracemalloc`.
+
+### Acceptance — spec scenarios covered
+All of `archive-writing`; `testing-contract` (*ZIP round-trip*, *TAR round-trip*);
+`format-zip` (*streaming write via data descriptor*).
+**Gates:** Pyrefly + ty + ruff clean; no full-archive buffering during stream conversion.
 
 ---
 
@@ -505,6 +522,19 @@ binaries.
 ---
 
 ## Cross-cutting concerns
+
+### Fuzzing & benchmarks (cross-cutting scaffold)
+
+- **Fuzzing** (see `docs/threat-model.md` O5), staged: (a) now — Hypothesis property
+  tests for the pure safety logic (naming, `check_universal`, link resolution,
+  detection) and a corpus **mutation harness** (bit-flips/truncations over generated
+  archives asserting never-crash / never-hang / always a typed `ArchiveyError`);
+  (b) Phase 6 entry gate — Atheris coverage-guided fuzzing of the native 7z/RAR
+  header parsers, corpus-seeded, short nightly CI runs; (c) public release —
+  OSS-Fuzz onboarding + `SECURITY.md`.
+- **Benchmarks as a gate** (see `VISION.md` budget): open/list/read/extract vs stdlib,
+  tracking **bytes-decompressed and seek counts** as well as wall time; stood up
+  before any performance claim, gating like the type checkers thereafter.
 
 ### Risk areas
 - **Spine-first ordering:** leaf backends in Phase 3+ attach to the Phase-1 ABC,

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # archivey
 
 Python library for reading, streaming, and safely extracting archives (ZIP, TAR, RAR, 7z, ISO, and more) through a unified interface.
+
+- **[VISION.md](VISION.md)** — what this project is trying to become and the priorities that follow.
+- **[docs/threat-model.md](docs/threat-model.md)** — trust boundaries, enforced guarantees, and the open security/compatibility gap register.
+- **[PLAN.md](PLAN.md)** — the phased implementation roadmap; **[IDEAS.md](IDEAS.md)** — the backlog.

--- a/VISION.md
+++ b/VISION.md
@@ -1,0 +1,140 @@
+# Archivey — Vision
+
+> What this project is trying to become, why it should exist, and the priorities that
+> follow. `SPEC.md` / `ARCHITECTURE.md` / `openspec/specs/` define *what the library
+> does*; this document defines *what it is for* and how to make trade-offs when they
+> conflict. (Recorded 2026-07 from maintainer + review discussions.)
+
+## The one-sentence pitch
+
+**The default Python library for dealing with archives** — the thing every project
+reaches for when it needs to read, inspect, stream, or safely extract any archive
+format, the way `requests` became the default for HTTP.
+
+This library *should* already exist — arguably in the stdlib — but doesn't: stdlib
+`zipfile`/`tarfile` are two inconsistent APIs with decades of known gotchas
+(`tarfile` path traversal took 15 years to get filters, PEP 706), `shutil.unpack_archive`
+is unsafe and shallow, and the third-party format libraries (`py7zr`, `rarfile`,
+libarchive bindings) each have their own APIs, error types, quirks, and performance
+traps. Realistically archivey will never *be* stdlib (stdlib is where libraries
+calcify — see the `compression.zstd` timeline); the goal is to be **so standard it
+feels like stdlib**.
+
+## The two load-bearing claims
+
+1. **Safe by default.** Extraction cannot be zip-slipped, symlink-escaped, or
+   decompression-bombed unless the caller explicitly opts out. Safety is a *contract*
+   (specced, tested, threat-modeled — see `docs/threat-model.md`), not a feature flag.
+2. **Memory-safe parsing of hostile input.** The native-first strategy for 7z/RAR (and
+   eventually ZIP) is not purity for its own sake: pure-Python parsers can be *wrong*
+   but they cannot be *corrupted*. C archive parsers (libarchive et al.) have a long
+   CVE history of memory-safety bugs triggered by crafted archives. "Parse untrusted
+   archives without native-code parser attack surface" is a differentiator no
+   mainstream alternative offers.
+
+Both claims must be *earned in public*: a written threat model, an adversarial corpus,
+coverage-guided fuzzing of every native parser, and a disclosure process — before the
+words "safe" or "secure" appear in marketing.
+
+## The founding use case (and what it implies)
+
+The project started as: **index and deduplicate decades of messy backups** — old
+downloads with wrong extensions, truncated/corrupted files, archives produced by buggy
+tools — where the job is *iterate members and hash contents*, and where `rarfile`/
+`py7zr` re-decompressing a solid block once per member made the job intractable.
+
+That origin story encodes priorities that remain core:
+
+- **Content-first, not extraction-first.** Reading, streaming, and metadata are the
+  primary API; extraction is the second; writing is a natural extension but explicitly
+  the lowest priority (may land after 1.0 — see roadmap).
+- **Identification must be evidence-based.** Wrong extensions are normal; magic-first
+  detection with honest confidence reporting is a feature, not plumbing.
+- **Never decompress the same byte twice** (without saying so). Solid blocks are read
+  once per pass; the access-mode/cost model exists so O(n²) traps are impossible to
+  hit *silently*.
+- **Damaged input is a first-class citizen** — the founding corpus is full of it. A
+  truncated archive should yield every member that *is* recoverable plus an honest
+  error, not a bare exception at open. (Gap today: reads are all-or-error; a
+  "salvage" read mode is on the backlog — see `IDEAS.md`.)
+- **Hashes without decompression where possible.** Formats already store CRC32/BLAKE2
+  digests; a dedupe pass should be able to use `member.hashes` without reading data.
+
+## What "no surprises" means concretely
+
+- Behavior differences between formats are surfaced as **data** (explicit fields,
+  `None`, documented sentinels) — never silent guesses. This is the standing design
+  authority (`openspec/project.md`).
+- Anything the library can only *warn* about should ideally also be **queryable as
+  data** — a logging warning most applications never see is a surprise deferred, not
+  avoided. (Backlog: the warnings-as-data sweep, `IDEAS.md`.)
+- Contracts hold under adversarial input, not just well-formed archives.
+
+## Performance budget
+
+- Target: **≤ 1.3×** stdlib wall-time for the common paths (open/list/read/extract on
+  ZIP and TAR); up to ~2× acceptable where a safety or correctness feature justifies it.
+- The bottleneck in real workloads is data movement and *re*-decompression, not header
+  parsing. So the benchmark suite must track **bytes decompressed and seek patterns**,
+  not just wall time — an implementation that re-reads a solid block fails the
+  benchmark even if a small test corpus hides it.
+- Benchmarks become a CI gate like the type checkers (backlog until stood up).
+
+## Quality scaffolding over promises
+
+No "bug-free" promises. Instead, machinery that catches bugs before release:
+
+- The spec corpus (`openspec/specs/`) with scenario-driven tests — every behavior
+  claim has a test.
+- The **declarative archive corpus + cross-format conformance sweep** (the
+  `retire-dev-oracle` change): every corpus archive must open/list/extract or raise
+  its documented error, across every implemented backend — the regression net that
+  catches "backend X broke shape Y" without a hand-written test per pair.
+- **Fuzzing**, staged: property-based tests (Hypothesis) for the pure logic now;
+  mutation fuzzing (bit-flips/truncation over the corpus, asserting
+  never-crash/never-hang/always-`ArchiveyError`) now; coverage-guided fuzzing
+  (Atheris) as an entry gate for the native 7z/RAR parsers; OSS-Fuzz onboarding at
+  public release.
+- Three-configuration CI (current / lowest / zero-dep) — already standing.
+
+## Adoption strategy (when the pieces are in place)
+
+- **Release when reading is complete** — ZIP/TAR/single-file/ISO/directory *plus native
+  7z/RAR* — since "reads everything" is the reason to switch. Writing is not a 1.0
+  requirement.
+- **The CLI is a wedge and a dev tool**, not the main act: `archivey list|test|extract`
+  is the safer `unzip`/`tar` that demos the library in ten seconds, and it doubles as
+  the maintainer's own inspection tool during development (moved earlier in the
+  roadmap accordingly).
+- Meet users where they are: a migration guide from `zipfile`/`tarfile`/
+  `shutil.unpack_archive`/`patool`; an fsspec filesystem adapter as an integration
+  channel; recipes for the data-pipeline crowd (who currently hand-roll unsafe
+  `extractall` on downloaded datasets).
+- A **public backend API** (the registry ABC, stabilized) turns "maximum format
+  compatibility" from a solo treadmill into an ecosystem: rare formats (CAB, CPIO,
+  SquashFS, WIM…) can live as third-party plugins. Pre-1.0 decision.
+
+## Non-goals
+
+- **Not an everything-tool**: no in-place archive modification, no encryption-write for
+  7z/RAR, no async API in v1 (decided deferrals — `openspec/project.md`).
+- **Not a backup engine** — but see the open metadata-fidelity decision (`IDEAS.md`):
+  whether xattrs/ACLs/owners round-trip determines whether backup tools can *build on*
+  archivey. Read-side fidelity is cheap to add later (fields are additive); the
+  decision truly binds only when writing lands.
+- **No compatibility shims for other libraries' APIs.** One clean API; migration
+  guides rather than emulation layers.
+- **No quirk-driven architecture.** Third-party format libraries whose behavioral
+  quirks would leak into the core contracts (py7zr/rarfile as read backends) are kept
+  out even at the cost of a longer road — the DEV codebase demonstrated where that
+  leads. Wrapping is acceptable only where the wrapped library is well-behaved under
+  our contract (`pycdlib`) or delegated cleanly at a process boundary (`unrar` as a
+  data decompressor).
+
+## Maintenance reality
+
+Developed for fun, released when ready, maintained by one person plus AI agents. The
+consequences are deliberate: a small dependency surface, heavy investment in
+self-checking scaffolding (specs, corpus sweep, fuzzing, CI matrix) over manual
+vigilance, a conservative public-API surface (easy to keep stable), and no promised
+support matrix beyond what CI actually exercises.

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -1,0 +1,161 @@
+# Threat model and security/compatibility gap register
+
+> The trust boundaries archivey defends, what is already enforced, and — importantly —
+> the **known open gaps** identified in the 2026-07 architecture review, recorded here so
+> they are not lost. Each open item should become an OpenSpec change (usually a
+> `safe-extraction` or `archive-reading` delta) when tackled; this document is the
+> holding area and the rationale, not the normative spec.
+
+## Trust boundaries
+
+- **The archive is untrusted.** Every byte of it: member names, link targets, sizes,
+  timestamps, comments, header structures, compressed streams. Crafted and adversarial
+  archives are in scope for *all* guarantees, not just well-formed ones.
+- **The destination directory and local filesystem are trusted at rest** — but not
+  their *contents produced by the extraction itself*: an earlier extracted member is
+  untrusted input to the handling of every later member (this is why symlink targets
+  are re-resolved against the live tree after creation).
+- **The local process and other local processes are trusted.** Concurrent hostile
+  modification of the destination *by another process* during extraction (a local
+  attacker racing us) is out of scope; if that ever changes, `O_NOFOLLOW`/`openat`-style
+  extraction is the direction.
+- **Optional dependencies and external tools** (`pycdlib`, codec packages, the `unrar`
+  binary) are trusted code but *not* trusted to be robust: their failures must surface
+  as translated archivey errors, never silently wrong data.
+
+## What is already enforced (implemented + specced)
+
+- **Path traversal:** `..` components (any separator), absolute paths, drive letters,
+  UNC prefixes, and null bytes are rejected before any write; the destination parent is
+  resolved and containment-checked (`safe-extraction`, `internal/filters.py`).
+- **Symlink escapes, three layers:** lexical target check at planning time; parent-dir
+  resolution; and post-`os.symlink` re-resolution against the real filesystem (catches
+  chained-symlink attacks staged by earlier members). Escaping links are removed and
+  rejected.
+- **Hardlink targets** are containment-checked and resolved positionally (an earlier
+  same-named member), so a crafted duplicate-name archive cannot redirect a link.
+- **Never write through a symlink:** overwrite handling replaces symlinks, never
+  follows them; atomic temp-file + `os.replace` writes mean interrupted extraction
+  never leaves a half-written destination file.
+- **Special files** (devices, FIFOs, sockets) are always rejected; NTFS junctions are
+  detected, flagged, and never traversed.
+- **Decompression bombs at extraction:** cumulative output cap, per-member ratio,
+  archive-wide static ratio, **live** ratio for unknown-size/pipe sources, and an entry
+  count cap — the global guards halt even under `OnError.CONTINUE`.
+- **Permission hygiene:** setuid/setgid/sticky stripped except under `TRUSTED`;
+  ownership applied only under `TRUSTED` as root.
+- **Error honesty:** codec/library exceptions are translated to typed `ArchiveyError`s
+  with context; genuine I/O errors propagate unchanged; no catch-all handlers.
+- **Accelerator lifecycle:** C++-threaded accelerators are close-guarded
+  (`weakref.finalize`) so crafted-input error paths cannot leave aborting threads
+  (see `known-issues.md`).
+
+## OPEN gaps — security
+
+### O1. Listing-time resource exhaustion (metadata bombs)
+
+`max_entries` and the byte/ratio guards protect **extraction only**. `members()` /
+`scan_members()` will happily materialize whatever the header claims: a small ZIP can
+carry hundreds of thousands of central-directory entries (or enormous
+comments/PAX blobs), costing gigabytes of `ArchiveMember` objects at *listing* time —
+before any extraction guard runs. `read()` is likewise documented as unbounded.
+
+*Direction:* listing guards in `ArchiveyConfig` (max member count, max total metadata
+bytes) enforced in `_get_members_registered`/the progressive pass; keep iteration
+(`stream_members`) as the unguarded-by-design escape hatch since it is O(1) in members.
+
+### O2. Case-insensitivity and Unicode-normalization collisions at extraction
+
+Two members whose names differ only by case (`README` / `readme`) or Unicode
+normalization form (NFC vs NFD `café`) are distinct in the archive but the **same file**
+on default Windows/macOS filesystems. Today: under `OverwritePolicy.ERROR` the second
+member fails with a confusing "already exists"; under `REPLACE` it **silently merges**
+— a crafted archive can use this to make content clobber other content on
+case-insensitive systems only (behavior differs by platform: a "surprise" squared).
+
+*Direction:* the coordinator tracks a casefolded+NFC key per written path and treats a
+collision as a first-class event on **all platforms** (deterministic cross-platform
+behavior): apply the `OverwritePolicy` deliberately, record the collision on the
+`ExtractionResult`, and consider a future `OverwritePolicy.RENAME` (extract as
+`name (1)`) for the archives-with-intentional-duplicates case. Needs a
+`safe-extraction` delta.
+
+### O3. Windows name mangling: reserved names, trailing dots/spaces
+
+`CON`, `NUL`, `COM1`… are device names; `foo.` and `foo ` are silently stripped by
+Win32 to `foo` (silent clobber / mismatch between reported and actual path). None of
+this is currently checked; behavior is platform-dependent.
+
+*Direction:* decide per policy — recommendation: `STRICT` rejects Windows-reserved and
+trailing-dot/space names on **every** platform (portability is part of no-surprises);
+`TRUSTED` allows what the local OS allows. `safe-extraction` delta.
+
+### O4. NTFS alternate data streams
+
+A member name containing `:` (`file.txt:hidden`) writes an invisible alternate data
+stream on NTFS. Not currently rejected.
+
+*Direction:* fold into the O3 policy work (reject `:` in names under `STRICT` on all
+platforms; it is never a portable filename character).
+
+### O5. Fuzzing does not exist yet
+
+The safety claims rest on curated tests. Before the native 7z/RAR parsers (which parse
+untrusted binary headers in Python) ship — and before any public "safe" claim:
+
+1. **Now:** property-based tests (Hypothesis) for the pure safety logic
+   (`normalize_member_name`, `check_universal`, `resolve_link_target_name`, volume
+   discovery, detection over arbitrary prefixes); a mutation harness (bit-flips /
+   truncations over the generated corpus) asserting *never crashes, never hangs,
+   always a typed `ArchiveyError` or correct data*.
+2. **Native-reader entry gate:** coverage-guided fuzzing (Atheris) of the 7z/RAR
+   header parsers, seeded from the corpus + adversarial fixtures; nightly short runs
+   in CI.
+3. **At public release:** OSS-Fuzz onboarding; `SECURITY.md` with a disclosure
+   process.
+
+### O6. Nested-archive amplification
+
+Opening archives-inside-archives is supported (and `size` advertisement makes it
+cheap); recursion is caller-driven, so a zip-quine (`droste.zip`) only loops if the
+caller loops. Still worth an explicit documented stance + a recipe for bounded
+recursive processing, since "index my backups" — the founding use case — does exactly
+this.
+
+## OPEN gaps — compatibility
+
+### C1. The RAR decompressor matrix (and unrar licensing)
+
+RAR member data requires an external tool. `unrar` is **non-free** (freeware license);
+`unrar-free` handles little of RAR5; `7z`/`bsdtar` coverage varies by build; `unar`
+exists on macOS. "Maximum compatibility" will otherwise degrade into "works on my
+machine".
+
+*Direction:* decide and **test** a supported decompressor matrix (candidate: prefer
+`unrar`, fall back `7z`, document capabilities per tool), surface which tool was used
+via `MissingComponent`-style data, and document the licensing situation prominently
+(archivey itself stays permissively licensed; the binary is a system dependency).
+Feeds the Phase-6 native-RAR design directly.
+
+### C2. Warnings that should be data
+
+Name normalization, format-detection conflicts, and O(n) rewinds warn via `logging` —
+invisible to most applications, so the "no surprises" property silently degrades to
+"surprises, but logged". Sweep candidates: normalization changes → a flag/field on the
+member (`raw_name` already preserves truth); detection conflicts → already in
+`FormatInfo`; rewind cost → already on `CostReceipt`; audit for the rest. Backlog in
+`IDEAS.md`.
+
+### C3. Metadata fidelity boundary (xattrs/ACLs/forks)
+
+PAX xattrs currently survive only inside `extra["tar.pax_headers"]`; ACLs, macOS
+resource forks, and NTFS ADS are untouched. Read-side promotion to a first-class field
+later is additive/cheap; applying xattrs at extraction is moderate (policy
+interactions); true fidelity only binds when **writing** lands (deferred, possibly
+post-1.0). Decision recorded in `IDEAS.md`; revisit at writing-spec time.
+
+### C4. Free-threaded Python
+
+`3.13t+` makes parallel extraction and parallel pure-Python decode realistic; the
+"one reader per thread" rule and the C++-thread accelerators need a position statement
+before users ask. Backlog.

--- a/openspec/project.md
+++ b/openspec/project.md
@@ -79,10 +79,10 @@ once. Specs themselves remain order-free; this table is the association.
 | 3 | Indexed leaf formats | `format-zip`, `format-tar` (random-access **read** + compressed-tar), `format-single-file-compressors`, `format-iso`, `format-detection`, `backend-registry` (selection/degradation + tri-state availability), `access-mode-and-cost` (CostReceipt values). (`format-directory` already landed in Phase 1.) |
 | 4 | TAR streaming & safe extraction | `format-tar` (forward-only `stream_members`), `safe-extraction` (incl. bomb limits + progress/result), `archive-reading` (sequential + `stream_members`) |
 | 5 | Public API finalization & cost surface | `archive-reading`, `archive-data-model`, `access-mode-and-cost`, `error-handling` |
-| 6 | Writing support | `archive-writing` (+ `format-zip` / `format-tar` writers) |
-| 7 | Native 7z reader + native RAR metadata parser | `format-7z`, `format-rar` (native-first: read path imports no third-party lib; `unrar` binary stays for RAR data; `py7zr` for 7z write only); `testing-contract` oracle cross-validation |
-| 8 | Seekable zstd + blocked gzip (rescoped — the original zst/lz4 *read* goals landed with Phases 2–3; `w:zst` writing moved to Phase 6) | `seekable-decompressor-streams`, `format-single-file-compressors` |
-| 9 | CLI | `cli` |
+| 6 | Native 7z reader + native RAR metadata parser (resequenced 2026-07 ahead of writing — see `VISION.md`; fuzzing is an entry gate) | `format-7z`, `format-rar` (native-first: read path imports no third-party lib; `unrar` binary stays for RAR data; `py7zr` for 7z write only); `testing-contract` oracle cross-validation |
+| 7 | CLI (pulled forward: dev tool + safe-extraction demo) | `cli` |
+| 8 | Seekable zstd + blocked gzip (rescoped — the original zst/lz4 *read* goals landed with Phases 2–3; `w:zst` writing moved to the writing phase) | `seekable-decompressor-streams`, `format-single-file-compressors` |
+| 9 | Writing support (not a 1.0 requirement; spec to cover reproducible output + metadata fidelity first) | `archive-writing` (+ `format-zip` / `format-tar` writers) |
 | 10 | Polish, packaging & oracle retirement | `cli`, `packaging-and-extras` (finalize), full `testing-contract` (corpus complete, frozen DEV oracle deleted) (+ cross-cutting: README, final CI tuning — the matrix is stood up in Phase 1; coverage is reported, **not** gated) |
 
 `logging` is cross-cutting and not owned by a single phase — the named-logger


### PR DESCRIPTION
Docs-only PR recording the outcomes of the high-level review discussion so nothing is lost to the conversation. No code changes.

## New documents

- **`VISION.md`** — the product vision: "default archive library" positioning ("the `requests` of archives"); the two load-bearing claims (*safe by default* and *memory-safe parsing of hostile input* — the latter is the security justification for the native-first 7z/RAR strategy); the founding use case (indexing/deduping messy backups) and the priorities it implies (content-first API, evidence-based detection, never silently re-decompress, damaged input as a first-class citizen, hashes without decompression); the performance budget (≤1.3× stdlib common paths, ~2× when justified; benchmarks must track bytes-decompressed/seeks, not just wall time); quality scaffolding instead of "bug-free" promises; adoption strategy (release when reading is complete incl. native 7z/RAR; CLI as wedge + dev tool; fsspec; migration guide; public backend API); non-goals; and the solo+agents maintenance reality.

- **`docs/threat-model.md`** — explicit trust boundaries, the guarantees already enforced, and the **open gap register** from the review, each with a suggested direction:
  - *Security:* listing-time metadata bombs (guards only cover extraction today); casefold/Unicode-normalization extraction collisions (silent merge under `REPLACE` on Windows/macOS); Windows reserved names / trailing dots+spaces / NTFS alternate data streams; the staged fuzzing program (Hypothesis property tests + corpus mutation harness now → Atheris as the native-reader entry gate → OSS-Fuzz + SECURITY.md at release); nested-archive amplification stance.
  - *Compatibility:* the RAR decompressor matrix + unrar licensing trap; warnings-that-should-be-data; the metadata-fidelity (xattrs/ACLs) boundary; free-threaded Python.

- **`IDEAS.md`** — new "Strategy & adoption" backlog section: salvage/best-effort read mode (a founding-use-case gap — truncated archives currently all-or-error), hashes-without-decompression recipe, benchmarks as a CI gate, public backend API, fsspec adapter, migration guide, warnings-as-data sweep, collision handling + `OverwritePolicy.RENAME`, writing-done-properly-later (reproducible output + metadata fidelity designed in from day one), free-threading, CLI positioning.

## Roadmap resequencing (`PLAN.md`, `openspec/project.md`)

Per the discussion: **native 7z/RAR reading moves before writing** (now Phase 6, with the fuzzing scaffold as an entry gate), the **CLI is pulled forward** (Phase 7 — dev tool + safe-extraction demo), and **writing is explicitly not a 1.0 requirement** (Phase 9, preceded by a spec exploration covering reproducible output and metadata fidelity). New cross-cutting "Fuzzing & benchmarks" scaffold section. Phase sections renumbered with "(was Phase N)" markers; archived changes keep historical numbering.

`README.md` and `CLAUDE.md` link the new documents.

## Checks

Suite still green (817 passed / 9 skipped), `ruff` clean, `openspec validate --all` 26/26 (docs only — no spec deltas; each threat-model open item becomes its own OpenSpec change when tackled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018HzpfVCSd345ukRJusWf6K

---
_Generated by [Claude Code](https://claude.ai/code/session_018HzpfVCSd345ukRJusWf6K)_