### PR TITLE
Fix Windows CI failure in bidi inferred-name test

### DIFF
--- a/tests/test_single_file.py
+++ b/tests/test_single_file.py
@@ -110,8 +110,12 @@ def test_inferred_bidi_control_name_warns_once(
     name = "invoice\u202ecod.exe"
     path = tmp_path / f"{name}.gz"
     path.write_bytes(gzip.compress(b"x"))
+    # rapidgzip's native path open rejects some Unicode filenames on Windows
+    # (U+202E); this test covers inferred-name presentation warnings, not the
+    # accelerator, so pin the stdlib gzip path.
+    config = ArchiveyConfig(use_rapidgzip=AcceleratorMode.OFF)
     with caplog.at_level(logging.WARNING, logger="archivey.normalization"):
-        with open_archive(path) as archive:
+        with open_archive(path, config=config) as archive:
             assert archive.members()[0].name == name
     warnings = [
         record


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Windows CI on PR #54 fails solely on `tests/test_single_file.py::test_inferred_bidi_control_name_warns_once` (both py3.11 and py3.14). Ubuntu/macOS are green; the adversarial corpus itself passes on Windows.

## Cause

That test creates a real `.gz` path containing U+202E (RIGHT-TO-LEFT OVERRIDE) and opens it via `open_archive(path)`. With the `[all]` extra, gzip goes through **rapidgzip**, whose native path open rejects that filename on Windows:

```
ValueError: Opening file '...\invoice\u202ecod.exe.gz' with mode 'rb' failed!
```

Python's own `open()` / stdlib `gzip` handle the path fine (the test already writes the file successfully). The sibling directory bidi test passes because it opens the parent directory, not the bidi-named file as the archive path.

## Fix

Pin `ArchiveyConfig(use_rapidgzip=AcceleratorMode.OFF)` for this test. It is asserting inferred-name presentation + the one-shot bidi warning, not accelerator behavior — same pattern already used elsewhere in `test_single_file.py`.

## What PR #54 is doing (context)

Implements the adversarial **Unicode-bombs** corpus: in-memory clean ZIP/TAR bases, length-preserving field splices (name / symlink target / comment), and a sweep that open/list/read/extract must yield typed `ArchiveyError` or clean success. Also centralizes bidi-control warnings at member registration so directory and single-file inferred names are covered once.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-140aad87-720d-4135-96eb-c394c302eb92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-140aad87-720d-4135-96eb-c394c302eb92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

