### PR TITLE
Specify lifecycle-aware diagnostics and extraction reports

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -25,7 +25,7 @@ are archived to `openspec/changes/archive/`). Phases without a change yet need a
 | 2 | Stream layer (compressed + seekable) | `compressed-streams`, `seekable-decompressor-streams` | `archive/2026-06-21-phase-2-stream-layer` ✓ |
 | 3 | Indexed leaf formats + detection | `format-zip`, `format-tar` (random-access read), `format-single-file-compressors`, `format-iso`, `format-detection`, `backend-registry`, `access-mode-and-cost` | `archive/2026-06-30-phase-3-indexed-leaf-formats` ✓ |
 | 4 | TAR streaming + safe extraction | `format-tar` (forward-only `stream_members`, hardlinks, truncation), `safe-extraction`, `archive-reading` (sequential + `stream_members`), `format-detection` (gzip-wrapped tar regression), `testing-contract` (adversarial + non-seekable `tar.gz`) | `archive/2026-06-30-package-layout-restructure` ✓ → `phase-4-tar-streaming` + `phase-4-safe-extraction` |
-| 5 | Public API finalization & cost | `archive-reading`, `archive-data-model`, `access-mode-and-cost`, `error-handling` | `phase-5-public-api` |
+| 5 | Public API finalization, cost & diagnostics | `archive-reading`, `archive-data-model`, `access-mode-and-cost`, `error-handling`, `diagnostics`, `logging`, `format-detection`, `safe-extraction`, `compressed-streams`, `seekable-decompressor-streams`, `format-directory`, `format-tar`, `format-zip` | `phase-5-public-api` → `diagnostics-warnings-as-data` (specs first; implementation follow-on before Phase 6) |
 | 6 | Native 7z + RAR read (was Phase 7; **fuzzing is an entry gate** — see cross-cutting) | `format-7z`, `format-rar`, `testing-contract` (oracle cross-validation) | — |
 | 7 | CLI (was Phase 9; pulled forward as dev tool + the safe-extraction demo, per `VISION.md`) | `cli` | — |
 | 8 | Seekable zstd + blocked gzip (rescoped; original zst/lz4 read goals landed in Phases 2–3, `w:zst` moved to the writing phase) | `seekable-decompressor-streams`, `format-single-file-compressors` | `seekable-gzip-and-block-writing` (partial) |
@@ -39,6 +39,9 @@ are archived to `openspec/changes/archive/`). Phases without a change yet need a
 
 **In-flight changes unrelated to a PLAN phase** (do not block Phase 4, but may land
 alongside): `seekable-gzip-and-block-writing`, `rapidgzip-truncation-investigation`.
+`diagnostics-warnings-as-data` is explicitly a **Phase 5 public-API follow-on** rather
+than an unsequenced cross-cutting change; its implementation must land before Phase 6
+native readers add more diagnostic-producing paths.
 Recently archived stream-layer / refactor follow-ons: `codec-descriptor-refactor`,
 `compression-library-evaluation`, `zstd-stdlib-backend-migration`.
 
@@ -113,9 +116,9 @@ Foundations (declarative corpus, on-demand generation + content-keyed cache unde
 The 7z/RAR **read** path is native-first, and DEV's `py7zr`/`rarfile` read
 backends are explicitly interim. The clean-slate answer to the open sequencing
 question in `openspec/project.md` is therefore: **do not port them.** 7z and RAR
-reads are marked `xfail`/`skip` until the native readers land in **Phase 7**;
+reads are marked `xfail`/`skip` until the native readers land in **Phase 6**;
 `py7zr`/`rarfile` enter earlier only as `dev`-group oracles. Those formats are
-simply absent from the equivalence matrix until Phase 7.
+simply absent from the equivalence matrix until Phase 6.
 
 ---
 
@@ -170,7 +173,7 @@ All codec/detection-dependent formats stay unwired until Phases 2–3.
    **reduced ~12-job matrix** (vs DEV's ~18): Linux × `{3.11,3.12,3.13,3.14}` ×
    `{core-only, [all]}` (8), plus macOS + Windows on min/max Python with `[all]` (4);
    each job runs ruff + Pyrefly + ty + pytest (coverage report only). uv-cached on
-   `uv.lock`; 7z/RAR read tests `xfail` until Phase 7.
+   `uv.lock`; 7z/RAR read tests `xfail` until Phase 6.
 
 ### Tests added
 Harness self-tests (corpus round-trips through generation+cache); `__version__`
@@ -332,9 +335,11 @@ as a light tripwire, not a hard ban).
 
 ---
 
-## Phase 5 — Public API finalization & cost surface
+## Phase 5 — Public API finalization, cost surface, and diagnostics
 
-**Goal:** the public surface matches `SPEC.md` across every format built so far.
+**Goal:** the public surface matches `SPEC.md` across every format built so far, and
+warning-producing paths use the lifecycle-aware diagnostics contract before native
+7z/RAR readers expand that surface.
 
 **Entry criteria:** Phase 4 green.
 
@@ -357,14 +362,23 @@ as a light tripwire, not a hard ban).
    ambient (contextvars/global) configuration. Also decided there: the password
    candidate-sequence + provider model, multi-source acceptance + path volume-set
    discovery, and the MemberSelector collection semantics.
+5. **Diagnostics follow-on** (specified by `diagnostics-warnings-as-data`) — add the
+   bounded lifecycle collector and exact counts; reader/stream/format/member/result
+   projections; first-class `ExtractionReport`; per-code policy/callback/escalation;
+   typed `DiagnosticRaisedError`; and migrate all 17 current warning calls. Runtime
+   rewind/index/EOF events stay off frozen `CostReceipt` / `ArchiveInfo`. This task is
+   ordered after `phase-5-public-api` and before Phase 6.
 
 ### Tests added
-`archive-data-model`, `access-mode-and-cost`, `error-handling`, and the remaining
-`archive-reading` scenarios; per-format CostReceipt assertions.
+`archive-data-model`, `access-mode-and-cost`, `error-handling`, `diagnostics`, and the
+remaining `archive-reading` scenarios; per-format CostReceipt assertions; policy,
+retention, lifecycle, callback, escalation, and extraction-report coverage for every
+migrated warning path.
 
 ### Acceptance — spec scenarios covered
 All of `archive-reading`, `archive-data-model`, `access-mode-and-cost`,
-`error-handling`.
+`error-handling`, and `diagnostics`, including affected deltas for detection,
+extraction, streams, formats, and logging.
 **Gates:** `pyrefly` + `ty` clean (strict); public API matches `SPEC.md §2–§7`; CostReceipt
 correct for every format implemented so far.
 

--- a/docs/library-analysis.md
+++ b/docs/library-analysis.md
@@ -306,7 +306,7 @@ Python implementation (same author as `pyppmd`/`py7zr`); no real alternative. `[
 ### PPMd (var.H) — `pyppmd`
 
 PPMd variant H (7z) via `pyppmd`. The only maintained Python PPMd binding. `[7z]` bundle.
-(Concrete construction lands with the native 7z reader in Phase 7; the backend selection and
+(Concrete construction lands with the native 7z reader in Phase 6; the backend selection and
 missing-dependency gating are already wired.)
 
 ---

--- a/openspec/changes/diagnostics-warnings-as-data/design.md
+++ b/openspec/changes/diagnostics-warnings-as-data/design.md
@@ -1,0 +1,148 @@
+# Design — diagnostics: warnings as queryable data
+
+This proposal is as much about *how to expose* advisories as *what to record*. The
+maintainer's steer — "how they can be exposed, maybe it will depend on the context" — is
+the organizing principle: there is no single right delivery, so the mechanism offers a few
+and lets the caller's context choose.
+
+## 1. The `Diagnostic` record
+
+```python
+@dataclass(frozen=True)
+class Diagnostic:
+    code: DiagnosticCode        # stable, machine-branchable (enum or str-enum)
+    severity: DiagnosticSeverity  # INFO | WARNING (errors stay exceptions)
+    message: str                # human-readable, formatted once
+    # Typed, optional context — populated per code:
+    member_name: str | None = None       # the member it concerns
+    raw_name: bytes | None = None         # before/after for normalization
+    normalized_name: str | None = None
+    offset: int | None = None             # byte offset, for structural advisories
+    detail: Mapping[str, object] = field(default_factory=dict)  # code-specific extras
+```
+
+The load-bearing field is **`code`**: a small, stable, enumerated set
+(`NAME_NORMALIZED`, `DETECTION_CONFLICT`, `REWIND_COST`, `MEMBER_SKIPPED`,
+`PASSWORD_GUESSED`, `INVALID_TIMESTAMP`, `DIGEST_UNVERIFIABLE`, `SCAN_ENTRY_VANISHED`, …).
+Callers branch on `code`; `message` is for humans only. Stability of `code` is the API
+contract, so codes get the same care as exception classes.
+
+Naming is open: `Diagnostic` (compiler idiom) vs the maintainer's `Occurrence` vs
+`ArchiveWarning`. "Diagnostic" reads well with a severity axis and avoids clashing with
+Python's `warnings`. Flagged as an open question below.
+
+## 2. Exposure is context-dependent — four channels
+
+The same diagnostic can reach the caller four ways. Which one(s) fire is the crux, and it
+depends on *where* the diagnostic arises and *who* is consuming.
+
+### (a) Attached to the most specific natural surface
+Where a diagnostic is *about* one object the caller already holds, it belongs on that
+object — no lookup, no correlation. This is the C2/IDEAS sweep:
+
+| Current `logger.warning` | Diagnostic code | Natural surface |
+|---|---|---|
+| name normalized (`naming.py`) | `NAME_NORMALIZED` | `ArchiveMember` |
+| detection magic vs extension (`detection.py`) | `DETECTION_CONFLICT` | `FormatInfo` / `ArchiveInfo` |
+| backward-seek rewind (`decompressor_stream.py`) | `REWIND_COST` | `CostReceipt` |
+| member/hardlink skipped (`extraction.py`) | `MEMBER_SKIPPED` | `ExtractionResult` |
+| invalid NTFS/DOS timestamp (`zip_reader.py`) | `INVALID_TIMESTAMP` | `ArchiveMember` |
+| digest not checkable (`verify.py`) | `DIGEST_UNVERIFIABLE` | `ArchiveMember` / read result |
+| guessed password (incoming) | `PASSWORD_GUESSED` | `ExtractionResult` / member |
+
+### (b) Aggregated into a per-operation collection
+A field-per-surface alone is not enough: some diagnostics have **no** per-object home
+("a directory vanished during scan", "trailing bytes after EOF"), and callers often want
+one question — *did anything noteworthy happen?* — answered without walking every member.
+So the reader exposes `reader.diagnostics` (everything emitted during this open/read), and
+`extract()` returns its diagnostics alongside the per-member `ExtractionResult`s. The
+per-surface field and the collection are the **same** `Diagnostic` objects, referenced
+twice, not duplicated data.
+
+### (c) Pushed eagerly via a callback
+For a long streaming pass or a large extraction, waiting until the end to inspect a
+collection is wrong — the caller may want to react (or print progress) as diagnostics
+occur. `ArchiveyConfig.on_diagnostic: Callable[[Diagnostic], None] | None` delivers each
+one as it happens. This is also the natural bridge to a caller's own logging/telemetry.
+
+### (d) Escalated to a typed error by policy
+Some contexts want a diagnostic to be **fatal**. A reproducible-build tool wants "a name
+was normalized" or "detection conflicted" to stop the build; a security-sensitive caller
+may want `PASSWORD_GUESSED` to raise rather than proceed on an unconfirmed password. A
+`WarningPolicy` maps codes/severities to a disposition — `IGNORE | COLLECT | RAISE` —
+default `COLLECT` (+ log). `RAISE` turns the diagnostic into a typed exception at the
+point it arises (see §5 for which exception).
+
+### (e) …and logging stays
+Every diagnostic is still logged on its existing `archivey.*` logger, so applications that
+do nothing keep exactly today's behaviour. Logging is the projection, not the source of
+truth.
+
+## 3. Consumer archetypes (why one shape can't win)
+
+- **CLI / interactive** — wants a human summary at the end (channel b), or streaming
+  notices (c); verbosity is the user's.
+- **Batch indexer** (the founding "index my backups" use case) — wants diagnostics
+  recorded *beside each member* as data (a), tolerant, never a crash (policy `COLLECT`).
+- **Reproducible-build / verifier** — wants selected codes to be hard errors (d), so a
+  normalized name or a detection conflict fails CI (policy `RAISE` for a chosen set).
+- **Library embedder / telemetry** — wants the eager callback (c) to forward into its own
+  metrics/log pipeline.
+
+The policy + callback + collection triple lets each pick without the others paying.
+
+## 4. Configuration
+
+```python
+class ArchiveyConfig:
+    on_diagnostic: Callable[[Diagnostic], None] | None = None
+    warning_policy: WarningPolicy = WarningPolicy()   # per-code / per-severity disposition
+```
+
+`WarningPolicy` needs: a default disposition, and per-`code` overrides (e.g.
+`{NAME_NORMALIZED: RAISE}`). Whether it also keys on `severity` or on logger name is an
+open question. Default keeps today's behaviour (COLLECT + log; nothing raises that did not
+already raise).
+
+## 5. Relationship to errors — and the honesty rule
+
+Diagnostics are **non-fatal advisories**; genuine failures remain exceptions (the
+`error-handling` contract is untouched). Escalation (§2d) is the one bridge: a `RAISE`
+disposition converts a diagnostic into an exception *at emission*. Open question: does it
+raise the existing typed exception family (e.g. a normalization escalation → a
+`FilterRejectionError`-like type) or a single new `DiagnosticRaisedError(code=…)`? A single
+wrapper is simpler and keeps the code queryable; per-family raises integrate better with
+existing `except` blocks. Leaning: a single `DiagnosticRaisedError` carrying the
+`Diagnostic`, because the set of escalable codes is open-ended.
+
+This also cleanly answers the `zip-multipassword-disambiguation` residual: "guessed
+password" is a `PASSWORD_GUESSED` diagnostic (default COLLECT + log), and a
+security-sensitive caller sets it to `RAISE` — no bespoke flag needed.
+
+## 6. Aggregation, dedup, volume
+
+"Occurrences" implies counting. A crafted or merely large archive can emit thousands of
+`NAME_NORMALIZED` diagnostics — the collection must not become its own memory bomb (cf.
+threat-model O1). Options: (i) cap the retained collection and expose per-code **counts**
+beyond the cap; (ii) always keep full detail but document the cost; (iii) rely on the
+callback for the unbounded case and keep the collection bounded. Leaning: a bounded
+collection with exact per-code counts (so "127 names normalized, first N retained"), the
+callback being the unbounded firehose. This interacts with the O1 listing-guard work and
+should share its bound.
+
+## 7. Open questions (for maintainer review)
+
+1. **Naming**: `Diagnostic` vs `Occurrence` vs `ArchiveWarning`; `diagnostics` capability
+   name.
+2. **Escalation home**: a single `DiagnosticRaisedError` (leaning) vs per-family raises;
+   and whether escalation belongs in this spec or `error-handling`.
+3. **Aggregation bound**: retained-count cap + per-code counts (leaning) vs unbounded;
+   shared bound with O1.
+4. **`logging` vs stdlib `warnings`**: keep `logging` as the projection (leaning) or also
+   emit `warnings.warn` for a subset? (`warnings` gives `-W error` interop but is noisy.)
+5. **Scope of the first cut**: land the primitive + collection + callback + the
+   normalization/detection/skip/guessed-password codes, and migrate the rest of the ~17
+   sites incrementally — vs sweep all sites at once.
+6. **Per-member field shape**: a list of `Diagnostic` on `ArchiveMember`, or a couple of
+   promoted booleans/fields (`name_normalized: bool`) *plus* the list? Promoted fields are
+   ergonomic for the common check; the list is complete.

--- a/openspec/changes/diagnostics-warnings-as-data/design.md
+++ b/openspec/changes/diagnostics-warnings-as-data/design.md
@@ -1,148 +1,375 @@
-# Design — diagnostics: warnings as queryable data
+# Design — lifecycle-aware diagnostics
 
-This proposal is as much about *how to expose* advisories as *what to record*. The
-maintainer's steer — "how they can be exposed, maybe it will depend on the context" — is
-the organizing principle: there is no single right delivery, so the mechanism offers a few
-and lets the caller's context choose.
+## 1. Goals and constraints
 
-## 1. The `Diagnostic` record
+Diagnostics are structured records for events where Archivey continues or deliberately
+degrades. They are not replacements for genuine failures. The design must:
+
+1. make every current warning machine-queryable;
+2. put each event on a surface whose lifetime can actually contain it;
+3. preserve exact counts without allowing retained details or attachments to become a
+   memory-amplification vector;
+4. support tolerant, streaming, logging-only, and strict callers with one deterministic
+   policy;
+5. remain JSON-safe and avoid secret leakage; and
+6. keep the public surface small enough to support for the long term.
+
+Pre-1.0 compatibility does not constrain the result. In particular, extraction changes
+return type instead of adding a parallel helper or tuple mode.
+
+## 2. Public values
+
+The exact module layout is an implementation detail; these are the public shapes:
 
 ```python
+class DiagnosticCode(str, Enum): ...
+class DiagnosticSeverity(str, Enum):
+    WARNING = "warning"
+
+class DiagnosticDisposition(str, Enum):
+    IGNORE = "ignore"
+    COLLECT = "collect"
+    RAISE = "raise"
+
 @dataclass(frozen=True)
 class Diagnostic:
-    code: DiagnosticCode        # stable, machine-branchable (enum or str-enum)
-    severity: DiagnosticSeverity  # INFO | WARNING (errors stay exceptions)
-    message: str                # human-readable, formatted once
-    # Typed, optional context — populated per code:
-    member_name: str | None = None       # the member it concerns
-    raw_name: bytes | None = None         # before/after for normalization
-    normalized_name: str | None = None
-    offset: int | None = None             # byte offset, for structural advisories
-    detail: Mapping[str, object] = field(default_factory=dict)  # code-specific extras
+    occurrence_id: str
+    code: DiagnosticCode
+    severity: DiagnosticSeverity
+    message: str
+    context: DiagnosticContext
+
+@dataclass(frozen=True)
+class DiagnosticSummary:
+    total_count: int
+    counts: Mapping[DiagnosticCode, int]
+    retained: tuple[Diagnostic, ...]
+    dropped_count: int
+
+@dataclass(frozen=True)
+class DiagnosticPolicy:
+    default: DiagnosticDisposition = DiagnosticDisposition.COLLECT
+    overrides: Mapping[DiagnosticCode, DiagnosticDisposition] = immutable_mapping()
+
+@dataclass(frozen=True)
+class ExtractionReport:
+    results: tuple[ExtractionResult, ...]
+    diagnostics: DiagnosticSummary
 ```
 
-The load-bearing field is **`code`**: a small, stable, enumerated set
-(`NAME_NORMALIZED`, `DETECTION_CONFLICT`, `REWIND_COST`, `MEMBER_SKIPPED`,
-`PASSWORD_GUESSED`, `INVALID_TIMESTAMP`, `DIGEST_UNVERIFIABLE`, `SCAN_ENTRY_VANISHED`, …).
-Callers branch on `code`; `message` is for humans only. Stability of `code` is the API
-contract, so codes get the same care as exception classes.
+`DiagnosticCode`, `severity`, and every context discriminator are string enums so the
+diagnostic serializes without a custom enum encoder. `DiagnosticSummary.counts` and policy
+overrides are immutable mappings. Their constructors defensively copy caller mappings;
+freezing only an outer dataclass while retaining a mutable dict is not sufficient.
 
-Naming is open: `Diagnostic` (compiler idiom) vs the maintainer's `Occurrence` vs
-`ArchiveWarning`. "Diagnostic" reads well with a severity axis and avoids clashing with
-Python's `warnings`. Flagged as an open question below.
+Only `WARNING` is needed initially. The severity axis remains in the record so a later
+informational taxonomy does not require changing the value shape, but policy matching is
+per code only in this proposal.
 
-## 2. Exposure is context-dependent — four channels
+### Typed, JSON-safe context
 
-The same diagnostic can reach the caller four ways. Which one(s) fire is the crux, and it
-depends on *where* the diagnostic arises and *who* is consuming.
+`Diagnostic.context` is a closed union of code-specific frozen context dataclasses, not a
+`Mapping[str, object]`. Every variant has a literal string `kind` discriminator. This is
+the complete initial code-to-context mapping:
 
-### (a) Attached to the most specific natural surface
-Where a diagnostic is *about* one object the caller already holds, it belongs on that
-object — no lookup, no correlation. This is the C2/IDEAS sweep:
+| `DiagnosticCode` | Required context variant and fields |
+|---|---|
+| `MEMBER_NAME_NORMALIZED` | `NameNormalizationContext(kind="name_normalization", archive_name: str \| None, member_name: str, member_id: int \| None, raw_name_base64: str \| None, presented_name: str, normalized_name: str)` |
+| `FORMAT_EXTENSION_CONFLICT` | `FormatConflictContext(kind="format_conflict", source_name: str \| None, extension: str \| None, extension_format: str, detected_format: str)` |
+| `SCAN_DIRECTORY_VANISHED` | `ScanRaceContext(kind="scan_race", archive_name: str \| None, relative_path: str, entry_kind="directory")` |
+| `SCAN_ENTRY_VANISHED` | `ScanRaceContext(kind="scan_race", archive_name: str \| None, relative_path: str, entry_kind="entry")` |
+| `ARCHIVE_EOF_MARKER_MISSING` | `ArchiveEofContext(kind="archive_eof", archive_name: str \| None, format: str, expected_marker: str, expected_bytes: int, observed_bytes: int, observed_kind: str)` |
+| `MEMBER_TIMESTAMP_INVALID` | `MemberTimestampContext(kind="member_timestamp", archive_name: str \| None, member_name: str, member_id: int \| None, field: str, source: str, value_repr: str)` |
+| `SYMLINK_TARGET_UNAVAILABLE` | `SymlinkTargetContext(kind="symlink_target", archive_name: str \| None, member_name: str, member_id: int \| None, reason: str)` |
+| `DIGEST_UNVERIFIABLE` | `DigestContext(kind="digest", archive_name: str \| None, member_name: str, member_id: int \| None, algorithm: str, reason: str)` |
+| `SEEK_INDEX_DEGRADED` | `SeekIndexContext(kind="seek_index", archive_name: str \| None, member_name: str \| None, member_id: int \| None, codec: str, scan: str, error_type: str)` |
+| `STREAM_REWIND_REDECOMPRESSES` | `StreamRewindContext(kind="stream_rewind", archive_name: str \| None, member_name: str \| None, member_id: int \| None, codec: str, from_offset: int, to_offset: int, accelerator: str \| None)` |
+| `EXTRACTION_MEMBER_REJECTED` | `ExtractionOutcomeContext(kind="extraction_outcome", archive_name: str \| None, member_name: str, member_id: int \| None, status="rejected", error_type: str, failure_group_id: str \| None, failure_group_size: int \| None)` |
+| `EXTRACTION_MEMBER_FAILED` | `ExtractionOutcomeContext(kind="extraction_outcome", archive_name: str \| None, member_name: str, member_id: int \| None, status="failed", error_type: str, failure_group_id: str \| None, failure_group_size: int \| None)` |
 
-| Current `logger.warning` | Diagnostic code | Natural surface |
-|---|---|---|
-| name normalized (`naming.py`) | `NAME_NORMALIZED` | `ArchiveMember` |
-| detection magic vs extension (`detection.py`) | `DETECTION_CONFLICT` | `FormatInfo` / `ArchiveInfo` |
-| backward-seek rewind (`decompressor_stream.py`) | `REWIND_COST` | `CostReceipt` |
-| member/hardlink skipped (`extraction.py`) | `MEMBER_SKIPPED` | `ExtractionResult` |
-| invalid NTFS/DOS timestamp (`zip_reader.py`) | `INVALID_TIMESTAMP` | `ArchiveMember` |
-| digest not checkable (`verify.py`) | `DIGEST_UNVERIFIABLE` | `ArchiveMember` / read result |
-| guessed password (incoming) | `PASSWORD_GUESSED` | `ExtractionResult` / member |
+Accordingly, the closed alias is
+`DiagnosticContext = NameNormalizationContext | FormatConflictContext |
+ScanRaceContext | ArchiveEofContext | MemberTimestampContext |
+SymlinkTargetContext | DigestContext | SeekIndexContext | StreamRewindContext |
+ExtractionOutcomeContext`; backends cannot supply ad-hoc mapping variants.
 
-### (b) Aggregated into a per-operation collection
-A field-per-surface alone is not enough: some diagnostics have **no** per-object home
-("a directory vanished during scan", "trailing bytes after EOF"), and callers often want
-one question — *did anything noteworthy happen?* — answered without walking every member.
-So the reader exposes `reader.diagnostics` (everything emitted during this open/read), and
-`extract()` returns its diagnostics alongside the per-member `ExtractionResult`s. The
-per-surface field and the collection are the **same** `Diagnostic` objects, referenced
-twice, not duplicated data.
+`observed_kind` is a documented string enum with initial values `"absent"`,
+`"short"`, and `"nonzero"`; `expected_marker` is a non-secret symbolic description
+such as `"two_zero_blocks"`, never raw archive bytes. `source`, `scan`, `reason`, and
+`error_type` similarly use documented non-secret string-enum/public-class-name values.
+`member_id` is `None` only when emission necessarily precedes member registration.
+`failure_group_id` and `failure_group_size` are both non-`None` only for results that
+failed from one shared hardlink-source incident.
 
-### (c) Pushed eagerly via a callback
-For a long streaming pass or a large extraction, waiting until the end to inspect a
-collection is wrong — the caller may want to react (or print progress) as diagnostics
-occur. `ArchiveyConfig.on_diagnostic: Callable[[Diagnostic], None] | None` delivers each
-one as it happens. This is also the natural bridge to a caller's own logging/telemetry.
+Every field is composed recursively only of `None`, `bool`, `int`, finite `float`, `str`,
+and tuples of those values. Raw bytes use an explicitly named base64 string field when
+lossless bytes are necessary. Exception objects, paths, arbitrary mappings, archive/member
+objects, callbacks, and backend handles are prohibited. Each context and the containing
+diagnostic provide a deterministic `to_dict()` whose result can be passed directly to
+`json.dumps()`.
 
-### (d) Escalated to a typed error by policy
-Some contexts want a diagnostic to be **fatal**. A reproducible-build tool wants "a name
-was normalized" or "detection conflicted" to stop the build; a security-sensitive caller
-may want `PASSWORD_GUESSED` to raise rather than proceed on an unconfirmed password. A
-`WarningPolicy` maps codes/severities to a disposition — `IGNORE | COLLECT | RAISE` —
-default `COLLECT` (+ log). `RAISE` turns the diagnostic into a typed exception at the
-point it arises (see §5 for which exception).
+Messages and contexts MUST NOT include passwords, password candidates, values returned by
+a `PasswordProvider`, encryption/decryption keys, key derivation material, or decrypted
+header/payload bytes. A reason such as `"password_required"` and non-secret facts such as
+an encrypted member's name are allowed. The same prohibition applies to the log projection
+and `DiagnosticRaisedError`.
 
-### (e) …and logging stays
-Every diagnostic is still logged on its existing `archivey.*` logger, so applications that
-do nothing keep exactly today's behaviour. Logging is the projection, not the source of
-truth.
+### Occurrence correlation, not identity
 
-## 3. Consumer archetypes (why one shape can't win)
+`occurrence_id` is opaque and unique for an emitted occurrence within the process. Copies
+of a diagnostic retained in a summary and on an object compare by value and carry the same
+id. The API promises neither `is` identity nor a stable id across runs. Ordering comes from
+the tuple order in each summary, not from parsing occurrence ids.
 
-- **CLI / interactive** — wants a human summary at the end (channel b), or streaming
-  notices (c); verbosity is the user's.
-- **Batch indexer** (the founding "index my backups" use case) — wants diagnostics
-  recorded *beside each member* as data (a), tolerant, never a crash (policy `COLLECT`).
-- **Reproducible-build / verifier** — wants selected codes to be hard errors (d), so a
-  normalized name or a detection conflict fails CI (policy `RAISE` for a chosen set).
-- **Library embedder / telemetry** — wants the eager callback (c) to forward into its own
-  metrics/log pipeline.
+## 3. Lifecycles and surfaces
 
-The policy + callback + collection triple lets each pick without the others paying.
+### Detection
 
-## 4. Configuration
+A standalone `detect_format()` call has one finite operation scope.
+`FormatInfo.diagnostics` is its final `DiagnosticSummary`. A magic/extension conflict
+attaches there; `ArchiveInfo` does not duplicate it.
 
-```python
-class ArchiveyConfig:
-    on_diagnostic: Callable[[Diagnostic], None] | None = None
-    warning_policy: WarningPolicy = WarningPolicy()   # per-code / per-severity disposition
-```
+`open_archive()` creates the prospective reader collector and its retention budget
+**before** automatic detection, records a detection watermark, and passes that collector
+into the internal detection routine. Successful backend construction transfers ownership
+of the same collector to the reader. It does not seed, copy, merge, or replay diagnostics
+into a second collector: detection and reader views address the same exact counters and
+retained occurrence slots, and each occurrence consumes the budget once. The internal
+`FormatInfo` has the point-in-time detection summary needed for backend selection; because
+`open_archive()` does not return it, the library does not retain that snapshot after
+handoff. If detection or open raises, the temporary collector is discarded after the
+exception propagates.
 
-`WarningPolicy` needs: a default disposition, and per-`code` overrides (e.g.
-`{NAME_NORMALIZED: RAISE}`). Whether it also keys on `severity` or on logger name is an
-open question. Default keeps today's behaviour (COLLECT + log; nothing raises that did not
-already raise).
+An explicit `format=` override still creates the prospective reader collector before
+backend open, but performs no detection and therefore creates no detection diagnostics.
 
-## 5. Relationship to errors — and the honesty rule
+### Reader and reader-owned streams
 
-Diagnostics are **non-fatal advisories**; genuine failures remain exceptions (the
-`error-handling` contract is untouched). Escalation (§2d) is the one bridge: a `RAISE`
-disposition converts a diagnostic into an exception *at emission*. Open question: does it
-raise the existing typed exception family (e.g. a normalization escalation → a
-`FilterRejectionError`-like type) or a single new `DiagnosticRaisedError(code=…)`? A single
-wrapper is simpler and keeps the code queryable; per-family raises integrate better with
-existing `except` blocks. Leaning: a single `DiagnosticRaisedError` carrying the
-`Diagnostic`, because the set of escalable codes is open-ended.
+Each `ArchiveReader` owns one collector from successful creation until close.
+`reader.diagnostics` returns a fresh immutable cumulative snapshot on every access:
 
-This also cleanly answers the `zip-multipassword-disambiguation` residual: "guessed
-password" is a `PASSWORD_GUESSED` diagnostic (default COLLECT + log), and a
-security-sensitive caller sets it to `RAISE` — no bespoke flag needed.
+- counts include every diagnostic emitted by detection/open/list/read/stream/extract work
+  owned by that reader, including events no longer retained;
+- retained occurrences are in emission order; and
+- a previously returned snapshot never changes.
 
-## 6. Aggregation, dedup, volume
+A reader-owned `ArchiveStream` exposes `stream.diagnostics`, an operation-filtered
+snapshot over that same collector. The collector stores one aggregate occurrence; the two
+views do not create separately retained copies. A standalone codec stream owns an
+equivalent stream-lifetime collector.
 
-"Occurrences" implies counting. A crafted or merely large archive can emit thousands of
-`NAME_NORMALIZED` diagnostics — the collection must not become its own memory bomb (cf.
-threat-model O1). Options: (i) cap the retained collection and expose per-code **counts**
-beyond the cap; (ii) always keep full detail but document the cost; (iii) rely on the
-callback for the unbounded case and keep the collection bounded. Leaning: a bounded
-collection with exact per-code counts (so "127 names normalized, first N retained"), the
-callback being the unbounded firehose. This interacts with the O1 listing-guard work and
-should share its bound.
+Runtime events belong here. A slow rewind, failed optional seek-index scan, directory scan
+race, and missing/trailing archive EOF event may happen long after open, so none is added
+to frozen `CostReceipt` or `ArchiveInfo`. Those values continue to describe static
+open-time properties only.
 
-## 7. Open questions (for maintainer review)
+### Member and extraction attachment
 
-1. **Naming**: `Diagnostic` vs `Occurrence` vs `ArchiveWarning`; `diagnostics` capability
-   name.
-2. **Escalation home**: a single `DiagnosticRaisedError` (leaning) vs per-family raises;
-   and whether escalation belongs in this spec or `error-handling`.
-3. **Aggregation bound**: retained-count cap + per-code counts (leaning) vs unbounded;
-   shared bound with O1.
-4. **`logging` vs stdlib `warnings`**: keep `logging` as the projection (leaning) or also
-   emit `warnings.warn` for a subset? (`warnings` gives `-W error` interop but is noisy.)
-5. **Scope of the first cut**: land the primitive + collection + callback + the
-   normalization/detection/skip/guessed-password codes, and migrate the rest of the ~17
-   sites incrementally — vs sweep all sites at once.
-6. **Per-member field shape**: a list of `Diagnostic` on `ArchiveMember`, or a couple of
-   promoted booleans/fields (`name_normalized: bool`) *plus* the list? Promoted fields are
-   ergonomic for the common check; the list is complete.
+Only an occurrence that is natural metadata about one concrete member is eligible for
+object attachment:
+
+- normalization, invalid timestamp, unavailable symlink target, or unverifiable digest
+  may attach to `ArchiveMember.diagnostics`;
+- format conflict attaches to `FormatInfo.diagnostics`.
+
+Extraction rejection/failure already has structured `ExtractionResult.status` and
+`.error`; duplicating it on a result diagnostics tuple would make that per-result API
+budget-dependent without adding information, so `ExtractionResult` has no diagnostics
+field. Extraction occurrences are retained only in the report/reader aggregate. Scan,
+seek-index, rewind, and archive EOF occurrences are also aggregate-only. Member
+attachments are read-only tuples on the otherwise live mutable member. A member's
+`.replace()` copies its currently attached tuple by value; copies made by callers are
+caller-owned and do not consume more library retention budget.
+
+### Extraction scopes
+
+`ArchiveReader.extract_all()` records a collector watermark before extraction and returns
+an `ExtractionReport` whose summary is the exact count/retained delta for that call. It
+does not include older reader occurrences; those remain visible through
+`reader.diagnostics`.
+
+Top-level `archivey.extract()` creates one operation collector and one report watermark
+before detection. It passes that collector through internal detection, backend open, and
+extraction; the temporary reader assumes ownership during the call, and extraction uses
+the original top-level watermark rather than creating a separate report collector.
+Consequently its report includes detection, open, read, and extraction diagnostics caused
+by the call with one counter set, one occurrence order, and one retention budget. No
+phase copies or re-retains an occurrence.
+
+At successful return, the report receives a bounded point-in-time summary and the
+temporary reader is closed; the returned values are caller-owned. If extraction halts by
+exception, no report is returned. On a caller-owned reader, the cumulative reader snapshot
+still exposes occurrences emitted before the halt; `DiagnosticRaisedError` also carries
+the escalated diagnostic.
+
+`ExtractionReport` is frozen and contains an immutable result tuple and immutable
+diagnostic snapshot. Each `ExtractionResult` is also frozen, so its `path`, `status`, and
+`error` reference cannot be replaced after return. This is **not** a deep-frozen archive
+snapshot: `ExtractionResult.member` refers to the original mutable, caller-read-only
+`ArchiveMember`, whose documented late-bound metadata and member diagnostics may still be
+filled in place. The report promises a point-in-time diagnostic summary and fixed outcome
+structure, not frozen member metadata or exception internals.
+
+## 4. One shared retention budget
+
+`ArchiveyConfig.max_retained_diagnostic_references` is a non-negative integer (default
+256). A standalone detection, reader lifetime, top-level extraction operation, or
+standalone stream owns one budget. The budget limits **all diagnostic references retained
+by the library for that collector**:
+
+1. each occurrence stored in the aggregate retained tuple consumes one slot; and
+2. each eligible `ArchiveMember` attachment consumes one additional slot.
+
+On emission, the collector allocates in a fixed order: aggregate slot first, then the one
+most-specific eligible attachment. An attachment is made only when the aggregate
+occurrence was retained. If insufficient slots remain, detail/attachment is omitted.
+Thus a member-specific occurrence normally uses two slots, while an aggregate-only event
+uses one. No extraction occurrence attaches to a result.
+
+Exact `total_count` and per-code counts increment for every event even after the budget is
+exhausted and even under `IGNORE`. They are integer counters, not retained references.
+`dropped_count == total_count - len(retained)` counts aggregate details not retained; it
+does not count omitted attachment slots.
+
+Snapshots contain at most the configured number of aggregate details and are not cached.
+A caller may retain snapshots or make member copies; that memory is caller-owned and
+outside the library's retention guarantee.
+
+Collector watermarks are opaque internal sequence/counter positions. Creating a watermark
+does not copy diagnostics or consume retention slots. A summary for a watermark range
+computes exact count deltas and filters the collector's already-retained tuple by
+occurrence sequence; the snapshot does not cause the library to re-retain occurrences.
+
+## 5. Policy and emission order
+
+The default disposition is `COLLECT`. Per-code overrides are the only matching dimension.
+The complete matrix is:
+
+| Disposition | Exact counts | Aggregate detail | Eligible attachment | WARNING log | Callback | Exception |
+|---|---:|---:|---:|---:|---:|---|
+| `IGNORE` | yes | no | no | no | no | none |
+| `COLLECT` | yes | budget permitting | budget permitting | yes | yes, if configured | none |
+| `RAISE` | yes | budget permitting | budget permitting | yes | yes, if configured | `DiagnosticRaisedError` |
+
+For each event the emitter performs these steps:
+
+1. validate the code, severity, message, and typed secret-free context payload;
+2. resolve disposition;
+3. under the collector's internal lock, allocate the occurrence id, construct the
+   immutable diagnostic, increment the one collector's exact counters, and reserve
+   aggregate/attachment slots in emission order;
+4. release the lock;
+5. for `COLLECT`/`RAISE`, emit the WARNING log projection;
+6. for `COLLECT`/`RAISE`, invoke `on_diagnostic(diagnostic)` on the calling thread; and
+7. for `RAISE`, if the callback returned normally, raise
+   `DiagnosticRaisedError(diagnostic)`.
+
+Logging handlers and callbacks are application code. Neither is invoked while an internal
+collector, reader, stream, backend, or registry lock is held. State is updated before
+either, so a callback may read `reader.diagnostics` and observe the current occurrence.
+Callbacks are synchronous and receive events in emission order.
+
+If logging itself raises because an application installed a failing handler, normal
+Python logging semantics apply: that exception propagates and the callback/escalation
+steps do not run. If `on_diagnostic` raises, its exception propagates unchanged; it is not
+wrapped, not converted into an extraction result, and is not governed by
+`OnError.CONTINUE`. The occurrence has already been counted/retained/logged. Under
+`RAISE`, the callback exception takes precedence over `DiagnosticRaisedError`, but the
+operation still halts.
+
+The callback may inspect immutable arguments and read snapshot properties. It MUST NOT
+drive another operation on the same reader/stream while that operation is emitting.
+Archivey detects same-emitter operational reentrancy and raises
+`UnsupportedOperationError` rather than deadlocking or recursively corrupting ordering.
+Using another reader is allowed. Snapshot access itself is explicitly non-reentrant and
+allowed.
+
+## 6. Escalation and specialized strictness
+
+`DiagnosticRaisedError` is a direct `ArchiveyError` subtype carrying a required
+`diagnostic: Diagnostic`. Standard format/archive/member context stamping still applies.
+It wraps no underlying exception merely because a diagnostic was escalated.
+
+It is an always-stop control exception. Extraction MUST NOT catch it as a per-member
+failure under `OnError.CONTINUE`, and it never becomes `FAILED` or `REJECTED`.
+
+`ArchiveyConfig.strict_archive_eof` remains the specialized contract for a missing archive
+EOF marker. The event is counted and processed under the matrix first. If
+`strict_archive_eof=True`, `TruncatedError` takes precedence over a `RAISE` disposition:
+
+- `IGNORE` counts then raises `TruncatedError`;
+- `COLLECT` counts/retains/logs/calls back then raises `TruncatedError`; and
+- `RAISE` does the same delivery but raises `TruncatedError`, not
+  `DiagnosticRaisedError`.
+
+A logging/callback exception still propagates at its ordered step before either terminal
+error. With `strict_archive_eof=False`, the ordinary policy applies, so `RAISE` yields
+`DiagnosticRaisedError`.
+
+## 7. Extraction result semantics
+
+`ExtractionReport.results` contains one result for every selected member processed by a
+successfully completed extraction operation. This includes a member rejected by
+universal/policy safety checks before the user filter runs:
+
+| Status | Meaning | `path` | `error` |
+|---|---|---|---|
+| `EXTRACTED` | destination entry successfully created | created path | `None` |
+| `SKIPPED` | intentionally not written: user filter returned `None` or `OverwritePolicy.SKIP` found an existing destination | `None` | `None` |
+| `REJECTED` | a `FilterRejectionError` blocked the member under `OnError.CONTINUE` | `None` | that error |
+| `FAILED` | another per-member `ArchiveyError` or allowed filesystem `OSError` failed under `OnError.CONTINUE` | `None` | that error |
+
+Selector-excluded members are outside the operation and have no result. `SKIPPED` is not a
+failure and does not itself create a diagnostic. Under `OnError.STOP`, a rejection or
+failure raises immediately, so no report is returned. Under `CONTINUE`, rejection/failure
+occurrences follow diagnostic policy: default `COLLECT` logs and records them; `IGNORE`
+still produces the correct result and count but no detail/log/callback; `RAISE` halts
+instead of returning that result as recoverable.
+
+The count unit for `EXTRACTION_MEMBER_REJECTED` and `EXTRACTION_MEMBER_FAILED` is one
+continued `ExtractionResult` with the corresponding status, not one root-cause incident
+or one warning call site. Therefore exact per-code counts equal the number of returned
+`REJECTED`/`FAILED` results under `IGNORE` or `COLLECT`. If one failed hardlink source
+causes `N` hardlink results to fail and disposition permits continuation (`IGNORE` or
+`COLLECT`), the coordinator emits `N` ordered `EXTRACTION_MEMBER_FAILED` occurrences.
+Their contexts carry the same opaque `failure_group_id` and `failure_group_size=N`, while
+each occurrence names its own failed result member. Under `RAISE`, the first occurrence in
+result order is counted/delivered and escalates immediately, so no completed report or
+promise of `N` emitted occurrences exists. This preserves per-result counting without
+retaining exception objects.
+
+## 8. Initial taxonomy: all 17 current warning calls
+
+Multiple call sites may intentionally share a code when their machine meaning is the same;
+typed context supplies the variant.
+
+| # | Current site | Stable code | Context / attachment |
+|---:|---|---|---|
+| 1 | `internal/streams/xz.py`: per-stream backward index scan failed | `SEEK_INDEX_DEGRADED` | codec=`xz`, scan=`per_stream`; stream/reader aggregate |
+| 2 | `internal/streams/verify.py`: digest algorithm unavailable | `DIGEST_UNVERIFIABLE` | algorithm + member; member eligible |
+| 3 | `internal/naming.py`: presented name normalized | `MEMBER_NAME_NORMALIZED` | stored/decoded + normalized name; member eligible |
+| 4 | `internal/streams/decompressor_stream.py`: backward index/trailer scan failed | `SEEK_INDEX_DEGRADED` | codec + scan kind + public error type; stream/reader aggregate |
+| 5 | `internal/streams/archive_stream.py`: rewind without available accelerator | `STREAM_REWIND_REDECOMPRESSES` | codec + offsets + accelerator; stream/reader aggregate |
+| 6 | `internal/streams/archive_stream.py`: rewind for codec with no index | `STREAM_REWIND_REDECOMPRESSES` | codec + offsets, accelerator=`None`; stream/reader aggregate |
+| 7 | `internal/extraction.py`: continued member rejection/failure | `EXTRACTION_MEMBER_REJECTED` or `EXTRACTION_MEMBER_FAILED` | one aggregate occurrence per corresponding result |
+| 8 | `internal/extraction.py`: orphaned hardlink source failed | `EXTRACTION_MEMBER_FAILED` | one occurrence per failed hardlink result; shared failure-group fields correlate them |
+| 9 | `internal/extraction.py`: individual hardlink failed | `EXTRACTION_MEMBER_FAILED` | one aggregate occurrence for that failed result |
+| 10 | `internal/backends/directory_reader.py`: directory vanished during scan | `SCAN_DIRECTORY_VANISHED` | relative directory; reader aggregate |
+| 11 | `internal/backends/directory_reader.py`: entry vanished during scan | `SCAN_ENTRY_VANISHED` | relative entry; reader aggregate |
+| 12 | `internal/backends/tar_reader.py`: missing/invalid TAR EOF marker | `ARCHIVE_EOF_MARKER_MISSING` | expected marker + observed length/type; reader aggregate |
+| 13 | `internal/backends/tar_reader.py`: invalid TAR mtime | `MEMBER_TIMESTAMP_INVALID` | member + field/source/value representation; member eligible |
+| 14 | `internal/backends/zip_reader.py`: invalid NTFS FILETIME | `MEMBER_TIMESTAMP_INVALID` | member + NTFS field + value; member eligible |
+| 15 | `internal/backends/zip_reader.py`: invalid ZIP DOS `date_time` | `MEMBER_TIMESTAMP_INVALID` | member + DOS field + value; member eligible |
+| 16 | `internal/backends/zip_reader.py`: encrypted symlink target unavailable | `SYMLINK_TARGET_UNAVAILABLE` | member + reason=`password_required`; member eligible |
+| 17 | `internal/detection.py`: extension conflicts with content | `FORMAT_EXTENSION_CONFLICT` | source + suggested/detected format; `FormatInfo` |
+
+The migration preserves the logger hierarchy and severity, but logging strings are the
+human projection of these records rather than a separate compatibility contract.
+
+## 9. Sequencing
+
+This capability changes the public reader, member, stream, extraction, config, and error
+surfaces. It is therefore a Phase 5 public-API follow-on and must land before Phase 6
+native 7z/RAR readers, whose parsers would otherwise introduce new raw warning paths that
+immediately need migration. The specs in this proposal land first; implementation follows
+only when the 11 tasks are explicitly started.

--- a/openspec/changes/diagnostics-warnings-as-data/proposal.md
+++ b/openspec/changes/diagnostics-warnings-as-data/proposal.md
@@ -1,76 +1,98 @@
-# Diagnostics: warnings as queryable data
+# Diagnostics: warnings as lifecycle-aware data
 
 ## Why
 
-Archivey's headline promise is **no surprises**. Today that promise quietly degrades to
-"no surprises — but logged", because every advisory the library produces is a
-`logging.warning` and nothing else. There are ~17 such sites: a member name was
-normalized (its meaning changed vs `raw_name`), format detection's magic disagreed with
-the extension, a backward seek forced an O(n) rewind, an extracted member was skipped, an
-NTFS/DOS timestamp was invalid, an expected digest could not be checked, a directory
-vanished mid-scan — and, incoming, "the password for this member was **guessed**"
-(`zip-multipassword-disambiguation`). Most applications never configure the `archivey`
-logger, so all of this is invisible: the data that would let a caller *act* (re-name the
-file, reject the archive, warn the user, record provenance) is thrown away after
-formatting a log string.
+Archivey's "no surprises" contract requires recoverable degradation and advisory events to
+be queryable, not only formatted through Python logging. The current implementation has 17
+`logger.warning` call sites covering changed names, detection conflicts, degraded seek
+indexes, expensive rewinds, unverifiable digests, invalid metadata, directory-scan races,
+TAR EOF problems, unavailable encrypted symlink targets, and continued extraction
+failures. Logging alone discards the structure callers need for indexing, auditing, user
+messages, and strict automation.
 
-The threat model records this as gap **C2 ("warnings that should be data")** and
-`IDEAS.md` sketches the sweep: each `logger.warning` should *also* be queryable as data
-on the natural result object (`ArchiveMember`, `FormatInfo`/`ArchiveInfo`, `CostReceipt`,
-`ExtractionResult`). But a field-per-surface sweep alone is fragmented and under-answers
-the real question the maintainer raised: **how should these be exposed — and does the
-right exposure depend on the context?** It does. A CLI wants to print them at the end; a
-long streaming pass wants them as they happen; a batch indexer wants them recorded beside
-each member and never wants a crash; a reproducible-build tool wants *some* of them to be
-hard **errors**. One delivery shape cannot serve all four.
+The first proposal attached diagnostics to static objects without accounting for when an
+event can occur. That would put runtime rewind and EOF events on frozen open-time
+`CostReceipt` / `ArchiveInfo` values, return extraction diagnostics "alongside" a list
+without defining an API, and bound only one aggregate while per-member attachments could
+still retain unbounded references. Pre-1.0 compatibility is not a constraint, so this
+revision chooses one coherent long-term contract instead of preserving those shapes.
 
-This change designs a single **diagnostic** primitive with **context-appropriate
-exposure**: attached to the most specific natural surface, aggregated into a queryable
-per-operation collection, delivered eagerly via an optional callback, and escalable to a
-typed error by policy — with `logging` unchanged as the zero-config default so nothing
-breaks. **Specs only — no code lands here.**
+This remains a **specifications-only proposal**. Its implementation tasks are not part of
+this change.
 
 ## What Changes
 
-- **New capability `diagnostics`.** A stable `Diagnostic` record — a machine-stable
-  `code`, a `severity`, a human `message`, and typed `context` (references to the member /
-  archive / offset it concerns, and the before/after values where relevant, e.g.
-  `raw_name` → `name`). Codes are enumerated and stable so callers can branch on them.
-
-- **Context-appropriate exposure (the crux).** Every diagnostic is delivered through as
-  many of these as fit its context, driven by config, not hard-coded:
-  1. **Attached to its natural surface** — normalization → a field on `ArchiveMember`;
-     detection conflict → `FormatInfo`/`ArchiveInfo`; rewind → `CostReceipt`;
-     skip/guessed-password → `ExtractionResult`.
-  2. **Aggregated** into a per-operation collection queryable from the reader
-     (`reader.diagnostics`) and the operation result (`extract()`), so diagnostics with no
-     natural per-object home (a directory vanished mid-scan) are still reachable, and so a
-     caller can ask "did anything happen?" once.
-  3. **Pushed eagerly** via an optional `ArchiveyConfig.on_diagnostic` callback, for
-     streaming/long operations where waiting for a result object is wrong.
-  4. **Escalated to a typed error** for a caller-selected set of codes/severities
-     (`WarningPolicy`), so strict consumers can make "a name was normalized" fatal.
-  5. **Logged** exactly as today — the existing `logging` behaviour is retained as the
-     default channel, so this change is **additive and non-breaking**.
-
-- **`logging` delta.** Clarify that each logged advisory is the log projection of a
-  `Diagnostic`; the logger hierarchy and "no handlers by default" rule are unchanged.
+- Add a `diagnostics` capability with:
+  - immutable `Diagnostic` values, stable `DiagnosticCode` string-enum values, severity,
+    an opaque occurrence id, a human message, and a code-specific immutable, JSON-safe
+    typed context;
+  - immutable `DiagnosticSummary` snapshots with exact total/per-code counts and bounded
+    retained occurrences;
+  - `DiagnosticPolicy` dispositions `IGNORE`, `COLLECT`, and `RAISE`, resolved per code;
+  - a single typed `DiagnosticRaisedError` escalation path; and
+  - a fully ordered emission contract covering logging, callbacks, callback failures,
+    reentrancy, and lock boundaries.
+- Make diagnostics lifecycle-aware:
+  - standalone detection diagnostics are final data on `FormatInfo`;
+  - an `ArchiveReader` owns a cumulative lifetime collector, and `reader.diagnostics`
+    returns an immutable snapshot each time;
+  - reader-owned streams expose operation-filtered snapshots over the same collector;
+  - `open_archive()` creates that collector before detection and transfers it intact to
+    the reader, while top-level `extract()` shares one collector and initial watermark
+    through detection, open, read, and extraction—no seeding, merging, or duplicated
+    retention;
+  - runtime rewind, seek-index degradation, scan-race, and trailing-EOF events remain in
+    reader/stream operation aggregates, never in frozen `CostReceipt` or `ArchiveInfo`;
+  - natural member-metadata occurrences may attach to `ArchiveMember`, but extraction
+    occurrences remain in the report/reader aggregate because `ExtractionResult.status`
+    and `.error` are already the complete per-result outcome; and
+  - every library-retained aggregate entry and member attachment shares one
+    collector-wide reference budget.
+- Replace extraction's list return with a first-class `ExtractionReport` containing
+  an immutable result tuple and the extraction operation's bounded diagnostic summary.
+  `EXTRACTED`, `SKIPPED`, `REJECTED`, and `FAILED` are defined by outcome rather than by
+  logging: intentional filter/overwrite skips are `SKIPPED`; safety-filter blocks are
+  `REJECTED`; operational failures are `FAILED`; selector-excluded members have no result.
+- Add `ArchiveyConfig.diagnostic_policy`,
+  `ArchiveyConfig.max_retained_diagnostic_references`, and an optional
+  `ArchiveyConfig.on_diagnostic` callback. The public policy is deliberately per-code
+  only: severity rules, logger-specific rules, mutable global configuration, callback
+  return values, and a second warnings framework are not added.
+- Specify that `RAISE` always halts, including under extraction
+  `OnError.CONTINUE`. For a missing archive EOF marker,
+  `strict_archive_eof=True` takes precedence and raises `TruncatedError`; diagnostic
+  policy still controls the event's counting/delivery before that specific error.
+- Audit all 17 current warning calls into the initial stable taxonomy. No unused
+  `PASSWORD_GUESSED` code is pre-reserved; the password-disambiguation change adds that
+  code and context when it defines the event. The initial code-to-context mapping is a
+  closed discriminated union. Extraction failure/rejection codes count results: a failed
+  hardlink source affecting `N` continued results emits `N` correlated occurrences.
+- Update the affected capabilities: `archive-reading`, `archive-data-model`,
+  `format-detection`, `safe-extraction`, `error-handling`, `logging`,
+  `access-mode-and-cost`, `compressed-streams`, `seekable-decompressor-streams`,
+  `format-directory`, `format-tar`, and `format-zip`.
+- Schedule implementation as the Phase 5 public-API follow-on that must land before the
+  Phase 6 native 7z/RAR readers add more warning-producing paths.
 
 ## Impact
 
-- New spec: `diagnostics`. Touched specs (light deltas, when scheduled): `logging`
-  (relationship), and the surfaces that grow a diagnostics accessor — `archive-reading`
-  (`reader.diagnostics`, `on_diagnostic`), `archive-data-model` (`ArchiveMember`
-  normalization/diagnostic field), `format-detection` (`FormatInfo`/`ArchiveInfo`),
-  `access-mode-and-cost` (`CostReceipt`), `safe-extraction` (`ExtractionResult`,
-  `extract()` collection). To keep this proposal reviewable those attachment points are
-  enumerated in the `diagnostics` spec and realized as tasks, not rewritten across five
-  specs here.
-- Consumers: the `zip-multipassword-disambiguation` residual ("guessed password") and the
-  extraction collision work (O2) both want this surface; this is the shared dependency
-  called out in that proposal.
-- Backwards compatible: default behaviour still just logs; the data/callback/escalation
-  channels are opt-in.
-- Open decisions for maintainer review are collected in `design.md` (naming, whether
-  escalation lives here or in `error-handling`, dedup/aggregation shape, `logging` vs the
-  stdlib `warnings` module).
+- **Public API:** new diagnostic values/policy/error, `reader.diagnostics`,
+  `ArchiveStream.diagnostics`, `FormatInfo.diagnostics`,
+  `ArchiveMember.diagnostics`, and `ExtractionReport`; `ArchiveReader.open()` and
+  `stream_members()` expose `ArchiveStream`, while `extract()` / `extract_all()` return
+  `ExtractionReport`. `ExtractionResult` has no diagnostics field.
+- **Control flow:** default `COLLECT` remains non-fatal and logs warning-severity
+  diagnostics. `IGNORE` suppresses retention/logging/callback delivery but not exact
+  counts. `RAISE` delivers then raises `DiagnosticRaisedError` and is always-stop.
+- **Memory:** one configured collector-wide budget covers every diagnostic reference the
+  library retains in aggregate and object attachments. Exact counts remain unbounded
+  integers; caller-held snapshots/copies are caller-owned and each snapshot is itself
+  bounded.
+- **Immutability:** reports, result outcome structure, and diagnostic summaries are
+  immutable points in time; result members remain the archive model's documented live
+  mutable, caller-read-only objects, so this is not falsely presented as a deep freeze.
+- **Security/privacy:** diagnostic messages and typed contexts must never contain
+  passwords, password candidates, provider return values, encryption keys, key material,
+  or decrypted secret bytes.
+- **Sequencing:** specs land now; the 11 implementation tasks remain unchecked and are
+  scheduled before native-reader implementation.

--- a/openspec/changes/diagnostics-warnings-as-data/proposal.md
+++ b/openspec/changes/diagnostics-warnings-as-data/proposal.md
@@ -1,0 +1,76 @@
+# Diagnostics: warnings as queryable data
+
+## Why
+
+Archivey's headline promise is **no surprises**. Today that promise quietly degrades to
+"no surprises — but logged", because every advisory the library produces is a
+`logging.warning` and nothing else. There are ~17 such sites: a member name was
+normalized (its meaning changed vs `raw_name`), format detection's magic disagreed with
+the extension, a backward seek forced an O(n) rewind, an extracted member was skipped, an
+NTFS/DOS timestamp was invalid, an expected digest could not be checked, a directory
+vanished mid-scan — and, incoming, "the password for this member was **guessed**"
+(`zip-multipassword-disambiguation`). Most applications never configure the `archivey`
+logger, so all of this is invisible: the data that would let a caller *act* (re-name the
+file, reject the archive, warn the user, record provenance) is thrown away after
+formatting a log string.
+
+The threat model records this as gap **C2 ("warnings that should be data")** and
+`IDEAS.md` sketches the sweep: each `logger.warning` should *also* be queryable as data
+on the natural result object (`ArchiveMember`, `FormatInfo`/`ArchiveInfo`, `CostReceipt`,
+`ExtractionResult`). But a field-per-surface sweep alone is fragmented and under-answers
+the real question the maintainer raised: **how should these be exposed — and does the
+right exposure depend on the context?** It does. A CLI wants to print them at the end; a
+long streaming pass wants them as they happen; a batch indexer wants them recorded beside
+each member and never wants a crash; a reproducible-build tool wants *some* of them to be
+hard **errors**. One delivery shape cannot serve all four.
+
+This change designs a single **diagnostic** primitive with **context-appropriate
+exposure**: attached to the most specific natural surface, aggregated into a queryable
+per-operation collection, delivered eagerly via an optional callback, and escalable to a
+typed error by policy — with `logging` unchanged as the zero-config default so nothing
+breaks. **Specs only — no code lands here.**
+
+## What Changes
+
+- **New capability `diagnostics`.** A stable `Diagnostic` record — a machine-stable
+  `code`, a `severity`, a human `message`, and typed `context` (references to the member /
+  archive / offset it concerns, and the before/after values where relevant, e.g.
+  `raw_name` → `name`). Codes are enumerated and stable so callers can branch on them.
+
+- **Context-appropriate exposure (the crux).** Every diagnostic is delivered through as
+  many of these as fit its context, driven by config, not hard-coded:
+  1. **Attached to its natural surface** — normalization → a field on `ArchiveMember`;
+     detection conflict → `FormatInfo`/`ArchiveInfo`; rewind → `CostReceipt`;
+     skip/guessed-password → `ExtractionResult`.
+  2. **Aggregated** into a per-operation collection queryable from the reader
+     (`reader.diagnostics`) and the operation result (`extract()`), so diagnostics with no
+     natural per-object home (a directory vanished mid-scan) are still reachable, and so a
+     caller can ask "did anything happen?" once.
+  3. **Pushed eagerly** via an optional `ArchiveyConfig.on_diagnostic` callback, for
+     streaming/long operations where waiting for a result object is wrong.
+  4. **Escalated to a typed error** for a caller-selected set of codes/severities
+     (`WarningPolicy`), so strict consumers can make "a name was normalized" fatal.
+  5. **Logged** exactly as today — the existing `logging` behaviour is retained as the
+     default channel, so this change is **additive and non-breaking**.
+
+- **`logging` delta.** Clarify that each logged advisory is the log projection of a
+  `Diagnostic`; the logger hierarchy and "no handlers by default" rule are unchanged.
+
+## Impact
+
+- New spec: `diagnostics`. Touched specs (light deltas, when scheduled): `logging`
+  (relationship), and the surfaces that grow a diagnostics accessor — `archive-reading`
+  (`reader.diagnostics`, `on_diagnostic`), `archive-data-model` (`ArchiveMember`
+  normalization/diagnostic field), `format-detection` (`FormatInfo`/`ArchiveInfo`),
+  `access-mode-and-cost` (`CostReceipt`), `safe-extraction` (`ExtractionResult`,
+  `extract()` collection). To keep this proposal reviewable those attachment points are
+  enumerated in the `diagnostics` spec and realized as tasks, not rewritten across five
+  specs here.
+- Consumers: the `zip-multipassword-disambiguation` residual ("guessed password") and the
+  extraction collision work (O2) both want this surface; this is the shared dependency
+  called out in that proposal.
+- Backwards compatible: default behaviour still just logs; the data/callback/escalation
+  channels are opt-in.
+- Open decisions for maintainer review are collected in `design.md` (naming, whether
+  escalation lives here or in `error-handling`, dedup/aggregation shape, `logging` vs the
+  stdlib `warnings` module).

--- a/openspec/changes/diagnostics-warnings-as-data/specs/access-mode-and-cost/spec.md
+++ b/openspec/changes/diagnostics-warnings-as-data/specs/access-mode-and-cost/spec.md
@@ -1,0 +1,24 @@
+# access-mode-and-cost — static cost versus runtime diagnostics
+
+## ADDED Requirements
+
+### Requirement: CostReceipt remains an immutable open-time cost description
+
+`CostReceipt` SHALL continue to describe static access properties known at open time and
+SHALL NOT retain runtime diagnostics. In particular, an actual backward seek that
+re-decompresses, or a later seek-index construction failure, SHALL be represented in the
+reader/stream operation diagnostic aggregate rather than mutating or replacing
+`CostReceipt`.
+
+Static `notes` MAY describe a general capability/caveat, but SHALL NOT be used as an
+occurrence log or exact counter.
+
+#### Scenario: actual slow rewind is not frozen into cost
+
+- **WHEN** a stream performs a backward seek after the reader was opened
+- **THEN** `STREAM_REWIND_REDECOMPRESSES` appears in stream/reader diagnostics and the original `CostReceipt` remains unchanged
+
+#### Scenario: failed optional index does not alter cost receipt
+
+- **WHEN** optional seek-index discovery degrades to sequential decoding at runtime
+- **THEN** `SEEK_INDEX_DEGRADED` is counted on the operation aggregate and no diagnostic field is added to `CostReceipt`

--- a/openspec/changes/diagnostics-warnings-as-data/specs/archive-data-model/spec.md
+++ b/openspec/changes/diagnostics-warnings-as-data/specs/archive-data-model/spec.md
@@ -1,0 +1,117 @@
+# archive-data-model — member diagnostic attachment and complete schema
+
+## MODIFIED Requirements
+
+### Requirement: The ArchiveMember record
+
+The system SHALL define the complete mutable, unhashable, caller-read-only
+`ArchiveMember` schema as:
+
+```python
+@dataclass
+class ArchiveMember:
+    type: MemberType
+
+    name: str
+    raw_name: bytes | None
+
+    size: int | None
+    compressed_size: int | None
+
+    modified: datetime | None
+    accessed: datetime | None
+    created: datetime | None
+
+    mode: int | None
+    uid: int | None
+    gid: int | None
+    uname: str | None
+    gname: str | None
+
+    link_target: str | None
+    link_target_member: "ArchiveMember | None"
+
+    compression: tuple[CompressionMethod, ...] = ()
+    is_encrypted: bool = False
+    is_sparse: bool = False
+
+    comment: str | None = None
+    create_system: "CreateSystem | None" = None
+    windows_attrs: int | None = None
+
+    hashes: Mapping[str, int | bytes] = field(default_factory=dict, compare=False)
+    diagnostics: tuple[Diagnostic, ...] = field(default=(), compare=False)
+    extra: dict[str, Any] = field(default_factory=dict, compare=False)
+
+    @property
+    def member_id(self) -> int: ...
+    @property
+    def archive_id(self) -> str: ...
+
+    @property
+    def is_file(self) -> bool: ...
+    @property
+    def is_dir(self) -> bool: ...
+    @property
+    def is_link(self) -> bool: ...
+    @property
+    def is_other(self) -> bool: ...
+    @property
+    def is_junction(self) -> bool: ...
+
+    def modified_utc(self, tz_for_naive: tzinfo | None = None) -> datetime | None: ...
+    def replace(self, **kwargs: Any) -> "ArchiveMember": ...
+```
+
+All existing field meanings remain: unavailable values are `None`; `name` follows the
+normalization contract while `raw_name` preserves stored bytes; timestamps preserve their
+stored timezone semantics; digest keys identify their real algorithms; link targets,
+sizes, hashes, and other late-bound values may be filled in place during streaming.
+`member_id`/`archive_id` preserve source identity, convenience properties are derived, and
+`replace()` creates an edited copy. `hashes`, `diagnostics`, and `extra` are excluded from
+equality. There is no `crc32` alias.
+
+`ArchiveMember` is intentionally not frozen because the library may complete metadata
+after yielding it. Callers SHALL treat it as read-only, and it SHALL remain unhashable.
+The `diagnostics` tuple itself is immutable/read-only, but the library MAY replace that
+tuple in place when a later member-specific event occurs. This is not a promise that a
+previously returned member is a point-in-time snapshot.
+
+Only occurrences about that concrete member are eligible: initially
+`MEMBER_NAME_NORMALIZED`, `MEMBER_TIMESTAMP_INVALID`,
+`SYMLINK_TARGET_UNAVAILABLE`, and `DIGEST_UNVERIFIABLE`. Attachment SHALL occur only when
+the owning collector first retained the aggregate occurrence and has another shared
+retention-budget slot. Aggregate and member values carry the same occurrence id but have
+no object-identity guarantee.
+
+Like other late-bound fields, an eligible diagnostic MAY be attached after the member is
+yielded. `member.replace()` copies the tuple's current value; caller-created copies do not
+consume additional library-retention slots.
+
+`ArchiveInfo` SHALL NOT carry runtime diagnostics. In particular, detection conflict lives
+on `FormatInfo`, while runtime scan/rewind/EOF events live on reader/stream summaries.
+
+#### Scenario: normalization attaches under the shared budget
+
+- **WHEN** normalization emits a retained member diagnostic and an attachment slot remains
+- **THEN** the member exposes it in `member.diagnostics` with the aggregate occurrence id
+
+#### Scenario: attachment is omitted when only aggregate capacity remains
+
+- **WHEN** a member diagnostic is emitted with one collector budget slot remaining
+- **THEN** the aggregate retains the occurrence, `member.diagnostics` does not, and exact counts still include it
+
+#### Scenario: late integrity diagnostic appears in place
+
+- **WHEN** an already-yielded member's stream discovers that its stored digest algorithm cannot be verified
+- **THEN** `DIGEST_UNVERIFIABLE` may be appended in place to that same member's diagnostics tuple, budget permitting
+
+#### Scenario: member references remain live in reports
+
+- **WHEN** an `ExtractionReport` contains a result referring to a member and the library later completes a late-bound field on that member
+- **THEN** the member field changes in place even though the report's result tuple and diagnostic summary remain immutable
+
+#### Scenario: ArchiveInfo remains an open-time value
+
+- **WHEN** a rewind or missing EOF marker occurs after open
+- **THEN** the reader/stream summary changes and frozen `ArchiveInfo` remains unchanged

--- a/openspec/changes/diagnostics-warnings-as-data/specs/archive-reading/spec.md
+++ b/openspec/changes/diagnostics-warnings-as-data/specs/archive-reading/spec.md
@@ -1,0 +1,231 @@
+# archive-reading — diagnostic-aware public API and lifecycles
+
+## MODIFIED Requirements
+
+### Requirement: Opening an archive for reading
+
+The system SHALL expose:
+
+```python
+archivey.open_archive(
+    source: str | Path | BinaryIO | Sequence[str | Path | BinaryIO],
+    *,
+    format: ArchiveFormat | None = None,
+    streaming: bool = False,
+    password: PasswordInput = None,
+    encoding: str | None = None,
+    config: ArchiveyConfig | None = None,
+) -> ArchiveReader
+```
+
+`source`, multi-volume ordering, `streaming`, password candidates/providers, encoding,
+configuration precedence, and backend selection retain their existing contracts.
+`format=None` performs automatic detection; an explicit format bypasses detection.
+
+The implementation SHALL create the prospective reader's one collector, budget, and
+initial operation watermark before detection or backend open. Automatic detection SHALL
+receive that collector. On successful open, the returned reader assumes ownership of the
+same collector; opening SHALL NOT seed, merge, replay, or copy detection events into a
+second collector. An occurrence retained during detection therefore consumes exactly one
+aggregate budget slot and keeps one occurrence id/order position in the reader lifetime.
+If detection/open raises, no reader is returned and the temporary collector is discarded
+after the exception propagates.
+
+#### Scenario: open with automatic detection transfers ownership
+
+- **WHEN** `open_archive()` automatically detects a format and successfully builds its reader
+- **THEN** the reader owns the exact collector used during detection, including its counters and retained entries, without duplicated references
+
+#### Scenario: explicit format has no detection events
+
+- **WHEN** `open_archive(source, format=ArchiveFormat.ZIP)` succeeds
+- **THEN** one collector still covers open and later work, but detection is not run and no detection diagnostic is recorded
+
+### Requirement: Reading member data
+
+The public `ArchiveStream` SHALL implement the `BinaryIO` contract, remain caller-closed,
+and additionally expose an immutable operation-filtered diagnostic snapshot:
+
+```python
+class ArchiveStream(BinaryIO):
+    @property
+    def diagnostics(self) -> DiagnosticSummary: ...
+
+def read(self, member: str | ArchiveMember) -> bytes: ...
+def open(self, member: str | ArchiveMember) -> ArchiveStream: ...
+```
+
+Both methods accept a name or an `ArchiveMember` yielded by this reader. An unknown name
+raises `KeyError`; a foreign member raises `ValueError`. `read()` materializes the entire
+payload without extraction bomb checks and is intended for small trusted members.
+`open()` streams in bounded chunks. Full reads verify any supported member digest;
+streaming verification raises `CorruptionError` on the terminal read only after all valid
+chunks have been delivered, while `read()` raises without returning bytes.
+
+A reader-owned stream SHALL use an operation token/watermark over the reader's collector.
+It SHALL NOT own or retain a second copy of its diagnostics. A standalone
+`ArchiveStream` not owned by a reader SHALL own one stream-lifetime collector.
+
+#### Scenario: opening a member returns the diagnostic stream type
+
+- **WHEN** `reader.open("data.bin")` succeeds
+- **THEN** it returns an `ArchiveStream` usable as `BinaryIO`, and `stream.diagnostics` reports only that stream operation's events
+
+#### Scenario: stream and reader do not duplicate retention
+
+- **WHEN** a reader-owned stream emits a rewind diagnostic
+- **THEN** stream and reader snapshots can both expose it while the shared collector retains and charges it only once
+
+### Requirement: Bounded-memory sequential streaming via stream_members
+
+The system SHALL provide:
+
+```python
+def stream_members(
+    self,
+    members: MemberSelector | None = None,
+) -> Iterator[tuple[ArchiveMember, ArchiveStream | None]]: ...
+```
+
+It yields original caller-read-only members in archive order and an `ArchiveStream` for
+file data (`None` for non-files), with peak memory bounded by decompressor state and one
+in-flight chunk rather than a whole solid block. A yielded stream is valid only until the
+iterator advances. Streams open lazily; selector-excluded and unread members are not
+opened. `members` keeps the existing name/member collection or predicate semantics.
+There is no transform `MemberFilter` on this pure generator because late-bound member
+metadata must continue to update the original member in place.
+
+Each yielded stream is an operation-filtered view over the reader's single collector and
+budget; advancing the iterator does not create a new diagnostic collector or aggregate
+copy.
+
+#### Scenario: sequential stream has public diagnostics
+
+- **WHEN** a yielded file stream encounters a diagnostic before the iterator advances
+- **THEN** the stream snapshot and cumulative reader snapshot expose that occurrence from one retained aggregate entry
+
+#### Scenario: skipped member data is never opened
+
+- **WHEN** a selector excludes a member or the caller does not read its yielded stream
+- **THEN** that member's data is not opened/decompressed and no data-path diagnostic is produced for it
+
+### Requirement: Transparent link following
+
+`open()` and `read()` SHALL transparently follow symlinks and hardlinks through the shared
+reader implementation, and `open()` SHALL preserve its public `ArchiveStream` return type
+after following:
+
+```python
+def open(self, member: str | ArchiveMember) -> ArchiveStream: ...
+```
+
+Hardlinks resolve to the most recent matching target strictly before the link, with the
+existing random-access fallback for a malformed later-only source; streaming mode cannot
+resolve that forward target. Random-access symlinks resolve to the last matching target
+overall, while streaming symlinks can resolve only to a target already seen. Hardlink
+targets are archive-root relative; symlink targets are resolved relative to the link's
+directory, and absolute/root-escaping targets do not resolve. Bare and trailing-slash
+directory forms are both considered.
+
+The reader SHALL follow chains recursively, detect actual cycles by member id rather than
+name, and impose no arbitrary depth limit. A missing/unresolvable target raises
+`LinkTargetNotFoundError`; a cycle raises `ReadError`. A stream reached through a link
+uses the same operation collector/token as the initiating `open()` call rather than
+creating or retaining another diagnostic operation.
+
+#### Scenario: linked open preserves stream diagnostics
+
+- **WHEN** `reader.open(link_member)` follows a valid chain to file data
+- **THEN** it returns one `ArchiveStream` whose operation-filtered diagnostics cover work performed while following and reading that open operation
+
+### Requirement: Explicit configuration object
+
+The system SHALL define these complete frozen configuration schemas:
+
+```python
+@dataclass(frozen=True)
+class ExtractionLimits:
+    max_extracted_bytes: int | None = 2 * 2**30
+    max_ratio: float | None = 1000.0
+    ratio_activation_threshold: int = 5 * 2**20
+    max_entries: int | None = 1_048_576
+
+    UNLIMITED: ClassVar["ExtractionLimits"]
+
+@dataclass(frozen=True)
+class ArchiveyConfig:
+    use_rapidgzip: AcceleratorMode = AcceleratorMode.AUTO
+    use_indexed_bzip2: AcceleratorMode = AcceleratorMode.AUTO
+    strict_archive_eof: bool = False
+    extraction_limits: ExtractionLimits = ExtractionLimits()
+    diagnostic_policy: DiagnosticPolicy = DiagnosticPolicy()
+    max_retained_diagnostic_references: int = 256
+    on_diagnostic: Callable[[Diagnostic], None] | None = None
+```
+
+`max_retained_diagnostic_references` SHALL be non-negative. Policy/default/override
+mappings and both config dataclasses SHALL be defensively immutable. `config=None`
+selects the immutable library default. Configuration is explicit only; Archivey SHALL
+read no mutable global/context-local diagnostic policy or callback.
+
+A reader carries its open config. A later `extract_all(config=...)` MAY override policy,
+callback, strictness, accelerators, and limits for new work, but its
+`max_retained_diagnostic_references` field SHALL NOT replace, reset, lower, or enlarge the
+existing reader collector's budget. Per-call `limits` still takes precedence over
+`config.extraction_limits`, then the reader/library default. Existing per-call operational
+arguments remain outside `ArchiveyConfig`.
+
+`strict_archive_eof=False` follows ordinary diagnostic policy for a failed EOF check.
+`True` forces `TruncatedError` after the ordered diagnostic counting/delivery rules
+specified by `error-handling`.
+
+Callbacks run synchronously after count/retention/logging updates and without any
+collector, reader, stream, backend, or registry lock. Snapshot reads from a callback are
+allowed. Starting another operation on the same currently emitting reader/stream SHALL
+raise `UnsupportedOperationError`; operating on a different reader is allowed.
+
+#### Scenario: complete default configuration
+
+- **WHEN** `ArchiveyConfig()` is used
+- **THEN** accelerators are AUTO, EOF strictness is false, extraction limits are the documented defaults, diagnostics default to COLLECT, the budget is 256, and no callback is installed
+
+#### Scenario: extraction override cannot replace lifetime budget
+
+- **WHEN** a reader opened with budget 10 calls `extract_all(config=ArchiveyConfig(max_retained_diagnostic_references=1000))`
+- **THEN** new policy/callback settings may apply, but all reader-owned diagnostics remain subject to the original budget 10
+
+## ADDED Requirements
+
+### Requirement: Reader-lifetime cumulative diagnostic snapshots
+
+Every successfully created `ArchiveReader` SHALL own a diagnostic collector for its
+lifetime and expose:
+
+```python
+@property
+def diagnostics(self) -> DiagnosticSummary: ...
+```
+
+Each access SHALL return a fresh immutable cumulative snapshot. Exact counts SHALL include
+automatic-detection occurrences that led to the reader plus every open/list/read/stream/
+extract occurrence subsequently owned by it, including events whose detail could not be
+retained. Previously returned snapshots SHALL not change.
+
+A stream returned by a reader SHALL expose an operation-filtered `diagnostics` snapshot
+over the same collector. It SHALL not separately retain aggregate copies merely to serve
+both stream and reader views.
+
+#### Scenario: reader snapshot grows over its lifetime
+
+- **WHEN** a reader is opened after a detection conflict, then listing emits a scan diagnostic and a member stream emits a rewind diagnostic
+- **THEN** a later `reader.diagnostics` has exact cumulative counts for all three in emission order, while an earlier snapshot remains unchanged
+
+#### Scenario: stream view is a filtered reader view
+
+- **WHEN** two member streams emit different diagnostics
+- **THEN** each stream's snapshot includes only its operation's events and the reader snapshot includes both, without separately retained aggregate copies
+
+#### Scenario: callback may query but not re-enter
+
+- **WHEN** `on_diagnostic` reads `reader.diagnostics` and then attempts `reader.read(...)` on the same emitting reader
+- **THEN** the snapshot read succeeds and includes the current event, while the operational reentry raises `UnsupportedOperationError`

--- a/openspec/changes/diagnostics-warnings-as-data/specs/compressed-streams/spec.md
+++ b/openspec/changes/diagnostics-warnings-as-data/specs/compressed-streams/spec.md
@@ -1,0 +1,62 @@
+# compressed-streams — integrity and stream diagnostics
+
+## MODIFIED Requirements
+
+### Requirement: Verify decompressed output against expected digests
+
+The verification stage SHALL continue to raise `CorruptionError` for a computable digest
+mismatch at clean EOF and skip verification after a partial read. It SHALL compute each
+available algorithm incrementally over decompressed bytes. A mismatch SHALL surface from
+the terminal read that would otherwise signal EOF, after every data chunk has been
+delivered; a bytes-returning full read SHALL raise and return no bytes. Codec-internal
+checks remain distinct from this container-supplied digest stage, and random-access/
+partial reads do not verify.
+
+When an expected digest algorithm cannot be computed because it is unknown or its backend
+is unavailable, the stage SHALL emit `DIGEST_UNVERIFIABLE` with typed context containing
+the algorithm, non-secret reason, and member identity when available.
+
+The event SHALL follow diagnostic policy. Under `COLLECT`, that algorithm is skipped while
+other computable algorithms are still verified; the occurrence appears in the stream/
+reader aggregate and MAY attach to the member under the shared retention budget. Under
+`IGNORE`, it is counted but has no delivery/detail and verification still skips it. Under
+`RAISE`, `DiagnosticRaisedError` halts the read.
+
+#### Scenario: unverifiable digest is collected as data
+
+- **WHEN** a member's expected `blake2sp` cannot be computed and default policy applies
+- **THEN** `DIGEST_UNVERIFIABLE` is counted/retained/logged, may attach to the member, and the readable bytes are returned without that digest check
+
+#### Scenario: digest mismatch on full read
+
+- **WHEN** a member is read to EOF and its decompressed bytes do not match an expected computable digest
+- **THEN** `CorruptionError` naming the algorithm is raised
+
+#### Scenario: mismatch does not discard the final chunk
+
+- **WHEN** a caller consumes chunks until EOF from a member whose digest mismatches
+- **THEN** every data chunk is delivered, and the following terminal read raises `CorruptionError`
+
+#### Scenario: partial read is not verified
+
+- **WHEN** a caller abandons a member stream before clean EOF
+- **THEN** no digest verdict or mismatch exception is produced
+
+#### Scenario: strict caller escalates unverifiable digest
+
+- **WHEN** `DIGEST_UNVERIFIABLE` resolves to `RAISE`
+- **THEN** `DiagnosticRaisedError` halts opening/reading the stream rather than silently skipping the check
+
+## ADDED Requirements
+
+### Requirement: Public ArchiveStream exposes bounded operation snapshots
+
+Every public `ArchiveStream` SHALL expose an immutable `diagnostics` snapshot. For a
+reader-owned stream this is an operation-filtered view over the reader collector; for a
+standalone codec stream it is a stream-lifetime collector. Serving the view SHALL not
+retain a second aggregate copy of each occurrence.
+
+#### Scenario: standalone stream owns its diagnostics
+
+- **WHEN** a standalone codec stream emits an index or rewind diagnostic
+- **THEN** `stream.diagnostics` exposes exact counts and bounded retained details without requiring an `ArchiveReader`

--- a/openspec/changes/diagnostics-warnings-as-data/specs/diagnostics/spec.md
+++ b/openspec/changes/diagnostics-warnings-as-data/specs/diagnostics/spec.md
@@ -1,88 +1,211 @@
-# diagnostics — warnings as queryable data
+# diagnostics — lifecycle-aware warnings as data
 
 ## ADDED Requirements
 
-### Requirement: Diagnostic record with stable codes
+### Requirement: Immutable diagnostic values with stable codes and safe typed context
 
-The system SHALL represent every non-fatal advisory it produces (a normalized name, a
-detection conflict, a rewind cost, a skipped member, a guessed password, an invalid
-timestamp, an unverifiable digest, a vanished scan entry, trailing data, and the like) as
-a **`Diagnostic`** value carrying at least: a machine-stable `code` from an enumerated set,
-a `severity`, a human-readable `message`, and typed context identifying what it concerns
-(the member name and/or byte offset, and the relevant before/after values such as the raw
-and normalized name). The `code` values SHALL be stable across releases so callers can
-branch on them programmatically; `message` is for human display only and is not part of the
-stable contract.
+The system SHALL represent every advisory event as an immutable `Diagnostic` carrying an
+opaque process-local `occurrence_id`, a stable string-enum `DiagnosticCode`, a
+`DiagnosticSeverity`, a human `message`, and a code-specific frozen `DiagnosticContext`.
+Codes are the machine contract; messages are not stable.
 
-#### Scenario: a normalized name is a diagnostic with a stable code and context
+Contexts SHALL form a closed typed union and contain only JSON-safe immutable scalar/tuple
+values. Raw bytes, when necessary, SHALL use an explicitly named base64 string field.
+`Diagnostic.to_dict()` and every context's `to_dict()` SHALL return values accepted by
+`json.dumps()` without a custom encoder.
 
-- **WHEN** normalizing a member's `name` changes its meaning relative to `raw_name`
-- **THEN** a `Diagnostic` with the stable normalization `code` is produced, carrying the member's `raw_name` and normalized `name`
+Every context SHALL have a literal string `kind` discriminator, and every initial code
+SHALL map to exactly this variant and field set:
 
-### Requirement: Diagnostics attached to their natural surface
+| Code | Variant and required fields |
+|---|---|
+| `MEMBER_NAME_NORMALIZED` | `NameNormalizationContext`: `kind="name_normalization"`, `archive_name: str \| None`, `member_name: str`, `member_id: int \| None`, `raw_name_base64: str \| None`, `presented_name: str`, `normalized_name: str` |
+| `FORMAT_EXTENSION_CONFLICT` | `FormatConflictContext`: `kind="format_conflict"`, `source_name: str \| None`, `extension: str \| None`, `extension_format: str`, `detected_format: str` |
+| `SCAN_DIRECTORY_VANISHED` | `ScanRaceContext`: `kind="scan_race"`, `archive_name: str \| None`, `relative_path: str`, `entry_kind="directory"` |
+| `SCAN_ENTRY_VANISHED` | `ScanRaceContext`: `kind="scan_race"`, `archive_name: str \| None`, `relative_path: str`, `entry_kind="entry"` |
+| `ARCHIVE_EOF_MARKER_MISSING` | `ArchiveEofContext`: `kind="archive_eof"`, `archive_name: str \| None`, `format: str`, `expected_marker: str`, `expected_bytes: int`, `observed_bytes: int`, `observed_kind: str` |
+| `MEMBER_TIMESTAMP_INVALID` | `MemberTimestampContext`: `kind="member_timestamp"`, `archive_name: str \| None`, `member_name: str`, `member_id: int \| None`, `field: str`, `source: str`, `value_repr: str` |
+| `SYMLINK_TARGET_UNAVAILABLE` | `SymlinkTargetContext`: `kind="symlink_target"`, `archive_name: str \| None`, `member_name: str`, `member_id: int \| None`, `reason: str` |
+| `DIGEST_UNVERIFIABLE` | `DigestContext`: `kind="digest"`, `archive_name: str \| None`, `member_name: str`, `member_id: int \| None`, `algorithm: str`, `reason: str` |
+| `SEEK_INDEX_DEGRADED` | `SeekIndexContext`: `kind="seek_index"`, `archive_name: str \| None`, `member_name: str \| None`, `member_id: int \| None`, `codec: str`, `scan: str`, `error_type: str` |
+| `STREAM_REWIND_REDECOMPRESSES` | `StreamRewindContext`: `kind="stream_rewind"`, `archive_name: str \| None`, `member_name: str \| None`, `member_id: int \| None`, `codec: str`, `from_offset: int`, `to_offset: int`, `accelerator: str \| None` |
+| `EXTRACTION_MEMBER_REJECTED` | `ExtractionOutcomeContext`: `kind="extraction_outcome"`, `archive_name: str \| None`, `member_name: str`, `member_id: int \| None`, `status="rejected"`, `error_type: str`, `failure_group_id: str \| None`, `failure_group_size: int \| None` |
+| `EXTRACTION_MEMBER_FAILED` | `ExtractionOutcomeContext`: `kind="extraction_outcome"`, `archive_name: str \| None`, `member_name: str`, `member_id: int \| None`, `status="failed"`, `error_type: str`, `failure_group_id: str \| None`, `failure_group_size: int \| None` |
 
-A diagnostic that concerns a specific result object the caller already holds SHALL be
-reachable from that object: a per-member diagnostic (normalization, timestamp, digest) from
-its `ArchiveMember`; a detection diagnostic from the archive's format info; a rewind-cost
-diagnostic from the relevant `CostReceipt`; an extraction diagnostic (skipped member,
-guessed password) from that member's `ExtractionResult`. The object-attached diagnostic and
-the aggregated collection (below) SHALL reference the **same** `Diagnostic` value, not
-duplicated data.
+`DiagnosticContext` SHALL be exactly the union of the ten named variants in this table;
+backend-defined mappings or unregistered context variants SHALL be rejected.
+`observed_kind` SHALL initially be one of `"absent"`, `"short"`, or `"nonzero"`;
+`expected_marker` SHALL be a symbolic value such as `"two_zero_blocks"`, not raw bytes.
+`member_id` MAY be `None` only if emission precedes registration.
+`failure_group_id`/`failure_group_size` SHALL both be present only when multiple hardlink
+results share one failed source and SHALL otherwise both be `None`.
 
-#### Scenario: a skipped member carries its diagnostic on the extraction result
+No diagnostic message, context, log projection, callback argument, or escalation error
+SHALL contain a password, password candidate, password-provider return value, encryption
+key, key-derivation material, or decrypted secret bytes.
 
-- **WHEN** a member is skipped during extraction under `OnError.CONTINUE`
-- **THEN** that member's `ExtractionResult` exposes the skip as a `Diagnostic`, and the same value appears in the operation's aggregated diagnostics
+Copies of one occurrence MAY be retained on multiple surfaces by value. They SHALL carry
+the same `occurrence_id`; the system SHALL NOT guarantee Python object identity, and ids
+need not be stable across runs.
 
-### Requirement: Per-operation aggregation
+#### Scenario: normalization produces a safe typed value
 
-The reader SHALL expose the diagnostics emitted during an open/read operation as a
-queryable collection, and `extract()` SHALL return the diagnostics emitted during
-extraction alongside the per-member results. The collection SHALL include diagnostics that
-have no per-object surface (for example a directory that vanished during a scan, or trailing
-bytes after the archive end). The retained collection SHALL be bounded and SHALL expose
-exact per-`code` counts, so an archive that emits a very large number of diagnostics cannot
-turn the collection into an unbounded memory cost.
+- **WHEN** a member name is normalized
+- **THEN** the diagnostic uses `MEMBER_NAME_NORMALIZED`, carries a typed member/name context that serializes directly to JSON, and contains no backend object or mutable mapping
 
-#### Scenario: a diagnostic with no natural object is still reachable
+#### Scenario: occurrence correlation does not depend on object identity
 
-- **WHEN** a directory vanishes during a directory scan
-- **THEN** the corresponding `Diagnostic` appears in the operation's aggregated diagnostics even though no member object represents it
+- **WHEN** one occurrence is retained in an aggregate and on its member
+- **THEN** both values carry the same opaque `occurrence_id` and compare by value, but callers are not promised that they are the same Python object
 
-#### Scenario: mass diagnostics are counted, not unboundedly retained
+#### Scenario: password material is prohibited
 
-- **WHEN** an archive causes a very large number of same-`code` diagnostics
-- **THEN** the aggregated collection retains a bounded number of them and still reports an exact count for that `code`
+- **WHEN** a diagnostic describes an unavailable encrypted symlink target
+- **THEN** it may carry reason `"password_required"` and the member name, but no password, candidate, provider return value, key, or decrypted target bytes
 
-### Requirement: Eager delivery via callback
+### Requirement: Exact bounded diagnostic summaries
 
-The library configuration SHALL accept an optional diagnostic callback that is invoked with
-each `Diagnostic` at the point it is emitted, so a caller performing a long streaming or
-extraction operation can react to diagnostics as they occur rather than only after the
-operation completes. When no callback is configured, diagnostics are still aggregated and
-logged.
+The system SHALL expose immutable `DiagnosticSummary` snapshots containing
+`total_count`, exact immutable per-code `counts`, retained occurrences in emission order,
+and `dropped_count`. Counts SHALL include every emitted event regardless of disposition or
+retention. `dropped_count` SHALL equal aggregate occurrences not retained.
 
-#### Scenario: callback receives diagnostics during a streaming pass
+Each standalone detection, reader lifetime, top-level extraction operation, or standalone
+stream SHALL enforce one `ArchiveyConfig.max_retained_diagnostic_references` budget
+(default 256) across every diagnostic reference the library retains for that collector.
+An aggregate retained occurrence consumes one slot; one eligible object attachment
+consumes another. Allocation
+order SHALL be aggregate first, then the one most-specific attachment. No attachment is
+created unless its aggregate occurrence was retained. Exact counters do not consume
+retention slots.
 
-- **WHEN** a diagnostic callback is configured and diagnostics arise during a streaming read
-- **THEN** the callback is invoked for each diagnostic as it occurs, before the operation completes
+Snapshots SHALL be freshly created, bounded, and never mutated. Caller-retained snapshots
+and caller-created member copies are caller-owned and outside the library-retention bound.
+An internal operation watermark consumes no slot and copies no occurrence; a ranged
+summary computes exact counter deltas and selects from already-retained aggregate entries.
 
-### Requirement: Configurable escalation, non-fatal by default
+#### Scenario: member occurrences consume aggregate and attachment slots
 
-Diagnostics SHALL be non-fatal by default: producing a diagnostic SHALL NOT by itself raise,
-and with default configuration the observable behaviour is unchanged except that diagnostics
-are also queryable as data. The configuration SHALL allow a caller to select a disposition
-per `code` (or severity) of ignore, collect, or **raise**; a `raise` disposition SHALL cause
-the diagnostic to surface as a typed exception at the point it is emitted, so a strict caller
-can make a chosen advisory (for example a normalized name, a detection conflict, or a guessed
-password) a hard error. Genuine failures remain exceptions regardless of this policy.
+- **WHEN** a member-specific diagnostic is emitted with at least two budget slots remaining
+- **THEN** one slot retains it in the aggregate and one attaches it to the member; with only one slot remaining only the aggregate retains it
 
-#### Scenario: default configuration does not change control flow
+#### Scenario: exhausted retention keeps exact counts
 
-- **WHEN** the library runs with default configuration on input that produces diagnostics
-- **THEN** no diagnostic causes an exception; the operation proceeds exactly as before, with the diagnostics additionally available as data and via logging
+- **WHEN** diagnostics continue after every retention slot is consumed
+- **THEN** no further detail or attachment is retained, while `total_count` and every per-code count remain exact
 
-#### Scenario: a caller escalates a chosen code to an error
+#### Scenario: snapshots are immutable points in time
 
-- **WHEN** a caller sets the disposition for the normalization `code` to raise, and a member name is normalized
-- **THEN** a typed exception carrying that `Diagnostic` is raised at the point of normalization
+- **WHEN** a caller stores `before = reader.diagnostics`, more events occur, and it reads `after = reader.diagnostics`
+- **THEN** `before` is unchanged and `after` includes the later exact counts in emission order
+
+### Requirement: Lifecycle-aware aggregation and attachment
+
+A standalone detection call SHALL create one collector and return its final summary on
+`FormatInfo`. `open_archive()` SHALL instead create one prospective-reader collector
+before automatic detection, pass that same collector into detection, and transfer
+ownership of it to the successfully opened reader. It SHALL NOT seed, merge, replay, or
+copy events into another collector. The detection watermark and reader views use the same
+exact counters, retained tuple, occurrence ids, order, and one-time budget charges.
+`ArchiveReader.diagnostics` SHALL snapshot every event owned by that reader over its
+lifetime. A reader-owned `ArchiveStream.diagnostics` SHALL return an operation-filtered
+view over the same collector without separately retaining the same aggregate occurrence;
+a standalone archive stream SHALL own a stream-lifetime collector.
+
+Only natural member-metadata diagnostics SHALL be eligible for
+`ArchiveMember.diagnostics`, under the shared budget. `ExtractionResult` SHALL have no
+diagnostics field: its status/error are authoritative and extraction diagnostics remain in
+the report/reader aggregate. Detection conflict SHALL attach to `FormatInfo`. Runtime
+rewind, seek-index degradation, directory scan race, and archive EOF diagnostics SHALL
+remain aggregate-only and SHALL NOT be attached to frozen `CostReceipt` or `ArchiveInfo`.
+
+#### Scenario: automatic detection transfers one collector
+
+- **WHEN** `open_archive()` detects a magic/extension conflict and successfully creates a reader
+- **THEN** detection and the reader use one collector and budget, so the conflict consumes one aggregate slot and appears in the reader's cumulative summary without seeding or copying retained references
+
+#### Scenario: one-shot extraction shares one operation collector
+
+- **WHEN** top-level `extract()` detects, opens, reads, and extracts an archive
+- **THEN** those phases use one collector created before detection and the returned report summarizes the original operation watermark without merging phase-local collectors
+
+#### Scenario: runtime rewind is visible at the right lifetimes
+
+- **WHEN** a reader-owned stream rewinds through an index-less codec
+- **THEN** the occurrence appears in the stream operation snapshot and cumulative reader snapshot, and no frozen `CostReceipt` or `ArchiveInfo` is mutated
+
+### Requirement: Complete per-code policy and delivery contract
+
+The system SHALL provide a frozen `DiagnosticPolicy` with a default disposition and
+immutable per-code overrides. The only dispositions are `IGNORE`, `COLLECT`, and `RAISE`;
+severity- and logger-based matching are not part of this capability.
+
+Disposition behavior SHALL be:
+
+| Disposition | Exact counts | Retain/attach | WARNING log | Callback | Raise |
+|---|---|---|---|---|---|
+| `IGNORE` | yes | no | no | no | no |
+| `COLLECT` | yes | budget permitting | yes | if configured | no |
+| `RAISE` | yes | budget permitting | yes | if configured | `DiagnosticRaisedError` |
+
+For each event the system SHALL validate the typed payload, resolve policy, then under its
+collector lock allocate the occurrence id, construct the immutable value, and update
+counts/retention. It SHALL release all internal locks, log, invoke the synchronous callback
+on the calling thread, then escalate. Logs and callbacks SHALL therefore observe
+already-updated snapshot state and occur in emission order.
+
+A logging-handler exception SHALL propagate and prevent later callback/escalation steps.
+A callback exception SHALL propagate unchanged, SHALL NOT be governed by
+`OnError.CONTINUE`, and SHALL prevent the later `DiagnosticRaisedError`; the operation
+nevertheless halts. The system SHALL hold no collector, reader, stream, backend, or
+registry lock while calling logging handlers or the callback.
+
+Callbacks MAY inspect immutable arguments and read diagnostics snapshots. Operational
+reentry on the same emitting reader/stream SHALL fail with `UnsupportedOperationError`;
+snapshot reads are allowed, and operations on another reader are allowed.
+
+#### Scenario: ignored event is still counted
+
+- **WHEN** a code resolves to `IGNORE`
+- **THEN** its exact count increments, but it is not retained, attached, logged, delivered to the callback, or raised
+
+#### Scenario: callback can observe current state without a lock
+
+- **WHEN** a callback reads `reader.diagnostics`
+- **THEN** it sees the current occurrence already counted/retained and no internal lock is held during the callback
+
+#### Scenario: callback failure halts unchanged
+
+- **WHEN** a callback raises `CallbackError` while processing a `RAISE` diagnostic
+- **THEN** `CallbackError` propagates unchanged, the occurrence remains counted/delivered through earlier steps, no `DiagnosticRaisedError` replaces it, and extraction cannot continue under `OnError.CONTINUE`
+
+#### Scenario: same-reader operational reentrancy fails loudly
+
+- **WHEN** the callback attempts to start another read/extraction operation on the same currently emitting reader
+- **THEN** `UnsupportedOperationError` is raised rather than deadlocking or recursively changing occurrence order
+
+### Requirement: Complete initial warning taxonomy
+
+The initial `DiagnosticCode` set SHALL cover all 17 current warning calls:
+
+`MEMBER_NAME_NORMALIZED`, `FORMAT_EXTENSION_CONFLICT`,
+`SCAN_DIRECTORY_VANISHED`, `SCAN_ENTRY_VANISHED`,
+`ARCHIVE_EOF_MARKER_MISSING`, `MEMBER_TIMESTAMP_INVALID`,
+`SYMLINK_TARGET_UNAVAILABLE`, `DIGEST_UNVERIFIABLE`,
+`SEEK_INDEX_DEGRADED`, `STREAM_REWIND_REDECOMPRESSES`,
+`EXTRACTION_MEMBER_REJECTED`, and `EXTRACTION_MEMBER_FAILED`.
+
+The 17-site mapping and required context/attachment are authoritative in
+the closed table above and the warning-site audit in `design.md` section 8. Multiple call
+sites SHALL share a code only when they have the same machine meaning; typed context
+distinguishes source variants. The extraction-code count unit SHALL be one continued
+result with the matching status. Under `IGNORE` or `COLLECT`, one failed hardlink source
+that causes `N` failed link results SHALL emit `N` `EXTRACTION_MEMBER_FAILED`
+occurrences, correlated by shared failure-group fields. Under `RAISE`, the first ordered
+occurrence escalates and no completed-result count guarantee applies. No unused future
+code is reserved.
+
+#### Scenario: every warning-only source is migrated
+
+- **WHEN** implementation of this change is complete
+- **THEN** each of the 17 warning calls emits one of the initial codes through the central path, and no current advisory remains logging-only

--- a/openspec/changes/diagnostics-warnings-as-data/specs/diagnostics/spec.md
+++ b/openspec/changes/diagnostics-warnings-as-data/specs/diagnostics/spec.md
@@ -1,0 +1,88 @@
+# diagnostics — warnings as queryable data
+
+## ADDED Requirements
+
+### Requirement: Diagnostic record with stable codes
+
+The system SHALL represent every non-fatal advisory it produces (a normalized name, a
+detection conflict, a rewind cost, a skipped member, a guessed password, an invalid
+timestamp, an unverifiable digest, a vanished scan entry, trailing data, and the like) as
+a **`Diagnostic`** value carrying at least: a machine-stable `code` from an enumerated set,
+a `severity`, a human-readable `message`, and typed context identifying what it concerns
+(the member name and/or byte offset, and the relevant before/after values such as the raw
+and normalized name). The `code` values SHALL be stable across releases so callers can
+branch on them programmatically; `message` is for human display only and is not part of the
+stable contract.
+
+#### Scenario: a normalized name is a diagnostic with a stable code and context
+
+- **WHEN** normalizing a member's `name` changes its meaning relative to `raw_name`
+- **THEN** a `Diagnostic` with the stable normalization `code` is produced, carrying the member's `raw_name` and normalized `name`
+
+### Requirement: Diagnostics attached to their natural surface
+
+A diagnostic that concerns a specific result object the caller already holds SHALL be
+reachable from that object: a per-member diagnostic (normalization, timestamp, digest) from
+its `ArchiveMember`; a detection diagnostic from the archive's format info; a rewind-cost
+diagnostic from the relevant `CostReceipt`; an extraction diagnostic (skipped member,
+guessed password) from that member's `ExtractionResult`. The object-attached diagnostic and
+the aggregated collection (below) SHALL reference the **same** `Diagnostic` value, not
+duplicated data.
+
+#### Scenario: a skipped member carries its diagnostic on the extraction result
+
+- **WHEN** a member is skipped during extraction under `OnError.CONTINUE`
+- **THEN** that member's `ExtractionResult` exposes the skip as a `Diagnostic`, and the same value appears in the operation's aggregated diagnostics
+
+### Requirement: Per-operation aggregation
+
+The reader SHALL expose the diagnostics emitted during an open/read operation as a
+queryable collection, and `extract()` SHALL return the diagnostics emitted during
+extraction alongside the per-member results. The collection SHALL include diagnostics that
+have no per-object surface (for example a directory that vanished during a scan, or trailing
+bytes after the archive end). The retained collection SHALL be bounded and SHALL expose
+exact per-`code` counts, so an archive that emits a very large number of diagnostics cannot
+turn the collection into an unbounded memory cost.
+
+#### Scenario: a diagnostic with no natural object is still reachable
+
+- **WHEN** a directory vanishes during a directory scan
+- **THEN** the corresponding `Diagnostic` appears in the operation's aggregated diagnostics even though no member object represents it
+
+#### Scenario: mass diagnostics are counted, not unboundedly retained
+
+- **WHEN** an archive causes a very large number of same-`code` diagnostics
+- **THEN** the aggregated collection retains a bounded number of them and still reports an exact count for that `code`
+
+### Requirement: Eager delivery via callback
+
+The library configuration SHALL accept an optional diagnostic callback that is invoked with
+each `Diagnostic` at the point it is emitted, so a caller performing a long streaming or
+extraction operation can react to diagnostics as they occur rather than only after the
+operation completes. When no callback is configured, diagnostics are still aggregated and
+logged.
+
+#### Scenario: callback receives diagnostics during a streaming pass
+
+- **WHEN** a diagnostic callback is configured and diagnostics arise during a streaming read
+- **THEN** the callback is invoked for each diagnostic as it occurs, before the operation completes
+
+### Requirement: Configurable escalation, non-fatal by default
+
+Diagnostics SHALL be non-fatal by default: producing a diagnostic SHALL NOT by itself raise,
+and with default configuration the observable behaviour is unchanged except that diagnostics
+are also queryable as data. The configuration SHALL allow a caller to select a disposition
+per `code` (or severity) of ignore, collect, or **raise**; a `raise` disposition SHALL cause
+the diagnostic to surface as a typed exception at the point it is emitted, so a strict caller
+can make a chosen advisory (for example a normalized name, a detection conflict, or a guessed
+password) a hard error. Genuine failures remain exceptions regardless of this policy.
+
+#### Scenario: default configuration does not change control flow
+
+- **WHEN** the library runs with default configuration on input that produces diagnostics
+- **THEN** no diagnostic causes an exception; the operation proceeds exactly as before, with the diagnostics additionally available as data and via logging
+
+#### Scenario: a caller escalates a chosen code to an error
+
+- **WHEN** a caller sets the disposition for the normalization `code` to raise, and a member name is normalized
+- **THEN** a typed exception carrying that `Diagnostic` is raised at the point of normalization

--- a/openspec/changes/diagnostics-warnings-as-data/specs/error-handling/spec.md
+++ b/openspec/changes/diagnostics-warnings-as-data/specs/error-handling/spec.md
@@ -1,0 +1,99 @@
+# error-handling — diagnostic escalation
+
+## MODIFIED Requirements
+
+### Requirement: Single Rooted Exception Hierarchy
+
+The system SHALL define every library exception under this complete hierarchy:
+
+```text
+ArchiveyError(Exception)
+├── OpenError
+│   ├── FormatDetectionError
+│   ├── UnsupportedFormatError
+│   └── StreamNotSeekableError
+├── ReadError
+│   ├── CorruptionError
+│   ├── TruncatedError
+│   ├── EncryptionError
+│   └── LinkTargetNotFoundError
+├── WriteError
+├── ExtractionError
+│   └── FilterRejectionError
+│       ├── PathTraversalError
+│       ├── SymlinkEscapeError
+│       └── SpecialFileError
+├── UnsupportedFeatureError
+├── PackageNotInstalledError
+├── UnsupportedOperationError
+└── DiagnosticRaisedError
+```
+
+All existing meanings and subclass boundaries remain. In particular,
+`UnsupportedFeatureError`/`PackageNotInstalledError` may occur at open or read time,
+`StreamNotSeekableError` is an `OpenError`, and `UnsupportedOperationError` denotes API
+misuse or invalid reader mode. `DiagnosticRaisedError` is a direct `ArchiveyError`
+subclass because diagnostic escalation can occur in detection, open, read, stream, or
+extraction and is not itself one of those underlying failures.
+
+#### Scenario: catch escalation at the common root
+
+- **WHEN** diagnostic policy escalates an advisory occurrence
+- **THEN** `except ArchiveyError` catches the resulting `DiagnosticRaisedError`
+
+## ADDED Requirements
+
+### Requirement: DiagnosticRaisedError is the typed escalation bridge
+
+The public exception hierarchy SHALL add a direct `ArchiveyError` subtype:
+
+```python
+class DiagnosticRaisedError(ArchiveyError):
+    diagnostic: Diagnostic
+```
+
+It SHALL require and expose the escalated immutable diagnostic. The standard
+`source_format`, `archive_name`, and `member_name` fields SHALL be stamped through the
+existing central context mechanism. Escalation alone has no underlying exception, so
+`__cause__` MAY be `None`; an exception from logging/callback delivery propagates itself
+instead and is not replaced.
+
+`DiagnosticRaisedError` is an always-stop control exception. Extraction SHALL propagate
+it even under `OnError.CONTINUE`, never record it as `FAILED`/`REJECTED`, and never proceed
+to another member.
+
+#### Scenario: strict policy raises a typed error carrying data
+
+- **WHEN** a code resolves to `RAISE` and logging/callback delivery returns normally
+- **THEN** `DiagnosticRaisedError` is raised with the exact emitted diagnostic and centrally stamped archive/member context
+
+#### Scenario: extraction continuation cannot swallow escalation
+
+- **WHEN** a member diagnostic escalates during `OnError.CONTINUE`
+- **THEN** `DiagnosticRaisedError` propagates immediately and extraction halts
+
+### Requirement: Specialized archive EOF strictness takes precedence
+
+For `ARCHIVE_EOF_MARKER_MISSING`, `ArchiveyConfig.strict_archive_eof=True` SHALL force
+`TruncatedError` after the diagnostic's policy-controlled count/retention/log/callback
+steps. This specific validation error SHALL take precedence over
+`DiagnosticRaisedError`: even when the code resolves to `RAISE`, the terminal exception is
+`TruncatedError`. With strict EOF disabled, the normal disposition applies.
+
+A logging-handler or callback exception still propagates at its earlier ordered delivery
+step and therefore prevents either terminal exception.
+
+#### Scenario: strict EOF overrides ignored disposition
+
+- **WHEN** the EOF code resolves to `IGNORE` but `strict_archive_eof=True`
+- **THEN** the exact diagnostic count increments and `TruncatedError` is raised without retention/logging/callback delivery
+
+#### Scenario: strict EOF overrides diagnostic escalation type
+
+- **WHEN** the EOF code resolves to `RAISE`, delivery succeeds, and `strict_archive_eof=True`
+- **THEN** the event is retained/logged/called back according to `RAISE`, then `TruncatedError` is raised instead of `DiagnosticRaisedError`
+
+#### Scenario: non-strict EOF follows ordinary raise policy
+
+- **WHEN** the EOF code resolves to `RAISE` and `strict_archive_eof=False`
+- **THEN** `DiagnosticRaisedError` is raised after delivery

--- a/openspec/changes/diagnostics-warnings-as-data/specs/format-detection/spec.md
+++ b/openspec/changes/diagnostics-warnings-as-data/specs/format-detection/spec.md
@@ -1,0 +1,104 @@
+# format-detection — operation diagnostics
+
+## MODIFIED Requirements
+
+### Requirement: detect_format() returns a FormatInfo
+
+The system SHALL expose:
+
+```python
+archivey.detect_format(
+    source: str | Path | BinaryIO,
+    *,
+    config: ArchiveyConfig | None = None,
+) -> FormatInfo
+```
+
+`config=None` selects the immutable library default. `FormatInfo` remains frozen and SHALL
+add the final bounded summary for this detection operation:
+
+```python
+class DetectionConfidence(Enum):
+    CERTAIN = "certain"
+    PROBABLE = "probable"
+    GUESS = "guess"
+
+@dataclass(frozen=True)
+class FormatInfo:
+    format: ArchiveFormat
+    confidence: DetectionConfidence
+    detected_by: str
+    encoding_hint: str | None
+    payload_offset: int = 0
+    diagnostics: DiagnosticSummary = DiagnosticSummary.empty()
+```
+
+`confidence` retains its discrete exact-magic / structural-probe / extension-guess
+meaning. `encoding_hint` remains format-signal-only (never a member scan), and
+`payload_offset > 0` remains the SFX indicator.
+
+Standalone detection creates one finite collector and applies the configured policy,
+callback, logging, and retention budget. When detection runs inside
+`open_archive(config=...)`, open creates one prospective-reader collector and a detection
+watermark first, then passes that collector into the internal detection routine. On
+success, the reader assumes ownership of that exact collector. The implementation SHALL
+NOT seed, merge, replay, or copy detection occurrences into another collector, and SHALL
+charge each retained occurrence against the one budget exactly once.
+
+The internal `FormatInfo.diagnostics` is the immutable point-in-time detection-range
+snapshot needed by detection consumers. Since `open_archive()` returns only the reader,
+the library SHALL not retain that internal snapshot after handoff; the same events remain
+available through the reader's cumulative collector.
+
+#### Scenario: standalone detection returns its final summary
+
+- **WHEN** `detect_format(path)` completes with a magic/extension conflict
+- **THEN** the returned `FormatInfo.diagnostics` contains the exact conflict count and its retained detail under the default budget
+
+#### Scenario: open detection transfers rather than seeds
+
+- **WHEN** automatic detection inside `open_archive()` emits and retains a conflict before backend construction succeeds
+- **THEN** the reader continues the same collector, occurrence order, and budget, with no copied aggregate reference
+
+#### Scenario: magic byte match
+
+- **WHEN** the source's leading bytes match a known magic pattern
+- **THEN** `detect_format()` returns `FormatInfo` with `confidence=CERTAIN` and `detected_by="magic"`
+
+#### Scenario: extension-only fallback
+
+- **WHEN** a path has no recognized content signature but has a known extension
+- **THEN** `detect_format()` returns `FormatInfo` with `confidence=GUESS` and `detected_by="extension"`
+
+#### Scenario: detect_format honors explicit policy
+
+- **WHEN** `detect_format(path, config=ArchiveyConfig(diagnostic_policy=...))` encounters a conflict
+- **THEN** the configured IGNORE/COLLECT/RAISE behavior applies to that finite detection operation
+
+### Requirement: Conflict resolution — magic wins and warning is emitted
+
+The system SHALL prefer the magic/content result over the extension result whenever the
+existing detection precedence rules select it. A genuine mismatch SHALL emit
+`FORMAT_EXTENSION_CONFLICT` with typed context containing the source display name and the
+extension-suggested and content-detected format strings. The occurrence SHALL be counted
+on and, under `COLLECT`/`RAISE` and available budget, retained by
+`FormatInfo.diagnostics`. It SHALL be logged through `archivey.detection` according to
+diagnostic policy.
+
+The occurrence SHALL NOT be attached to `ArchiveInfo`. If detection creates a reader, it
+SHALL already belong to the collector transferred to that reader.
+
+#### Scenario: mismatched extension and magic
+
+- **WHEN** a file named `archive.tar.gz` has 7-Zip magic
+- **THEN** detection selects `ArchiveFormat.SEVEN_Z`, emits `FORMAT_EXTENSION_CONFLICT` on `FormatInfo`, and default policy logs it through `archivey.detection`
+
+#### Scenario: conflict escalation prevents open
+
+- **WHEN** `open_archive()` uses a policy that raises `FORMAT_EXTENSION_CONFLICT`
+- **THEN** `DiagnosticRaisedError` is raised during detection and no reader is returned
+
+#### Scenario: explicit format override has no detection event
+
+- **WHEN** `open_archive(source, format=ArchiveFormat.ZIP)` bypasses automatic detection
+- **THEN** no format-conflict diagnostic is emitted into the reader's collector

--- a/openspec/changes/diagnostics-warnings-as-data/specs/format-directory/spec.md
+++ b/openspec/changes/diagnostics-warnings-as-data/specs/format-directory/spec.md
@@ -1,0 +1,29 @@
+# format-directory — scan-race diagnostics
+
+## MODIFIED Requirements
+
+### Requirement: Scan errors are loud, races are tolerated
+
+Genuine directory-walk `OSError`s SHALL continue to propagate unchanged. When a listed
+entry or subdirectory vanishes before inspection, the reader SHALL continue and emit
+`SCAN_ENTRY_VANISHED` or `SCAN_DIRECTORY_VANISHED` with a JSON-safe relative path and path
+kind. These events are reader-operation aggregate data and SHALL not attach to a member
+that does not exist.
+
+Under `RAISE`, `DiagnosticRaisedError` SHALL halt the scan. Context SHALL not retain
+`DirEntry`, `Path`, exception, or filesystem handle objects.
+
+#### Scenario: entry deleted mid-walk is collected
+
+- **WHEN** an entry disappears between directory listing and `stat` under default policy
+- **THEN** it is skipped, `SCAN_ENTRY_VANISHED` is counted/retained/logged on the reader, and the walk continues
+
+#### Scenario: directory race is escalated by policy
+
+- **WHEN** a subdirectory vanishes and `SCAN_DIRECTORY_VANISHED` resolves to `RAISE`
+- **THEN** `DiagnosticRaisedError` halts the scan
+
+#### Scenario: permission error remains genuine I/O
+
+- **WHEN** walking a subdirectory raises `PermissionError`
+- **THEN** that original error propagates unchanged and no vanished-path diagnostic substitutes for it

--- a/openspec/changes/diagnostics-warnings-as-data/specs/format-tar/spec.md
+++ b/openspec/changes/diagnostics-warnings-as-data/specs/format-tar/spec.md
@@ -1,0 +1,65 @@
+# format-tar — metadata and EOF diagnostics
+
+## ADDED Requirements
+
+### Requirement: Invalid TAR timestamps are member diagnostic data
+
+The existing TAR mapping remains. If `TarInfo.mtime` cannot be represented as a Python
+`datetime`, the member's `modified` SHALL be `None` and the reader SHALL emit
+`MEMBER_TIMESTAMP_INVALID` with member identity, field/source kind, and a JSON-safe value
+representation. Under default policy the occurrence is collected/logged and MAY attach to
+the member under the shared budget; under `RAISE`, listing halts with
+`DiagnosticRaisedError`.
+
+#### Scenario: invalid TAR mtime is member data
+
+- **WHEN** a TAR member carries an out-of-range mtime
+- **THEN** `modified is None`, `MEMBER_TIMESTAMP_INVALID` is counted on the reader, and its retained occurrence may attach to the member
+
+## MODIFIED Requirements
+
+### Requirement: Detect truncated TAR archives
+
+After full iteration, a missing/invalid TAR end marker SHALL emit
+`ARCHIVE_EOF_MARKER_MISSING` on the reader operation aggregate. It SHALL not attach to
+`ArchiveInfo`, `CostReceipt`, or a member.
+
+Its context SHALL be `ArchiveEofContext(kind="archive_eof", format="tar",
+expected_marker="two_zero_blocks", expected_bytes=1024, observed_bytes=...,
+observed_kind=...)` plus the best-effort archive display name. `observed_kind` SHALL be
+`"absent"`, `"short"`, or `"nonzero"` as applicable; raw trailing archive bytes SHALL
+not be retained.
+
+The event first follows the common count/retention/log/callback order. Then:
+
+- with `strict_archive_eof=False`, ordinary disposition applies (`IGNORE` continues,
+  `COLLECT` continues, `RAISE` raises `DiagnosticRaisedError`);
+- with `strict_archive_eof=True`, `TruncatedError` always halts and takes precedence over
+  `DiagnosticRaisedError`, including when disposition is `IGNORE` or `RAISE`.
+
+A logging-handler or callback exception propagates at its earlier ordered step.
+
+#### Scenario: valid TAR marker has no event
+
+- **WHEN** full iteration ends with valid null-filled end-of-archive marker blocks
+- **THEN** no EOF diagnostic or error is produced
+
+#### Scenario: missing marker collected by default
+
+- **WHEN** a TAR pass reaches a missing EOF marker with default config
+- **THEN** `ARCHIVE_EOF_MARKER_MISSING` is counted/retained/logged on the reader and the pass completes
+
+#### Scenario: ignored missing marker is still strict
+
+- **WHEN** the code resolves to `IGNORE` and `strict_archive_eof=True`
+- **THEN** the event count increments without delivery and `TruncatedError` is raised
+
+#### Scenario: strict error type wins over diagnostic raise
+
+- **WHEN** the code resolves to `RAISE`, delivery succeeds, and `strict_archive_eof=True`
+- **THEN** `TruncatedError` is raised after delivery rather than `DiagnosticRaisedError`
+
+#### Scenario: runtime EOF event does not mutate open-time info
+
+- **WHEN** the missing marker is discovered only after iteration
+- **THEN** `reader.diagnostics` changes and frozen `ArchiveInfo` / `CostReceipt` remain unchanged

--- a/openspec/changes/diagnostics-warnings-as-data/specs/format-zip/spec.md
+++ b/openspec/changes/diagnostics-warnings-as-data/specs/format-zip/spec.md
@@ -1,0 +1,46 @@
+# format-zip — member metadata diagnostics
+
+## ADDED Requirements
+
+### Requirement: Invalid ZIP timestamps are member diagnostic data
+
+The existing ZIP mapping and timestamp precedence remain. If a DOS `date_time` or NTFS
+FILETIME cannot be represented as a Python `datetime`, the affected field SHALL fall
+through to the next valid precedence layer or `None`, and the reader SHALL emit
+`MEMBER_TIMESTAMP_INVALID` with member identity, timestamp source/field, and a JSON-safe
+stored-value representation.
+
+Under default policy the occurrence is collected/logged and MAY attach to the member under
+the shared retention budget. Under `RAISE`, listing halts with
+`DiagnosticRaisedError`.
+
+#### Scenario: invalid NTFS timestamp remains queryable
+
+- **WHEN** a ZIP member has an out-of-range NTFS FILETIME
+- **THEN** timestamp precedence falls back as specified, `MEMBER_TIMESTAMP_INVALID` is counted, and retained detail may attach to the member
+
+#### Scenario: invalid DOS timestamp can be escalated
+
+- **WHEN** a ZIP DOS `date_time` is invalid and the timestamp code resolves to `RAISE`
+- **THEN** listing halts with `DiagnosticRaisedError` carrying the typed timestamp context
+
+### Requirement: Unavailable encrypted symlink target is member diagnostic data
+
+When ZIP listing cannot read a symlink target because a correct password is unavailable,
+the member's `link_target` SHALL remain unset and the reader SHALL emit
+`SYMLINK_TARGET_UNAVAILABLE` with the member identity and non-secret reason
+`"password_required"`. The event MAY attach to the member under the shared budget.
+
+No message/context/log/error SHALL include attempted passwords, candidates, provider
+returns, key material, or decrypted target bytes. Under `RAISE`, listing SHALL halt with
+`DiagnosticRaisedError`.
+
+#### Scenario: unavailable target is collected without a secret
+
+- **WHEN** an encrypted ZIP symlink target cannot be read under default policy
+- **THEN** listing continues with `link_target=None`, the member may carry `SYMLINK_TARGET_UNAVAILABLE`, and serialized diagnostic data contains no password or decrypted target
+
+#### Scenario: strict caller rejects unavailable target
+
+- **WHEN** `SYMLINK_TARGET_UNAVAILABLE` resolves to `RAISE`
+- **THEN** listing halts with `DiagnosticRaisedError`

--- a/openspec/changes/diagnostics-warnings-as-data/specs/logging/spec.md
+++ b/openspec/changes/diagnostics-warnings-as-data/specs/logging/spec.md
@@ -1,0 +1,17 @@
+# logging — diagnostics relationship delta
+
+## ADDED Requirements
+
+### Requirement: Logged advisories are the projection of diagnostics
+
+Every advisory the library logs at WARNING (name normalization, detection conflict, rewind
+cost, skipped member, invalid timestamp, unverifiable digest, and the like) SHALL correspond
+to a `Diagnostic` (see the `diagnostics` capability): logging is the human-facing projection
+of the diagnostic, not a separate source of truth. The logger hierarchy and the "the library
+installs no handlers, levels, or formatters" rule are unchanged, and an application that
+configures only logging SHALL observe the same log output as before this capability existed.
+
+#### Scenario: logging-only application sees unchanged output
+
+- **WHEN** an application configures the `archivey` logger but uses none of the diagnostics data/callback/escalation channels
+- **THEN** it observes the same WARNING records as before, each corresponding to an emitted `Diagnostic`

--- a/openspec/changes/diagnostics-warnings-as-data/specs/logging/spec.md
+++ b/openspec/changes/diagnostics-warnings-as-data/specs/logging/spec.md
@@ -1,17 +1,36 @@
-# logging — diagnostics relationship delta
+# logging — diagnostic projection
 
 ## ADDED Requirements
 
-### Requirement: Logged advisories are the projection of diagnostics
+### Requirement: Warning logs are ordered projections of diagnostics
 
-Every advisory the library logs at WARNING (name normalization, detection conflict, rewind
-cost, skipped member, invalid timestamp, unverifiable digest, and the like) SHALL correspond
-to a `Diagnostic` (see the `diagnostics` capability): logging is the human-facing projection
-of the diagnostic, not a separate source of truth. The logger hierarchy and the "the library
-installs no handlers, levels, or formatters" rule are unchanged, and an application that
-configures only logging SHALL observe the same log output as before this capability existed.
+Every library advisory logged at WARNING SHALL originate as a `Diagnostic`; logging SHALL
+not be a second source of truth. For `COLLECT` and `RAISE`, the WARNING record SHALL be
+emitted after exact counts/retention are updated and before the diagnostic callback or
+escalation. For `IGNORE`, no WARNING record SHALL be emitted.
 
-#### Scenario: logging-only application sees unchanged output
+The record SHALL use the existing named `archivey.*` logger appropriate to the event and
+SHALL expose `diagnostic_code` as the code's string value and
+`diagnostic_occurrence_id` as the opaque id in `LogRecord.extra`. Human message text is
+not a byte-for-byte compatibility contract. The existing rule remains: the library
+installs no handlers, levels, filters, or formatters.
 
-- **WHEN** an application configures the `archivey` logger but uses none of the diagnostics data/callback/escalation channels
-- **THEN** it observes the same WARNING records as before, each corresponding to an emitted `Diagnostic`
+Logging handlers are application code. The system SHALL hold no collector, reader,
+stream, backend, or registry lock while invoking them. If a configured logging handler
+raises, normal Python logging semantics apply: that exception propagates and the later
+callback/escalation steps for the occurrence do not run.
+
+#### Scenario: default collected diagnostic logs
+
+- **WHEN** a warning-severity diagnostic resolves to the default `COLLECT` disposition
+- **THEN** its exact count/retention state is updated and one WARNING record carrying `diagnostic_code` and `diagnostic_occurrence_id` is emitted on the appropriate existing `archivey.*` logger
+
+#### Scenario: ignored diagnostic is not logged
+
+- **WHEN** a warning-severity diagnostic resolves to `IGNORE`
+- **THEN** its exact count increments but no log record is emitted
+
+#### Scenario: logging runs without internal locks
+
+- **WHEN** an application logging handler runs for a diagnostic
+- **THEN** no diagnostic collector, reader, stream, backend, or registry lock is held by Archivey

--- a/openspec/changes/diagnostics-warnings-as-data/specs/safe-extraction/spec.md
+++ b/openspec/changes/diagnostics-warnings-as-data/specs/safe-extraction/spec.md
@@ -1,0 +1,263 @@
+# safe-extraction — first-class report and diagnostic semantics
+
+## MODIFIED Requirements
+
+### Requirement: One-Shot Extraction API
+
+The top-level API SHALL return a first-class report rather than a bare result list:
+
+```python
+archivey.extract(
+    source: str | Path | BinaryIO | Sequence[str | Path | BinaryIO],
+    dest: str | Path,
+    *,
+    policy: ExtractionPolicy = ExtractionPolicy.STRICT,
+    overwrite: OverwritePolicy = OverwritePolicy.ERROR,
+    on_error: OnError = OnError.STOP,
+    format: ArchiveFormat | None = None,
+    password: str | bytes | Sequence[str | bytes] | PasswordProvider | None = None,
+    encoding: str | None = None,
+    on_progress: Callable[[ExtractionProgress], None] | None = None,
+    config: ArchiveyConfig | None = None,
+    limits: ExtractionLimits | None = None,
+) -> ExtractionReport
+```
+
+The one-shot call SHALL create one collector, one retention budget, and its report
+watermark before format detection. It SHALL pass that collector through internal
+detection, backend open, read, and extraction; the temporary reader owns it during the
+call. No phase creates a second collector, seeds/copies retained occurrences, or resets
+the budget. The final report summary SHALL span the original watermark and therefore
+include all events caused by the call exactly once.
+
+`results` SHALL be an immutable tuple. If an always-stop condition or `OnError.STOP`
+raises, no report is returned.
+The function still extracts all members and deliberately has no `members=` selector;
+subset extraction uses `ArchiveReader.extract_all()` on an already-open reader.
+`source`, `password`, `encoding`, config/limits precedence, default STRICT policy,
+default ERROR overwrite behavior, and automatic streaming mode for a non-seekable source
+retain their existing contracts.
+
+#### Scenario: successful one-shot extraction returns one report
+
+- **WHEN** `archivey.extract(source, dest)` completes
+- **THEN** it returns `ExtractionReport(results=(...), diagnostics=...)`, including any detection and extraction diagnostics caused by the call
+
+#### Scenario: one-shot phases share one collector
+
+- **WHEN** detection emits one retained conflict and extraction later emits one retained failure
+- **THEN** the report uses one occurrence order and budget from before detection, with neither event copied or re-retained at a phase handoff
+
+#### Scenario: one-shot extraction from a non-seekable pipe
+
+- **WHEN** `archivey.extract(pipe, dest)` receives a non-seekable supported source
+- **THEN** it opens in streaming mode automatically and extracts in one forward pass
+
+#### Scenario: subset extraction goes through an open reader
+
+- **WHEN** a caller wants only some members
+- **THEN** they open the archive and call `reader.extract_all(dest, members=...)`; the top-level function has no selection parameter
+
+### Requirement: Per-Reader Extract-All Helper
+
+`ArchiveReader.extract_all()` SHALL return:
+
+```python
+def extract_all(
+    dest: str | Path,
+    *,
+    members: MemberSelector | None = None,
+    filter: MemberFilter | None = None,
+    policy: ExtractionPolicy = ExtractionPolicy.STRICT,
+    overwrite: OverwritePolicy = OverwritePolicy.ERROR,
+    on_error: OnError = OnError.STOP,
+    on_progress: Callable[[ExtractionProgress], None] | None = None,
+    config: ArchiveyConfig | None = None,
+    limits: ExtractionLimits | None = None,
+) -> ExtractionReport: ...
+```
+
+The reader records a collector watermark when the call begins. The returned report's
+diagnostic summary SHALL contain exact count/retained deltas for this extraction call only,
+while `reader.diagnostics` remains cumulative and includes earlier and later events.
+An extraction config override changes new-event policy/callback behavior but uses the
+reader's existing collector and retention maximum.
+Selection, filter ordering, one-pass selected extraction, reader-config inheritance, and
+per-call limits precedence retain their existing contracts. There is still no
+single-member `reader.extract()` method.
+
+#### Scenario: extraction report excludes prior reader events
+
+- **WHEN** a reader emits a diagnostic before `extract_all()` and another during extraction
+- **THEN** the report summary includes only the extraction occurrence, while `reader.diagnostics` includes both
+
+#### Scenario: selected solid members extract in one pass
+
+- **WHEN** `reader.extract_all(dest, members=["a", "b"])` runs on a solid archive
+- **THEN** only those members are selected and their data is extracted in one decompression pass
+
+### Requirement: Extraction reads limits and strictness from the configuration object
+
+`archivey.extract()` and `ArchiveReader.extract_all()` SHALL accept
+`config: ArchiveyConfig | None` and `limits: ExtractionLimits | None`. Per-call `limits`
+takes precedence over `config.extraction_limits`, then the reader/library default.
+`ExtractionLimits.UNLIMITED` disables all four guards. Extraction policy/overwrite/error/
+progress/member-selection arguments remain keyword operational arguments outside config.
+
+Top-level `extract()` uses the supplied config for its one collector. `extract_all()` uses
+the reader config by default; an explicit config may change new-event diagnostic policy
+and callback but SHALL use the existing collector and its original retention maximum.
+
+Both APIs return `ExtractionReport`, whose result tuple is always accumulated. There is no
+no-tracking mode in this capability. The report diagnostic summary is bounded by the
+collector's shared budget.
+
+#### Scenario: limits override does not split diagnostics
+
+- **WHEN** `extract_all(limits=...)` overrides bomb limits on an existing reader
+- **THEN** the limits apply to that extraction while its report remains a watermark range over the reader's existing diagnostic collector
+
+### Requirement: Per-ArchiveMember ExtractionResult with Status
+
+`ExtractionReport.results` SHALL contain one `ExtractionResult` for every selected member
+the extraction coordinator processes when the operation completes. This includes a member
+rejected by universal/policy safety checks before the user filter runs. Selector-excluded
+members are outside the operation and SHALL have no result.
+
+```python
+@dataclass(frozen=True)
+class ExtractionResult:
+    member: ArchiveMember
+    path: Path | None
+    status: ExtractionStatus
+    error: ArchiveyError | OSError | None = None
+
+class ExtractionStatus(str, Enum):
+    EXTRACTED = "extracted"
+    SKIPPED = "skipped"
+    REJECTED = "rejected"
+    FAILED = "failed"
+```
+
+Statuses SHALL mean:
+
+- `EXTRACTED`: an entry was successfully created; `path` is that path and `error=None`.
+- `SKIPPED`: writing was intentionally bypassed because the user filter returned `None`
+  or `OverwritePolicy.SKIP` found an existing destination; `path=None`, `error=None`.
+- `REJECTED`: a `FilterRejectionError` blocked the member under
+  `OnError.CONTINUE`; `path=None`, `error` is that rejection.
+- `FAILED`: another per-member `ArchiveyError` or permitted filesystem `OSError` failed
+  under `OnError.CONTINUE`; `path=None`, `error` is that failure.
+
+`SKIPPED` is not a failure and SHALL NOT itself emit a diagnostic. A continued rejection
+or failure SHALL emit `EXTRACTION_MEMBER_REJECTED` or
+`EXTRACTION_MEMBER_FAILED`. Those occurrences live only in the extraction/reader
+aggregate. `ExtractionResult` deliberately has no diagnostics field: `status` and `error`
+are the complete per-result outcome, independent of detail-retention budget.
+
+Each continued `REJECTED` or `FAILED` result SHALL produce exactly one occurrence of its
+matching code. Thus exact extraction code counts equal result counts under `IGNORE` or
+`COLLECT`. If one failed hardlink source causes `N` hardlink results to fail under
+`IGNORE` or `COLLECT`, the coordinator SHALL emit `N` ordered
+`EXTRACTION_MEMBER_FAILED` occurrences, one naming each result member. Their contexts
+SHALL share `failure_group_id` and `failure_group_size=N`. Under `RAISE`, the first
+occurrence in result order escalates immediately; no completed report or `N`-occurrence
+guarantee applies.
+
+#### Scenario: user-filter skip is represented
+
+- **WHEN** a selected member's user filter returns `None`
+- **THEN** the report includes that member with `SKIPPED`, `path=None`, `error=None`, and no skip diagnostic
+
+#### Scenario: selector exclusion is not a skip result
+
+- **WHEN** a selector excludes a member before extraction
+- **THEN** that member has no `ExtractionResult` and does not affect report result counts
+
+#### Scenario: rejection and failure are distinct
+
+- **WHEN** one member is blocked by `PathTraversalError` and another encounters a write `OSError`, both under `OnError.CONTINUE`
+- **THEN** their results are respectively `REJECTED` and `FAILED`, with matching errors and diagnostic codes
+
+#### Scenario: group hardlink failure counts results
+
+- **WHEN** one failed source causes three hardlink members to receive `FAILED` results under `OnError.CONTINUE`
+- **THEN** the report count for `EXTRACTION_MEMBER_FAILED` increases by three and the three retained contexts, if budget permits, share one failure-group id and size three
+
+### Requirement: Error Policy (OnError) for extraction failures
+
+`OnError.STOP` and `CONTINUE` SHALL retain their per-member meanings, but diagnostic
+disposition composes as follows:
+
+- Under `IGNORE` or `COLLECT`, `CONTINUE` records `REJECTED`/`FAILED` and proceeds.
+- Under `RAISE`, emission raises `DiagnosticRaisedError`; this is an always-stop control
+  exception and SHALL NOT be caught, converted to `REJECTED`/`FAILED`, or suppressed by
+  `OnError.CONTINUE`.
+- A diagnostic logging-handler or callback exception likewise propagates unchanged and is
+  always-stop.
+- Existing global resource guards, `KeyboardInterrupt`, `MemoryError`, and unexpected
+  programming exceptions remain always-stop.
+
+Under `OnError.STOP`, the original rejection/failure raises immediately. It SHALL not also
+be converted to an extraction advisory, because the operation did not continue; genuine
+exceptions remain the source of truth for fatal failures.
+
+A per-member failure remains a `FilterRejectionError`, another member-scoped
+`ArchiveyError`, or a filesystem `OSError` raised while reading/writing that member.
+Under `CONTINUE`, partial output is removed before recording the result. A per-member
+ratio violation remains continuable; cumulative bytes, archive-wide/live ratio, and
+entry-count guards remain global always-stop limits. Exceptions outside the documented
+`ArchiveyError` / per-member `OSError` set are never swallowed.
+
+#### Scenario: collected continued failure returns in report
+
+- **WHEN** a corrupt member fails under `OnError.CONTINUE` and default diagnostic policy
+- **THEN** extraction logs/collects `EXTRACTION_MEMBER_FAILED`, records a `FAILED` result, and continues
+
+#### Scenario: raised diagnostic defeats CONTINUE
+
+- **WHEN** `EXTRACTION_MEMBER_FAILED` resolves to `RAISE` under `OnError.CONTINUE`
+- **THEN** `DiagnosticRaisedError` carrying that occurrence halts extraction immediately and no report is returned
+
+#### Scenario: STOP raises the genuine failure without advisory duplication
+
+- **WHEN** a member raises `CorruptionError` under `OnError.STOP`
+- **THEN** that `CorruptionError` propagates immediately and no continued-failure diagnostic is emitted
+
+#### Scenario: filesystem error remains a continued member failure
+
+- **WHEN** writing one member raises `OSError` under `OnError.CONTINUE`
+- **THEN** partial output is removed, a `FAILED` result and `EXTRACTION_MEMBER_FAILED` occurrence are recorded, and extraction proceeds
+
+#### Scenario: global resource guard still halts
+
+- **WHEN** cumulative extracted bytes exceed their limit under `OnError.CONTINUE`
+- **THEN** `ExtractionError` propagates immediately and no later member is processed
+
+## ADDED Requirements
+
+### Requirement: ExtractionReport is an immutable operation result
+
+The system SHALL define:
+
+```python
+@dataclass(frozen=True)
+class ExtractionReport:
+    results: tuple[ExtractionResult, ...]
+    diagnostics: DiagnosticSummary
+```
+
+The summary SHALL preserve exact operation counts after detail retention is exhausted.
+The report SHALL not duplicate the cumulative reader collector or retain diagnostics
+beyond the configured shared budget.
+
+The report and each `ExtractionResult` freeze their structure, but this is not a deep
+freeze. `ExtractionResult.member` is the original mutable, caller-read-only
+`ArchiveMember`; its documented late-bound metadata and diagnostics MAY still change in
+place. `error` may likewise refer to an ordinary exception object. The fixed result
+outcomes and point-in-time `DiagnosticSummary` SHALL not change.
+
+#### Scenario: report remains a point-in-time value
+
+- **WHEN** a caller retains an extraction report and the reader later performs more work
+- **THEN** the result tuple/outcome fields and diagnostic summary remain unchanged, although a referenced member may receive documented late-bound metadata

--- a/openspec/changes/diagnostics-warnings-as-data/specs/seekable-decompressor-streams/spec.md
+++ b/openspec/changes/diagnostics-warnings-as-data/specs/seekable-decompressor-streams/spec.md
@@ -1,0 +1,58 @@
+# seekable-decompressor-streams — runtime seek diagnostics
+
+## MODIFIED Requirements
+
+### Requirement: Index-less codecs warn on a rewinding seek
+
+When an index-less codec first services a backward seek by re-decompressing from the
+start, the system SHALL emit `STREAM_REWIND_REDECOMPRESSES` with codec, before/after
+offsets, and accelerator name (or `None`) in typed context. It SHALL be emitted at most
+once per stream, matching the existing warning's transition semantics; exact counts
+therefore report affected streams, not every seek call.
+
+The event SHALL live on the stream operation and cumulative owning-reader aggregate, never
+on `CostReceipt` or `ArchiveInfo`. Diagnostic policy controls logging, callback delivery,
+and escalation. Forward/no-op seeks SHALL emit nothing.
+
+This applies to gzip/bzip2 when their accelerator is unavailable or disabled and to
+brotli, lz4, zstd, and zlib, which have no random-access index. Gzip/bzip2 context names
+the `[seekable]` accelerator; the other codecs record no accelerator. XZ, lzip, and
+unix-compress use their own indexes and SHALL not emit this event for indexed seeks.
+
+#### Scenario: repeated rewinds emit once for the stream
+
+- **WHEN** one index-less stream performs 1,000 backward seeks
+- **THEN** it emits one `STREAM_REWIND_REDECOMPRESSES` occurrence, later rewinds emit no duplicate, and no open-time metadata object changes
+
+#### Scenario: raised rewind halts at the seek
+
+- **WHEN** `STREAM_REWIND_REDECOMPRESSES` resolves to `RAISE`
+- **THEN** the backward seek's diagnostic is delivered and `DiagnosticRaisedError` is raised from that seek operation
+
+#### Scenario: forward seek has no rewind event
+
+- **WHEN** an index-less stream seeks only forward or to its current position
+- **THEN** no `STREAM_REWIND_REDECOMPRESSES` occurrence is emitted
+
+## ADDED Requirements
+
+### Requirement: Optional seek-index degradation is diagnostic data
+
+When an XZ/lzip backward index or trailer scan fails in a way for which the stream can
+safely fall back to sequential decompression, the system SHALL emit
+`SEEK_INDEX_DEGRADED` with codec, scan kind, and public failure type in typed context.
+The occurrence SHALL be aggregate-only on the stream/reader operation.
+
+If policy escalates the code, the stream SHALL halt with `DiagnosticRaisedError` instead
+of taking the fallback. Genuine corruption that already makes decoding unsafe remains its
+typed read exception rather than a diagnostic.
+
+#### Scenario: recoverable XZ index failure falls back under default policy
+
+- **WHEN** an XZ backward index scan fails but sequential decompression remains valid
+- **THEN** `SEEK_INDEX_DEGRADED` is collected/logged and the stream uses sequential fallback
+
+#### Scenario: unsafe corruption remains an error
+
+- **WHEN** the same corruption prevents correct sequential decoding
+- **THEN** the appropriate `CorruptionError`/`TruncatedError` is raised rather than converting the failure to a recoverable diagnostic

--- a/openspec/changes/diagnostics-warnings-as-data/tasks.md
+++ b/openspec/changes/diagnostics-warnings-as-data/tasks.md
@@ -1,40 +1,68 @@
-# Tasks — diagnostics: warnings as queryable data
+# Tasks — lifecycle-aware diagnostics
 
-> Specs-only proposal. These tasks describe the implementation when the change is accepted
-> and scheduled; nothing is implemented here. Several open decisions (design.md §7) should
-> be settled first. Run tools through `uv` (`uv run pytest`, `uv run pyrefly check`,
-> `uv run ty check`, `uv run ruff`).
+> Specifications-only proposal. All 11 implementation tasks remain intentionally
+> unchecked. Do not implement them as part of this proposal.
 
-## 1. The primitive
+## 1. Diagnostic values and collector
 
-- [ ] 1.1 Add `Diagnostic` (frozen dataclass), `DiagnosticSeverity`, and a `DiagnosticCode`
-      enum seeded with the current warning sites (`NAME_NORMALIZED`, `DETECTION_CONFLICT`,
-      `REWIND_COST`, `MEMBER_SKIPPED`, `PASSWORD_GUESSED`, `INVALID_TIMESTAMP`,
-      `DIGEST_UNVERIFIABLE`, `SCAN_ENTRY_VANISHED`, `TRAILING_DATA`).
-- [ ] 1.2 A central emit path that (per policy) attaches, aggregates, calls back, logs, and
-      optionally escalates — replacing raw `logger.warning` calls incrementally.
+- [ ] 1.1 Add the public `DiagnosticCode`, `DiagnosticSeverity`,
+      `DiagnosticDisposition`, `Diagnostic`, code-specific frozen context types,
+      `DiagnosticSummary`, and `DiagnosticPolicy` values; enforce immutable mappings,
+      the closed discriminated code→context mapping, deterministic JSON-safe
+      serialization, opaque occurrence ids, and the prohibition on password/key material.
+- [ ] 1.2 Implement the lifecycle collector and immutable snapshots: exact lifetime,
+      operation, and per-code counts; deterministic emission order; operation watermarks;
+      and a single `max_retained_diagnostic_references` budget covering aggregate entries
+      plus every library-retained member attachment. Create the prospective collector
+      before `open_archive()` detection and transfer it to the reader without copying;
+      carry one top-level `extract()` collector/watermark through detect/open/extract.
+- [ ] 1.3 Add `ArchiveyConfig.diagnostic_policy`,
+      `max_retained_diagnostic_references`, and `on_diagnostic`; implement the complete
+      IGNORE/COLLECT/RAISE matrix and ordered count → retain/attach → log → callback →
+      escalation path, with no internal lock held during logging/callbacks and explicit
+      same-emitter reentrancy rejection.
 
-## 2. Exposure channels
+## 2. Lifecycle-aware public surfaces
 
-- [ ] 2.1 Per-operation collection on the reader (`reader.diagnostics`) and on the
-      `extract()` result; same `Diagnostic` objects referenced from the natural surface.
-- [ ] 2.2 Natural-surface accessors: `ArchiveMember` (normalization/timestamp/digest),
-      `FormatInfo`/`ArchiveInfo` (detection conflict, trailing data), `CostReceipt`
-      (rewind), `ExtractionResult` (skip, guessed password).
-- [ ] 2.3 `ArchiveyConfig.on_diagnostic` callback, invoked at emission.
-- [ ] 2.4 `WarningPolicy` (default + per-code disposition IGNORE/COLLECT/RAISE) on
-      `ArchiveyConfig`; `RAISE` escalates per the settled §5 decision.
-- [ ] 2.5 Bounded aggregation with exact per-code counts (design.md §6); share the O1 bound.
+- [ ] 2.1 Add cumulative `ArchiveReader.diagnostics` and operation-filtered
+      `ArchiveStream.diagnostics` snapshots over the same collector; change public
+      `open()` / `stream_members()` return types to `ArchiveStream`; transfer
+      automatic-detection collector ownership to the reader; and keep runtime
+      seek/index/scan/EOF events off `CostReceipt` and `ArchiveInfo`.
+- [ ] 2.2 Add bounded `FormatInfo.diagnostics` and `ArchiveMember.diagnostics`
+      projections, correlated by occurrence id without object-identity guarantees and
+      attached only when the shared collector budget has a slot. Do not add
+      `ExtractionResult.diagnostics`.
+- [ ] 2.3 Add frozen `ExtractionReport(results, diagnostics)` and frozen result outcome
+      structures, while documenting that referenced `ArchiveMember`s remain live; change
+      `archivey.extract()` / `ArchiveReader.extract_all()` to return the report; make
+      selected user-filter and overwrite skips `SKIPPED`, safety-filter blocks
+      `REJECTED`, other continued member errors `FAILED`, and selector-excluded members
+      absent.
 
-## 3. Migration
+## 3. Errors and warning migration
 
-- [ ] 3.1 Convert each of the ~17 `logger.warning` sites to emit a `Diagnostic` (which still
-      logs), starting with normalization / detection / skip / guessed-password.
-- [ ] 3.2 Keep the `logging` behaviour byte-for-byte for callers that only use logging.
+- [ ] 3.1 Add `DiagnosticRaisedError` to the public error hierarchy, carrying the
+      escalated diagnostic; make it always-stop despite `OnError.CONTINUE`, and implement
+      `strict_archive_eof=True` precedence so a missing EOF marker raises
+      `TruncatedError` after policy delivery rather than `DiagnosticRaisedError`.
+- [ ] 3.2 Replace all 17 current `logger.warning` calls with central diagnostic emission
+      using the complete initial taxonomy in `design.md`; preserve logger placement and
+      warning severity as projections while removing direct warning-only sources of
+      truth. Emit one extraction occurrence per continued result, including one correlated
+      occurrence per hardlink result affected by a shared source failure.
 
-## 4. Tests
+## 4. Verification and documentation
 
-- [ ] 4.1 Each code: emitted with correct context, attached to its surface, present in the
-      collection, delivered to the callback, and (when policy=RAISE) raised.
-- [ ] 4.2 Default config still only logs (no behaviour change); volume/aggregation bound
-      holds under a many-normalization archive. Green in all three dependency configs.
+- [ ] 4.1 Add focused tests for every policy-matrix cell, exact counts after retention
+      exhaustion, aggregate/attachment shared-budget accounting, occurrence-id value
+      correlation, immutable/JSON-safe context, secret redaction, callback order/failure,
+      snapshot access from callbacks, operational reentrancy rejection, and lock release.
+- [ ] 4.2 Add behavior tests for detection→reader collector transfer, one-shot collector
+      handoff, cumulative reader and filtered stream lifecycles, each of the 17 migrated
+      warning sites, extraction group-failure count units, `ExtractionReport` scope/status
+      and live-member semantics, `RAISE` versus `OnError.CONTINUE`, and all
+      `strict_archive_eof` × disposition precedence combinations.
+- [ ] 4.3 Export and document the final public API, update examples/type contracts, and
+      run lint, Pyrefly, ty, docs, and the full current/lowest/core-only test matrix before
+      implementation is committed.

--- a/openspec/changes/diagnostics-warnings-as-data/tasks.md
+++ b/openspec/changes/diagnostics-warnings-as-data/tasks.md
@@ -1,0 +1,40 @@
+# Tasks — diagnostics: warnings as queryable data
+
+> Specs-only proposal. These tasks describe the implementation when the change is accepted
+> and scheduled; nothing is implemented here. Several open decisions (design.md §7) should
+> be settled first. Run tools through `uv` (`uv run pytest`, `uv run pyrefly check`,
+> `uv run ty check`, `uv run ruff`).
+
+## 1. The primitive
+
+- [ ] 1.1 Add `Diagnostic` (frozen dataclass), `DiagnosticSeverity`, and a `DiagnosticCode`
+      enum seeded with the current warning sites (`NAME_NORMALIZED`, `DETECTION_CONFLICT`,
+      `REWIND_COST`, `MEMBER_SKIPPED`, `PASSWORD_GUESSED`, `INVALID_TIMESTAMP`,
+      `DIGEST_UNVERIFIABLE`, `SCAN_ENTRY_VANISHED`, `TRAILING_DATA`).
+- [ ] 1.2 A central emit path that (per policy) attaches, aggregates, calls back, logs, and
+      optionally escalates — replacing raw `logger.warning` calls incrementally.
+
+## 2. Exposure channels
+
+- [ ] 2.1 Per-operation collection on the reader (`reader.diagnostics`) and on the
+      `extract()` result; same `Diagnostic` objects referenced from the natural surface.
+- [ ] 2.2 Natural-surface accessors: `ArchiveMember` (normalization/timestamp/digest),
+      `FormatInfo`/`ArchiveInfo` (detection conflict, trailing data), `CostReceipt`
+      (rewind), `ExtractionResult` (skip, guessed password).
+- [ ] 2.3 `ArchiveyConfig.on_diagnostic` callback, invoked at emission.
+- [ ] 2.4 `WarningPolicy` (default + per-code disposition IGNORE/COLLECT/RAISE) on
+      `ArchiveyConfig`; `RAISE` escalates per the settled §5 decision.
+- [ ] 2.5 Bounded aggregation with exact per-code counts (design.md §6); share the O1 bound.
+
+## 3. Migration
+
+- [ ] 3.1 Convert each of the ~17 `logger.warning` sites to emit a `Diagnostic` (which still
+      logs), starting with normalization / detection / skip / guessed-password.
+- [ ] 3.2 Keep the `logging` behaviour byte-for-byte for callers that only use logging.
+
+## 4. Tests
+
+- [ ] 4.1 Each code: emitted with correct context, attached to its surface, present in the
+      collection, delivered to the callback, and (when policy=RAISE) raised.
+- [ ] 4.2 Default config still only logs (no behaviour change); volume/aggregation bound
+      holds under a many-normalization archive. Green in all three dependency configs.

--- a/openspec/project.md
+++ b/openspec/project.md
@@ -41,6 +41,7 @@ surfaces the inconsistency as an explicit, documented field value (`None` or an
 | `format-detection` | `detect_format()`, magic table, non-seekable peek/replay |
 | `backend-registry` | Backend registration, selection, the `Backend` ABC, optional deps |
 | `error-handling` | The `ArchiveyError` hierarchy and error-translation contract |
+| `diagnostics` | Lifecycle-aware advisory data: stable codes, exact bounded summaries, reader/stream/format/member/extraction aggregates, policy/callback delivery, and typed escalation |
 | `logging` | The `archivey` logger hierarchy (cross-cutting; library never configures handlers) |
 | `format-zip` / `format-tar` / `format-single-file-compressors` / `format-7z` / `format-rar` / `format-iso` / `format-directory` | Per-format behavioral contracts |
 | `compressed-streams` | Uniform pull-based codec decompressor layer (single-file + 7z/ZIP container codecs + AES stage); format parsers compose it instead of calling codec libs |
@@ -75,10 +76,10 @@ once. Specs themselves remain order-free; this table is the association.
 | Phase | Theme | Primary capabilities advanced |
 |-------|-------|-------------------------------|
 | 1 | Scaffold + spine + new test harness + directory backend | `packaging-and-extras` (pyproject, extras, env matrix, `__version__`); `backend-registry`, `archive-data-model`, `error-handling`, `access-mode-and-cost` (types/contracts written fresh); `format-directory` (the spine's first backend — no codec/detection layer needed); `logging`; `testing-contract` (framework foundations: declarative corpus, on-demand generation + cache, no committed binaries). DEV cloned as a frozen oracle. |
-| 2 | Stream layer (compressed + seekable) | `compressed-streams`, `seekable-decompressor-streams`. (7z/ZIP container codecs `pyppmd`/`inflate64`/AES stage land with Phase 7.) |
+| 2 | Stream layer (compressed + seekable) | `compressed-streams`, `seekable-decompressor-streams`. (7z/ZIP container codecs `pyppmd`/`inflate64`/AES stage land with Phase 6.) |
 | 3 | Indexed leaf formats | `format-zip`, `format-tar` (random-access **read** + compressed-tar), `format-single-file-compressors`, `format-iso`, `format-detection`, `backend-registry` (selection/degradation + tri-state availability), `access-mode-and-cost` (CostReceipt values). (`format-directory` already landed in Phase 1.) |
 | 4 | TAR streaming & safe extraction | `format-tar` (forward-only `stream_members`), `safe-extraction` (incl. bomb limits + progress/result), `archive-reading` (sequential + `stream_members`) |
-| 5 | Public API finalization & cost surface | `archive-reading`, `archive-data-model`, `access-mode-and-cost`, `error-handling` |
+| 5 | Public API finalization, cost surface & diagnostics | `archive-reading`, `archive-data-model`, `access-mode-and-cost`, `error-handling`; then the `diagnostics-warnings-as-data` follow-on advances `diagnostics`, `logging`, `format-detection`, `safe-extraction`, `compressed-streams`, `seekable-decompressor-streams`, `format-directory`, `format-tar`, and `format-zip` before Phase 6 |
 | 6 | Native 7z reader + native RAR metadata parser (resequenced 2026-07 ahead of writing — see `VISION.md`; fuzzing is an entry gate) | `format-7z`, `format-rar` (native-first: read path imports no third-party lib; `unrar` binary stays for RAR data; `py7zr` for 7z write only); `testing-contract` oracle cross-validation |
 | 7 | CLI (pulled forward: dev tool + safe-extraction demo) | `cli` |
 | 8 | Seekable zstd + blocked gzip (rescoped — the original zst/lz4 *read* goals landed with Phases 2–3; `w:zst` writing moved to the writing phase) | `seekable-decompressor-streams`, `format-single-file-compressors` |
@@ -86,9 +87,11 @@ once. Specs themselves remain order-free; this table is the association.
 | 10 | Polish, packaging & oracle retirement | `cli`, `packaging-and-extras` (finalize), full `testing-contract` (corpus complete, frozen DEV oracle deleted) (+ cross-cutting: README, final CI tuning — the matrix is stood up in Phase 1; coverage is reported, **not** gated) |
 
 `logging` is cross-cutting and not owned by a single phase — the named-logger
-hierarchy is established in Phase 1 and used by every phase thereafter. The new
-test suite is built incrementally from Phase 1 and becomes the sole suite in
-Phase 10, when the frozen DEV oracle is deleted.
+hierarchy is established in Phase 1 and used by every phase thereafter. Structured
+`diagnostics` is sequenced as a Phase 5 public-API follow-on, before the Phase 6 native
+readers add further advisory paths; logging becomes a policy-controlled projection of
+those values. The new test suite is built incrementally from Phase 1 and becomes the sole
+suite in Phase 10, when the frozen DEV oracle is deleted.
 
 > **Note:** decompression-bomb limits and extraction progress/result reporting
 > were previously separate `bomb-protection` and `progress-and-logging` specs.
@@ -98,9 +101,9 @@ Phase 10, when the frozen DEV oracle is deleted.
 
 > **7z/RAR sequencing (resolved):** under the clean-slate approach we do **not**
 > port DEV's `py7zr`/`rarfile` read backends (they would only be thrown away). 7z
-> and RAR reads are marked `xfail`/`skip` until the native readers land in Phase 7;
+> and RAR reads are marked `xfail`/`skip` until the native readers land in Phase 6;
 > `py7zr`/`rarfile` enter earlier only as `dev`-group test oracles. Those formats
-> are absent from the equivalence matrix until Phase 7.
+> are absent from the equivalence matrix until Phase 6.
 
 ## Deferred / out of scope (v1)
 

--- a/openspec/specs/backend-registry/spec.md
+++ b/openspec/specs/backend-registry/spec.md
@@ -260,11 +260,11 @@ level) and the *codec backends* a format can use (the `compressed-streams` layer
   unavailable.
 - A multi-codec container (7z, RAR) whose format backend is available is **FULL**
   when every optional codec/tool it can use is present, otherwise **PARTIAL**.
-- **ZIP is an exception until Phase 7** (see `format-zip`): member *data* decompression
+- **ZIP is an exception until Phase 6** (see `format-zip`): member *data* decompression
   still goes through stdlib `zipfile`, which cannot use deflate64/PPMd (or zstd before
   Python 3.14) even when the corresponding codec packages are installed. Therefore
   `format_availability(ArchiveFormat.ZIP)` SHALL report **PARTIAL** regardless of
-  optional codec installation until Phase 7 wires the shared codec layer into ZIP
+  optional codec installation until Phase 6 wires the shared codec layer into ZIP
   member reads. When optional ZIP member-codec packages are absent, `missing` lists
   them as for any other multi-codec container; when every package is present, `missing`
   is empty — support remains `PARTIAL` because the read-time gap is implementation
@@ -323,7 +323,7 @@ def list_known_formats() -> list[ArchiveFormat]:  # every format the registry kn
 
 - **WHEN** `format_availability(ArchiveFormat.ZIP)` is queried on a system with every optional ZIP member codec installed (deflate64, PPMd, zstd)
 - **THEN** `support` is `FormatSupport.PARTIAL` and `missing` is empty
-- **AND** reading a deflate64/PPMd/zstd member still raises `UnsupportedFeatureError` until Phase 7 wires the codec layer into ZIP member reads
+- **AND** reading a deflate64/PPMd/zstd member still raises `UnsupportedFeatureError` until Phase 6 wires the codec layer into ZIP member reads
 
 #### Scenario: ZIP partial when optional member codecs are missing
 

--- a/openspec/specs/format-7z/spec.md
+++ b/openspec/specs/format-7z/spec.md
@@ -233,7 +233,7 @@ repeated access to members of the same folder is served without re-decoding — 
 such retention MUST honor `archive-reading`'s bounded-memory rule (no growing cache of
 decompressed block data held in RAM until `close()`): a decoded-folder cache is spilled
 to a temporary file on disk and/or explicitly bounded, with the exact mechanism decided
-in the Phase 7 change proposal.
+in the Phase 6 change proposal.
 
 #### Scenario: streaming a solid 7z archive
 

--- a/openspec/specs/format-zip/spec.md
+++ b/openspec/specs/format-zip/spec.md
@@ -49,18 +49,18 @@ The system SHALL map each `ZipInfo` entry to a `ArchiveMember` dataclass using t
 > **Phase 3 → 7 gap (member decode via stdlib zipfile).** Member *data* decompression
 > currently goes through stdlib `zipfile`, which cannot decode deflate64/PPMd (or zstd
 > before Python 3.14) even when the corresponding codec packages are installed —
-> reading such a member raises `UnsupportedFeatureError`. Until Phase 7 wires the shared
+> reading such a member raises `UnsupportedFeatureError`. Until Phase 6 wires the shared
 > `compressed-streams` codec layer into ZIP member reads (see `openspec/project.md`),
 > `format_availability(ZIP)` SHALL report **PARTIAL** regardless of optional codec
 > installation (`backend-registry`); listing is unaffected. Installing `[7z]` / `[zstd]`
-> alone does not unlock those member reads before Phase 7.
+> alone does not unlock those member reads before Phase 6.
 >
-> The intended fix (Phase 7, alongside the 7z container codecs) keeps `zipfile` for the
+> The intended fix (Phase 6, alongside the 7z container codecs) keeps `zipfile` for the
 > central directory but bypasses its decompressor for member data: locate the member's
 > raw compressed bytes (local-header offset + a `SlicingStream` view) and decode them
 > through the shared `compressed-streams` codec layer. `zipfile` exposes no decompressor
 > plug-in point, so this raw-slice route — a first step toward the full native ZIP
-> reader in `IDEAS.md` — is the mechanism; the Phase 7 change proposal specifies it.
+> reader in `IDEAS.md` — is the mechanism; the Phase 6 change proposal specifies it.
 
 #### Scenario: Unix mode from external_attr
 

--- a/openspec/specs/testing-contract/spec.md
+++ b/openspec/specs/testing-contract/spec.md
@@ -120,7 +120,7 @@ contents (names, types, sizes, link targets), and extract cleanly to a temporary
 directory under the default safety policy with contents verified — or, for an entry that
 declares an expected failure (encrypted without a password, unsupported variant,
 adversarial member), raise exactly the documented `ArchiveyError` subclass. Corpus
-entries for formats that are not yet implemented (7z/RAR before Phase 7) SHALL be
+entries for formats that are not yet implemented (7z/RAR before Phase 6) SHALL be
 carried in the corpus but skipped by the sweep via a registry-driven guard, so enabling
 a format activates its entries without re-porting. Entries needing an absent optional
 dependency SHALL skip, not fail.


### PR DESCRIPTION
## What

A **specs-only** OpenSpec proposal for the "warnings that should be data" mechanism (threat-model **C2**) — the shared dependency the `zip-multipassword-disambiguation` ladder (and the O2 collision work) need for surfacing outcomes like "the password was *guessed*".

## The idea

Archivey's "no surprises" promise currently degrades to "no surprises — but logged": all ~17 advisories are `logging.warning` and nothing else, so most applications never see them. This introduces a single **`Diagnostic`** primitive (stable `code` + `severity` + `message` + typed context) that is queryable as data.

## The crux — exposure depends on context

Per the maintainer's steer that *how* they're exposed depends on context, a diagnostic reaches the caller through whichever of four channels fit, driven by config:

1. **Attached to its natural surface** — normalization → `ArchiveMember`; detection conflict → `FormatInfo`; rewind → `CostReceipt`; skip/guessed-password → `ExtractionResult`.
2. **Aggregated** into a bounded per-operation collection (`reader.diagnostics`, `extract()` result) — for diagnostics with no natural object, and for "did anything happen?" in one query.
3. **Pushed eagerly** via an optional `on_diagnostic` callback — for long streaming/extraction passes.
4. **Escalated to a typed error** by a per-code `WarningPolicy` — so a reproducible-build or security-sensitive caller can make a chosen advisory fatal.

…with **logging retained as the zero-config default**, so the change is additive and non-breaking.

`design.md` works the four channels against four consumer archetypes (CLI, batch indexer, reproducible-build verifier, telemetry embedder) and lays out the **open decisions** for review: naming (`Diagnostic`/`Occurrence`/`ArchiveWarning`), where escalation lives, the aggregation bound (shared with O1), `logging` vs stdlib `warnings`, and first-cut scope.

## Contents

New `diagnostics` capability spec + a `logging` relationship delta; `proposal.md`, `design.md`, `tasks.md`. `openspec validate --strict` clean. No code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q8xe33Xw66VCBsmqv1pE1J

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q8xe33Xw66VCBsmqv1pE1J)_