### PR TITLE
Propose native 7z reader (OpenSpec)

### DIFF
--- a/openspec/changes/native-7z-reader/.openspec.yaml
+++ b/openspec/changes/native-7z-reader/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-11

--- a/openspec/changes/native-7z-reader/design.md
+++ b/openspec/changes/native-7z-reader/design.md
@@ -15,13 +15,15 @@ Provenance: DEV exploration + `ARCHITECTURE.md` §5.6 / §7.3.
 - Zero-dep core 7z **read** (common codecs) with true pull streaming.
 - Oracle parity with `py7zr` / `7z` CLI on supported archives.
 - Correct password handling with KDF caching; never silent garbage.
-- Anti-items listed and extracted like the `7z` CLI (delete destination).
+- Anti-items and superseded revisions listed with `is_anti` / `is_current`; extraction
+  reproduces the archive's final tree without deleting data it did not create.
 - Atheris harness for the header parser (Phase 6 fuzz entry companion).
 
 **Non-Goals:**
 - RAR reader; ZIP Deflate64/PPMd wiring; 7z writing.
 - Decoded-folder spool / disk cache.
-- Native BCJ2; general `is_current` / skip-non-current iteration filters (sibling if needed).
+- Native BCJ2; computing `is_current` shadowing for non-7z formats (ZIP/TAR duplicate
+  names — sibling if needed); the opt-in `7z x`-style differential-restore extraction mode.
 - Pulling `pybcj` into the runtime dependency surface.
 
 ## Decisions
@@ -53,6 +55,14 @@ Cache derived 32-byte keys by `(password, salt, cycles)` for the life of the rea
 Try known-good candidates first; promote successes. Wrong password →
 `EncryptionError`/`CorruptionError`, never wrong bytes.
 
+**Placement:** the 7z SHA-256 KDF (UTF-16LE password + salt + `1 << NumCyclesPower`
+rounds, incl. the `0x3f` special case) is 7z-specific — RAR and WinZip-AES derive keys
+differently — so it lives in a **7z-local area of the crypto module** (a `sevenzip`
+helper beside `streams/crypto.py`), not on the generic crypto backend surface. It emits
+the 32-byte key + IV that feed the shared, format-agnostic AES decrypt stage as
+`AesParams`; the reader never imports `cryptography` directly. If a later format turns
+out to share the exact scheme, promote it to a shared helper then — not preemptively.
+
 ### 5. Unsupported codec combinations
 - **BCJ2** / unknown method IDs / newer BCJ absent from liblzma → `UnsupportedFeatureError`.
 - **LZMA1+BCJ**: attempt a correct stdlib-only composition (separate stages if needed). If
@@ -60,21 +70,44 @@ Try known-good candidates first; promote successes. Wrong password →
   raise `UnsupportedFeatureError`, documenting it for later (py7zr uses `pybcj` for this
   path — we will not add that runtime dep here).
 
-### 6. Anti-items (`is_anti`)
-CLI validation (7z 23.01): members with `Anti = +` appear in `7z l -slt`; on `7z x` the
-destination path is **deleted** if present; size is 0. **py7zr 1.1.3 cannot parse**
-archives with the `ANTI` (`0x10`) property (`Bad7zFile: invalid type b'\x10'`), so the
-oracle for anti is the **`7z` CLI**, not py7zr.
+### 6. Anti-items (`is_anti`) and superseded revisions (`is_current`)
+What anti-items are *for*: 7z records them in **differential/incremental** archives —
+an entry with a name, zero content, and the `ANTI` (`0x10`) bit means "this path was
+deleted since the base." Their meaning is relative to a pre-existing base tree; `7z x`
+consumes them by deleting the path from an already-extracted base. CLI validation
+(7z 23.01): `Anti = +` members appear in `7z l -slt`; on `7z x` the destination is
+**deleted** if present; size is 0. **py7zr 1.1.3 cannot parse** archives with the
+`ANTI` property (`Bad7zFile: invalid type b'\x10'`), so the anti oracle is the **`7z`
+CLI**, not py7zr.
 
-Design:
-- Add `ArchiveMember.is_anti: bool = False`.
-- Always include anti members in listing / iteration.
-- `open` / stream data: empty (no payload).
-- `extract`: if `is_anti`, **unlink** the destination (file or empty dir per 7z behavior)
-  when it exists **inside the extract root**, after universal path checks — do not write
-  content. Emit a diagnostic if useful.
-- Defer a general `is_current` flag and optional iteration skip filters to a sibling
-  change; `is_anti` is the precise 7z signal.
+The key insight: this couples two separable facts — the raw deletion bit, and which
+revision of a path is *live*. We model them separately:
+
+- **`is_anti`** (raw): the faithful ANTI bit. Listed/iterated as-is.
+- **`is_current`** (derived): last-entry-wins by name. A content member deleted by a
+  later anti-item, or re-added later, is `is_current=False`; the surviving entry is
+  `is_current=True`. An anti-item that is the last word on its path is itself
+  `is_current=True` (final state = "deleted"). This is a general concept that also
+  covers duplicate-name shadowing in appended/updated ZIP/TAR — but this change only
+  requires the **7z reader** to compute it; other formats keep the default
+  `is_current=True` until a sibling change.
+
+Extraction (see `safe-extraction`) then reproduces the archive's **final tree**:
+- Non-current members are **skipped** by default (no redundant writes; the archive's
+  own duplicates don't trip `OverwritePolicy.ERROR`).
+- An anti-item **never deletes data this extraction did not create**. Since the content
+  it supersedes is already skipped as non-current, an anti-item is a **no-op on disk**
+  in the common case. The only delete that ever fires is bounded to a path *this same
+  extraction wrote* — a safety upper bound matching the maintainer's rule ("delete only
+  if the current extraction wrote it, otherwise don't"), using `lstat`/`unlink` (never
+  through a symlink) and only for a file or empty dir.
+- `open` / stream data for an anti-item: empty (no payload).
+
+**Rejected:** `7z x`-style deletion of pre-existing on-disk files by default. Reaching
+outside the current extraction to remove user data that merely shares a name is a
+foot-gun and contradicts archivey's safety posture (cf. the deliberate `tarfile`
+symlink-copy deviation). That behavior is deferred to a future explicit opt-in mode
+("differential restore"), never the default.
 
 ### 7. Multi-volume
 Discovery already lives in `volumes.py`. Join = sequential concatenation into one logical
@@ -94,7 +127,8 @@ harness. Mutation/Hypothesis gates are already green.
 | Risk | Mitigation |
 |------|------------|
 | LZMA1+BCJ silent corruption | Fixture test; unsupported raise if unsure |
-| Anti delete surprises callers | Spec + docs; only under extract; path-confined |
+| Anti delete surprises callers | Default never deletes pre-existing data; only removes paths the same extraction wrote; `7z x`-style restore is opt-in |
+| `is_current` diverges from `7z x` on a populated tree | Documented: default = final tree on a fresh dest; opt-in mode matches `7z x` differential restore |
 | py7zr oracle gaps (anti, some codecs) | Prefer `7z` CLI for those fixtures |
 | KDF cost on multi-password archives | Cache by `(password, salt, cycles)`; known-good first |
 | Solid `open()` O(prefix) cost | Honest `CostReceipt`; prefer `stream_members()` |
@@ -103,10 +137,11 @@ harness. Mutation/Hypothesis gates are already green.
 ## Migration Plan
 
 - Register the backend → corpus 7z entries activate automatically.
-- No API break beyond additive `is_anti`.
+- No API break beyond additive `is_anti` / `is_current` fields.
 - Stale "Phase 7" comments in `crypto.py` / `PpmdCodec` updated to Phase 6.
 
 ## Open Questions
 
-None blocking. Sibling follow-ups if needed: `is_current` + skip filters; LZMA1+BCJ via
-optional helper; ZIP shared-codec wiring; RAR native reader.
+None blocking. Sibling follow-ups if needed: `is_current` shadowing for ZIP/TAR
+duplicate names; the opt-in `7z x`-style differential-restore extraction mode;
+LZMA1+BCJ via optional helper; ZIP shared-codec wiring; RAR native reader.

--- a/openspec/changes/native-7z-reader/design.md
+++ b/openspec/changes/native-7z-reader/design.md
@@ -1,0 +1,112 @@
+## Context
+
+`format-7z` already specifies a native reader; no backend is registered yet. The DEV
+`sevenzip-native-reader` design (`docs/sevenzip-native-reader-design.md` in
+`archivey-dev`) remains the format/codec reference. v2 already has the host layers:
+`compressed-streams` (incl. raw LZMA + filter IDs; PPMd/AES stubs), `SharedSource`,
+password candidates, and volume *discovery*. This change fills the reader and finishes
+the stubs.
+
+Provenance: DEV exploration + `ARCHITECTURE.md` §5.6 / §7.3.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Zero-dep core 7z **read** (common codecs) with true pull streaming.
+- Oracle parity with `py7zr` / `7z` CLI on supported archives.
+- Correct password handling with KDF caching; never silent garbage.
+- Anti-items listed and extracted like the `7z` CLI (delete destination).
+- Atheris harness for the header parser (Phase 6 fuzz entry companion).
+
+**Non-Goals:**
+- RAR reader; ZIP Deflate64/PPMd wiring; 7z writing.
+- Decoded-folder spool / disk cache.
+- Native BCJ2; general `is_current` / skip-non-current iteration filters (sibling if needed).
+- Pulling `pybcj` into the runtime dependency surface.
+
+## Decisions
+
+### 1. Module layout
+- `internal/backends/sevenzip_parser.py` — header parse → member list + folder/coder map.
+- `internal/backends/sevenzip_reader.py` — `BaseArchiveReader` + `ReadBackend` registration.
+- Folder pipeline stays in the reader (or a tiny private helper); it **only** composes
+  `compressed-streams` / `crypto` APIs.
+
+### 2. Solid random access = re-decode only
+No spool, no temp files, no decoded-folder RAM cache. `stream_members()` decodes each
+folder once and slices forward; `open()` on a solid member re-decodes from the folder
+start and skips to the substream. Peak memory = decompressor working set.
+
+**Rejected:** disk spill / single-folder spool (complexity; contradicts "no disk writes").
+
+### 3. SharedSource for pack ranges
+Pack streams are `SharedSource.view(pack_offset, pack_size)` so concurrent `open()` under
+`MemberStreams.CONCURRENT` is correct by construction.
+
+### 4. Password KDF cache (correctness first)
+7z has **no check value**. Cost of a try ≈ SHA-256 KDF (`1 << NumCyclesPower`, commonly
+`2^19` rounds) **per distinct `(password, salt, cycles)`**, then decrypt+decode until CRC
+fails (usually fast). Salt can differ per folder/header, so the cost is **not** "once per
+archive" unless salts match.
+
+Cache derived 32-byte keys by `(password, salt, cycles)` for the life of the reader.
+Try known-good candidates first; promote successes. Wrong password →
+`EncryptionError`/`CorruptionError`, never wrong bytes.
+
+### 5. Unsupported codec combinations
+- **BCJ2** / unknown method IDs / newer BCJ absent from liblzma → `UnsupportedFeatureError`.
+- **LZMA1+BCJ**: attempt a correct stdlib-only composition (separate stages if needed). If
+  that cannot be validated against a fixture (never guess), leave **unimplemented** and
+  raise `UnsupportedFeatureError`, documenting it for later (py7zr uses `pybcj` for this
+  path — we will not add that runtime dep here).
+
+### 6. Anti-items (`is_anti`)
+CLI validation (7z 23.01): members with `Anti = +` appear in `7z l -slt`; on `7z x` the
+destination path is **deleted** if present; size is 0. **py7zr 1.1.3 cannot parse**
+archives with the `ANTI` (`0x10`) property (`Bad7zFile: invalid type b'\x10'`), so the
+oracle for anti is the **`7z` CLI**, not py7zr.
+
+Design:
+- Add `ArchiveMember.is_anti: bool = False`.
+- Always include anti members in listing / iteration.
+- `open` / stream data: empty (no payload).
+- `extract`: if `is_anti`, **unlink** the destination (file or empty dir per 7z behavior)
+  when it exists **inside the extract root**, after universal path checks — do not write
+  content. Emit a diagnostic if useful.
+- Defer a general `is_current` flag and optional iteration skip filters to a sibling
+  change; `is_anti` is the precise 7z signal.
+
+### 7. Multi-volume
+Discovery already lives in `volumes.py`. Join = sequential concatenation into one logical
+seekable stream, then normal parse. Missing/out-of-order parts → error, not garbage.
+
+### 8. Writing / oracles
+Reads never import `py7zr`. Tests use `py7zr` + `7z` CLI as oracles (skip if absent).
+`[7z-write]` stays Phase 9.
+
+### 9. Fuzzing
+Ship an Atheris (or documented harness scaffold if Atheris packaging is awkward) targeting
+the header parser, seeded from corpus + adversarial bytes; env-gated like the mutation
+harness. Mutation/Hypothesis gates are already green.
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+|------|------------|
+| LZMA1+BCJ silent corruption | Fixture test; unsupported raise if unsure |
+| Anti delete surprises callers | Spec + docs; only under extract; path-confined |
+| py7zr oracle gaps (anti, some codecs) | Prefer `7z` CLI for those fixtures |
+| KDF cost on multi-password archives | Cache by `(password, salt, cycles)`; known-good first |
+| Solid `open()` O(prefix) cost | Honest `CostReceipt`; prefer `stream_members()` |
+| Encoder header / empty archives | Handle absent `FILES_INFO` / empty folders explicitly |
+
+## Migration Plan
+
+- Register the backend → corpus 7z entries activate automatically.
+- No API break beyond additive `is_anti`.
+- Stale "Phase 7" comments in `crypto.py` / `PpmdCodec` updated to Phase 6.
+
+## Open Questions
+
+None blocking. Sibling follow-ups if needed: `is_current` + skip filters; LZMA1+BCJ via
+optional helper; ZIP shared-codec wiring; RAR native reader.

--- a/openspec/changes/native-7z-reader/proposal.md
+++ b/openspec/changes/native-7z-reader/proposal.md
@@ -1,0 +1,36 @@
+## Why
+
+Phase 6 needs a zero-dependency native 7z reader so listing and decoding no longer wait on (or import) `py7zr`. The DEV `sevenzip-native-reader` exploration already proved feasibility: stdlib `lzma` `FORMAT_RAW` covers LZMA1/LZMA2 + BCJ + Delta, and the v2 spine (`compressed-streams`, `SharedSource`, password candidates, volume discovery) is ready to host it.
+
+## What Changes
+
+- Implement a **native 7z header parser** and **`SevenZipReader` backend** that registers `ArchiveFormat.SEVEN_Z` (seek required; listing O(1); no third-party import on the read path).
+- Decode folders by **composing `compressed-streams`** only (never calling `lzma`/`pyppmd`/crypto from the reader). Finish the PPMd open path and the AES-CBC decrypt stage + 7z SHA-256 KDF.
+- **Solid `open()`**: always re-decode from the folder start — **no spool, no disk writes**, no decoded-folder cache.
+- **Multi-volume**: join `.7z.001`+ siblings (or an explicit ordered list) by concatenation; incomplete sets error cleanly.
+- **Passwords**: candidate model + derived-key cache keyed by `(password, salt, cycles)`; prefer correctness over speculative fast-reject.
+- **Anti-items**: list them; on extract, **delete** the destination path (7z CLI parity), under safe-extraction path rules. `py7zr` cannot parse `ANTI` — oracle for this path is the `7z` CLI.
+- **Unsupported combinations** (notably BCJ2, and any coder chain we cannot decode correctly without custom/non-stdlib code such as LZMA1+BCJ if stdlib composition fails): raise `UnsupportedFeatureError`, never wrong bytes; document for later.
+- Wire **py7zr** (and `7z` CLI where useful) as **test oracles**; activate corpus 7z entries; add an Atheris harness for the header parser.
+- **Out of scope (siblings):** RAR native reader; ZIP Deflate64/PPMd shared-codec wiring; 7z writing (`[7z-write]` / Phase 9); general `is_current` / skip-non-current iteration filters.
+
+## Capabilities
+
+### New Capabilities
+
+- (none)
+
+### Modified Capabilities
+
+- `format-7z`: lock solid random-access = re-decode only; specify anti-item list + extract-delete; document unsupported codec combinations.
+- `archive-data-model`: add `ArchiveMember.is_anti`.
+- `safe-extraction`: anti-item extraction deletes the in-root destination (7z CLI parity) instead of writing bytes.
+- `compressed-streams`: complete PPMd stream open + AES decrypt stage (7z KDF feeds `AesParams`).
+- `testing-contract`: activate native↔py7zr/7z CLI cross-validation for 7z; anti-item fixtures via `7z` CLI when py7zr cannot parse them.
+
+## Impact
+
+- New: `internal/backends/sevenzip_reader.py`, `internal/backends/sevenzip_parser.py` (names may fold), folder-pipeline helper.
+- Touch: `streams/codecs.py` (PpmdCodec), `streams/crypto.py` (AES stage + KDF helpers), `volumes.py` (join), registry/detection, corpus builders/sweep.
+- Deps unchanged for core reads; `[7z]` / `[crypto]` remain optional; `py7zr` stays **dev oracle** (+ future `[7z-write]`).
+- Public API: new `ArchiveMember.is_anti` field (default `False`); no other breaking surface.

--- a/openspec/changes/native-7z-reader/proposal.md
+++ b/openspec/changes/native-7z-reader/proposal.md
@@ -9,10 +9,10 @@ Phase 6 needs a zero-dependency native 7z reader so listing and decoding no long
 - **Solid `open()`**: always re-decode from the folder start — **no spool, no disk writes**, no decoded-folder cache.
 - **Multi-volume**: join `.7z.001`+ siblings (or an explicit ordered list) by concatenation; incomplete sets error cleanly.
 - **Passwords**: candidate model + derived-key cache keyed by `(password, salt, cycles)`; prefer correctness over speculative fast-reject.
-- **Anti-items**: list them; on extract, **delete** the destination path (7z CLI parity), under safe-extraction path rules. `py7zr` cannot parse `ANTI` — oracle for this path is the `7z` CLI.
+- **Anti-items / superseded revisions**: parse the `ANTI` bitmask, expose `is_anti`, and compute a derived `is_current` (last-entry-wins by name; a content member deleted by a later anti-item or re-added later is `is_current=False`). Default extraction reproduces the archive's **final tree** — non-current members are skipped, and an anti-item **never deletes data the extraction did not create** (it is a no-op on disk in the common case). `7z x`-style deletion over a pre-existing tree is a future explicit opt-in, not the default. `py7zr` cannot parse `ANTI` — oracle for this path is the `7z` CLI.
 - **Unsupported combinations** (notably BCJ2, and any coder chain we cannot decode correctly without custom/non-stdlib code such as LZMA1+BCJ if stdlib composition fails): raise `UnsupportedFeatureError`, never wrong bytes; document for later.
 - Wire **py7zr** (and `7z` CLI where useful) as **test oracles**; activate corpus 7z entries; add an Atheris harness for the header parser.
-- **Out of scope (siblings):** RAR native reader; ZIP Deflate64/PPMd shared-codec wiring; 7z writing (`[7z-write]` / Phase 9); general `is_current` / skip-non-current iteration filters.
+- **Out of scope (siblings):** RAR native reader; ZIP Deflate64/PPMd shared-codec wiring; 7z writing (`[7z-write]` / Phase 9); computing `is_current` shadowing for other formats (ZIP/TAR duplicate names — they default `is_current=True` until a sibling change); the opt-in `7z x`-style differential-restore extraction mode.
 
 ## Capabilities
 
@@ -22,10 +22,10 @@ Phase 6 needs a zero-dependency native 7z reader so listing and decoding no long
 
 ### Modified Capabilities
 
-- `format-7z`: lock solid random-access = re-decode only; specify anti-item list + extract-delete; document unsupported codec combinations.
-- `archive-data-model`: add `ArchiveMember.is_anti`.
-- `safe-extraction`: anti-item extraction deletes the in-root destination (7z CLI parity) instead of writing bytes.
-- `compressed-streams`: complete PPMd stream open + AES decrypt stage (7z KDF feeds `AesParams`).
+- `format-7z`: lock solid random-access = re-decode only; specify anti-item list + `is_current` computation; document unsupported codec combinations.
+- `archive-data-model`: add `ArchiveMember.is_anti` (raw ANTI bit) and `ArchiveMember.is_current` (derived last-entry-wins by name).
+- `safe-extraction`: skip non-current members by default; anti-item extraction never deletes data the extraction did not create (no-op on disk in the common case) instead of writing bytes.
+- `compressed-streams`: complete PPMd stream open + format-agnostic AES decrypt stage, fed by a 7z-local KDF helper (`AesParams`).
 - `testing-contract`: activate native↔py7zr/7z CLI cross-validation for 7z; anti-item fixtures via `7z` CLI when py7zr cannot parse them.
 
 ## Impact
@@ -33,4 +33,4 @@ Phase 6 needs a zero-dependency native 7z reader so listing and decoding no long
 - New: `internal/backends/sevenzip_reader.py`, `internal/backends/sevenzip_parser.py` (names may fold), folder-pipeline helper.
 - Touch: `streams/codecs.py` (PpmdCodec), `streams/crypto.py` (AES stage + KDF helpers), `volumes.py` (join), registry/detection, corpus builders/sweep.
 - Deps unchanged for core reads; `[7z]` / `[crypto]` remain optional; `py7zr` stays **dev oracle** (+ future `[7z-write]`).
-- Public API: new `ArchiveMember.is_anti` field (default `False`); no other breaking surface.
+- Public API: new `ArchiveMember.is_anti` field (default `False`) and `ArchiveMember.is_current` field (default `True`); both additive, no other breaking surface.

--- a/openspec/changes/native-7z-reader/specs/archive-data-model/spec.md
+++ b/openspec/changes/native-7z-reader/specs/archive-data-model/spec.md
@@ -3,9 +3,11 @@
 ### Requirement: ArchiveMember anti-item flag
 
 The system SHALL expose `is_anti: bool = False` on `ArchiveMember`. When `True`, the
-member is a format-level deletion marker (7z ANTI), not ordinary file content.
-Callers iterating the archive SHALL see anti members unless a future optional filter
-excludes them. Equality includes `is_anti`.
+member is a format-level deletion marker (7z ANTI), not ordinary file content. It is
+the **faithful raw signal** from the container — the policy decisions it drives (skip
+the superseded content, or delete on extract) live in `safe-extraction`, not on this
+flag. Callers iterating the archive SHALL see anti members. Equality includes
+`is_anti`.
 
 #### Scenario: default is non-anti
 
@@ -16,3 +18,39 @@ excludes them. Equality includes `is_anti`.
 
 - **WHEN** a 7z anti-item is parsed
 - **THEN** `member.is_anti` is `True`
+
+### Requirement: ArchiveMember current-version flag
+
+The system SHALL expose `is_current: bool = True` on `ArchiveMember`. It is `True`
+when the member represents the **live final state** of its path within the archive,
+and `False` when a later member supersedes it — another member that writes the same
+path later in archive order (an updated/appended archive that re-adds a name), or a
+later anti-item that deletes that path. `is_current` is a **derived**,
+last-entry-wins-by-name computation, distinct from the raw `is_anti` bit:
+
+- A content member with no same-path successor is `is_current=True`.
+- A content member shadowed by a later same-path member or a later anti-item is
+  `is_current=False`.
+- An anti-item that is the last word on its path is itself `is_current=True` — the
+  path's final state is "deleted" — even though it carries no content.
+
+Backends that do not compute name shadowing leave every member at the default
+`is_current=True`, preserving their existing behavior; the native 7z reader SHALL
+compute `is_current` from the ANTI bitmask and same-name shadowing. Extraction
+consumes this field per `safe-extraction` (non-current members are skipped by
+default). Equality includes `is_current`.
+
+#### Scenario: default is current
+
+- **WHEN** a member has no later member for the same path
+- **THEN** `member.is_current` is `True`
+
+#### Scenario: shadowed duplicate is not current
+
+- **WHEN** two members share a path and one appears later in archive order
+- **THEN** the earlier member is `is_current=False` and the later member is `is_current=True`
+
+#### Scenario: content superseded by a later anti-item
+
+- **WHEN** a content member's path is deleted by a later anti-item
+- **THEN** the content member is `is_current=False`, and the anti-item is `is_anti=True` and `is_current=True`

--- a/openspec/changes/native-7z-reader/specs/archive-data-model/spec.md
+++ b/openspec/changes/native-7z-reader/specs/archive-data-model/spec.md
@@ -1,0 +1,18 @@
+## ADDED Requirements
+
+### Requirement: ArchiveMember anti-item flag
+
+The system SHALL expose `is_anti: bool = False` on `ArchiveMember`. When `True`, the
+member is a format-level deletion marker (7z ANTI), not ordinary file content.
+Callers iterating the archive SHALL see anti members unless a future optional filter
+excludes them. Equality includes `is_anti`.
+
+#### Scenario: default is non-anti
+
+- **WHEN** a member is produced for a normal file, directory, or link
+- **THEN** `member.is_anti` is `False`
+
+#### Scenario: 7z anti-item sets the flag
+
+- **WHEN** a 7z anti-item is parsed
+- **THEN** `member.is_anti` is `True`

--- a/openspec/changes/native-7z-reader/specs/compressed-streams/spec.md
+++ b/openspec/changes/native-7z-reader/specs/compressed-streams/spec.md
@@ -5,9 +5,13 @@
 The system SHALL derive 7z AES-256 keys using the 7z SHA-256 scheme (UTF-16LE
 password, salt, `1 << NumCyclesPower` rounds — with the documented `0x3f` special
 case) and pass the resulting key and IV to the shared crypto backend as `AesParams`.
-Derived keys SHALL be cacheable by `(password, salt, cycles)` for reuse across
-folders/header decrypts within one reader. Format parsers MUST NOT import
-`cryptography` directly. PPMd var.H streams SHALL open through the shared
+Because this KDF is 7z-specific (RAR and WinZip-AES derive keys differently), it SHALL
+live as a **7z-local helper within the crypto layer**, not on the generic crypto
+backend surface — so a format's key-derivation scheme does not accrete onto the shared
+AES stage. The shared AES decrypt stage itself stays format-agnostic and consumes only
+the derived `AesParams`. Derived keys SHALL be cacheable by `(password, salt, cycles)`
+for reuse across folders/header decrypts within one reader. Format parsers MUST NOT
+import `cryptography` directly. PPMd var.H streams SHALL open through the shared
 `PpmdCodec` once parameters from the 7z coder properties are supplied.
 
 #### Scenario: 7z folder decrypt uses derived AesParams

--- a/openspec/changes/native-7z-reader/specs/compressed-streams/spec.md
+++ b/openspec/changes/native-7z-reader/specs/compressed-streams/spec.md
@@ -1,0 +1,26 @@
+## ADDED Requirements
+
+### Requirement: 7z AES key derivation feeds the shared crypto stage
+
+The system SHALL derive 7z AES-256 keys using the 7z SHA-256 scheme (UTF-16LE
+password, salt, `1 << NumCyclesPower` rounds — with the documented `0x3f` special
+case) and pass the resulting key and IV to the shared crypto backend as `AesParams`.
+Derived keys SHALL be cacheable by `(password, salt, cycles)` for reuse across
+folders/header decrypts within one reader. Format parsers MUST NOT import
+`cryptography` directly. PPMd var.H streams SHALL open through the shared
+`PpmdCodec` once parameters from the 7z coder properties are supplied.
+
+#### Scenario: 7z folder decrypt uses derived AesParams
+
+- **WHEN** an AES-encrypted 7z folder is decoded with a correct password and `[crypto]` installed
+- **THEN** the reader derives the key via the 7z KDF, builds an AES-CBC decrypt stage through the crypto wrapper, then decompresses
+
+#### Scenario: derived keys are reused for the same KDF inputs
+
+- **WHEN** two folders share the same `(password, salt, cycles)` within one open reader
+- **THEN** the KDF result is reused from the cache rather than recomputed
+
+#### Scenario: PPMd var.H opens via PpmdCodec
+
+- **WHEN** a 7z folder coded as PPMd var.H is decoded and `pyppmd` is installed
+- **THEN** decompression goes through the shared PPMd codec with the coder's parameters

--- a/openspec/changes/native-7z-reader/specs/format-7z/spec.md
+++ b/openspec/changes/native-7z-reader/specs/format-7z/spec.md
@@ -57,15 +57,78 @@ unbounded RAM cache — repeated `open()` calls MAY re-decode.
 
 ---
 
+### Requirement: Decode folder coder chains natively
+
+The system SHALL decode each folder's coder chain by composing decompressors —
+the common codecs needing only the standard library, with a few less-common ones
+provided by small optional packages:
+
+| 7z codec | Method ID | Backend | Availability |
+|----------|-----------|---------|--------------|
+| STORED | `0x00` | pass-through | core |
+| LZMA1 / LZMA2 | `0x030101` / `0x21` | `lzma` `FORMAT_RAW` | core |
+| Delta | `0x03` | `lzma.FILTER_DELTA` | core |
+| BCJ x86/ARM/ARMT/PPC/SPARC/IA64 | `0x04`–`0x09`, `0x03030103`… | `lzma.FILTER_X86`/`ARM`/… | core |
+| Deflate | `0x040108` | `zlib` (raw) | core |
+| BZip2 | `0x040202` | `bz2` | core |
+| Zstd | `0x04f71101` | stdlib `compression.zstd` / `backports.zstd` | optional `[7z]` on <3.14; core on 3.14+ |
+| Brotli | `0x04f71102` | `brotli` | optional `[7z]` |
+| PPMd (var.H) | `0x030401` | `pyppmd` | optional `[7z]` |
+| Deflate64 | `0x040109` | `inflate64` | optional `[7z]` |
+| AES-256 / SHA-256 | `0x06f10701` | crypto backend | optional `[7z]` |
+| BCJ2 | `0x0303011B` | — | unsupported (detect & raise) |
+
+Files within a folder are laid out contiguously in the decompressed output, so the
+backend produces a member's stream by reading exactly `member.size` bytes, in
+order, from the folder's decompressed byte stream. The core codec set requires no
+third-party runtime dependency; the `[7z]` bundle adds every optional 7z codec
+(PPMd, Deflate64, Zstd, Brotli) and AES decryption in one install. A coder chain is
+applied in reverse coder order for decoding (e.g. an `AES → LZMA2` coder list means
+decrypt, then decompress). Decoding composes the shared `compressed-streams`
+backends — the 7z reader does NOT call codec libraries (`lzma`, `pyppmd`,
+`inflate64`, the crypto backend) directly — and the reader verifies each member's
+stored CRC32 (`hashes["crc32"]`) via the shared `compressed-streams` verification
+stage as it is read.
+
+The BCJ branch filters compose into a single `lzma` `FORMAT_RAW` filter chain when
+paired with **LZMA2** (the common 7z executable case, e.g. `BCJ → LZMA2`), so that
+pairing is core/supported as the table shows. The **LZMA1+BCJ** pairing is NOT assumed
+to decode correctly through a single raw chain — it is governed by the *Reject
+genuinely unsupported codecs and variants* requirement above (supported only if a
+validated stdlib-only composition exists, otherwise `UnsupportedFeatureError`, never
+wrong bytes). "BCJ is core" in the table therefore means the BCJ-over-LZMA2 chain, not
+every possible pairing.
+
+#### Scenario: member compressed with a BCJ + LZMA2 chain
+
+- **WHEN** a member lives in a folder coded as BCJ-over-LZMA2
+- **THEN** the backend composes the shared `lzma` `FORMAT_RAW` filter-chain backend, decodes the folder, and returns bytes identical to the original file content
+
+#### Scenario: per-member CRC verified on read
+
+- **WHEN** a 7z member that records a CRC32 is decoded
+- **THEN** the reader verifies the decompressed bytes against `hashes["crc32"]` and raises `CorruptionError` on mismatch
+
+#### Scenario: PPMd member without the [7z] extra
+
+- **WHEN** a folder is PPMd-compressed and `pyppmd` is not installed
+- **THEN** the backend raises `PackageNotInstalledError` naming `pyppmd` (installable via the `[7z]` extra)
+
+---
+
 ## ADDED Requirements
 
 ### Requirement: List and extract 7z anti-items
 
 The system SHALL parse the `FILES_INFO` ANTI bitmask and expose every anti-item as
 an `ArchiveMember` with `is_anti=True` in the member list and during iteration.
-Anti-items typically have no payload (`size` 0 / empty stream). Extraction behavior
-for anti-items is defined by `safe-extraction` (delete the in-root destination,
-matching the `7z` CLI). The member list MUST remain well-formed when anti-items are
+Anti-items typically have no payload (`size` 0 / empty stream). The reader SHALL also
+compute each member's `is_current` (see `archive-data-model`) from the ANTI bitmask
+and same-name shadowing, so a content member superseded by a later anti-item (or by a
+later re-add of the same name) is `is_current=False` while the surviving entry is
+`is_current=True`. Extraction behavior for anti-items is defined by `safe-extraction`:
+superseded content is skipped by default and an anti-item never deletes data the
+extraction did not create. The member list MUST remain well-formed when anti-items are
 present (no dropped neighbors, no corrupt indices).
 
 #### Scenario: anti-items appear in the member list
@@ -78,3 +141,8 @@ present (no dropped neighbors, no corrupt indices).
 
 - **WHEN** `ar.open(anti_member)` is called
 - **THEN** the returned stream is empty (no file content)
+
+#### Scenario: an anti-item marks the superseded content non-current
+
+- **WHEN** a 7z archive adds a path and a later anti-item deletes it
+- **THEN** the content member is `is_current=False`, and the anti-item is `is_anti=True` and `is_current=True`

--- a/openspec/changes/native-7z-reader/specs/format-7z/spec.md
+++ b/openspec/changes/native-7z-reader/specs/format-7z/spec.md
@@ -1,0 +1,80 @@
+## MODIFIED Requirements
+
+### Requirement: Reject genuinely unsupported codecs and variants
+
+The system SHALL raise `UnsupportedFeatureError`, naming the codec, when a folder
+uses a coder with no available backend — notably **BCJ2** (`0x0303011B`), a
+multi-stream filter not implemented by any standard or available package, or any
+newer branch filter absent from the installed liblzma — or an unrecognized method
+ID. The system SHALL also raise `UnsupportedFeatureError` for coder combinations
+that cannot be decoded **correctly** with the available stdlib/optional backends
+without custom non-stdlib filter code (in particular **LZMA1+BCJ** when a validated
+stdlib-only composition is not available). The library MUST NOT silently return
+incorrect data and MUST NOT fall back to a third-party reader. (PPMd and Deflate64
+are supported via the optional `[7z]` extra and are NOT in this category;
+multi-volume 7z is supported by volume-joining, see the next requirement, not
+rejected. Anti-items are listed and extracted per the anti-item requirement, not
+rejected.)
+
+#### Scenario: BCJ2-filtered member
+
+- **WHEN** a member's folder uses the BCJ2 filter
+- **THEN** `UnsupportedFeatureError` is raised naming BCJ2, with no garbage output
+
+#### Scenario: unrecognized method ID
+
+- **WHEN** a folder uses a coder whose method ID is not recognized
+- **THEN** `UnsupportedFeatureError` is raised naming the unknown method ID
+
+#### Scenario: LZMA1+BCJ without a validated stdlib path
+
+- **WHEN** a folder uses an LZMA1+BCJ coder chain and no validated stdlib-only decode path is implemented
+- **THEN** `UnsupportedFeatureError` is raised naming the combination, with no garbage output
+- **AND** the limitation is documented for a later improvement (the reader MUST NOT pull in `pybcj` solely for this path)
+
+---
+
+### Requirement: True pull-based streaming with bounded memory
+
+The system SHALL provide `stream_members()` as a true pull stream: each folder is
+decoded once, its members yielded in archive order as the decompressor produces
+bytes, with no buffering of the whole folder and no background thread or queue.
+Peak memory is bounded by the decompressor's working set rather than the folder's
+uncompressed size. For random `ar.open()` of a member inside a solid folder, the
+backend SHALL decode the folder from its start and skip to the member's substream.
+The backend MUST NOT retain decoded folder output in a spool, temporary file, or
+unbounded RAM cache — repeated `open()` calls MAY re-decode.
+
+#### Scenario: streaming a solid 7z archive
+
+- **WHEN** a caller iterates a solid 7-Zip archive with `stream_members()`
+- **THEN** each folder is decoded once and its members are yielded as a pull stream, with peak memory bounded by the decompressor working set, not the folder size
+
+#### Scenario: random access into a solid folder
+
+- **WHEN** `ar.open(member)` is called for a member inside a multi-file folder
+- **THEN** the backend decodes the folder from its start to produce the member's bytes, without writing decoded output to disk and without retaining a decoded-folder cache across opens
+
+---
+
+## ADDED Requirements
+
+### Requirement: List and extract 7z anti-items
+
+The system SHALL parse the `FILES_INFO` ANTI bitmask and expose every anti-item as
+an `ArchiveMember` with `is_anti=True` in the member list and during iteration.
+Anti-items typically have no payload (`size` 0 / empty stream). Extraction behavior
+for anti-items is defined by `safe-extraction` (delete the in-root destination,
+matching the `7z` CLI). The member list MUST remain well-formed when anti-items are
+present (no dropped neighbors, no corrupt indices).
+
+#### Scenario: anti-items appear in the member list
+
+- **WHEN** a 7z archive contains one or more anti-items
+- **THEN** each anti-item is present in the member list with `is_anti=True`
+- **AND** non-anti members remain listed with correct metadata
+
+#### Scenario: opening an anti-item yields no payload
+
+- **WHEN** `ar.open(anti_member)` is called
+- **THEN** the returned stream is empty (no file content)

--- a/openspec/changes/native-7z-reader/specs/safe-extraction/spec.md
+++ b/openspec/changes/native-7z-reader/specs/safe-extraction/spec.md
@@ -1,25 +1,64 @@
 ## ADDED Requirements
 
-### Requirement: Anti-item extraction deletes the destination
+### Requirement: Non-current members are skipped by default
 
-When extracting a member with `is_anti=True`, the system SHALL **not** write file
-content. Instead it SHALL delete the destination path if it already exists inside
-the extract root — matching `7z` CLI extract behavior for `Anti = +` entries —
-after the same universal path-safety checks that apply to ordinary members. If the
-destination does not exist, extraction of that member succeeds as a no-op. Deletion
-MUST refuse paths that escape the extract root. Overwrite-policy interaction: an
-anti-item targets removal, not creation; policies that only govern writing new files
-do not block the delete of an existing in-root path.
+When a member has `is_current=False` (superseded by a later same-path member or by a
+later anti-item — see `archive-data-model`), extraction SHALL skip it by default: no
+content is written, and the member does NOT count toward the entry-count, cumulative-
+byte, or ratio guards. The member receives a `SKIPPED` `ExtractionResult`.
 
-#### Scenario: anti-item removes an existing file
+This makes the extracted tree the archive's **final state** (last write wins; deleted
+paths absent) rather than a replay of every superseded revision, and it keeps an
+archive's own internal duplicate names from tripping `OverwritePolicy.ERROR`. A caller
+MAY opt in to materializing superseded revisions through a future explicit option; the
+default extracts only current members.
 
-- **WHEN** extract runs on an anti-item whose destination path exists inside the extract root
-- **THEN** that path is removed and no file content is written for the member
+#### Scenario: superseded duplicate is skipped
 
-#### Scenario: anti-item with missing destination
+- **WHEN** an archive holds two members for the same path and it is extracted with default options
+- **THEN** only the current (last) member is written; the superseded member gets a `SKIPPED` result and is not written
 
-- **WHEN** extract runs on an anti-item whose destination does not exist
-- **THEN** the member extracts successfully without error and without creating the path
+#### Scenario: non-current member does not count against limits
+
+- **WHEN** a non-current member is skipped
+- **THEN** it does not increment the entry count, the cumulative extracted-byte total, or the ratio denominators
+
+### Requirement: Anti-item extraction never deletes data it did not create
+
+When extracting a member with `is_anti=True`, the system SHALL NOT write file content,
+and SHALL NOT delete any on-disk entry that this same extraction did not create.
+Because the content member an anti-item supersedes is already skipped as non-current
+(above), an anti-item is by default a **no-op on disk**: the deleted path is simply
+never written in the first place.
+
+Only when — within the same extraction — an earlier member wrote the anti-item's
+destination path and the anti-item then supersedes it, the system SHALL delete that
+just-created entry, using `lstat`/`unlink` semantics (the directory entry itself is
+removed, never followed through a symlink), and only when it is a file or an **empty**
+directory — never a recursive delete of a populated directory. The universal
+path-safety checks apply as for any member: a delete MUST refuse a path that escapes
+the extract root, and MUST NOT touch a destination the extraction did not write.
+
+Applying an anti-item as a deletion against a **pre-existing** destination tree (the
+`7z x` "differential restore" behavior, which removes files already on disk from an
+earlier extraction of the base) is NOT the default. It is available only through an
+explicit opt-in extraction mode; the safe default never removes data the current
+extraction did not produce.
+
+#### Scenario: anti-item over a pre-existing destination is a no-op
+
+- **WHEN** an anti-item's destination already exists on disk but was not written by this extraction
+- **THEN** the existing entry is left untouched, no content is written, and the member succeeds
+
+#### Scenario: anti-item with a missing destination
+
+- **WHEN** an anti-item's destination does not exist
+- **THEN** the member succeeds as a no-op without creating the path
+
+#### Scenario: anti-item removes only a path created in the same extraction
+
+- **WHEN** an earlier member of the same extraction created the anti-item's destination and the anti-item supersedes it
+- **THEN** that just-created file or empty directory is removed via `lstat`/`unlink` semantics, and no pre-existing, populated-directory, or out-of-root path is deleted
 
 #### Scenario: anti-item cannot escape the extract root
 

--- a/openspec/changes/native-7z-reader/specs/safe-extraction/spec.md
+++ b/openspec/changes/native-7z-reader/specs/safe-extraction/spec.md
@@ -1,0 +1,27 @@
+## ADDED Requirements
+
+### Requirement: Anti-item extraction deletes the destination
+
+When extracting a member with `is_anti=True`, the system SHALL **not** write file
+content. Instead it SHALL delete the destination path if it already exists inside
+the extract root — matching `7z` CLI extract behavior for `Anti = +` entries —
+after the same universal path-safety checks that apply to ordinary members. If the
+destination does not exist, extraction of that member succeeds as a no-op. Deletion
+MUST refuse paths that escape the extract root. Overwrite-policy interaction: an
+anti-item targets removal, not creation; policies that only govern writing new files
+do not block the delete of an existing in-root path.
+
+#### Scenario: anti-item removes an existing file
+
+- **WHEN** extract runs on an anti-item whose destination path exists inside the extract root
+- **THEN** that path is removed and no file content is written for the member
+
+#### Scenario: anti-item with missing destination
+
+- **WHEN** extract runs on an anti-item whose destination does not exist
+- **THEN** the member extracts successfully without error and without creating the path
+
+#### Scenario: anti-item cannot escape the extract root
+
+- **WHEN** an anti-item name would resolve outside the extract root
+- **THEN** extraction is rejected by the universal path-safety checks (no delete outside the root)

--- a/openspec/changes/native-7z-reader/specs/testing-contract/spec.md
+++ b/openspec/changes/native-7z-reader/specs/testing-contract/spec.md
@@ -3,15 +3,23 @@
 ### Requirement: Native 7z anti-item fixtures use the 7z CLI oracle
 
 Because `py7zr` cannot parse archives that include the 7z `ANTI` property, tests for
-anti-item listing and extract-delete behavior SHALL build fixtures with the `7z` CLI
-(or committed fixtures produced by it) and validate against `7z l -slt` / `7z x`
-behavior. Those tests SHALL skip (not fail) when the `7z` binary is absent. Ordinary
-non-anti 7z corpus cross-validation against `py7zr` remains as already specified.
+anti-item listing and current/anti extraction behavior SHALL build fixtures with the
+`7z` CLI (or committed fixtures produced by it) and validate against `7z l -slt` /
+`7z x` behavior. Those tests SHALL skip (not fail) when the `7z` binary is absent.
+Ordinary non-anti 7z corpus cross-validation against `py7zr` remains as already
+specified.
 
-#### Scenario: anti-item extract matches 7z CLI
+Because archivey's **default** extraction never deletes data it did not create (see
+`safe-extraction`), the oracle comparison against `7z x` is made into a **fresh**
+destination, where both produce the same final tree (superseded/anti paths absent,
+surviving content identical). Parity with `7z x`'s deletion of pre-existing files on
+disk (differential restore over a populated tree) is asserted only for the explicit
+opt-in mode, not the default.
 
-- **WHEN** a 7z archive containing an anti-item is extracted by archivey and by `7z x` into matching destination trees
-- **THEN** the resulting trees match (anti paths removed; non-anti content identical)
+#### Scenario: anti-item extract matches 7z CLI on a fresh destination
+
+- **WHEN** a 7z archive containing an anti-item is extracted by archivey and by `7z x`, each into its own fresh (empty) destination
+- **THEN** the resulting trees match (superseded/anti paths absent, non-anti content identical)
 - **AND** the test is skipped if `7z` is not installed
 
 #### Scenario: py7zr oracle still used for non-anti archives

--- a/openspec/changes/native-7z-reader/specs/testing-contract/spec.md
+++ b/openspec/changes/native-7z-reader/specs/testing-contract/spec.md
@@ -1,0 +1,20 @@
+## ADDED Requirements
+
+### Requirement: Native 7z anti-item fixtures use the 7z CLI oracle
+
+Because `py7zr` cannot parse archives that include the 7z `ANTI` property, tests for
+anti-item listing and extract-delete behavior SHALL build fixtures with the `7z` CLI
+(or committed fixtures produced by it) and validate against `7z l -slt` / `7z x`
+behavior. Those tests SHALL skip (not fail) when the `7z` binary is absent. Ordinary
+non-anti 7z corpus cross-validation against `py7zr` remains as already specified.
+
+#### Scenario: anti-item extract matches 7z CLI
+
+- **WHEN** a 7z archive containing an anti-item is extracted by archivey and by `7z x` into matching destination trees
+- **THEN** the resulting trees match (anti paths removed; non-anti content identical)
+- **AND** the test is skipped if `7z` is not installed
+
+#### Scenario: py7zr oracle still used for non-anti archives
+
+- **WHEN** a non-anti 7z corpus archive is read by the native reader and by `py7zr`
+- **THEN** member metadata and decompressed bytes match per the existing native↔py7zr scenario

--- a/openspec/changes/native-7z-reader/tasks.md
+++ b/openspec/changes/native-7z-reader/tasks.md
@@ -1,7 +1,7 @@
 ## 1. Data model + crypto/codec stubs
 
-- [ ] 1.1 Add `ArchiveMember.is_anti: bool = False` (types + archive-data-model consumers/tests)
-- [ ] 1.2 Implement 7z SHA-256 KDF + AES-CBC decrypt stage in `streams/crypto.py`; key cache helper by `(password, salt, cycles)`
+- [ ] 1.1 Add `ArchiveMember.is_anti: bool = False` (raw ANTI bit) and `ArchiveMember.is_current: bool = True` (derived last-entry-wins) — types + archive-data-model consumers/tests; both included in equality
+- [ ] 1.2 Implement the format-agnostic AES-CBC decrypt stage on the shared crypto surface, and a **7z-local** SHA-256 KDF helper beside it (UTF-16LE pw + salt + `1 << NumCyclesPower`, `0x3f` special case) — not on the generic crypto backend; emits `AesParams`; key cache helper by `(password, salt, cycles)`; reader never imports `cryptography`
 - [ ] 1.3 Finish `PpmdCodec.open` for PPMd var.H parameters from 7z coder properties
 - [ ] 1.4 Update stale "Phase 7" comments in crypto/PPMd paths to Phase 6
 
@@ -25,8 +25,8 @@
 ## 4. Volumes + anti-items + extraction
 
 - [ ] 4.1 Join multi-volume sets (discovered siblings or explicit list) by concatenation; error on incomplete sets
-- [ ] 4.2 Expose anti members with `is_anti=True`; empty payload on open
-- [ ] 4.3 Extraction: anti-items delete in-root destination (7z CLI parity) after path-safety checks; missing dest = success no-op
+- [ ] 4.2 Expose anti members with `is_anti=True`; empty payload on open; compute `is_current` from the ANTI bitmask + same-name shadowing (superseded content → `is_current=False`)
+- [ ] 4.3 Extraction: skip `is_current=False` members by default (SKIPPED result; no limit counting); anti-items delete **only** a path this same extraction wrote (`lstat`/`unlink`, file/empty-dir only), never pre-existing/populated/out-of-root data; missing or not-written dest = success no-op
 
 ## 5. Tests, oracles, fuzz
 
@@ -34,7 +34,7 @@
 - [ ] 5.2 Per-codec fixtures: STORED, LZMA2, LZMA2+BCJ, LZMA2+Delta, Deflate, BZip2, Zstd, Brotli, PPMd, Deflate64, AES, solid, multi-password, header-encrypted, multi-volume
 - [ ] 5.3 LZMA1+BCJ fixture: either correct decode vs oracle or asserted `UnsupportedFeatureError` + short design note
 - [ ] 5.4 BCJ2 / unknown method rejection tests
-- [ ] 5.5 Anti-item fixtures via `7z` CLI; list + extract-delete vs `7z x` (skip without `7z`); do not require py7zr for these
+- [ ] 5.5 Anti-item fixtures via `7z` CLI; list + `is_current` computation; extract into a fresh dest and compare final tree vs `7z x` into a fresh dest (skip without `7z`); assert an anti-item leaves a pre-existing not-written destination untouched; do not require py7zr for these
 - [ ] 5.6 Core-only / `[7z]` / `[crypto]` gating tests (`PackageNotInstalledError` paths)
 - [ ] 5.7 Atheris (or env-gated harness) for header parser seeded from corpus + adversarial bytes
 - [ ] 5.8 `openspec validate native-7z-reader --strict`; `ruff` / `pyrefly` / `ty`; three-config pytest gate

--- a/openspec/changes/native-7z-reader/tasks.md
+++ b/openspec/changes/native-7z-reader/tasks.md
@@ -1,0 +1,40 @@
+## 1. Data model + crypto/codec stubs
+
+- [ ] 1.1 Add `ArchiveMember.is_anti: bool = False` (types + archive-data-model consumers/tests)
+- [ ] 1.2 Implement 7z SHA-256 KDF + AES-CBC decrypt stage in `streams/crypto.py`; key cache helper by `(password, salt, cycles)`
+- [ ] 1.3 Finish `PpmdCodec.open` for PPMd var.H parameters from 7z coder properties
+- [ ] 1.4 Update stale "Phase 7" comments in crypto/PPMd paths to Phase 6
+
+## 2. Native header parser
+
+- [ ] 2.1 Add `sevenzip_parser.py`: signature header, end-header CRC, `HEADER` / `ENCODED_HEADER`
+- [ ] 2.2 Parse `PACK_INFO`, `UNPACK_INFO` (folders, coders, bind pairs), `SUBSTREAMS_INFO`, `FILES_INFO` (names, times, attrs, empty/anti bitmasks, comment)
+- [ ] 2.3 Map files → `(folder_index, file_in_folder)`, sizes/CRCs, `is_solid`, per-folder encryption, `compression` chains
+- [ ] 2.4 Header-encrypted archives: decrypt via candidates + KDF cache before parse; no password → `EncryptionError`
+
+## 3. Reader backend + folder decode
+
+- [ ] 3.1 Implement `SevenZipReader` / `SevenZipReadBackend`; register; require seek; use `SharedSource` for pack views
+- [ ] 3.2 Folder pipeline: compose `compressed-streams` (+ AES stage) in reverse coder order; verify per-member CRC32
+- [ ] 3.3 `stream_members()`: decode each folder once, slice by substream size (pull, no spool)
+- [ ] 3.4 `open()`: re-decode folder from start and skip to member; no disk/RAM decoded-folder cache
+- [ ] 3.5 Reject BCJ2 / unknown IDs / unimplemented combinations (incl. LZMA1+BCJ if not validated) with `UnsupportedFeatureError`
+- [ ] 3.6 Wire password candidates for header + per-folder units; promote known-good; never wrong bytes
+- [ ] 3.7 Populate `ArchiveInfo` (solid, encrypted, comment, multivolume) and `CostReceipt` folder signals
+
+## 4. Volumes + anti-items + extraction
+
+- [ ] 4.1 Join multi-volume sets (discovered siblings or explicit list) by concatenation; error on incomplete sets
+- [ ] 4.2 Expose anti members with `is_anti=True`; empty payload on open
+- [ ] 4.3 Extraction: anti-items delete in-root destination (7z CLI parity) after path-safety checks; missing dest = success no-op
+
+## 5. Tests, oracles, fuzz
+
+- [ ] 5.1 Activate corpus 7z builders/sweep; native ↔ `py7zr` metadata+bytes cross-check (skip if absent)
+- [ ] 5.2 Per-codec fixtures: STORED, LZMA2, LZMA2+BCJ, LZMA2+Delta, Deflate, BZip2, Zstd, Brotli, PPMd, Deflate64, AES, solid, multi-password, header-encrypted, multi-volume
+- [ ] 5.3 LZMA1+BCJ fixture: either correct decode vs oracle or asserted `UnsupportedFeatureError` + short design note
+- [ ] 5.4 BCJ2 / unknown method rejection tests
+- [ ] 5.5 Anti-item fixtures via `7z` CLI; list + extract-delete vs `7z x` (skip without `7z`); do not require py7zr for these
+- [ ] 5.6 Core-only / `[7z]` / `[crypto]` gating tests (`PackageNotInstalledError` paths)
+- [ ] 5.7 Atheris (or env-gated harness) for header parser seeded from corpus + adversarial bytes
+- [ ] 5.8 `openspec validate native-7z-reader --strict`; `ruff` / `pyrefly` / `ty`; three-config pytest gate


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

OpenSpec change proposal for Phase 6 **native 7z reading only** (`openspec/changes/native-7z-reader/`). RAR and ZIP shared-codec wiring are deferred to sibling changes.

Incorporates the reviewed revisions from #65 (anti-item / `is_current` redesign + BCJ/KDF clarifications).

## Decisions locked

- **Solid `open()`**: re-decode from folder start — no spool / disk cache
- **Unsupported chains** (BCJ2, unvalidated LZMA1+BCJ, unknown IDs): `UnsupportedFeatureError`, never wrong bytes; BCJ is core when paired with LZMA2
- **Anti-items / `is_current`**: list with `is_anti`; derive `is_current` (last-entry-wins). Default extract skips non-current members and **never deletes data the extraction did not create**. `7z x`-style differential restore over a pre-existing tree is a future opt-in
- **Passwords**: 7z-local KDF helper caches by `(password, salt, cycles)` and feeds shared AES stage as `AesParams`
- **Oracles**: `py7zr` for normal archives; `7z` CLI for anti (py7zr cannot parse `ANTI`); fresh-destination tree comparison

## Artifacts

- `proposal.md` / `design.md` / `tasks.md`
- Delta specs: `format-7z`, `archive-data-model`, `safe-extraction`, `compressed-streams`, `testing-contract`

Validated with `openspec validate native-7z-reader --strict`.

Ready for `/opsx:apply` when you want implementation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fea97377-75c0-427b-b3c3-f8a24f1b141f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fea97377-75c0-427b-b3c3-f8a24f1b141f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

