### PR TITLE
Propose reader-concurrency-coordination (blocking materialization + draining close)

### DIFF
--- a/openspec/changes/reader-concurrency-coordination/.openspec.yaml
+++ b/openspec/changes/reader-concurrency-coordination/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: minimalist
+created: 2026-07-11

--- a/openspec/changes/reader-concurrency-coordination/specs/archive-reading/spec.md
+++ b/openspec/changes/reader-concurrency-coordination/specs/archive-reading/spec.md
@@ -1,0 +1,90 @@
+## ADDED Requirements
+
+These requirements close the two gaps between today's supported `MemberStreams.CONCURRENT`
+fan-out seam and a reader that is safe to drive from any thread without the caller
+pre-serializing setup and teardown. They coordinate exactly two operations — **first-touch
+materialization** and **reader close** — by making them *block and share* instead of
+*reject*. Overlapping distinct reader-wide passes and same-stream access are deliberately
+left single-owner (final requirement) so "coordinated" does not over-promise.
+
+### Requirement: Coordinated first-touch materialization
+
+A reader opened with `MemberStreams.CONCURRENT` SHALL coordinate concurrent first-touch
+operations on a not-yet-materialized member list by blocking all but one caller until the
+immutable snapshot is published, rather than rejecting the overlap. Materialization SHALL
+run exactly once, and the non-concurrent and uncontended paths SHALL be unchanged.
+
+#### Scenario: concurrent first-touch converges on one materialization
+
+- **WHEN** several threads call `open()`, `members()`, or `get()` simultaneously as the
+  first operations on an un-materialized `CONCURRENT` reader
+- **THEN** exactly one thread performs materialization while the others block on a
+  condition, and once the immutable snapshot is published every waiting thread proceeds
+  against it with no thread receiving `ArchiveyUsageError` for the overlap
+
+#### Scenario: failed first-touch wakes every waiter without a partial snapshot
+
+- **WHEN** the electing thread's first-touch materialization fails (for example a corrupt
+  header) while other threads are blocked waiting
+- **THEN** the cache returns to the un-materialized state, no partial snapshot is ever
+  observed, and each waiting thread either observes the same translated error or cleanly
+  re-elects a fresh attempt
+
+#### Scenario: uncontended and default paths are unchanged
+
+- **WHEN** materialization happens on a default (non-`CONCURRENT`) reader or with no
+  contention
+- **THEN** no waiting is introduced, and the member scan, link reads, and callbacks still
+  run with no reader-state lock held
+
+### Requirement: Draining reader close
+
+Under `MemberStreams.CONCURRENT`, `reader.close()` SHALL wait for in-flight worker
+`open()`/`read()` calls to return and then transition the reader to closed, rather than
+raising because workers are active. Escaped open member streams SHALL remain governed by
+the existing lifecycle-lease contract, and close idempotency, one-shot teardown, and
+post-close rejection SHALL be preserved.
+
+#### Scenario: close drains in-flight worker calls
+
+- **WHEN** a thread calls `reader.close()` while one or more worker `open()`/`read()` calls
+  are executing on other threads
+- **THEN** `close()` blocks until those calls return, then transitions the reader to
+  closed, and does not raise `ArchiveyUsageError` merely because workers were active
+
+#### Scenario: escaped stream survives a drained close
+
+- **WHEN** a member stream that escaped the reader is still open as `close()` returns
+- **THEN** it remains readable under the lifecycle-lease contract until its own `close()`,
+  and archive teardown runs exactly once after the final lease is released
+
+#### Scenario: concurrent double close is idempotent
+
+- **WHEN** two threads call `reader.close()` (or `__exit__`) simultaneously
+- **THEN** teardown runs exactly once, both calls return without error, and simultaneous
+  inner-close and teardown failures surface once as an `ExceptionGroup`
+
+#### Scenario: operations after close still reject
+
+- **WHEN** a new `open()` or other reader operation is attempted after `close()` returned
+- **THEN** it raises `ArchiveyUsageError` (post-close), unchanged from today
+
+### Requirement: Distinct passes and shared streams remain single-owner
+
+This change SHALL NOT make overlapping *distinct* reader-wide passes or concurrent access
+to a single stream object safe; those remain rejected or caller-synchronized exactly as
+today, so the coordinated contract stays bounded to materialization and close.
+
+#### Scenario: a different reader-wide pass is still rejected
+
+- **WHEN** a reader is running `extract_all()` or an active `stream_members()` pass and
+  another thread starts a different pass (`__iter__`, `stream_members()`, or
+  `extract_all()`)
+- **THEN** the later operation is rejected with `ArchiveyUsageError`, unchanged
+
+#### Scenario: same-stream access stays the caller's responsibility
+
+- **WHEN** two threads call `read`/`readinto`/`seek`/`close` on the same `ArchiveStream`
+  object concurrently
+- **THEN** correctness is the caller's responsibility under standard file semantics; this
+  change adds no per-stream locking

--- a/openspec/changes/reader-concurrency-coordination/tasks.md
+++ b/openspec/changes/reader-concurrency-coordination/tasks.md
@@ -1,0 +1,57 @@
+## 1. Blocking first-touch materialization
+
+- [ ] 1.1 In `ReaderState`, replace the "second overlapping materialization →
+      `ArchiveyUsageError`" path with a condition-variable wait: `MATERIALIZING` blocks
+      later first-touch callers; on `complete_materialization` the holder notifies all
+      waiters, which then read the published snapshot; the overlap no longer raises.
+- [ ] 1.2 On `fail_materialization`, return to `UNMATERIALIZED`, wake all waiters, and let
+      them re-elect a fresh attempt or observe the same translated error — never publish a
+      partial snapshot.
+- [ ] 1.3 Keep the heavy work (member scan, link reads, callbacks) outside the reader-state
+      lock; only the short wait/notify is under it. Materialization still runs exactly once.
+- [ ] 1.4 Leave the uncontended and default (non-`CONCURRENT`) paths byte-for-byte
+      unchanged — no wait when there is no contention.
+
+## 2. Draining reader close
+
+- [ ] 2.1 In `ReaderState.mark_reader_closed`, when workers are active under `CONCURRENT`,
+      wait on a condition until the active worker-token set drains, then mark
+      `READER_CLOSED` — instead of raising because workers are present.
+- [ ] 2.2 Distinguish transient worker calls (drained by close) from escaped idle-stream
+      leases (still defer teardown): `close()` waits only for in-flight `open()`/`read()`
+      calls, not for the caller to close streams that escaped the reader.
+- [ ] 2.3 Preserve idempotent `close()`/`__exit__`, one-shot teardown, the `ExceptionGroup`
+      on dual inner-close/teardown failure, and post-close `ArchiveyUsageError` for new
+      operations.
+- [ ] 2.4 Document that `close()` blocks until worker calls return: a worker that never
+      returns is a caller bug (same as any lock), so no artificial timeout is added — state
+      this explicitly in the docstring.
+
+## 3. Boundaries
+
+- [ ] 3.1 Keep distinct reader-wide passes (`__iter__` / `stream_members` / `extract_all`)
+      single-owner: overlap by a *different* pass still raises `ArchiveyUsageError`.
+- [ ] 3.2 Do not add per-stream locking; same-stream concurrent access stays caller
+      responsibility (standard file semantics).
+
+## 4. Tests
+
+- [ ] 4.1 Multi-thread: N threads first-touch `open()` on an unmaterialized `CONCURRENT`
+      reader all succeed with correct bytes; assert materialization ran exactly once (spy on
+      the member scan).
+- [ ] 4.2 Multi-thread: first-touch materialization failure wakes every waiter with the
+      translated error / clean retry and publishes no partial snapshot.
+- [ ] 4.3 Multi-thread: `close()` during in-flight reads drains then closes; escaped streams
+      stay readable to EOF; concurrent double-`close()` is idempotent with correct
+      exception grouping on failure.
+- [ ] 4.4 Mark the new tests `concurrent_reader` so the Linux `3.13t`
+      `free-threaded-concurrency` job exercises them.
+- [ ] 4.5 Update the thread-safety contract in `packaging-and-extras`, the `MemberStreams`
+      docstring, and `docs/parallel-reader.md`: first-touch materialization and `close()`
+      are now coordinated; distinct passes and shared streams remain single-owner.
+
+## 5. Verify
+
+- [ ] 5.1 `openspec validate --strict reader-concurrency-coordination`.
+- [ ] 5.2 Full suite in all three dependency configurations (`all`, `all-lowest`,
+      `core-only`) plus the `3.13t` marked run; `ruff` / `pyrefly` / `ty` clean.

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,1 +1,1 @@
-schema: spec-driven
+schema: minimalist

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,1 +1,1 @@
-schema: minimalist
+schema: spec-driven

--- a/openspec/schemas/minimalist/README.md
+++ b/openspec/schemas/minimalist/README.md
@@ -1,0 +1,29 @@
+# Minimalist OpenSpec Schema
+
+`minimalist` is for getting to build quickly with a direct `specs -> tasks` flow.
+
+- Good fit: landing pages and simple apps with too many technical design decisions.
+- Not a good fit: complete apps with multiple layers, database work, and broader architecture concerns.
+
+## Install (copy/paste)
+
+Use the root `README.md` single-line install command with:
+- `SCHEMA="minimalist"`
+
+## Activate
+
+Set this in `openspec/config.yaml`:
+
+```yaml
+schema: minimalist
+```
+
+## Spec Format
+
+When authoring `specs` artifacts in this schema:
+- Write each requirement as a user story:
+  `As a <role>, I want <capability>, so that <benefit>.`
+- Write acceptance criteria using Gherkin structure:
+  `Given ...`, `When ...`, `Then ...`
+
+For more schemas, refer to https://github.com/intent-driven-dev/openspec-schemas.

--- a/openspec/schemas/minimalist/schema.yaml
+++ b/openspec/schemas/minimalist/schema.yaml
@@ -1,0 +1,19 @@
+name: minimalist
+version: 1
+description: Lightweight schema for well-scoped, low-risk changes
+artifacts:
+  - id: specs
+    generates: specs/**/*.md
+    description: Specifications authored as user stories with Given/When/Then acceptance criteria
+    template: specs/spec.md
+    requires: []
+  - id: tasks
+    generates: tasks.md
+    description: Implementation checklist with trackable tasks
+    template: tasks.md
+    requires:
+      - specs
+apply:
+  requires:
+    - tasks
+  tracks: tasks.md

--- a/openspec/schemas/minimalist/templates/specs/spec.md
+++ b/openspec/schemas/minimalist/templates/specs/spec.md
@@ -1,0 +1,27 @@
+## ADDED User Stories
+
+### User Story: <capability or behavior>
+As a <role>, I want <capability>, so that <benefit>.
+
+#### Acceptance Criteria
+- **Given** <context>
+- **When** <condition>
+- **Then** <expected outcome>
+
+## MODIFIED User Stories
+
+### User Story: <existing capability or behavior>
+As a <role>, I want <updated capability>, so that <updated benefit>.
+
+#### Acceptance Criteria
+- **Given** <context>
+- **When** <updated condition>
+- **Then** <updated expected outcome>
+
+## REMOVED User Stories
+
+### User Story: <removed capability or behavior>
+As a <role>, I wanted <removed capability>, so that <previous benefit>.
+
+#### Removal Rationale
+Explain why this user story is removed.

--- a/openspec/schemas/minimalist/templates/tasks.md
+++ b/openspec/schemas/minimalist/templates/tasks.md
@@ -1,0 +1,11 @@
+## 1. Implement the Change
+
+- [ ] 1.1 Update implementation to satisfy the delta specs.
+- [ ] 1.2 Add or update tests where behavior changes.
+- [ ] 1.3 Run targeted checks for the changed areas.
+
+## 2. Verify and Wrap Up
+
+- [ ] 2.1 Validate acceptance criteria from delta specs.
+- [ ] 2.2 Remove temporary debugging code and notes.
+- [ ] 2.3 Prepare concise reviewer notes.


### PR DESCRIPTION
## Summary

Proposal-only change (no runtime code yet) capturing the two steps that would take the
reader from today's **supported `MemberStreams.CONCURRENT` fan-out seam** to **safe to
drive from any thread** — the follow-up identified while reviewing PR #61.

Also installs the third-party **`minimalist`** OpenSpec schema (`specs → tasks`, no
proposal/design). It is **scoped to this change only** via the change's `.openspec.yaml`;
the repo default stays `spec-driven`. Global adoption to be investigated separately.

### The proposed change: `reader-concurrency-coordination`

Coordinates exactly two operations by making them **block-and-share** instead of
**reject**:

1. **Coordinated first-touch materialization** — concurrent first opens on an
   un-materialized `CONCURRENT` reader block until one thread publishes the snapshot,
   instead of one winning and the others getting `ArchiveyUsageError`. Removes the
   "materialize from one thread before fanning out" requirement.
2. **Draining reader close** — `close()` waits for in-flight worker `open()`/`read()`
   calls to return instead of raising; escaped streams still ride the lifecycle-lease
   contract.

Explicitly **out of scope** (stay single-owner / caller-synchronized): overlapping
*distinct* reader-wide passes (`__iter__` / `stream_members` / `extract_all`) and
concurrent access to the same stream object. Those have no coherent "make concurrent"
semantics, so the contract stays bounded.

### Schema note

The `minimalist` schema is installed under `openspec/schemas/` and pinned by this change
only (repo default reverted to `spec-driven`). Caveat: `minimalist`'s
User-Story/Acceptance-Criteria template dialect is **not** parsed by `openspec validate`
(1.6.0), which hardcodes `## ADDED Requirements` / `#### Scenario:` delta headers — so the
delta uses those headers within the minimalist (specs+tasks-only) structure. Worth
resolving before adopting the schema globally.

## Verification
- `openspec validate --strict reader-concurrency-coordination` → valid (via its pinned `minimalist` schema)
- `openspec validate --all` → 30 passed, 0 failed (existing changes pin `spec-driven`, unaffected)
- `openspec schema validate minimalist` → valid

## Test plan
- [ ] Maintainer review of the proposed contract
- [ ] (on implementation) multi-thread + `3.13t` `concurrent_reader` coverage per `tasks.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MQJMSU5GahPoGJT1jKMyFm