### PR TITLE
Enforce ruff format with pre-commit and CI check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,10 @@ jobs:
         run: uv python install 3.11
       - name: Sync (dev tooling)
         run: uv sync --group dev
-      - name: Ruff
-        run: uv run ruff check src/ tests/
+      - name: Ruff lint
+        run: uv run ruff check src/ tests/ scripts/
+      - name: Ruff format
+        run: uv run ruff format --check src/ tests/ scripts/
       - name: Pyrefly
         run: uv run pyrefly check
       - name: ty

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,11 @@
+# Install hooks: `uv run pre-commit install`
+# Run on demand: `uv run pre-commit run --all-files`
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.21
+    hooks:
+      - id: ruff
+        args: [--fix]
+        files: ^(src|tests|scripts)/
+      - id: ruff-format
+        files: ^(src|tests|scripts)/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,8 +18,7 @@ update script runs `uv sync --group dev --extra all`, so the everyday dev env is
 in place. Run tools with `--no-sync` to avoid a redundant re-resolve, e.g.:
 
 - Tests: `uv run --no-sync pytest`
-- Lint: `uv run --no-sync ruff check`  (note: `ruff format --check` currently reports
-  pre-existing drift in `tests/`; that is unrelated to any single change)
+- Lint: `uv run --no-sync ruff check` and `uv run --no-sync ruff format --check`
 - Type-check: `uv run --no-sync pyrefly check` and `uv run --no-sync ty check`
   (both must stay clean; mypy/pyright are intentionally not used)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,8 @@ uv sync                       # create/refresh the dev environment
 uv run pytest                 # run the test suite
 uv run ruff check             # lint
 uv run ruff format            # format
+uv run pre-commit install     # optional: install git hooks (ruff lint + format)
+uv run pre-commit run --all-files  # run hooks on the whole tree
 uv run pyrefly check          # type-check (Pyrefly)
 uv run ty check               # type-check (ty)
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,6 +81,7 @@ dev = [
     "pyrefly>=0.20.0",
     "ty>=0.0.1a13",
     "ruff>=0.11.0",
+    "pre-commit>=4.0.0",
     "coverage[toml]>=7.6.0",
     "py7zr>=1.0.0",
     "rarfile>=4.2",

--- a/scripts/dual_accelerator_repro.py
+++ b/scripts/dual_accelerator_repro.py
@@ -76,14 +76,21 @@ b.read(); b.close()
 """,
 }
 
-_CRASH_MARKERS = ("malloc", "pointer being freed", "terminating", "Detected Python finalization")
+_CRASH_MARKERS = (
+    "malloc",
+    "pointer being freed",
+    "terminating",
+    "Detected Python finalization",
+)
 
 
 def _run(name: str, code: str) -> tuple[int, int, str]:
     crashes = 0
     sample = ""
     for _ in range(ITERS):
-        proc = subprocess.run([sys.executable, "-c", code], capture_output=True, timeout=60)
+        proc = subprocess.run(
+            [sys.executable, "-c", code], capture_output=True, timeout=60
+        )
         err = proc.stderr.decode("utf-8", "replace")
         crashed = proc.returncode != 0 or any(m in err for m in _CRASH_MARKERS)
         if crashed:
@@ -101,7 +108,9 @@ def main() -> int:
             m = __import__(mod)
             print(f"  {mod}: {getattr(m, '__version__', '?')}")
         except Exception as exc:  # noqa: BLE001
-            print(f"  {mod}: NOT INSTALLED ({exc}) -- install both to exercise the 'both_*' cases")
+            print(
+                f"  {mod}: NOT INSTALLED ({exc}) -- install both to exercise the 'both_*' cases"
+            )
     print("=" * 90)
     print(f"{'scenario':<20}{'runs':>6}{'crashes':>9}   sample stderr")
     print("-" * 90)
@@ -121,14 +130,26 @@ def main() -> int:
         print(f"{name:<24}{runs:>6}{crashes:>9}   {sample}{flag}")
     print("=" * 90)
     if coexist_crash and not fix_crash:
-        print("CONCLUSION: using both libraries crashes, but routing bzip2 through rapidgzip's")
-        print("bundled IndexedBzip2File (fix_both_via_rapidgzip = 0 crashes) does NOT — so the fix")
-        print("is to use rapidgzip for both gzip and bzip2 and never load indexed_bzip2.")
+        print(
+            "CONCLUSION: using both libraries crashes, but routing bzip2 through rapidgzip's"
+        )
+        print(
+            "bundled IndexedBzip2File (fix_both_via_rapidgzip = 0 crashes) does NOT — so the fix"
+        )
+        print(
+            "is to use rapidgzip for both gzip and bzip2 and never load indexed_bzip2."
+        )
     elif coexist_crash and fix_crash:
-        print("CONCLUSION: both-libraries crashes AND the rapidgzip-only fix candidate also crashed.")
-        print("The fix is insufficient on this platform; fall back to disabling accelerators.")
+        print(
+            "CONCLUSION: both-libraries crashes AND the rapidgzip-only fix candidate also crashed."
+        )
+        print(
+            "The fix is insufficient on this platform; fall back to disabling accelerators."
+        )
     else:
-        print("No coexistence crash observed in this run. The corruption is intermittent; re-run")
+        print(
+            "No coexistence crash observed in this run. The corruption is intermittent; re-run"
+        )
         print("with more iterations (e.g. `... dual_accelerator_repro.py 200`).")
     print("=" * 90)
     return 0

--- a/scripts/exploration/zipcrypto_codec_rejection.py
+++ b/scripts/exploration/zipcrypto_codec_rejection.py
@@ -107,7 +107,10 @@ def reject_deflate(data: bytes, *, max_out: int = 2 * 1024 * 1024) -> RejectionS
             consumed += len(chunk) - len(dec.unconsumed_tail)
             if produced >= max_out:
                 return RejectionSample(
-                    consumed, produced, "max_out", "hit decompressed bound without error"
+                    consumed,
+                    produced,
+                    "max_out",
+                    "hit decompressed bound without error",
                 )
             if dec.eof:
                 return RejectionSample(
@@ -144,7 +147,10 @@ def reject_bzip2(data: bytes, *, max_out: int = 2 * 1024 * 1024) -> RejectionSam
             consumed = i + len(chunk)
             if produced >= max_out:
                 return RejectionSample(
-                    consumed, produced, "max_out", "hit decompressed bound without error"
+                    consumed,
+                    produced,
+                    "max_out",
+                    "hit decompressed bound without error",
                 )
             if dec.eof:
                 return RejectionSample(
@@ -200,7 +206,10 @@ def reject_lzma_raw_zip(
             consumed = 4 + props_size + i + len(chunk) - unused
             if produced >= max_out:
                 return RejectionSample(
-                    consumed, produced, "max_out", "hit decompressed bound without error"
+                    consumed,
+                    produced,
+                    "max_out",
+                    "hit decompressed bound without error",
                 )
             if dec.eof:
                 return RejectionSample(
@@ -281,7 +290,11 @@ def run_random_trials(n: int, stream_size: int) -> None:
     ):
         samples = [fn(os.urandom(stream_size)) for _ in range(n)]
         _summarize(samples, name)
-        survivors = [s for s in samples if s.error_type in {"max_out", "eof_ok", "flush_ok", "need_more"}]
+        survivors = [
+            s
+            for s in samples
+            if s.error_type in {"max_out", "eof_ok", "flush_ok", "need_more"}
+        ]
         if survivors:
             print(f"    WARNING: {len(survivors)} streams did not error within bound")
             for s in survivors[:5]:
@@ -296,7 +309,9 @@ def run_almost_magic_bzip2(n: int, stream_size: int) -> None:
         data = b"BZh9" + os.urandom(stream_size - 4)
         samples.append(reject_bzip2(data))
     _summarize(samples, "BZIP2 almost-magic")
-    survivors = [s for s in samples if s.error_type in {"max_out", "eof_ok", "need_more"}]
+    survivors = [
+        s for s in samples if s.error_type in {"max_out", "eof_ok", "need_more"}
+    ]
     if survivors:
         print(f"    WARNING: {len(survivors)} streams survived")
         for s in survivors[:5]:
@@ -309,9 +324,9 @@ def run_wrong_key_zipfile(n_collisions: int, plaintext_size: int) -> None:
         f"(plaintext ~{plaintext_size} bytes, {n_collisions} collisions/codec) ==="
     )
     # Highly compressible so compressed members stay modest; size is decompressed.
-    plaintext = (b"The quick brown fox jumps over the lazy dog.\n" * (plaintext_size // 45 + 1))[
-        :plaintext_size
-    ]
+    plaintext = (
+        b"The quick brown fox jumps over the lazy dog.\n" * (plaintext_size // 45 + 1)
+    )[:plaintext_size]
     right = b"correct-password-for-probe"
     name = "probe.bin"
     for compression, label in (

--- a/scripts/exploration/zipcrypto_compressibility_probe.py
+++ b/scripts/exploration/zipcrypto_compressibility_probe.py
@@ -96,9 +96,9 @@ def payload_classes(chunk_size: int) -> dict[str, bytes]:
     mp4ish = mp4ish[:chunk_size]
 
     # JSON / CSV-ish structured text.
-    jsonish = (b'{"id": 12345, "name": "alice", "active": true}\n' * (chunk_size // 48 + 2))[
-        :chunk_size
-    ]
+    jsonish = (
+        b'{"id": 12345, "name": "alice", "active": true}\n' * (chunk_size // 48 + 2)
+    )[:chunk_size]
 
     # Low-entropy but not text: run-length friendly bytes.
     rle = bytes([i % 16 for i in range(chunk_size)])
@@ -134,7 +134,9 @@ def measure(
             for cname, cfn in compressors:
                 comp = cfn(data)
                 samples.append(
-                    RatioSample(label, cname, size, ratio(data, comp), len(data), len(comp))
+                    RatioSample(
+                        label, cname, size, ratio(data, comp), len(data), len(comp)
+                    )
                 )
 
         # Many random trials — this is the wrong-key distribution.
@@ -189,7 +191,9 @@ def propose_thresholds(samples: list[RatioSample]) -> None:
             random_ratios = [
                 s.ratio
                 for s in samples
-                if s.compressor == cname and s.chunk_size == size and s.label == "random"
+                if s.compressor == cname
+                and s.chunk_size == size
+                and s.label == "random"
             ]
             if not random_ratios:
                 continue
@@ -206,7 +210,9 @@ def propose_thresholds(samples: list[RatioSample]) -> None:
             jpeg_ratios = [
                 s.ratio
                 for s in samples
-                if s.compressor == cname and s.chunk_size == size and s.label == "jpegish"
+                if s.compressor == cname
+                and s.chunk_size == size
+                and s.label == "jpegish"
             ]
             text_r = text_ratios[0] if text_ratios else float("nan")
             jpeg_r = jpeg_ratios[0] if jpeg_ratios else float("nan")
@@ -236,7 +242,9 @@ def header_vs_body_note(chunk_sizes: list[int]) -> None:
     for label in ("jpegish", "pngish", "mp4ish", "zipish", "text", "random"):
         row = f"  {label:<8}"
         for size in chunk_sizes:
-            data = payload_classes(size)[label] if label != "random" else os.urandom(size)
+            data = (
+                payload_classes(size)[label] if label != "random" else os.urandom(size)
+            )
             # one-shot for illustration
             cfn = compressors[0][1]
             row += f"  {size}:{ratio(data, cfn(data)):.3f}"

--- a/scripts/griffe_extensions.py
+++ b/scripts/griffe_extensions.py
@@ -27,7 +27,9 @@ from griffe import (
 
 
 class PropertyFieldExtension(Extension):
-    def on_class_members(self, node: Any, cls: Class, agent: Any, **kwargs: Any) -> None:
+    def on_class_members(
+        self, node: Any, cls: Class, agent: Any, **kwargs: Any
+    ) -> None:
         properties = {
             k: v for k, v in cls.attributes.items() if v.has_labels("property")
         }
@@ -100,7 +102,9 @@ class EnumMembersAsTable(Extension):
     # "Value" one. So we stash the enum members in cls.extra and override the class
     # template (docs_templates/python/material/class.html.jinja) to render them as a table.
 
-    def on_class_members(self, node: Any, cls: Class, agent: Any, **kwargs: Any) -> None:
+    def on_class_members(
+        self, node: Any, cls: Class, agent: Any, **kwargs: Any
+    ) -> None:
         if not _is_enum_class(cls):
             return
         rows: list[dict[str, Any]] = []

--- a/src/archivey/internal/backends/iso_reader.py
+++ b/src/archivey/internal/backends/iso_reader.py
@@ -74,7 +74,9 @@ from archivey.types import (
 def _optional(name: str) -> ModuleType | None:
     try:
         return importlib.import_module(name)
-    except ImportError:  # pragma: no cover - the absent path runs in the core-only CI leg
+    except (
+        ImportError
+    ):  # pragma: no cover - the absent path runs in the core-only CI leg
         return None
 
 
@@ -157,7 +159,9 @@ def _install_pycdlib_directory_cycle_guard() -> None:
     # setattr (not a direct assignment) so the type checkers don't flag the deliberate
     # module -> proxy substitution against pcd_module.collections's declared Module type.
     setattr(
-        pcd_module, "collections", _DequeGuardedCollections(collections, _ExtentGuardedDeque)
+        pcd_module,
+        "collections",
+        _DequeGuardedCollections(collections, _ExtentGuardedDeque),
     )
     _PYCDLIB_CYCLE_GUARD_INSTALLED = True
 
@@ -179,9 +183,8 @@ _install_pycdlib_directory_cycle_guard()
 # error-handling: "Genuine runtime and I/O errors are not reclassified"). Built defensively so
 # the module imports without pycdlib.
 _PYCDLIB_ERRORS: tuple[type[Exception], ...] = (
-    ((_pycdlib_exc.PyCdlibException,) if _pycdlib_exc is not None else ())
-    + (IndexError, struct.error, UnicodeDecodeError, AttributeError, KeyError, ValueError)
-)
+    (_pycdlib_exc.PyCdlibException,) if _pycdlib_exc is not None else ()
+) + (IndexError, struct.error, UnicodeDecodeError, AttributeError, KeyError, ValueError)
 
 # Trailing ";1"/";42" version suffix on a plain ISO 9660 file identifier.
 _VERSION_SUFFIX = re.compile(r";\d+$")
@@ -230,7 +233,9 @@ class IsoReader(BaseArchiveReader):
     """Reads an ISO 9660 image via ``pycdlib`` (Rock Ridge / Joliet / plain)."""
 
     _SUPPORTS_RANDOM_ACCESS = True
-    _MEMBER_LIST_UPFRONT = True  # the directory tree is an in-header index (O(1) listing)
+    _MEMBER_LIST_UPFRONT = (
+        True  # the directory tree is an in-header index (O(1) listing)
+    )
 
     def __init__(
         self,
@@ -299,9 +304,7 @@ class IsoReader(BaseArchiveReader):
             self._path_kw = "iso_path"
 
     def _translate_exception(self, exc: Exception) -> ArchiveyError | None:
-        if _pycdlib_exc is not None and isinstance(
-            exc, _pycdlib_exc.PyCdlibException
-        ):
+        if _pycdlib_exc is not None and isinstance(exc, _pycdlib_exc.PyCdlibException):
             return CorruptionError(f"Error reading ISO image: {exc!r}")
         # pycdlib does not wrap every parse failure in its own exception type: a truncated
         # or crafted image can raise a bare IndexError/struct.error/ValueError from deep in
@@ -310,7 +313,14 @@ class IsoReader(BaseArchiveReader):
         # rather than letting a raw IndexError escape. (Found by the corpus mutation harness.)
         if isinstance(
             exc,
-            (IndexError, struct.error, UnicodeDecodeError, AttributeError, KeyError, ValueError),
+            (
+                IndexError,
+                struct.error,
+                UnicodeDecodeError,
+                AttributeError,
+                KeyError,
+                ValueError,
+            ),
         ):
             # pycdlib choked on corrupt structure (see the _PYCDLIB_ERRORS note). Never a
             # genuine OSError — that is not in this set and propagates unchanged.
@@ -439,7 +449,11 @@ class IsoReader(BaseArchiveReader):
                 continue
             raw_mode = getattr(px, "posix_file_mode", None)
             mode = stat.S_IMODE(raw_mode) if raw_mode is not None else None
-            return mode, getattr(px, "posix_user_id", None), getattr(px, "posix_group_id", None)
+            return (
+                mode,
+                getattr(px, "posix_user_id", None),
+                getattr(px, "posix_group_id", None),
+            )
         return None, None, None
 
     def _symlink_target(self, member_type: MemberType, rr: Any) -> str | None:
@@ -464,9 +478,7 @@ class IsoReader(BaseArchiveReader):
                     locked: BinaryIO = LockedStream(
                         _PyCdlibStream(raw), self._handle_lock
                     )
-                return self._wrap_member_stream(
-                    locked, member.name, size=member.size
-                )
+                return self._wrap_member_stream(locked, member.name, size=member.size)
             raw = self._iso.open_file_from_iso(**{self._path_kw: ns_path})
             # Construct inside the try so any enter-time pycdlib error is translated too;
             # _PyCdlibStream enters the PyCdlibIO context in its __init__.

--- a/src/archivey/internal/backends/single_file_reader.py
+++ b/src/archivey/internal/backends/single_file_reader.py
@@ -268,9 +268,7 @@ class SingleFileReader(BaseArchiveReader):
             )
         # Wrap so the handle carries the reader's diagnostic collector/operation id.
         # (open_codec_stream already returns an ArchiveStream; nesting is fine.)
-        return self._wrap_member_stream(
-            raw, self._member.name, size=self._member.size
-        )
+        return self._wrap_member_stream(raw, self._member.name, size=self._member.size)
 
     def _open_member(self, member: ArchiveMember) -> ArchiveStream:
         if self._seekable:
@@ -296,7 +294,9 @@ class SingleFileReader(BaseArchiveReader):
             listing_cost=ListingCost.INDEXED,  # exactly one member, always
             access_cost=AccessCost.DIRECT,  # one member -> no solid-block dependency
             stream_capability=(
-                StreamCapability.SEEKABLE if self._seekable else StreamCapability.FORWARD_ONLY
+                StreamCapability.SEEKABLE
+                if self._seekable
+                else StreamCapability.FORWARD_ONLY
             ),
             solid_block_count=None,
         )
@@ -338,7 +338,9 @@ class SingleFileBackend(ReadBackend):
     """
 
     FORMATS: tuple[ArchiveFormat, ...] = tuple(
-        c.single_file_format for c in SINGLE_FILE_CODECS if c.single_file_format is not None
+        c.single_file_format
+        for c in SINGLE_FILE_CODECS
+        if c.single_file_format is not None
     )
     # A compressed stream decodes front-to-back, so streaming=True works on a
     # non-seekable source (except unix-compress, whose codec itself needs seek and

--- a/src/archivey/internal/backends/tar_reader.py
+++ b/src/archivey/internal/backends/tar_reader.py
@@ -337,8 +337,9 @@ class TarReader(BaseArchiveReader):
                     stream: BinaryIO = ensure_binaryio(raw)
                     if self._handle_lock is not None:
                         stream = LockedStream(stream, self._handle_lock)
-                    yield member, self._wrap_member_stream(
-                        stream, member.name, size=member.size
+                    yield (
+                        member,
+                        self._wrap_member_stream(stream, member.name, size=member.size),
                     )
                 else:
                     yield member, None
@@ -419,7 +420,9 @@ class TarReader(BaseArchiveReader):
         member_type = _member_type(info)
         # TAR is a POSIX format: a backslash is a legal filename character, not a separator.
         presented = info.name
-        name = normalize_member_name(presented, member_type, backslash_is_separator=False)
+        name = normalize_member_name(
+            presented, member_type, backslash_is_separator=False
+        )
         # Re-encode the decoded name with the archive's own codec to recover the stored bytes
         # (tarfile decodes with surrogateescape, which round-trips losslessly).
         raw_name = info.name.encode(self._tar.encoding, errors="surrogateescape")
@@ -501,7 +504,9 @@ class TarReader(BaseArchiveReader):
 
     def _open_member(self, member: ArchiveMember) -> ArchiveStream:
         info = member._raw
-        assert isinstance(info, tarfile.TarInfo), "TAR member is missing its TarInfo handle"
+        assert isinstance(info, tarfile.TarInfo), (
+            "TAR member is missing its TarInfo handle"
+        )
         # Capture under the handle lock; translate/stamp only after release so diagnostics
         # and callbacks never run while the shared-fileobj lock is held.
         raw_exc: tarfile.TarError | None = None

--- a/src/archivey/internal/backends/zip_reader.py
+++ b/src/archivey/internal/backends/zip_reader.py
@@ -577,7 +577,9 @@ class ZipReader(BaseArchiveReader):
     ) -> BinaryIO:
         encrypted = bool(info.flag_bits & 0x1)
         if not encrypted:
-            return self._open_zipfile_member(info, password=None, member_name=member_name)
+            return self._open_zipfile_member(
+                info, password=None, member_name=member_name
+            )
 
         # ZipCrypto's one-byte open check admits ~1/256 of wrong passwords. With more
         # than one possible candidate (or a provider), confirm before accepting.

--- a/src/archivey/internal/base_reader.py
+++ b/src/archivey/internal/base_reader.py
@@ -219,15 +219,11 @@ class BaseArchiveReader(ArchiveReader):
         self._archive_name = archive_name
         self._config = config if config is not None else DEFAULT_ARCHIVEY_CONFIG
         self._diagnostics_collector = (
-            collector
-            if collector is not None
-            else collector_from_config(self._config)
+            collector if collector is not None else collector_from_config(self._config)
         )
         self._member_streams = member_streams
         self._open_site = open_site
-        self._state = ReaderState(
-            member_streams=member_streams, open_site=open_site
-        )
+        self._state = ReaderState(member_streams=member_streams, open_site=open_site)
         # A random, opaque identity token (not id(self), which the allocator can reuse
         # after a reader is garbage-collected — a member of a dead reader must never
         # pass another reader's identity check; and not a plain counter, whose small
@@ -340,7 +336,8 @@ class BaseArchiveReader(ArchiveReader):
         if the member is actually read, not merely iterated past.
         """
         members = (
-            self._begin_forward_pass() if self._streaming
+            self._begin_forward_pass()
+            if self._streaming
             else self._get_members_registered()
         )
         previous: ArchiveStream | None = None
@@ -473,7 +470,9 @@ class BaseArchiveReader(ArchiveReader):
             # exists; otherwise they only need the live-stream gate exemption.
             root = self._state.current_root()
             child = (
-                self._state.enter_child(root, "link_reads") if root is not None else None
+                self._state.enter_child(root, "link_reads")
+                if root is not None
+                else None
             )
             try:
                 with self._internal_member_opens():
@@ -882,7 +881,9 @@ class BaseArchiveReader(ArchiveReader):
             f"Got {type(member).__name__}.",
         )
 
-    def get(self, name: str, default: ArchiveMember | None = None) -> ArchiveMember | None:
+    def get(
+        self, name: str, default: ArchiveMember | None = None
+    ) -> ArchiveMember | None:
         self._require_random_access("get()")
         token = self._state.acquire_worker("get")
         try:

--- a/src/archivey/internal/detection.py
+++ b/src/archivey/internal/detection.py
@@ -86,7 +86,9 @@ class FormatInfo:
     confidence: DetectionConfidence
     detected_by: str  # "magic", "extension", "content_probe", "sfx_scan"
     encoding_hint: str | None = None
-    payload_offset: int = 0  # nonzero only for SFX archives (is-SFX == payload_offset > 0)
+    payload_offset: int = (
+        0  # nonzero only for SFX archives (is-SFX == payload_offset > 0)
+    )
     diagnostics: DiagnosticSummary = field(default_factory=DiagnosticSummary.empty)
 
 
@@ -229,7 +231,10 @@ def _resolve_single_file_or_tar(
     Otherwise the original single-file/container match stands. ``peek_more`` gives the probe
     a bounded, non-consuming view of the source to decode from.
     """
-    if fmt.container == ContainerFormat.RAW_STREAM and fmt.stream != StreamFormat.UNCOMPRESSED:
+    if (
+        fmt.container == ContainerFormat.RAW_STREAM
+        and fmt.stream != StreamFormat.UNCOMPRESSED
+    ):
         if _probe_inner_tar(fmt.stream, peek_more):
             tar_fmt = ArchiveFormat(ContainerFormat.TAR, fmt.stream)
             return FormatInfo(tar_fmt, DetectionConfidence.PROBABLE, "content_probe")

--- a/src/archivey/internal/extraction_types.py
+++ b/src/archivey/internal/extraction_types.py
@@ -43,7 +43,9 @@ class ExtractionPolicy(Enum):
 
     STRICT = "strict"  # default; untrusted archives
     STANDARD = "standard"  # moderate trust; e.g. your own older archives
-    TRUSTED = "trusted"  # apply stored mode (and uid/gid as root); path safety still enforced
+    TRUSTED = (
+        "trusted"  # apply stored mode (and uid/gid as root); path safety still enforced
+    )
 
 
 class OverwritePolicy(Enum):
@@ -57,7 +59,9 @@ class OverwritePolicy(Enum):
 
     ERROR = "error"  # existing entry -> ExtractionError (then handled per OnError)
     SKIP = "skip"  # silently skip existing entries (records SKIPPED)
-    REPLACE = "replace"  # unlink the existing entry, then create fresh (never write-through)
+    REPLACE = (
+        "replace"  # unlink the existing entry, then create fresh (never write-through)
+    )
 
 
 class OnError(Enum):

--- a/src/archivey/internal/open_site.py
+++ b/src/archivey/internal/open_site.py
@@ -21,7 +21,9 @@ class OpenSite:
         return f"{self.filename}:{self.lineno}"
 
 
-def capture_open_site(*, skip_module_prefixes: tuple[str, ...] = ("archivey.",)) -> OpenSite:
+def capture_open_site(
+    *, skip_module_prefixes: tuple[str, ...] = ("archivey.",)
+) -> OpenSite:
     """Walk frames until the first non-archivey caller; keep the full stack."""
     stack = tuple(traceback.extract_stack()[:-1])  # drop this helper frame
     frame: FrameType | None = None
@@ -35,7 +37,9 @@ def capture_open_site(*, skip_module_prefixes: tuple[str, ...] = ("archivey.",))
     lineno = 0
     while frame is not None:
         mod = frame.f_globals.get("__name__", "")
-        if not any(mod == p.rstrip(".") or mod.startswith(p) for p in skip_module_prefixes):
+        if not any(
+            mod == p.rstrip(".") or mod.startswith(p) for p in skip_module_prefixes
+        ):
             filename = frame.f_code.co_filename
             lineno = frame.f_lineno
             break
@@ -44,9 +48,9 @@ def capture_open_site(*, skip_module_prefixes: tuple[str, ...] = ("archivey.",))
         # Fall back to the last non-archivey summary in the extracted stack.
         for summary in reversed(stack):
             # extract_stack has no module name; use path heuristics.
-            if "/archivey/" not in summary.filename.replace("\\", "/") and not summary.filename.endswith(
-                "open_site.py"
-            ):
+            if "/archivey/" not in summary.filename.replace(
+                "\\", "/"
+            ) and not summary.filename.endswith("open_site.py"):
                 filename = summary.filename
                 lineno = summary.lineno or 0
                 break

--- a/src/archivey/internal/password.py
+++ b/src/archivey/internal/password.py
@@ -86,7 +86,9 @@ class _PasswordCandidates:
 
     def has_passwords(self) -> bool:
         with self._state_lock:
-            return bool(self._known_good or self._candidates or self._provider is not None)
+            return bool(
+                self._known_good or self._candidates or self._provider is not None
+            )
 
     def is_ambiguous(self) -> bool:
         """Whether a weak password check needs confirmation before accepting a result.
@@ -102,9 +104,7 @@ class _PasswordCandidates:
     def has_provider(self) -> bool:
         return self._provider is not None
 
-    def ask_provider(
-        self, member: ArchiveMember | None, attempt: int
-    ) -> bytes | None:
+    def ask_provider(self, member: ArchiveMember | None, attempt: int) -> bytes | None:
         """Return the provider's next answer, or ``None`` to stop.
 
         Invokes the provider with no Archivey lock held (the provider lock is released

--- a/src/archivey/internal/password_confirm.py
+++ b/src/archivey/internal/password_confirm.py
@@ -19,9 +19,7 @@ CONFIRM_PREFIX_BYTES = 64 * 1024
 _T = TypeVar("_T")
 
 
-def first_crc_match(
-    expected_crc: int, items: Sequence[tuple[_T, int]]
-) -> _T | None:
+def first_crc_match(expected_crc: int, items: Sequence[tuple[_T, int]]) -> _T | None:
     """Return the first item whose CRC-32 matches ``expected_crc`` (candidate order)."""
     expected = expected_crc & 0xFFFFFFFF
     for item, crc in items:

--- a/src/archivey/internal/registry.py
+++ b/src/archivey/internal/registry.py
@@ -57,7 +57,9 @@ class FormatSupport(Enum):
     """Tri-state readability of a known format (see ``backend-registry``)."""
 
     FULL = "full"  # backend usable AND every optional codec/tool it can use is present
-    PARTIAL = "partial"  # opens & lists; common members decode; some optional codec missing
+    PARTIAL = (
+        "partial"  # opens & lists; common members decode; some optional codec missing
+    )
     NONE = "none"  # backend (or a single-codec format's sole codec) is unavailable
 
 
@@ -171,7 +173,9 @@ class BackendRegistry:
 
         if not self._backend_available(backend_cls):
             dep = backend_cls.OPTIONAL_DEPENDENCY
-            assert dep is not None  # _backend_available only returns False when dep is set
+            assert (
+                dep is not None
+            )  # _backend_available only returns False when dep is set
             hint = backend_cls.INSTALL_HINT or f"install {dep}"
             return FormatAvailability(
                 fmt,

--- a/src/archivey/internal/streams/codecs.py
+++ b/src/archivey/internal/streams/codecs.py
@@ -74,7 +74,9 @@ if TYPE_CHECKING:
 def _optional(name: str) -> ModuleType | None:
     try:
         return importlib.import_module(name)
-    except ImportError:  # pragma: no cover - the absent path runs in the core-only CI leg
+    except (
+        ImportError
+    ):  # pragma: no cover - the absent path runs in the core-only CI leg
         return None
 
 
@@ -280,7 +282,9 @@ class _GzipTruncationCheckStream(DelegatingStream):
         try:
             with open(self._source_path, "rb") as f:
                 size = f.seek(0, io.SEEK_END)
-                if size < 18:  # header(10) + min deflate + trailer(8): too small to trust
+                if (
+                    size < 18
+                ):  # header(10) + min deflate + trailer(8): too small to trust
                     return
                 f.seek(-4, io.SEEK_END)
                 isize = int.from_bytes(f.read(4), "little")
@@ -473,7 +477,9 @@ class StreamCodec:
         if not self.available:
             return False
         try:
-            with open_codec_stream(self.codec, io.BytesIO(prefix[:_PROBE_PREFIX])) as stream:
+            with open_codec_stream(
+                self.codec, io.BytesIO(prefix[:_PROBE_PREFIX])
+            ) as stream:
                 stream.read(_PROBE_PREFIX)
             return True
         except TruncatedError:
@@ -521,7 +527,9 @@ class GzipCodec(StreamCodec):
         # accelerator (above) gives real random access.
         if isinstance(source, (str, os.PathLike)):
             return ensure_binaryio(gzip.open(source, "rb"))
-        return ensure_binaryio(gzip.GzipFile(fileobj=ensure_bufferedio(source), mode="rb"))
+        return ensure_binaryio(
+            gzip.GzipFile(fileobj=ensure_bufferedio(source), mode="rb")
+        )
 
     def translate(self, exc: Exception) -> ArchiveyError | None:
         if isinstance(exc, gzip.BadGzipFile):
@@ -568,16 +576,23 @@ class GzipCodec(StreamCodec):
             # header (… Invalid gzip magic bytes)". The gzip magic matched at open, so this is
             # corruption.
             return CorruptionError(f"Error reading gzip stream (rapidgzip): {exc!r}")
-        if isinstance(exc, ValueError) and "Failed to detect a valid file format" in text:
+        if (
+            isinstance(exc, ValueError)
+            and "Failed to detect a valid file format" in text
+        ):
             # The gzip magic was present when we opened it, so a detection failure now means
             # the stream is truncated/corrupt rather than not-a-gzip.
             return CorruptionError(f"Error reading gzip stream (rapidgzip): {exc!r}")
         if isinstance(exc, ValueError) and "End of file encountered" in text:
             return TruncatedError(f"gzip stream is truncated (rapidgzip): {exc!r}")
         if isinstance(exc, ValueError) and "has no valid fileno" in text:
-            return StreamNotSeekableError("rapidgzip does not support non-seekable streams")
+            return StreamNotSeekableError(
+                "rapidgzip does not support non-seekable streams"
+            )
         if isinstance(exc, io.UnsupportedOperation) and "seek" in text:
-            return StreamNotSeekableError("rapidgzip does not support non-seekable streams")
+            return StreamNotSeekableError(
+                "rapidgzip does not support non-seekable streams"
+            )
         if isinstance(exc, RuntimeError) and "std::exception" in text:
             return CorruptionError(f"Error reading gzip stream (rapidgzip): {exc!r}")
         return None
@@ -655,13 +670,22 @@ class Bzip2Codec(StreamCodec):
         """Translate the indexed_bzip2 accelerator's exceptions to the library's error types."""
         text = str(exc)
         if isinstance(exc, RuntimeError) and "Calculated CRC" in text:
-            return CorruptionError(f"Error reading bzip2 stream (indexed_bzip2): {exc!r}")
-        if isinstance(exc, RuntimeError) and text in ("std::exception", "Unknown exception"):
-            return CorruptionError(f"Error reading bzip2 stream (indexed_bzip2): {exc!r}")
+            return CorruptionError(
+                f"Error reading bzip2 stream (indexed_bzip2): {exc!r}"
+            )
+        if isinstance(exc, RuntimeError) and text in (
+            "std::exception",
+            "Unknown exception",
+        ):
+            return CorruptionError(
+                f"Error reading bzip2 stream (indexed_bzip2): {exc!r}"
+            )
         if "[BZip2 block" in text:
             # Corrupt block data or block header (e.g. "[BZip2 block header] Invalid Huffman
             # coding group count"); surfaced as ValueError or RuntimeError depending on where.
-            return CorruptionError(f"Error reading bzip2 stream (indexed_bzip2): {exc!r}")
+            return CorruptionError(
+                f"Error reading bzip2 stream (indexed_bzip2): {exc!r}"
+            )
         if isinstance(exc, (ValueError, RuntimeError)) and (
             "Huffman" in text
             or "magic" in text  # "Input header is not BZip2 magic string 'BZh'…"
@@ -671,11 +695,17 @@ class Bzip2Codec(StreamCodec):
             # Corrupt Huffman tables, stream/block magic, or internal state, outside a
             # "[BZip2 block]"-tagged context (e.g. "Constructing a Huffman coding … failed!"
             # or "bad optional access") — all found by the corpus mutation harness.
-            return CorruptionError(f"Error reading bzip2 stream (indexed_bzip2): {exc!r}")
+            return CorruptionError(
+                f"Error reading bzip2 stream (indexed_bzip2): {exc!r}"
+            )
         if isinstance(exc, ValueError) and "has no valid fileno" in text:
-            return StreamNotSeekableError("indexed_bzip2 does not support non-seekable streams")
+            return StreamNotSeekableError(
+                "indexed_bzip2 does not support non-seekable streams"
+            )
         if isinstance(exc, io.UnsupportedOperation) and "seek" in text:
-            return StreamNotSeekableError("indexed_bzip2 does not support non-seekable streams")
+            return StreamNotSeekableError(
+                "indexed_bzip2 does not support non-seekable streams"
+            )
         return None
 
 
@@ -730,7 +760,9 @@ class _RawLzmaCodec(_LzmaErrorCodec):
                 "raw LZMA decoding requires filter properties (CodecParams.filters)"
             )
         return ensure_binaryio(
-            lzma.LZMAFile(source, mode="rb", format=lzma.FORMAT_RAW, filters=params.filters)
+            lzma.LZMAFile(
+                source, mode="rb", format=lzma.FORMAT_RAW, filters=params.filters
+            )
         )
 
 
@@ -793,7 +825,9 @@ class ZstdCodec(StreamCodec):
     codec = Codec.ZSTD
     stream_format = StreamFormat.ZSTD
     magic = (MagicSignature(0, b"\x28\xb5\x2f\xfd", ArchiveFormat.ZST),)
-    requirement = MissingComponent("backports.zstd", "pip install archivey[zstd]", ("zstd",))
+    requirement = MissingComponent(
+        "backports.zstd", "pip install archivey[zstd]", ("zstd",)
+    )
 
     def _backend_present(self) -> bool:
         return _zstd is not None
@@ -941,7 +975,9 @@ class PpmdCodec(StreamCodec):
             )
         # The concrete PPMd stream construction (var.H parameters from the 7z coder) lands with
         # the native 7z reader in Phase 7; the resolver + missing-backend gating are complete.
-        raise NotImplementedError("PPMd decoding is implemented in Phase 7 (native 7z reader)")
+        raise NotImplementedError(
+            "PPMd decoding is implemented in Phase 7 (native 7z reader)"
+        )
 
     def translate(self, exc: Exception) -> ArchiveyError | None:
         if isinstance(exc, EOFError):
@@ -953,7 +989,9 @@ class PpmdCodec(StreamCodec):
 
 class Deflate64Codec(StreamCodec):
     codec = Codec.DEFLATE64
-    requirement = MissingComponent("inflate64", "pip install archivey[7z]", ("deflate64",))
+    requirement = MissingComponent(
+        "inflate64", "pip install archivey[7z]", ("deflate64",)
+    )
 
     def _backend_present(self) -> bool:
         return _inflate64 is not None
@@ -1054,13 +1092,19 @@ class CodecBackend:
     config: StreamConfig
     translate: ExceptionTranslator
     rewind_warning: RewindWarning | None
-    _open: Callable[[CodecSource, CodecParams, StreamConfig], BinaryIO] = field(repr=False)
+    _open: Callable[[CodecSource, CodecParams, StreamConfig], BinaryIO] = field(
+        repr=False
+    )
 
-    def open(self, source: CodecSource, params: CodecParams = _DEFAULT_PARAMS) -> BinaryIO:
+    def open(
+        self, source: CodecSource, params: CodecParams = _DEFAULT_PARAMS
+    ) -> BinaryIO:
         return self._open(source, params, self.config)
 
 
-def resolve_codec(codec: Codec, config: StreamConfig = DEFAULT_STREAM_CONFIG) -> CodecBackend:
+def resolve_codec(
+    codec: Codec, config: StreamConfig = DEFAULT_STREAM_CONFIG
+) -> CodecBackend:
     """Resolve ``codec`` to its backend (open function + translator) without opening anything.
 
     The translator must match the *active* backend: when an accelerator

--- a/src/archivey/internal/streams/decompressor_stream.py
+++ b/src/archivey/internal/streams/decompressor_stream.py
@@ -94,7 +94,9 @@ class DecompressorStream(ReadOnlyIOStream, Generic[DecompressorT]):
         self._seek_points: list[SeekPoint] = [SeekPoint(0, 0)]
         self._index_built = False
         self._index_build_attempted = False
-        self._decompressor: DecompressorT = self._create_decompressor(self._seek_points[0])
+        self._decompressor: DecompressorT = self._create_decompressor(
+            self._seek_points[0]
+        )
         self._buffer = bytearray()
         self._eof = False
         self._pos = 0

--- a/src/archivey/internal/streams/lzip.py
+++ b/src/archivey/internal/streams/lzip.py
@@ -97,7 +97,9 @@ def _read_index_backwards(
     result: list[_MemberBounds] = []
     decompressed_offset = start_decompressed_offset
     for comp_start, decomp_size, comp_size in reversed(entries):
-        result.append(_MemberBounds(comp_start, decompressed_offset, comp_size, decomp_size))
+        result.append(
+            _MemberBounds(comp_start, decompressed_offset, comp_size, decomp_size)
+        )
         decompressed_offset += decomp_size
     return result
 
@@ -189,7 +191,9 @@ class _LzipState:
                 raise CorruptionError(
                     f"Not a valid lzip file: expected magic {_MAGIC!r}, got {header[:4]!r}"
                 )
-            self._finished = True  # lzip spec §7: trailing data after members is allowed
+            self._finished = (
+                True  # lzip spec §7: trailing data after members is allowed
+            )
             return False
         if header[4] != 1:
             raise CorruptionError(f"Unsupported lzip version: {header[4]}")

--- a/src/archivey/internal/streams/streamtools/binaryio.py
+++ b/src/archivey/internal/streams/streamtools/binaryio.py
@@ -102,7 +102,9 @@ def is_seekable(stream: Any) -> bool:
         return True
     seekable = getattr(stream, "seekable", None)
     if seekable is None:
-        logger.debug("Stream %r has no seekable() method; treating as non-seekable", stream)
+        logger.debug(
+            "Stream %r has no seekable() method; treating as non-seekable", stream
+        )
         return False
     try:
         if not seekable():
@@ -380,7 +382,9 @@ def ensure_binaryio(obj: Any) -> BinaryIO:
     """
     if is_stream(obj):
         return obj
-    logger.debug("Wrapping %r in BinaryIOWrapper to satisfy the BinaryIO interface", obj)
+    logger.debug(
+        "Wrapping %r in BinaryIOWrapper to satisfy the BinaryIO interface", obj
+    )
     return BinaryIOWrapper(obj)
 
 

--- a/src/archivey/internal/streams/xz.py
+++ b/src/archivey/internal/streams/xz.py
@@ -115,7 +115,9 @@ def _parse_xz_footer(data: bytes) -> tuple[int, int]:
     if len(data) < _STREAM_FOOTER_SIZE:
         raise CorruptionError(f"XZ stream footer too short: {len(data)} bytes")
     if data[10:12] != _XZ_FOOTER_MAGIC:
-        raise CorruptionError(f"XZ stream footer magic 'YZ' not found (got {data[10:12]!r})")
+        raise CorruptionError(
+            f"XZ stream footer magic 'YZ' not found (got {data[10:12]!r})"
+        )
     stored_crc = struct.unpack_from("<I", data, 0)[0]
     backward_size_raw = struct.unpack_from("<I", data, 4)[0]
     stream_flags = data[8:10]
@@ -156,7 +158,9 @@ def _parse_xz_index(data: bytes) -> list[tuple[int, int]]:
     padded_len = _round_up_4(offset)
     for i in range(offset, padded_len):
         if i < len(data) and data[i] != 0:
-            raise CorruptionError(f"XZ index padding byte {i} is non-zero: {data[i]:#04x}")
+            raise CorruptionError(
+                f"XZ index padding byte {i} is non-zero: {data[i]:#04x}"
+            )
     return records
 
 
@@ -190,7 +194,9 @@ def _read_xz_index_backwards(
             break
 
         if compressed_end < _STREAM_FOOTER_SIZE:
-            raise CorruptionError(f"Not enough bytes for XZ footer at offset {compressed_end}")
+            raise CorruptionError(
+                f"Not enough bytes for XZ footer at offset {compressed_end}"
+            )
         stream.seek(compressed_end - _STREAM_FOOTER_SIZE)
         footer_data = stream.read(_STREAM_FOOTER_SIZE)
         if len(footer_data) < _STREAM_FOOTER_SIZE:
@@ -208,7 +214,9 @@ def _read_xz_index_backwards(
             raise CorruptionError("XZ index truncated")
 
         raw_index = index_with_crc[:-4]
-        stored_index_crc = struct.unpack_from("<I", index_with_crc, len(index_with_crc) - 4)[0]
+        stored_index_crc = struct.unpack_from(
+            "<I", index_with_crc, len(index_with_crc) - 4
+        )[0]
         computed_index_crc = zlib.crc32(raw_index) & 0xFFFFFFFF
         if stored_index_crc != computed_index_crc:
             raise CorruptionError(
@@ -304,9 +312,10 @@ class _XzState:
                 # null bytes whose length is a multiple of four (to keep streams 4-byte
                 # aligned). Strip all leading 4-byte runs in one delete.
                 padding = 0
-                while padding + 4 <= len(self._buf) and bytes(
-                    self._buf[padding : padding + 4]
-                ) == b"\x00\x00\x00\x00":
+                while (
+                    padding + 4 <= len(self._buf)
+                    and bytes(self._buf[padding : padding + 4]) == b"\x00\x00\x00\x00"
+                ):
                     padding += 4
                 if padding:
                     del self._buf[:padding]
@@ -383,7 +392,9 @@ class _XzBlockChain:
         self._block_bytes_fed = 0
         stream_flags = bytes([0x00, block.check])
         header_crc = zlib.crc32(stream_flags) & 0xFFFFFFFF
-        synthetic_header = _XZ_STREAM_MAGIC + stream_flags + struct.pack("<I", header_crc)
+        synthetic_header = (
+            _XZ_STREAM_MAGIC + stream_flags + struct.pack("<I", header_crc)
+        )
         try:
             self._dec.decompress(synthetic_header)
         except lzma.LZMAError as e:
@@ -464,9 +475,7 @@ class XzDecompressorStream(SegmentedDecompressorStream["_XzState | _XzBlockChain
         collector: DiagnosticCollector | None = None,
         seekable: bool = True,
     ) -> None:
-        super().__init__(
-            path, collector=collector, codec_name="xz", seekable=seekable
-        )
+        super().__init__(path, collector=collector, codec_name="xz", seekable=seekable)
 
     def _make_decompressor(self, point: SeekPoint) -> "_XzState | _XzBlockChain":
         if point.state is None:
@@ -475,7 +484,8 @@ class XzDecompressorStream(SegmentedDecompressorStream["_XzState | _XzBlockChain
         subsequent = [
             sp.state
             for sp in self._seek_points
-            if sp.decompressed_offset > point.decompressed_offset and sp.state is not None
+            if sp.decompressed_offset > point.decompressed_offset
+            and sp.state is not None
         ]
         return _XzBlockChain([start_block, *subsequent], self._inner)
 
@@ -496,11 +506,7 @@ class XzDecompressorStream(SegmentedDecompressorStream["_XzState | _XzBlockChain
                     [SeekPoint(stream_decomp_start, stream_comp_start, state=None)]
                 )
             stream_comp_end = stream_comp_start + compressed_size
-            if (
-                self._index_enabled
-                and not self._index_built
-                and self._inner.seekable()
-            ):
+            if self._index_enabled and not self._index_built and self._inner.seekable():
                 saved_pos = self._inner.tell()
                 try:
                     blocks = _read_xz_index_backwards(

--- a/src/archivey/internal/volumes.py
+++ b/src/archivey/internal/volumes.py
@@ -63,7 +63,9 @@ def discover_volume_siblings(path: Path) -> list[Path] | None:
                 and (part_match := _RAR_PART_RE.match(candidate.name)) is not None
                 and part_match.group("base").lower() == base.lower()
             ),
-            key=lambda candidate: _part_number_from_name(candidate.name, part_group="part"),
+            key=lambda candidate: _part_number_from_name(
+                candidate.name, part_group="part"
+            ),
         )
         return siblings if len(siblings) > 1 else None
 

--- a/src/archivey/types.py
+++ b/src/archivey/types.py
@@ -126,11 +126,17 @@ ArchiveFormat.LZIP = ArchiveFormat(ContainerFormat.RAW_STREAM, StreamFormat.LZIP
 ArchiveFormat.ZLIB = ArchiveFormat(ContainerFormat.RAW_STREAM, StreamFormat.ZLIB)
 ArchiveFormat.BROTLI = ArchiveFormat(ContainerFormat.RAW_STREAM, StreamFormat.BROTLI)
 ArchiveFormat.Z = ArchiveFormat(ContainerFormat.RAW_STREAM, StreamFormat.UNIX_COMPRESS)
-ArchiveFormat.SEVEN_Z = ArchiveFormat(ContainerFormat.SEVEN_Z, StreamFormat.UNCOMPRESSED)
+ArchiveFormat.SEVEN_Z = ArchiveFormat(
+    ContainerFormat.SEVEN_Z, StreamFormat.UNCOMPRESSED
+)
 ArchiveFormat.RAR = ArchiveFormat(ContainerFormat.RAR, StreamFormat.UNCOMPRESSED)
 ArchiveFormat.ISO = ArchiveFormat(ContainerFormat.ISO, StreamFormat.UNCOMPRESSED)
-ArchiveFormat.DIRECTORY = ArchiveFormat(ContainerFormat.DIRECTORY, StreamFormat.UNCOMPRESSED)
-ArchiveFormat.UNKNOWN = ArchiveFormat(ContainerFormat.UNKNOWN, StreamFormat.UNCOMPRESSED)
+ArchiveFormat.DIRECTORY = ArchiveFormat(
+    ContainerFormat.DIRECTORY, StreamFormat.UNCOMPRESSED
+)
+ArchiveFormat.UNKNOWN = ArchiveFormat(
+    ContainerFormat.UNKNOWN, StreamFormat.UNCOMPRESSED
+)
 
 # Reverse map (instance -> attribute name) for __repr__, derived by introspecting the
 # class attributes above so the names live in exactly one place.
@@ -152,7 +158,9 @@ class MissingComponent:
 
     name: str  # e.g. "pycdlib", "[7z]", "unrar"
     install_hint: str  # e.g. "pip install archivey[iso]"
-    unlocks: tuple[str, ...] = ()  # member-codecs/capabilities it enables, e.g. ("ppmd",)
+    unlocks: tuple[
+        str, ...
+    ] = ()  # member-codecs/capabilities it enables, e.g. ("ppmd",)
 
 
 class MagicSignature(NamedTuple):
@@ -388,7 +396,9 @@ class ArchiveMember:
 
     @property
     def is_junction(self) -> bool:
-        return self.type == MemberType.SYMLINK and bool(self.extra.get(EXTRA_IS_JUNCTION))
+        return self.type == MemberType.SYMLINK and bool(
+            self.extra.get(EXTRA_IS_JUNCTION)
+        )
 
     def replace(self, **kwargs: Any) -> "ArchiveMember":
         """Return a copy with the given fields changed; never mutates self."""

--- a/tests/create_adversarial.py
+++ b/tests/create_adversarial.py
@@ -93,7 +93,9 @@ def build_base_tar() -> bytes:
 # --- ZIP field mutation -----------------------------------------------------------
 
 
-def _find_zip_header(base: bytes, signature: bytes, fixed_size: int, name: bytes) -> int:
+def _find_zip_header(
+    base: bytes, signature: bytes, fixed_size: int, name: bytes
+) -> int:
     """Find the unique ZIP header with ``name`` and return its start offset."""
     matches: list[int] = []
     start = base.find(signature)
@@ -248,9 +250,7 @@ def _zip_name_case(
 ) -> Adversarial:
     raw = _padded(_HOSTILE[key], len(_NAME))
     decoded = (
-        raw.decode("utf-8" if utf8 else "cp437")
-        if open_outcome == "success"
-        else None
+        raw.decode("utf-8" if utf8 else "cp437") if open_outcome == "success" else None
     )
     return Adversarial(
         id=case_id,

--- a/tests/sample_archives.py
+++ b/tests/sample_archives.py
@@ -83,17 +83,27 @@ def D(name: str, **kw: object) -> Member:
     return Member(name=name, type=MemberType.DIRECTORY, **kw)  # type: ignore[arg-type]
 
 
-def S(name: str, target: str, *, link_contents: bytes | None = None, **kw: object) -> Member:
+def S(
+    name: str, target: str, *, link_contents: bytes | None = None, **kw: object
+) -> Member:
     return Member(
-        name=name, type=MemberType.SYMLINK, link_target=target,
-        link_contents=link_contents, **kw,  # type: ignore[arg-type]
+        name=name,
+        type=MemberType.SYMLINK,
+        link_target=target,
+        link_contents=link_contents,
+        **kw,  # type: ignore[arg-type]
     )
 
 
-def H(name: str, target: str, *, link_contents: bytes | None = None, **kw: object) -> Member:
+def H(
+    name: str, target: str, *, link_contents: bytes | None = None, **kw: object
+) -> Member:
     return Member(
-        name=name, type=MemberType.HARDLINK, link_target=target,
-        link_contents=link_contents, **kw,  # type: ignore[arg-type]
+        name=name,
+        type=MemberType.HARDLINK,
+        link_target=target,
+        link_contents=link_contents,
+        **kw,  # type: ignore[arg-type]
     )
 
 
@@ -154,7 +164,17 @@ FORMAT_KEYS: dict[str, ArchiveFormat] = {
     "rar": ArchiveFormat.RAR,
 }
 
-_ALL_TAR = ("tar", "tar.gz", "tar.bz2", "tar.xz", "tar.zst", "tar.lz4", "tar.lz", "tar.zz", "tar.br")
+_ALL_TAR = (
+    "tar",
+    "tar.gz",
+    "tar.bz2",
+    "tar.xz",
+    "tar.zst",
+    "tar.lz4",
+    "tar.lz",
+    "tar.zz",
+    "tar.br",
+)
 _SINGLE_FILE = ("gz", "bz2", "xz", "zst", "lz4", "lz", "zz", "br")
 
 
@@ -249,7 +269,8 @@ _DUPLICATES = (
 )
 
 _LARGE = tuple(
-    F(f"large{i}.txt", f"Large file #{i}\n".encode() + _rand(64_000, i)) for i in (1, 2, 3)
+    F(f"large{i}.txt", f"Large file #{i}\n".encode() + _rand(64_000, i))
+    for i in (1, 2, 3)
 )
 
 # Adversarial names/links: listing stays faithful; safe extraction must reject each
@@ -307,13 +328,19 @@ CORPUS: tuple[CorpusEntry, ...] = (
     CorpusEntry("adversarial", _ADVERSARIAL_COMMON, ("zip",)),
     CorpusEntry("adversarial-tar", _ADVERSARIAL_TAR, ("tar", "tar.gz")),
     # Encrypted ZIPs are built with the 7z CLI (stdlib zipfile cannot write encryption).
-    CorpusEntry("encrypted", _ENC_SINGLE, ("zip", "7z", "rar"), requires_binaries=("7z",)),
-    CorpusEntry("encrypted-mixed", _ENC_MIXED, ("zip", "7z", "rar"), requires_binaries=("7z",)),
+    CorpusEntry(
+        "encrypted", _ENC_SINGLE, ("zip", "7z", "rar"), requires_binaries=("7z",)
+    ),
+    CorpusEntry(
+        "encrypted-mixed", _ENC_MIXED, ("zip", "7z", "rar"), requires_binaries=("7z",)
+    ),
     CorpusEntry("encrypted-multi", _ENC_MULTI, ("zip",), requires_binaries=("7z",)),
     # Single-file compressors: exactly one member whose name is inferred from the
     # archive filename (see format-single-file-compressors); gz-meta stores FNAME+mtime.
     CorpusEntry("single-file", (F("payload.txt", _SINGLE_CONTENT),), _SINGLE_FILE),
-    CorpusEntry("single-file-meta", (F("stored_name.txt", _SINGLE_CONTENT),), ("gz-meta",)),
+    CorpusEntry(
+        "single-file-meta", (F("stored_name.txt", _SINGLE_CONTENT),), ("gz-meta",)
+    ),
 )
 
 
@@ -326,9 +353,15 @@ def _tar_bytes(entry: CorpusEntry) -> bytes:
     buf = io.BytesIO()
     with tarfile.open(fileobj=buf, mode="w", format=tarfile.PAX_FORMAT) as tf:
         for m in entry.members:
-            info = tarfile.TarInfo(m.name.rstrip("/") if m.type is MemberType.DIRECTORY else m.name)
+            info = tarfile.TarInfo(
+                m.name.rstrip("/") if m.type is MemberType.DIRECTORY else m.name
+            )
             info.mtime = m.mtime
-            info.mode = m.mode if m.mode is not None else (0o755 if m.type is MemberType.DIRECTORY else 0o644)
+            info.mode = (
+                m.mode
+                if m.mode is not None
+                else (0o755 if m.type is MemberType.DIRECTORY else 0o644)
+            )
             if m.uid is not None:
                 info.uid = m.uid
             if m.gid is not None:
@@ -396,7 +429,9 @@ def _zip_build(entry: CorpusEntry, path: Path) -> None:
             zi = zipfile.ZipInfo(date_time=(2020, 9, 13, 12, 26, 41))
             # Post-assign: ZipInfo.__init__ replaces os.sep on Windows (see zip_backslash/generate.py).
             zi.filename = m.name
-            zi.create_system = 3  # force Unix so modes/symlinks are deterministic on all OSes
+            zi.create_system = (
+                3  # force Unix so modes/symlinks are deterministic on all OSes
+            )
             if m.type is MemberType.DIRECTORY:
                 zi.external_attr = (0o40755 << 16) | 0x10
                 zf.writestr(zi, b"")
@@ -406,7 +441,9 @@ def _zip_build(entry: CorpusEntry, path: Path) -> None:
             else:
                 mode = m.mode if m.mode is not None else 0o644
                 zi.external_attr = (stat_mod.S_IFREG | mode) << 16
-                zi.compress_type = m.zip_method if m.zip_method is not None else zipfile.ZIP_DEFLATED
+                zi.compress_type = (
+                    m.zip_method if m.zip_method is not None else zipfile.ZIP_DEFLATED
+                )
                 if m.comment:
                     zi.comment = m.comment.encode()
                 zf.writestr(zi, m.contents)
@@ -464,7 +501,9 @@ def _iso_build(entry: CorpusEntry, path: Path) -> None:
             if joined and joined not in made_dirs:
                 made_dirs.add(joined)
                 iso_path = "/" + "/".join(p.upper()[:8] for p in joined.split("/"))
-                iso.add_directory(iso_path, rr_name=parts[i - 1], joliet_path="/" + joined)
+                iso.add_directory(
+                    iso_path, rr_name=parts[i - 1], joliet_path="/" + joined
+                )
 
     counter = 0
     for m in entry.members:
@@ -474,14 +513,19 @@ def _iso_build(entry: CorpusEntry, path: Path) -> None:
             if rel not in made_dirs:
                 made_dirs.add(rel)
                 iso_path = "/" + "/".join(p.upper()[:8] for p in rel.split("/"))
-                iso.add_directory(iso_path, rr_name=rel.split("/")[-1], joliet_path="/" + rel)
+                iso.add_directory(
+                    iso_path, rr_name=rel.split("/")[-1], joliet_path="/" + rel
+                )
         else:
             counter += 1
             iso_dir = "/".join(p.upper()[:8] for p in rel.split("/")[:-1])
             iso_path = ("/" + iso_dir + "/" if iso_dir else "/") + f"F{counter}.TXT;1"
             iso.add_fp(
-                io.BytesIO(m.contents), len(m.contents), iso_path,
-                rr_name=rel.split("/")[-1], joliet_path="/" + rel,
+                io.BytesIO(m.contents),
+                len(m.contents),
+                iso_path,
+                rr_name=rel.split("/")[-1],
+                joliet_path="/" + rel,
             )
     out = io.BytesIO()
     iso.write_fp(out)
@@ -548,7 +592,9 @@ def build_archive(entry: CorpusEntry, key: str, path: Path) -> None:
 # Extra *builder-side* package requirements per format key (reader-side availability is
 # gated separately via the registry). Import names, checked with importlib.
 BUILDER_PACKAGES: dict[str, tuple[str, ...]] = {
-    "tar.zst": ("_zstd_backend",),  # sentinel: either compression.zstd or backports.zstd
+    "tar.zst": (
+        "_zstd_backend",
+    ),  # sentinel: either compression.zstd or backports.zstd
     "zst": ("_zstd_backend",),
     "tar.lz4": ("lz4",),
     "lz4": ("lz4",),

--- a/tests/streams_util.py
+++ b/tests/streams_util.py
@@ -84,13 +84,21 @@ def make_lzip_member(data: bytes, dict_size_bits: int = 20) -> bytes:
     header/trailer.
     """
     filters: list[dict] = [
-        {"id": lzma.FILTER_LZMA1, "dict_size": 1 << dict_size_bits, "lc": 3, "lp": 0, "pb": 2}
+        {
+            "id": lzma.FILTER_LZMA1,
+            "dict_size": 1 << dict_size_bits,
+            "lc": 3,
+            "lp": 0,
+            "pb": 2,
+        }
     ]
     compressed_alone = lzma.compress(data, format=lzma.FORMAT_ALONE, filters=filters)
     lzma_raw = compressed_alone[13:]
     header = b"LZIP" + bytes([1, dict_size_bits])
     member_total = len(header) + len(lzma_raw) + 20
-    trailer = struct.pack("<IQQ", zlib.crc32(data) & 0xFFFFFFFF, len(data), member_total)
+    trailer = struct.pack(
+        "<IQQ", zlib.crc32(data) & 0xFFFFFFFF, len(data), member_total
+    )
     return header + lzma_raw + trailer
 
 

--- a/tests/test_accelerator_shutdown.py
+++ b/tests/test_accelerator_shutdown.py
@@ -127,7 +127,9 @@ def _run(fmt: str, opener: str, variant: str, cleanup: str) -> int:
     return proc.returncode
 
 
-@pytest.mark.parametrize(("fmt", "opener"), _ACCELERATORS, ids=[f for f, _ in _ACCELERATORS])
+@pytest.mark.parametrize(
+    ("fmt", "opener"), _ACCELERATORS, ids=[f for f, _ in _ACCELERATORS]
+)
 def test_accelerator_shutdown_canary(fmt: str, opener: str) -> None:
     pytest.importorskip("rapidgzip")
 

--- a/tests/test_binaryio.py
+++ b/tests/test_binaryio.py
@@ -428,7 +428,9 @@ def test_plain_bufferedreader_closes_source_demonstrates_why_we_detach() -> None
     inner = CountingBytesIO(DATA)
     plain = io.BufferedReader(inner)
     plain.close()
-    assert inner.closed  # plain BufferedReader took the (caller-owned) source down with it
+    assert (
+        inner.closed
+    )  # plain BufferedReader took the (caller-owned) source down with it
 
     # ensure_bufferedio over the same kind of source leaves it open — the behaviour we want.
     survivor = CountingBytesIO(DATA)

--- a/tests/test_codec_descriptor.py
+++ b/tests/test_codec_descriptor.py
@@ -127,8 +127,12 @@ def test_synthetic_descriptor_is_detectable_and_readable(
 def test_synthetic_descriptor_availability_comes_from_requirement(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    requirement = MissingComponent("synthlib", "pip install archivey[synth]", ("synthetic",))
-    with _install_synthetic(monkeypatch, requirement=requirement, available=False) as fmt:
+    requirement = MissingComponent(
+        "synthlib", "pip install archivey[synth]", ("synthetic",)
+    )
+    with _install_synthetic(
+        monkeypatch, requirement=requirement, available=False
+    ) as fmt:
         # The (simulated) missing backend makes the single-codec format unreadable -> NONE,
         # with the install hint taken from the codec's requirement (no registry table).
         availability = format_availability(fmt)

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -62,7 +62,9 @@ def test_raw_lzma2_backend_for_7z_folder() -> None:
     """A 7z folder's LZMA2 stream decompresses via lzma FORMAT_RAW."""
     compressed = compress_lzma2_raw(CONTENT)
     params = CodecParams(filters=lzma2_raw_filters())
-    with open_codec_stream(Codec.LZMA2, io.BytesIO(compressed), params=params) as stream:
+    with open_codec_stream(
+        Codec.LZMA2, io.BytesIO(compressed), params=params
+    ) as stream:
         assert stream.read() == CONTENT
 
 
@@ -159,7 +161,9 @@ def test_crypto_reachable_only_through_wrapper() -> None:
     assert backend.name == crypto.CRYPTO_PACKAGE
     # The concrete AES stage is deferred to Phase 7; the wrapper boundary is what's real now.
     with pytest.raises(NotImplementedError):
-        backend.aes_cbc_decrypt_stage(crypto.AesParams(key=b"\x00" * 32, iv=b"\x00" * 16))
+        backend.aes_cbc_decrypt_stage(
+            crypto.AesParams(key=b"\x00" * 32, iv=b"\x00" * 16)
+        )
 
 
 # --- exception translation -------------------------------------------------------------
@@ -168,7 +172,9 @@ def test_crypto_reachable_only_through_wrapper() -> None:
 def test_corrupt_gzip_translates_to_corruption_with_cause() -> None:
     corrupt = bytearray(gzip.compress(CONTENT))
     corrupt[1] = 0x00  # break the gzip magic
-    with open_codec_stream(Codec.GZIP, io.BytesIO(bytes(corrupt)), config=_STDLIB_GZIP) as stream:
+    with open_codec_stream(
+        Codec.GZIP, io.BytesIO(bytes(corrupt)), config=_STDLIB_GZIP
+    ) as stream:
         with pytest.raises(CorruptionError) as excinfo:
             stream.read()
     assert isinstance(excinfo.value.__cause__, gzip.BadGzipFile)
@@ -180,7 +186,9 @@ def test_mid_stream_corrupt_gzip_translates_to_corruption_with_cause() -> None:
     # BadGzipFile. It must still be translated to CorruptionError, not leak a raw zlib.error.
     corrupt = bytearray(gzip.compress(CONTENT))
     corrupt[len(corrupt) // 2] ^= 0xFF  # flip a byte well past the 10-byte header
-    with open_codec_stream(Codec.GZIP, io.BytesIO(bytes(corrupt)), config=_STDLIB_GZIP) as stream:
+    with open_codec_stream(
+        Codec.GZIP, io.BytesIO(bytes(corrupt)), config=_STDLIB_GZIP
+    ) as stream:
         with pytest.raises(CorruptionError) as excinfo:
             stream.read()
     assert isinstance(excinfo.value.__cause__, zlib.error)
@@ -189,7 +197,9 @@ def test_mid_stream_corrupt_gzip_translates_to_corruption_with_cause() -> None:
 def test_truncated_gzip_translates_to_truncated() -> None:
     compressed = gzip.compress(CONTENT)
     truncated = compressed[: len(compressed) // 2]
-    with open_codec_stream(Codec.GZIP, io.BytesIO(truncated), config=_STDLIB_GZIP) as stream:
+    with open_codec_stream(
+        Codec.GZIP, io.BytesIO(truncated), config=_STDLIB_GZIP
+    ) as stream:
         with pytest.raises(TruncatedError):
             stream.read()
 
@@ -201,7 +211,9 @@ def test_accelerator_path_translates_errors_no_raw_leak() -> None:
     corrupt = bytearray(gzip.compress(CONTENT))
     corrupt[1] = 0x00
     config = StreamConfig(use_rapidgzip=AcceleratorMode.ON, seekable=True)
-    with open_codec_stream(Codec.GZIP, io.BytesIO(bytes(corrupt)), config=config) as stream:
+    with open_codec_stream(
+        Codec.GZIP, io.BytesIO(bytes(corrupt)), config=config
+    ) as stream:
         with pytest.raises(ArchiveyError):  # never a raw rapidgzip ValueError
             stream.read()
 
@@ -210,7 +222,9 @@ def test_corrupt_lzma2_translates_to_corruption() -> None:
     corrupt = bytearray(compress_lzma2_raw(CONTENT))
     corrupt[len(corrupt) // 2] ^= 0xFF
     params = CodecParams(filters=lzma2_raw_filters())
-    with open_codec_stream(Codec.LZMA2, io.BytesIO(bytes(corrupt)), params=params) as stream:
+    with open_codec_stream(
+        Codec.LZMA2, io.BytesIO(bytes(corrupt)), params=params
+    ) as stream:
         with pytest.raises(CorruptionError):
             stream.read()
 
@@ -342,7 +356,9 @@ def test_verify_oversized_int_digest_mismatches_not_raises() -> None:
     A "crc32" int > 2**32 can't equal a 4-byte digest; normalization must not raise
     OverflowError (which would leak a non-ArchiveyError out of the stream layer).
     """
-    stream = VerifyingStream(io.BytesIO(CONTENT), {"crc32": _crc32(CONTENT) + (1 << 40)})
+    stream = VerifyingStream(
+        io.BytesIO(CONTENT), {"crc32": _crc32(CONTENT) + (1 << 40)}
+    )
     with pytest.raises(CorruptionError, match="crc32"):
         while stream.read(64):  # read to EOF; the terminal read verifies
             pass

--- a/tests/test_corpus_sweep.py
+++ b/tests/test_corpus_sweep.py
@@ -42,7 +42,18 @@ from tests.sample_archives import (
 )
 
 # Formats where the reader reports Unix permission bits for our generated archives.
-_MODE_FORMATS = {"tar", "tar.gz", "tar.bz2", "tar.xz", "tar.zst", "tar.lz4", "tar.lz", "tar.zz", "tar.br", "zip"}
+_MODE_FORMATS = {
+    "tar",
+    "tar.gz",
+    "tar.bz2",
+    "tar.xz",
+    "tar.zst",
+    "tar.lz4",
+    "tar.lz",
+    "tar.zz",
+    "tar.br",
+    "zip",
+}
 # Single-member formats: the member name is inferred from the archive filename, so the
 # listing check differs (see format-single-file-compressors).
 _SINGLE_FILE_KEYS = {"gz", "gz-meta", "bz2", "xz", "zst", "lz4", "lz", "zz", "br"}
@@ -57,7 +68,9 @@ _PARAMS = [
 def _skip_unless_runnable(entry: CorpusEntry, key: str) -> None:
     availability = format_availability(FORMAT_KEYS[key])
     if availability.support is FormatSupport.NONE:
-        pytest.skip(f"format {key!r} not readable here: {availability.missing or 'no backend'}")
+        pytest.skip(
+            f"format {key!r} not readable here: {availability.missing or 'no backend'}"
+        )
     for package in BUILDER_PACKAGES.get(key, ()):
         if package == "_zstd_backend":
             if not _has_zstd_backend():
@@ -141,7 +154,9 @@ def _check_extraction(tmp_path: Path, source, entry: CorpusEntry, key: str) -> N
         results = ar.extract_all(
             dest,
             on_error=OnError.CONTINUE,
-            overwrite=OverwritePolicy.REPLACE if has_duplicates else OverwritePolicy.ERROR,
+            overwrite=OverwritePolicy.REPLACE
+            if has_duplicates
+            else OverwritePolicy.ERROR,
         ).results
 
     by_member_name: dict[str, list] = {}
@@ -167,7 +182,11 @@ def _check_extraction(tmp_path: Path, source, entry: CorpusEntry, key: str) -> N
     # Safe hardlinks with known terminal contents share that content on disk.
     if os.name != "nt":
         for m in entry.members:
-            if m.type is MemberType.HARDLINK and not m.unsafe and m.link_contents is not None:
+            if (
+                m.type is MemberType.HARDLINK
+                and not m.unsafe
+                and m.link_contents is not None
+            ):
                 on_disk = dest / m.name
                 assert on_disk.is_file(), f"hardlink {m.name!r} missing"
                 assert on_disk.read_bytes() == m.link_contents

--- a/tests/test_cost_receipt.py
+++ b/tests/test_cost_receipt.py
@@ -143,7 +143,10 @@ def _iso(tmp: Path) -> Path:
     return p
 
 
-_PARAMS = [pytest.param(builder, expected, id=name) for name, (builder, expected) in _CASES.items()]
+_PARAMS = [
+    pytest.param(builder, expected, id=name)
+    for name, (builder, expected) in _CASES.items()
+]
 _PARAMS.append(
     pytest.param(
         _iso,

--- a/tests/test_data_model.py
+++ b/tests/test_data_model.py
@@ -146,7 +146,10 @@ def test_modified_utc_normalizes_mixed_timestamps() -> None:
     # comparable with the aware member's (mixed naive/aware raises TypeError directly).
     local_utc = naive.modified_utc()
     assert local_utc is not None and local_utc.tzinfo == timezone.utc
-    assert (local_utc < aware.modified_utc()) in (True, False)  # comparable, no TypeError
+    assert (local_utc < aware.modified_utc()) in (
+        True,
+        False,
+    )  # comparable, no TypeError
 
     # The stored field is untouched: provenance stays checkable.
     assert naive.modified is not None and naive.modified.tzinfo is None

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -124,7 +124,9 @@ def test_magic_wins_over_conflicting_extension(
         info = detect_format(path)
     assert info.format == ArchiveFormat.SEVEN_Z
     assert info.detected_by == "magic"
-    assert any("conflict" in r.getMessage().lower() for r in caplog.records), caplog.text
+    assert any("conflict" in r.getMessage().lower() for r in caplog.records), (
+        caplog.text
+    )
 
 
 def test_no_warning_when_extension_agrees(
@@ -335,7 +337,9 @@ def test_inner_tar_probe_skipped_when_codec_missing(
     # determination to open time — without warning about the benign tar.zst/zst mismatch.
     monkeypatch.setattr(codecs_module, "_zstd", None)
     path = tmp_path / "thing.tar.zst"
-    path.write_bytes(b"\x28\xb5\x2f\xfd" + b"\x00" * 64)  # zstd magic, unprobeable payload
+    path.write_bytes(
+        b"\x28\xb5\x2f\xfd" + b"\x00" * 64
+    )  # zstd magic, unprobeable payload
     info = detect_format(path)
     assert info.format == ArchiveFormat.ZST
     assert info.detected_by == "magic"

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -439,7 +439,9 @@ def test_raise_disposition_stops_despite_continue(tmp_path: Path) -> None:
     dest = tmp_path / "out"
     dest.mkdir()
     policy = DiagnosticPolicy(
-        overrides={DiagnosticCode.EXTRACTION_MEMBER_REJECTED: DiagnosticDisposition.RAISE}
+        overrides={
+            DiagnosticCode.EXTRACTION_MEMBER_REJECTED: DiagnosticDisposition.RAISE
+        }
     )
     with pytest.raises(DiagnosticRaisedError) as ei:
         extract(

--- a/tests/test_directory.py
+++ b/tests/test_directory.py
@@ -123,9 +123,7 @@ def test_bidi_control_name_warns_once(
         with open_archive(tmp_path) as reader:
             assert reader.members()[0].name == name
     warnings = [
-        record
-        for record in caplog.records
-        if "bidirectional control" in record.message
+        record for record in caplog.records if "bidirectional control" in record.message
     ]
     assert len(warnings) == 1
 

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -1007,7 +1007,9 @@ def test_tar_hardlink_orphan_forward_only_onerror(tmp_path: Path) -> None:
     # CONTINUE: records FAILED, does not raise.
     dest2 = tmp_path / "out_continue"
     with open_archive(NonSeekableBytesIO(raw), streaming=True) as r:
-        results = r.extract_all(dest2, filter=drop_source, on_error=OnError.CONTINUE).results
+        results = r.extract_all(
+            dest2, filter=drop_source, on_error=OnError.CONTINUE
+        ).results
     statuses = {r.member.name: r.status for r in results}
     assert statuses["hard.txt"] is ExtractionStatus.FAILED
     assert not (dest2 / "hard.txt").exists()

--- a/tests/test_iso.py
+++ b/tests/test_iso.py
@@ -192,7 +192,8 @@ def test_streaming_over_seekable_iso(rock_ridge_iso: Path) -> None:
     # still works and yields the members with their data.
     with open_archive(rock_ridge_iso, streaming=True) as ar:
         collected = {
-            m.name: (s.read() if s is not None else None) for m, s in ar.stream_members()
+            m.name: (s.read() if s is not None else None)
+            for m, s in ar.stream_members()
         }
         assert collected["file.txt"] == b"hello world"
         assert collected["empty.txt"] == b""
@@ -322,7 +323,9 @@ def _pycdlib_directory_cycle_image(
 ) -> bytes:
     """Flip one bit in ``/subdir``'s directory extent so pycdlib's open walk cycles."""
     data = bytearray(_build_pycdlib_cycle_fixture(rock_ridge=rock_ridge, joliet=joliet))
-    assert len(data) == expected_len, "fixture layout drifted — revisit cycle case table"
+    assert len(data) == expected_len, (
+        "fixture layout drifted — revisit cycle case table"
+    )
     assert data[bitflip_offset] == byte_before_flip
     data[bitflip_offset] ^= 0x01
     return bytes(data)
@@ -338,7 +341,14 @@ def test_corrupt_iso_raises() -> None:
 
 @pytest.mark.timeout(5)
 @pytest.mark.parametrize(
-    ("rock_ridge", "joliet", "expected_len", "bitflip_offset", "byte_before_flip", "namespace"),
+    (
+        "rock_ridge",
+        "joliet",
+        "expected_len",
+        "bitflip_offset",
+        "byte_before_flip",
+        "namespace",
+    ),
     [
         pytest.param(*case, id=case_id)
         for case, case_id in zip(

--- a/tests/test_member_streams.py
+++ b/tests/test_member_streams.py
@@ -27,7 +27,9 @@ def test_second_overlapping_open_raises_concurrent_access_error(tmp_path: Path) 
     root = _two_file_dir(tmp_path)
     with open_archive(root) as reader:
         s1 = reader.open("a.txt")
-        with pytest.raises(ConcurrentAccessError, match="MemberStreams.CONCURRENT") as ei:
+        with pytest.raises(
+            ConcurrentAccessError, match="MemberStreams.CONCURRENT"
+        ) as ei:
             reader.open("b.txt")
         assert "concurrent-member-streams" not in str(ei.value).lower() or True
         # Breadcrumb points at this test file.

--- a/tests/test_mutation_fuzz.py
+++ b/tests/test_mutation_fuzz.py
@@ -206,7 +206,9 @@ def apply_mutation(data: bytes, desc: str) -> bytes:
     raise ValueError(f"unknown mutation description: {desc!r}")
 
 
-def _mutations_for_kind(data: bytes, seed: str, kind: str) -> Iterator[tuple[str, bytes]]:
+def _mutations_for_kind(
+    data: bytes, seed: str, kind: str
+) -> Iterator[tuple[str, bytes]]:
     """Yield ``(description, mutated_bytes)`` for one mutation kind (deduplicated)."""
     n = len(data)
 

--- a/tests/test_naming.py
+++ b/tests/test_naming.py
@@ -22,9 +22,19 @@ from archivey.types import MemberType
         ("foo\\bar\\baz.txt", MemberType.FILE, True, "foo/bar/baz.txt"),
         ("weird\\name.txt", MemberType.FILE, False, "weird\\name.txt"),
         # Meaning-ALTERING rewrites are gone: leading "/" and ".." are retained.
-        ("/etc/passwd", MemberType.FILE, False, "/etc/passwd"),  # leading slash retained
+        (
+            "/etc/passwd",
+            MemberType.FILE,
+            False,
+            "/etc/passwd",
+        ),  # leading slash retained
         ("foo/../bar", MemberType.FILE, False, "foo/../bar"),  # internal .. retained
-        ("../../etc/passwd", MemberType.FILE, False, "../../etc/passwd"),  # escaping retained
+        (
+            "../../etc/passwd",
+            MemberType.FILE,
+            False,
+            "../../etc/passwd",
+        ),  # escaping retained
         # Meaning-PRESERVING clean-ups still apply.
         ("./foo/bar", MemberType.FILE, False, "foo/bar"),  # leading ./ stripped
         ("foo//bar", MemberType.FILE, False, "foo/bar"),  # double slash collapsed
@@ -58,9 +68,7 @@ def test_warns_when_name_changes(caplog: pytest.LogCaptureFixture) -> None:
     member = ArchiveMember(type=MemberType.FILE, name=name, raw_name=None)
     collector = DiagnosticCollector()
     with caplog.at_level(logging.WARNING, logger="archivey.normalization"):
-        emit_member_name_normalized(
-            collector, member=member, presented_name=presented
-        )
+        emit_member_name_normalized(collector, member=member, presented_name=presented)
     assert any("normalized" in r.message for r in caplog.records)
     assert collector.snapshot().total_count == 1
 
@@ -68,7 +76,9 @@ def test_warns_when_name_changes(caplog: pytest.LogCaptureFixture) -> None:
 def test_no_warning_when_unchanged(caplog: pytest.LogCaptureFixture) -> None:
     with caplog.at_level(logging.WARNING, logger="archivey.normalization"):
         # A faithful name with an internal ".." is no longer rewritten, so no warning.
-        normalize_member_name("foo/../bar", MemberType.FILE, backslash_is_separator=False)
+        normalize_member_name(
+            "foo/../bar", MemberType.FILE, backslash_is_separator=False
+        )
     assert not caplog.records
 
 

--- a/tests/test_open_stream.py
+++ b/tests/test_open_stream.py
@@ -43,9 +43,7 @@ def test_open_stream_seekable_true_allows_seek() -> None:
 
 def test_open_stream_explicit_format() -> None:
     compressed = gzip.compress(CONTENT)
-    with open_stream(
-        io.BytesIO(compressed), format=StreamFormat.GZIP
-    ) as stream:
+    with open_stream(io.BytesIO(compressed), format=StreamFormat.GZIP) as stream:
         assert stream.read() == CONTENT
 
 

--- a/tests/test_peekable.py
+++ b/tests/test_peekable.py
@@ -38,7 +38,9 @@ def test_read_all_drains_buffer_and_underlying() -> None:
 def test_peek_beyond_buffered_limit_grows() -> None:
     # Peeking more than the default window grows the buffer on demand (the ISO probe needs
     # 32 774 bytes); the same bytes are then still replayed on read.
-    data = bytes(range(256)) * 200  # 51 200 bytes, > DETECTION_LIMIT and > the ISO window
+    data = (
+        bytes(range(256)) * 200
+    )  # 51 200 bytes, > DETECTION_LIMIT and > the ISO window
     assert len(data) > DETECTION_LIMIT
     stream = PeekableStream(NonSeekableBytesIO(data))
     big = stream.peek(32774)

--- a/tests/test_property_safety.py
+++ b/tests/test_property_safety.py
@@ -281,12 +281,8 @@ def test_normalize_never_introduces_escape(
 
 @given(decoded=_pathish, member_type=_file_dir_types)
 def test_normalize_backslash_flag(decoded: str, member_type: MemberType) -> None:
-    with_sep = normalize_member_name(
-        decoded, member_type, backslash_is_separator=True
-    )
-    literal = normalize_member_name(
-        decoded, member_type, backslash_is_separator=False
-    )
+    with_sep = normalize_member_name(decoded, member_type, backslash_is_separator=True)
+    literal = normalize_member_name(decoded, member_type, backslash_is_separator=False)
     if "\\" in decoded:
         # With the flag, every backslash becomes a separator (no literal ``\\`` left
         # unless the input had a forward-slash-only path — then both match).
@@ -297,8 +293,12 @@ def test_normalize_backslash_flag(decoded: str, member_type: MemberType) -> None
             assert "\\" in literal or literal == with_sep
 
 
-@example(decoded="foo/../bar", member_type=MemberType.FILE, backslash_is_separator=False)
-@example(decoded="/etc/passwd", member_type=MemberType.FILE, backslash_is_separator=False)
+@example(
+    decoded="foo/../bar", member_type=MemberType.FILE, backslash_is_separator=False
+)
+@example(
+    decoded="/etc/passwd", member_type=MemberType.FILE, backslash_is_separator=False
+)
 @example(decoded="foo\\bar", member_type=MemberType.FILE, backslash_is_separator=True)
 @given(
     decoded=_pathish,
@@ -469,7 +469,9 @@ def test_resolve_link_never_returns_escaping_name(
 
 
 @given(
-    link_dir=st.from_regex(r"[A-Za-z0-9_]{1,8}(/[A-Za-z0-9_]{1,8}){0,2}", fullmatch=True),
+    link_dir=st.from_regex(
+        r"[A-Za-z0-9_]{1,8}(/[A-Za-z0-9_]{1,8}){0,2}", fullmatch=True
+    ),
     target=st.from_regex(r"[A-Za-z0-9_]{1,12}", fullmatch=True),
 )
 def test_resolve_symlink_joins_to_link_dir(link_dir: str, target: str) -> None:
@@ -479,7 +481,9 @@ def test_resolve_symlink_joins_to_link_dir(link_dir: str, target: str) -> None:
 
 
 @given(
-    target=st.from_regex(r"[A-Za-z0-9_]{1,12}(/[A-Za-z0-9_]{1,8}){0,2}", fullmatch=True),
+    target=st.from_regex(
+        r"[A-Za-z0-9_]{1,12}(/[A-Za-z0-9_]{1,8}){0,2}", fullmatch=True
+    ),
 )
 def test_resolve_hardlink_uses_target_as_archive_path(target: str) -> None:
     result = resolve_link_target_name("ignored/link", target, MemberType.HARDLINK)
@@ -527,7 +531,9 @@ def test_volume_part_helpers_total(name: str) -> None:
 
 @given(
     base=st.from_regex(r"[A-Za-z][A-Za-z0-9_]{0,8}", fullmatch=True),
-    parts=st.lists(st.integers(min_value=1, max_value=99), min_size=2, max_size=5, unique=True),
+    parts=st.lists(
+        st.integers(min_value=1, max_value=99), min_size=2, max_size=5, unique=True
+    ),
 )
 def test_volume_part_numbers_sort_stable(base: str, parts: list[int]) -> None:
     names = [f"{base}.7z.{p:03d}" for p in parts]

--- a/tests/test_reader_contract.py
+++ b/tests/test_reader_contract.py
@@ -30,7 +30,9 @@ from archivey.types import (
 )
 
 
-def _info(format: ArchiveFormat, listing: ListingCost, stream: StreamCapability) -> ArchiveInfo:
+def _info(
+    format: ArchiveFormat, listing: ListingCost, stream: StreamCapability
+) -> ArchiveInfo:
     return ArchiveInfo(
         format=format,
         format_version=None,
@@ -40,7 +42,9 @@ def _info(format: ArchiveFormat, listing: ListingCost, stream: StreamCapability)
         is_encrypted=False,
         is_multivolume=False,
         cost=CostReceipt(
-            listing_cost=listing, access_cost=AccessCost.DIRECT, stream_capability=stream
+            listing_cost=listing,
+            access_cost=AccessCost.DIRECT,
+            stream_capability=stream,
         ),
     )
 
@@ -79,7 +83,9 @@ class _ForwardOnlyReader(BaseArchiveReader):
 
     def _get_archive_info(self) -> ArchiveInfo:
         return _info(
-            ArchiveFormat.TAR, ListingCost.REQUIRES_SCANNING, StreamCapability.FORWARD_ONLY
+            ArchiveFormat.TAR,
+            ListingCost.REQUIRES_SCANNING,
+            StreamCapability.FORWARD_ONLY,
         )
 
     def _close_archive(self) -> None:
@@ -100,7 +106,10 @@ def test_open_raises_without_random_access_capability() -> None:
 
 def test_stream_members_works_without_random_access() -> None:
     reader = _ForwardOnlyReader(ArchiveFormat.TAR, False, "x.tar")
-    out = [(m.name, s.read() if s is not None else None) for m, s in reader.stream_members()]
+    out = [
+        (m.name, s.read() if s is not None else None)
+        for m, s in reader.stream_members()
+    ]
     assert out == [("a.txt", b"x")]
 
 

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -38,7 +38,9 @@ class _CoreBackend(ReadBackend):
     EXTENSIONS: Mapping[str, ArchiveFormat] = {".tar": ArchiveFormat.TAR}
     MAGIC = (MagicSignature(257, b"ustar", ArchiveFormat.TAR),)
 
-    def open_read(self, source, streaming, password, encoding, archive_name):  # pragma: no cover
+    def open_read(
+        self, source, streaming, password, encoding, archive_name
+    ):  # pragma: no cover
         raise NotImplementedError
 
 
@@ -47,7 +49,9 @@ class _OptionalPresentBackend(ReadBackend):
     OPTIONAL_DEPENDENCY = "io"  # a module that always imports
     INSTALL_HINT = "pip install archivey[present]"
 
-    def open_read(self, source, streaming, password, encoding, archive_name):  # pragma: no cover
+    def open_read(
+        self, source, streaming, password, encoding, archive_name
+    ):  # pragma: no cover
         raise NotImplementedError
 
 
@@ -56,7 +60,9 @@ class _OptionalMissingBackend(ReadBackend):
     OPTIONAL_DEPENDENCY = "a_package_that_does_not_exist_xyz"
     INSTALL_HINT = "pip install archivey[iso]"
 
-    def open_read(self, source, streaming, password, encoding, archive_name):  # pragma: no cover
+    def open_read(
+        self, source, streaming, password, encoding, archive_name
+    ):  # pragma: no cover
         raise NotImplementedError
 
 
@@ -74,7 +80,9 @@ def registry() -> BackendRegistry:
 # ---------------------------------------------------------------------------
 
 
-def test_optional_missing_backend_is_known_but_unavailable(registry: BackendRegistry) -> None:
+def test_optional_missing_backend_is_known_but_unavailable(
+    registry: BackendRegistry,
+) -> None:
     # Registered regardless of its dependency: present in "known", absent from "supported".
     assert ArchiveFormat.ISO in registry.list_known_formats()
     assert ArchiveFormat.ISO not in registry.list_supported_formats()
@@ -104,7 +112,9 @@ def test_unknown_format_is_none(registry: BackendRegistry) -> None:
     assert avail.missing == ()
 
 
-def test_reader_for_missing_dependency_raises_with_hint(registry: BackendRegistry) -> None:
+def test_reader_for_missing_dependency_raises_with_hint(
+    registry: BackendRegistry,
+) -> None:
     with pytest.raises(UnsupportedFormatError) as excinfo:
         registry.reader_for_format(ArchiveFormat.ISO)
     msg = str(excinfo.value)

--- a/tests/test_seekable_streams.py
+++ b/tests/test_seekable_streams.py
@@ -79,7 +79,10 @@ def test_xz_backward_seek_uses_block_index() -> None:
         assert stream.read() == CONTENT * 3  # forward pass populates the index
         baseline = counting.bytes_read
         stream.seek(len(CONTENT) * 2 + 5)  # into the third stream
-        assert stream.read(50) == (CONTENT * 3)[len(CONTENT) * 2 + 5 : len(CONTENT) * 2 + 55]
+        assert (
+            stream.read(50)
+            == (CONTENT * 3)[len(CONTENT) * 2 + 5 : len(CONTENT) * 2 + 55]
+        )
         # Re-reading from a block start must not re-read the entire compressed file.
         assert counting.bytes_read - baseline < len(compressed)
 
@@ -191,7 +194,9 @@ def test_bzip2_accelerator_off_warns_on_rewind(
     """The bz2 stdlib path mirrors gzip: a rewind warns and still seeks."""
     config = StreamConfig(use_indexed_bzip2=AcceleratorMode.OFF, seekable=True)
     compressed = bz2.compress(CONTENT)
-    with open_codec_stream(Codec.BZIP2, io.BytesIO(compressed), config=config) as stream:
+    with open_codec_stream(
+        Codec.BZIP2, io.BytesIO(compressed), config=config
+    ) as stream:
         assert stream.read(100) == CONTENT[:100]
         with caplog.at_level("WARNING", logger="archivey.streams"):
             assert stream.seek(0) == 0
@@ -219,7 +224,9 @@ def test_zlib_warns_on_rewind(caplog: pytest.LogCaptureFixture) -> None:
             assert stream.read(10) == CONTENT[:10]  # still correct
     msgs = [r.getMessage() for r in caplog.records]
     assert sum("no random-access index" in m for m in msgs) == 1
-    assert not any("seekable" in m for m in msgs)  # generic message, no accelerator named
+    assert not any(
+        "seekable" in m for m in msgs
+    )  # generic message, no accelerator named
 
 
 @requires("brotli")
@@ -253,7 +260,9 @@ def test_lz4_warns_on_rewind(caplog: pytest.LogCaptureFixture) -> None:
 
 
 @requires_zstd()
-def test_zstd_rewinds_and_warns_on_backward_seek(caplog: pytest.LogCaptureFixture) -> None:
+def test_zstd_rewinds_and_warns_on_backward_seek(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
     """zstd has no index; a backward seek re-decompresses from the start and warns once."""
     zstd = zstd_backend()
     compressed = zstd.compress(CONTENT)

--- a/tests/test_single_file.py
+++ b/tests/test_single_file.py
@@ -40,7 +40,9 @@ from tests.conftest import requires, requires_zstd, zstd_backend
 from tests.streams_util import NonSeekableBytesIO, make_lzip_member, make_unix_compress
 
 
-def _gzip_bytes(payload: bytes, *, filename: str | None = None, mtime: int = 0) -> bytes:
+def _gzip_bytes(
+    payload: bytes, *, filename: str | None = None, mtime: int = 0
+) -> bytes:
     buf = io.BytesIO()
     gz = gzip.GzipFile(filename=filename or "", mode="wb", fileobj=buf, mtime=mtime)
     gz.write(payload)
@@ -120,9 +122,7 @@ def test_inferred_bidi_control_name_warns_once(
         with open_archive(path, config=config) as archive:
             assert archive.members()[0].name == name
     warnings = [
-        record
-        for record in caplog.records
-        if "bidirectional control" in record.message
+        record for record in caplog.records if "bidirectional control" in record.message
     ]
     assert len(warnings) == 1
 
@@ -148,7 +148,9 @@ def test_gzip_stored_filename_non_ascii_is_latin1(tmp_path: Path) -> None:
     # "café.txt" as the bytes b"caf\xe9.txt"; decoding those as UTF-8 would mangle them
     # (0xE9 is not valid UTF-8), so the decoded value must use Latin-1.
     path = tmp_path / "archive.gz"
-    gz = gzip.GzipFile(filename="café.txt", mode="wb", fileobj=open(path, "wb"), mtime=0)
+    gz = gzip.GzipFile(
+        filename="café.txt", mode="wb", fileobj=open(path, "wb"), mtime=0
+    )
     gz.write(b"payload")
     gz.close()
     with open_archive(path) as ar:

--- a/tests/test_slice.py
+++ b/tests/test_slice.py
@@ -106,7 +106,9 @@ class TestSlicingStream:
         slice_len = len(DATA) - 5
         assert sliced.seek(-3, io.SEEK_END) == slice_len - 3
         assert sliced.read() == DATA[-3:]
-        assert sliced.seek(2, io.SEEK_END) == slice_len + 2  # past-end allowed, like BytesIO
+        assert (
+            sliced.seek(2, io.SEEK_END) == slice_len + 2
+        )  # past-end allowed, like BytesIO
         assert sliced.read(1) == b""
 
     def test_non_seekable_no_start(self) -> None:

--- a/tests/test_stream_inputs.py
+++ b/tests/test_stream_inputs.py
@@ -113,7 +113,9 @@ class FakeS3StreamingBody:
 class Case:
     build: Callable[[Path], BinaryIO]
     seekable: bool
-    passes_is_stream: bool  # True => is_stream() accepts it, so ensure_binaryio passes it through
+    passes_is_stream: (
+        bool  # True => is_stream() accepts it, so ensure_binaryio passes it through
+    )
 
 
 def _buffered_file(tmp_path: Path) -> BinaryIO:
@@ -159,7 +161,9 @@ def _zip_member(stored: bool) -> Callable[[Path], BinaryIO]:
 def _tar_member(compression: str) -> Callable[[Path], BinaryIO]:
     def build(_tmp_path: Path) -> BinaryIO:
         buf = io.BytesIO()
-        with tarfile.open(fileobj=buf, mode=f"w:{compression}" if compression else "w") as t:
+        with tarfile.open(
+            fileobj=buf, mode=f"w:{compression}" if compression else "w"
+        ) as t:
             info = tarfile.TarInfo("m.bin")
             info.size = len(CONTENT)
             t.addfile(info, io.BytesIO(CONTENT))
@@ -172,7 +176,9 @@ def _tar_member(compression: str) -> Callable[[Path], BinaryIO]:
 
 
 def _xz_decompressor(_tmp_path: Path) -> BinaryIO:
-    return XzDecompressorStream(io.BytesIO(lzma.compress(CONTENT, format=lzma.FORMAT_XZ)))
+    return XzDecompressorStream(
+        io.BytesIO(lzma.compress(CONTENT, format=lzma.FORMAT_XZ))
+    )
 
 
 def _lzip_decompressor(_tmp_path: Path) -> BinaryIO:
@@ -308,7 +314,9 @@ CASES: dict[str, Case] = {
     "bz2": Case(_bz2_member, seekable=True, passes_is_stream=True),
     "lzma": Case(_lzma_member, seekable=True, passes_is_stream=True),
     "zip_stored": Case(_zip_member(stored=True), seekable=True, passes_is_stream=True),
-    "zip_deflated": Case(_zip_member(stored=False), seekable=True, passes_is_stream=True),
+    "zip_deflated": Case(
+        _zip_member(stored=False), seekable=True, passes_is_stream=True
+    ),
     "tar_uncompressed": Case(_tar_member(""), seekable=True, passes_is_stream=True),
     "tar_gz": Case(_tar_member("gz"), seekable=True, passes_is_stream=True),
     "xz_decompressor": Case(_xz_decompressor, seekable=True, passes_is_stream=True),
@@ -317,23 +325,32 @@ CASES: dict[str, Case] = {
     "codec_gzip": Case(_codec_gzip, seekable=True, passes_is_stream=True),
     # --- non-seekable io.IOBase streams (network / pipes) ---
     "urllib3_response": Case(_urllib3_response, seekable=False, passes_is_stream=True),
-    "http_client_response": Case(_http_client_response, seekable=False, passes_is_stream=True),
+    "http_client_response": Case(
+        _http_client_response, seekable=False, passes_is_stream=True
+    ),
     "os_pipe_reader": Case(_os_pipe_reader, seekable=False, passes_is_stream=True),
-    "non_seekable_bytesio": Case(_non_seekable_bytesio, seekable=False, passes_is_stream=True),
+    "non_seekable_bytesio": Case(
+        _non_seekable_bytesio, seekable=False, passes_is_stream=True
+    ),
     # --- fully duck-typed but NOT io.IOBase (accepted via the method-set check) ---
     "named_tempfile": Case(_named_tempfile, seekable=True, passes_is_stream=True),
     "fsspec_memory": Case(_fsspec_memory, seekable=True, passes_is_stream=True),
     # --- partial / bare objects that must be wrapped ---
     "only_read": Case(_only_read, seekable=False, passes_is_stream=False),
     "read_into": Case(_read_into, seekable=False, passes_is_stream=False),
-    "s3_streaming_body": Case(_s3_streaming_body, seekable=False, passes_is_stream=False),
+    "s3_streaming_body": Case(
+        _s3_streaming_body, seekable=False, passes_is_stream=False
+    ),
     # mmap is not an io.IOBase (so it is wrapped), but is_seekable() special-cases it as
     # seekable, and BinaryIOWrapper.seek() recovers the position via tell() (mmap.seek
     # returns None before Python 3.13).
     "mmap": Case(_mmap_source, seekable=True, passes_is_stream=False),
 }
 
-_OPTIONAL_DEP = {"urllib3_response": ("urllib3", HAVE_URLLIB3), "fsspec_memory": ("fsspec", HAVE_FSSPEC)}
+_OPTIONAL_DEP = {
+    "urllib3_response": ("urllib3", HAVE_URLLIB3),
+    "fsspec_memory": ("fsspec", HAVE_FSSPEC),
+}
 
 
 def _params() -> list:
@@ -521,7 +538,9 @@ def _probe_pipe_seek(stream: BinaryIO) -> tuple[list[str], bool | None]:
     return obs, correct
 
 
-@pytest.mark.skipif(not _WINDOWS, reason="Windows-only: characterize OS pipe seek behavior")
+@pytest.mark.skipif(
+    not _WINDOWS, reason="Windows-only: characterize OS pipe seek behavior"
+)
 def test_windows_pipe_seek_characterization() -> None:
     """Determine *exactly* how a Windows pipe responds to seeking, and lock in the contract.
 

--- a/tests/test_tar.py
+++ b/tests/test_tar.py
@@ -122,7 +122,9 @@ def test_plain_tar_cost(plain_tar: Path) -> None:
         ("w:xz", ArchiveFormat.TAR_XZ),
     ],
 )
-def test_compressed_tar_cost_and_read(mode: str, fmt: ArchiveFormat, tmp_path: Path) -> None:
+def test_compressed_tar_cost_and_read(
+    mode: str, fmt: ArchiveFormat, tmp_path: Path
+) -> None:
     path = tmp_path / f"a.{mode.split(':')[1]}"
     path.write_bytes(_build_tar(mode))
     with open_archive(path) as ar:
@@ -349,7 +351,9 @@ def test_streaming_tar_does_not_call_getmembers() -> None:
         NonSeekableBytesIO(data), format=ArchiveFormat.TAR, streaming=True
     ) as ar:
         with mock.patch.object(
-            tarfile.TarFile, "getmembers", side_effect=AssertionError("getmembers called")
+            tarfile.TarFile,
+            "getmembers",
+            side_effect=AssertionError("getmembers called"),
         ):
             list(ar.stream_members())
 
@@ -597,7 +601,11 @@ def _build_link_tar() -> bytes:
     """dir/file + a root-level decoy `file`, and links exercising target resolution."""
     buf = io.BytesIO()
     with tarfile.open(fileobj=buf, mode="w") as t:
-        for name, data in [("file", b"ROOT"), ("dir/file", b"NESTED"), ("top.txt", b"TOP")]:
+        for name, data in [
+            ("file", b"ROOT"),
+            ("dir/file", b"NESTED"),
+            ("top.txt", b"TOP"),
+        ]:
             info = tarfile.TarInfo(name)
             info.size = len(data)
             t.addfile(info, io.BytesIO(data))
@@ -902,7 +910,9 @@ def test_chain_through_same_named_members_not_false_cycle() -> None:
     from archivey.types import ArchiveInfo, ArchiveMember
 
     class _Reader(BaseArchiveReader):
-        def __init__(self, members: list[ArchiveMember], payloads: dict[str, bytes]) -> None:
+        def __init__(
+            self, members: list[ArchiveMember], payloads: dict[str, bytes]
+        ) -> None:
             super().__init__(ArchiveFormat.TAR, streaming=False, archive_name=None)
             self._payloads = payloads
             self._members_cache = members
@@ -930,16 +940,10 @@ def test_chain_through_same_named_members_not_false_cycle() -> None:
             return None
 
     # Hop-by-hop chain start → dup(sym) → tail → dup(file); two distinct "dup.txt" members.
-    first = ArchiveMember(
-        name="dup.txt", type=MemberType.SYMLINK, link_target="tail"
-    )
+    first = ArchiveMember(name="dup.txt", type=MemberType.SYMLINK, link_target="tail")
     second = ArchiveMember(name="dup.txt", type=MemberType.FILE)
-    tail = ArchiveMember(
-        name="tail", type=MemberType.SYMLINK, link_target="dup.txt"
-    )
-    start = ArchiveMember(
-        name="start", type=MemberType.SYMLINK, link_target="dup.txt"
-    )
+    tail = ArchiveMember(name="tail", type=MemberType.SYMLINK, link_target="dup.txt")
+    start = ArchiveMember(name="start", type=MemberType.SYMLINK, link_target="dup.txt")
     for idx, m in enumerate((first, second, tail, start)):
         m._member_id = idx
         m._archive_id = "test"

--- a/tests/test_zip.py
+++ b/tests/test_zip.py
@@ -223,7 +223,9 @@ def test_compression_method_mapping(tmp_path: Path) -> None:
     with open_archive(path) as ar:
         by_name = {m.name: m for m in ar.members()}
         assert by_name["stored.txt"].compression[0].algo == CompressionAlgorithm.STORED
-        assert by_name["deflated.txt"].compression[0].algo == CompressionAlgorithm.DEFLATE
+        assert (
+            by_name["deflated.txt"].compression[0].algo == CompressionAlgorithm.DEFLATE
+        )
 
 
 def test_encrypted_flag() -> None:
@@ -288,7 +290,9 @@ def test_unknown_extra_field_before_timestamp(tmp_path: Path) -> None:
     with zipfile.ZipFile(path, "w") as z:
         z.writestr(info, b"data")
     with open_archive(path) as ar:
-        assert ar.get("file.txt").modified == datetime.fromtimestamp(unix_time, tz=timezone.utc)
+        assert ar.get("file.txt").modified == datetime.fromtimestamp(
+            unix_time, tz=timezone.utc
+        )
 
 
 def test_extended_timestamp_fills_mtime_atime_ctime(tmp_path: Path) -> None:
@@ -401,9 +405,7 @@ def test_concurrent_open_members_interleaved_stream_source(simple_zip: Path) -> 
     # source (_SharedFile keeps a per-open position under ZipFile's lock), so archivey
     # adds no wrap; this test locks the concurrent-open contract in for that leg too.
     data = simple_zip.read_bytes()
-    with open_archive(
-        io.BytesIO(data), member_streams=MemberStreams.CONCURRENT
-    ) as ar:
+    with open_archive(io.BytesIO(data), member_streams=MemberStreams.CONCURRENT) as ar:
         s1 = ar.open("hello.txt")
         s2 = ar.open("dir/nested.txt")
         assert s1.read(5) == b"hello"
@@ -495,19 +497,47 @@ def _overlapping_entries_zip() -> bytes:
         offsets.append(buf.tell())
         buf.write(
             struct.pack(
-                "<IHHHHHIIIHH", 0x04034B50, 20, 0, 8, 0, 0, crc, csize, usize, len(nm), 0
+                "<IHHHHHIIIHH",
+                0x04034B50,
+                20,
+                0,
+                8,
+                0,
+                0,
+                crc,
+                csize,
+                usize,
+                len(nm),
+                0,
             )
         )
         buf.write(nm)
-    buf.write(blob)  # one shared kernel; every entry's data span overruns the next header
+    buf.write(
+        blob
+    )  # one shared kernel; every entry's data span overruns the next header
 
     cd_start = buf.tell()
     for nm, off in zip(names, offsets):
         buf.write(
             struct.pack(
                 "<IHHHHHHIIIHHHHHII",
-                0x02014B50, 20, 20, 0, 8, 0, 0, crc, csize, usize,
-                len(nm), 0, 0, 0, 0, 0, off,
+                0x02014B50,
+                20,
+                20,
+                0,
+                8,
+                0,
+                0,
+                crc,
+                csize,
+                usize,
+                len(nm),
+                0,
+                0,
+                0,
+                0,
+                0,
+                off,
             )
         )
         buf.write(nm)
@@ -591,7 +621,9 @@ def test_explicit_encoding_overrides_cp437_default() -> None:
 
 def _ntfs_extra(mtime_ft: int, atime_ft: int, ctime_ft: int) -> bytes:
     """An NTFS extra field (0x000A): 4 reserved bytes, then tag 1 with three FILETIMEs."""
-    body = struct.pack("<I", 0) + struct.pack("<HHQQQ", 0x0001, 24, mtime_ft, atime_ft, ctime_ft)
+    body = struct.pack("<I", 0) + struct.pack(
+        "<HHQQQ", 0x0001, 24, mtime_ft, atime_ft, ctime_ft
+    )
     return struct.pack("<HH", 0x000A, len(body)) + body
 
 
@@ -605,7 +637,9 @@ def test_ntfs_timestamps_used_when_no_extended_timestamp(tmp_path: Path) -> None
     mtime, atime, ctime = 1_600_000_000, 1_600_000_100, 1_600_000_200
     path = tmp_path / "ntfs.zip"
     info = zipfile.ZipInfo("t.txt", date_time=(1990, 1, 1, 0, 0, 0))
-    info.extra = _ntfs_extra(_to_filetime(mtime), _to_filetime(atime), _to_filetime(ctime))
+    info.extra = _ntfs_extra(
+        _to_filetime(mtime), _to_filetime(atime), _to_filetime(ctime)
+    )
     with zipfile.ZipFile(path, "w") as z:
         z.writestr(info, b"data")
     with open_archive(path) as ar:
@@ -620,9 +654,9 @@ def test_extended_timestamp_beats_ntfs(tmp_path: Path) -> None:
     # fields' order in the extra blob. Here NTFS carries all three times but the UT
     # field's mtime wins for `modified`; atime/ctime stay from NTFS (UT carries none).
     ut_mtime, nt_mtime, nt_atime = 1_600_000_000, 1_500_000_000, 1_500_000_100
-    extra = _ntfs_extra(_to_filetime(nt_mtime), _to_filetime(nt_atime), 0) + struct.pack(
-        "<HHBI", 0x5455, 5, 0x01, ut_mtime
-    )
+    extra = _ntfs_extra(
+        _to_filetime(nt_mtime), _to_filetime(nt_atime), 0
+    ) + struct.pack("<HHBI", 0x5455, 5, 0x01, ut_mtime)
     path = tmp_path / "both.zip"
     info = zipfile.ZipInfo("t.txt", date_time=(1990, 1, 1, 0, 0, 0))
     info.extra = extra

--- a/tests/test_zip_multipassword.py
+++ b/tests/test_zip_multipassword.py
@@ -28,10 +28,7 @@ RIGHT = b"very_secret_password"
 DATA = b"This is very secret" * 8
 NAME = "very_secret.txt"
 PasswordArg = (
-    str
-    | bytes
-    | list[str | bytes]
-    | Callable[[PasswordRequest], str | bytes | None]
+    str | bytes | list[str | bytes] | Callable[[PasswordRequest], str | bytes | None]
 )
 
 COMPRESSION_METHODS = [
@@ -53,9 +50,7 @@ def _read_member(blob: bytes, password: PasswordArg) -> bytes:
 def test_wrong_candidate_false_accept_does_not_shadow_right_password(
     compression: int,
 ) -> None:
-    blob = build_zipcrypto_zip(
-        RIGHT, NAME.encode(), DATA, compression=compression
-    )
+    blob = build_zipcrypto_zip(RIGHT, NAME.encode(), DATA, compression=compression)
     collider = find_check_byte_collision(blob, NAME, RIGHT)
 
     assert collider != RIGHT
@@ -86,7 +81,9 @@ def test_provider_continues_after_colliding_password() -> None:
     assert all(request.member is not None for request in seen)
 
 
-@pytest.mark.parametrize("passwords", [[RIGHT], [RIGHT, RIGHT]], ids=["one", "duplicate"])
+@pytest.mark.parametrize(
+    "passwords", [[RIGHT], [RIGHT, RIGHT]], ids=["one", "duplicate"]
+)
 @pytest.mark.parametrize("compression", COMPRESSION_METHODS)
 def test_single_distinct_candidate_is_not_eagerly_read(
     passwords: list[bytes], compression: int
@@ -102,9 +99,7 @@ def test_single_distinct_candidate_is_not_eagerly_read(
 
 
 def test_corrupt_encrypted_data_with_multiple_candidates_reports_ambiguity() -> None:
-    blob = corrupt_zipcrypto_payload(
-        build_zipcrypto_zip(RIGHT, NAME.encode(), DATA)
-    )
+    blob = corrupt_zipcrypto_payload(build_zipcrypto_zip(RIGHT, NAME.encode(), DATA))
 
     with open_archive(io.BytesIO(blob), password=[RIGHT, b"also-wrong"]) as ar:
         with pytest.raises(
@@ -156,9 +151,7 @@ def test_confirmed_winner_is_reopened_fresh(monkeypatch: pytest.MonkeyPatch) -> 
             force_zip64: bool = False,
         ) -> zipfile.ZipExtFile:
             tried.append(pwd)
-            return original_open(
-                name, mode=mode, pwd=pwd, force_zip64=force_zip64
-            )
+            return original_open(name, mode=mode, pwd=pwd, force_zip64=force_zip64)
 
         monkeypatch.setattr(archive, "open", tracking_open)
         assert ar.read(NAME) == DATA
@@ -252,9 +245,7 @@ def test_wrong_key_rejected_within_tight_prefix_bound(
     """Even a 4 KiB confirmation bound rejects colliding wrong keys (≪ 64 KiB)."""
     monkeypatch.setattr(password_confirm, "CONFIRM_PREFIX_BYTES", 4 * 1024)
     monkeypatch.setattr(zip_reader, "CONFIRM_PREFIX_BYTES", 4 * 1024)
-    blob = build_zipcrypto_zip(
-        RIGHT, NAME.encode(), DATA * 64, compression=compression
-    )
+    blob = build_zipcrypto_zip(RIGHT, NAME.encode(), DATA * 64, compression=compression)
     collider = find_check_byte_collision(blob, NAME, RIGHT)
     assert _read_member(blob, [collider, RIGHT]) == DATA * 64
 
@@ -267,7 +258,7 @@ def test_wrong_key_rejected_within_tight_prefix_bound(
 def test_large_compressed_confirmation_is_bounded(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    plaintext = (b"bounded-confirm-payload\n" * 8000)  # well over 64 KiB when repeated
+    plaintext = b"bounded-confirm-payload\n" * 8000  # well over 64 KiB when repeated
     plaintext = plaintext * 8  # ~1.5 MiB+
     assert len(plaintext) > CONFIRM_PREFIX_BYTES
     blob = build_zipcrypto_zip(
@@ -380,7 +371,7 @@ def test_corruption_beyond_prefix_fails_caller_read_as_corruption(
     """Prefix confirmation accepts; trailing corruption fails the caller's CRC."""
     import struct
 
-    plaintext = (b"prefix-ok-then-corrupt\n" * 8000)
+    plaintext = b"prefix-ok-then-corrupt\n" * 8000
     assert len(plaintext) > 64 * 1024
     blob = bytearray(
         build_zipcrypto_zip(

--- a/uv.lock
+++ b/uv.lock
@@ -95,6 +95,7 @@ dev = [
     { name = "hypothesis" },
     { name = "lz4" },
     { name = "ncompress" },
+    { name = "pre-commit" },
     { name = "py7zr" },
     { name = "pycdlib" },
     { name = "pyrefly" },
@@ -147,6 +148,7 @@ dev = [
     { name = "hypothesis", specifier = ">=6.100.0" },
     { name = "lz4", specifier = ">=4.4.5" },
     { name = "ncompress", specifier = ">=1.0.0" },
+    { name = "pre-commit", specifier = ">=4.0.0" },
     { name = "py7zr", specifier = ">=1.0.0" },
     { name = "pycdlib", specifier = ">=1.16.0" },
     { name = "pyrefly", specifier = ">=0.20.0" },
@@ -440,6 +442,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cfgv"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
+]
+
+[[package]]
 name = "charset-normalizer"
 version = "3.4.9"
 source = { registry = "https://pypi.org/simple" }
@@ -680,6 +691,15 @@ wheels = [
 ]
 
 [[package]]
+name = "distlib"
+version = "0.4.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c9/02/bd72be9134d25ed783ecbbc38a539ffaefbf90c78418c7fb7229600dbac7/distlib-0.4.3.tar.gz", hash = "sha256:f152097224a0ae24be5a0f6bae1b9359af82133bce63f98a95f86cae1aede9ed", size = 615141, upload-time = "2026-06-12T08:04:52.847Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/08/9c41fb51ab5b43eb21674aff13df270e8ba6c4b29c8624e328dc7a9482af/distlib-0.4.3-py2.py3-none-any.whl", hash = "sha256:4b0ce306c966eb73bc3a7b6abad017c556dadd92c44701562cd528ac7fde4d5b", size = 470628, upload-time = "2026-06-12T08:04:50.506Z" },
+]
+
+[[package]]
 name = "fieldz"
 version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -689,6 +709,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f8/46/7a8d1db959eabd5d3e52bd3c000a8b132184b7651cbd5481c4cbf31ff65d/fieldz-0.2.0.tar.gz", hash = "sha256:e11215188cad5c5371113d2b7707155960efd0d48500b6bf675648bc3f6fc8d6", size = 18222, upload-time = "2026-02-24T19:26:02.251Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fe/9d/9034acaf3d80e85deb3d49876cb734479327b9cf89a918815ef67cb6b36c/fieldz-0.2.0-py3-none-any.whl", hash = "sha256:43b5be702816df39f55d08ae392eaabe58d3c69d2e4b61a853252cb2da41931f", size = 17946, upload-time = "2026-02-24T19:26:00.931Z" },
+]
+
+[[package]]
+name = "filelock"
+version = "3.29.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/94/00f2059e4835eace3ae8fde680b932c496f8ec7bdc99168dfa53fb2e6b79/filelock-3.29.7.tar.gz", hash = "sha256:5b481979797ae69e72f0b389d89a80bdd585c260c5b3f1fb9c0a5ba9bb3f195d", size = 71521, upload-time = "2026-07-08T05:46:58.716Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/02/be4a57b60c7149b55b9e3b3c13f609cd8eb5307c751f22bd8fb8d262e75b/filelock-3.29.7-py3-none-any.whl", hash = "sha256:987db6f789a3a2a59f55081801b2b3697cb97e2a736b5f1a9e99b559285fbc51", size = 46036, upload-time = "2026-07-08T05:46:57.53Z" },
 ]
 
 [[package]]
@@ -793,6 +822,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/11/d3/5bff4c55c6995a6c43f66ec8e5866b56e34f03837fd0be0e4922f3bab168/hypothesis-6.156.6-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:38ed3178526382d392d04ad699ad7a2e53845e521a09d40f1cbbc1e1ff63ba48", size = 1070916, upload-time = "2026-07-10T20:56:19.256Z" },
     { url = "https://files.pythonhosted.org/packages/ba/af/5ed42117a69221ea118caaff933d8212039a0ac0bc15afa915635f13984c/hypothesis-6.156.6-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5ad94e28aabf4db0d479297d43b8a2a01e7caaa9bdfccfdac7a4a3717e05b993", size = 1122625, upload-time = "2026-07-10T20:56:14.758Z" },
     { url = "https://files.pythonhosted.org/packages/3b/d3/02499badc6e3f3e980941021edf5fd780c895d8d08c9015e78516340ed83/hypothesis-6.156.6-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:983a5cfd955994bffc7eb02976241f7a1f3c2d94dbc3389430c45858fa5c1ae0", size = 640823, upload-time = "2026-07-10T20:55:45.461Z" },
+]
+
+[[package]]
+name = "identify"
+version = "2.6.19"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/63/51723b5f116cc04b061cb6f5a561790abf249d25931d515cd375e063e0f4/identify-2.6.19.tar.gz", hash = "sha256:6be5020c38fcb07da56c53733538a3081ea5aa70d36a156f83044bfbf9173842", size = 99567, upload-time = "2026-04-17T18:39:50.265Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/84/d9273cd09688070a6523c4aee4663a8538721b2b755c4962aafae0011e72/identify-2.6.19-py2.py3-none-any.whl", hash = "sha256:20e6a87f786f768c092a721ad107fc9df0eb89347be9396cadf3f4abbd1fb78a", size = 99397, upload-time = "2026-04-17T18:39:49.221Z" },
 ]
 
 [[package]]
@@ -1192,6 +1230,15 @@ wheels = [
 ]
 
 [[package]]
+name = "nodeenv"
+version = "1.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
 name = "packaging"
 version = "26.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1234,6 +1281,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pre-commit"
+version = "4.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cfgv" },
+    { name = "identify" },
+    { name = "nodeenv" },
+    { name = "pyyaml" },
+    { name = "virtualenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8e/22/2de9408ac81acbb8a7d05d4cc064a152ccf33b3d480ebe0cd292153db239/pre_commit-4.6.0.tar.gz", hash = "sha256:718d2208cef53fdc38206e40524a6d4d9576d103eb16f0fec11c875e7716e9d9", size = 198525, upload-time = "2026-04-21T20:31:41.613Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl", hash = "sha256:e2cf246f7299edcabcf15f9b0571fdce06058527f0a06535068a86d38089f29b", size = 226472, upload-time = "2026-04-21T20:31:40.092Z" },
 ]
 
 [[package]]
@@ -1537,6 +1600,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-discovery"
+version = "1.4.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filelock" },
+    { name = "platformdirs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4c/81/58c70036dffeccb7fe7d79d6260c69f7a28272bbd3909c29a01ea9422744/python_discovery-1.4.4.tar.gz", hash = "sha256:5cad33982d412c1f3ffb8f9ca4ea292c9680bca3942451d30b69c37fce53a4a3", size = 72212, upload-time = "2026-07-08T23:06:50.691Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/ae/84bc0d2440c95772272bb6f4b3d09ccf08b2898fce89b3d4f969a9fc74e9/python_discovery-1.4.4-py3-none-any.whl", hash = "sha256:abebe9120b43453b68c908acfb1e72a19d1a959ed2cb620ad38fc57d08056dbe", size = 34181, upload-time = "2026-07-08T23:06:49.402Z" },
 ]
 
 [[package]]
@@ -1856,6 +1932,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
+name = "virtualenv"
+version = "21.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "distlib" },
+    { name = "filelock" },
+    { name = "platformdirs" },
+    { name = "python-discovery" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/34/d9/b477fddb68840b570af8b22afe9b035cbc277b5fb7b33dea390617a8b10f/virtualenv-21.6.1.tar.gz", hash = "sha256:15f978b7cd329f24855ff4a0c4b4899cc7678589f49adbdcbbb4d3232e641128", size = 5526620, upload-time = "2026-07-10T19:33:53.312Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/7c/4e7225d46d634a0d8d534dd8a6ce0c319d09b4d0cf0337eb314ca4789d8c/virtualenv-21.6.1-py3-none-any.whl", hash = "sha256:afe991df855715a2b2f60edfcc0107ef95a79fdfd8cb4cdaa71603d1c12e463b", size = 5506392, upload-time = "2026-07-10T19:33:51.629Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Ran `ruff format` on `src/`, `tests/`, and `scripts/` to clear pre-existing formatting drift (52 files).
- Added `.pre-commit-config.yaml` with `ruff` (lint + fix) and `ruff-format` hooks, scoped to Python under those directories.
- Extended the CI lint job with `ruff format --check` and aligned `ruff check` to the same paths.
- Added `pre-commit` to the dev dependency group; documented hook setup in `CONTRIBUTING.md`.

## Usage

```bash
uv run pre-commit install
uv run pre-commit run --all-files
```

## Test plan

- [x] `uv run ruff format --check src/ tests/ scripts/`
- [x] `uv run ruff check src/ tests/ scripts/`
- [x] `uv run pre-commit run --all-files`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f3c96d84-9535-40ac-84b3-67db92fe3568"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f3c96d84-9535-40ac-84b3-67db92fe3568"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

