### PR TITLE
Implement native 7z reader (OpenSpec native-7z-reader)

### DIFF
--- a/openspec/changes/native-7z-reader/design.md
+++ b/openspec/changes/native-7z-reader/design.md
@@ -70,6 +70,10 @@ out to share the exact scheme, promote it to a shared helper then — not preemp
   raise `UnsupportedFeatureError`, documenting it for later (py7zr uses `pybcj` for this
   path — we will not add that runtime dep here).
 
+**Limitation:** LZMA1+BCJ is intentionally unsupported in this change. A real py7zr
+fixture exercises the path and the reader raises `UnsupportedFeatureError` until a
+stdlib-only decode path is validated against an oracle.
+
 ### 6. Anti-items (`is_anti`) and superseded revisions (`is_current`)
 What anti-items are *for*: 7z records them in **differential/incremental** archives —
 an entry with a name, zero content, and the `ANTI` (`0x10`) bit means "this path was

--- a/openspec/changes/native-7z-reader/tasks.md
+++ b/openspec/changes/native-7z-reader/tasks.md
@@ -30,11 +30,11 @@
 
 ## 5. Tests, oracles, fuzz
 
-- [ ] 5.1 Activate corpus 7z builders/sweep; native ↔ `py7zr` metadata+bytes cross-check (skip if absent)
-- [ ] 5.2 Per-codec fixtures: STORED, LZMA2, LZMA2+BCJ, LZMA2+Delta, Deflate, BZip2, Zstd, Brotli, PPMd, Deflate64, AES, solid, multi-password, header-encrypted, multi-volume
-- [ ] 5.3 LZMA1+BCJ fixture: either correct decode vs oracle or asserted `UnsupportedFeatureError` + short design note
-- [ ] 5.4 BCJ2 / unknown method rejection tests
-- [ ] 5.5 Anti-item fixtures via `7z` CLI; list + `is_current` computation; extract into a fresh dest and compare final tree vs `7z x` into a fresh dest (skip without `7z`); assert an anti-item leaves a pre-existing not-written destination untouched; do not require py7zr for these
-- [ ] 5.6 Core-only / `[7z]` / `[crypto]` gating tests (`PackageNotInstalledError` paths)
-- [ ] 5.7 Atheris (or env-gated harness) for header parser seeded from corpus + adversarial bytes
-- [ ] 5.8 `openspec validate native-7z-reader --strict`; `ruff` / `pyrefly` / `ty`; three-config pytest gate
+- [x] 5.1 Activate corpus 7z builders/sweep; native ↔ `py7zr` metadata+bytes cross-check (skip if absent)
+- [x] 5.2 Per-codec fixtures: STORED, LZMA2, LZMA2+BCJ, LZMA2+Delta, Deflate, BZip2, Zstd, Brotli, PPMd, Deflate64, AES, solid, multi-password, header-encrypted, multi-volume
+- [x] 5.3 LZMA1+BCJ fixture: either correct decode vs oracle or asserted `UnsupportedFeatureError` + short design note
+- [x] 5.4 BCJ2 / unknown method rejection tests
+- [x] 5.5 Anti-item fixtures via `7z` CLI; list + `is_current` computation; extract into a fresh dest and compare final tree vs `7z x` into a fresh dest (skip without `7z`); assert an anti-item leaves a pre-existing not-written destination untouched; do not require py7zr for these
+- [x] 5.6 Core-only / `[7z]` / `[crypto]` gating tests (`PackageNotInstalledError` paths)
+- [x] 5.7 Atheris (or env-gated harness) for header parser seeded from corpus + adversarial bytes
+- [x] 5.8 `openspec validate native-7z-reader --strict`; `ruff` / `pyrefly` / `ty`; three-config pytest gate

--- a/openspec/changes/native-7z-reader/tasks.md
+++ b/openspec/changes/native-7z-reader/tasks.md
@@ -1,32 +1,32 @@
 ## 1. Data model + crypto/codec stubs
 
-- [ ] 1.1 Add `ArchiveMember.is_anti: bool = False` (raw ANTI bit) and `ArchiveMember.is_current: bool = True` (derived last-entry-wins) — types + archive-data-model consumers/tests; both included in equality
-- [ ] 1.2 Implement the format-agnostic AES-CBC decrypt stage on the shared crypto surface, and a **7z-local** SHA-256 KDF helper beside it (UTF-16LE pw + salt + `1 << NumCyclesPower`, `0x3f` special case) — not on the generic crypto backend; emits `AesParams`; key cache helper by `(password, salt, cycles)`; reader never imports `cryptography`
-- [ ] 1.3 Finish `PpmdCodec.open` for PPMd var.H parameters from 7z coder properties
-- [ ] 1.4 Update stale "Phase 7" comments in crypto/PPMd paths to Phase 6
+- [x] 1.1 Add `ArchiveMember.is_anti: bool = False` (raw ANTI bit) and `ArchiveMember.is_current: bool = True` (derived last-entry-wins) — types + archive-data-model consumers/tests; both included in equality
+- [x] 1.2 Implement the format-agnostic AES-CBC decrypt stage on the shared crypto surface, and a **7z-local** SHA-256 KDF helper beside it (UTF-16LE pw + salt + `1 << NumCyclesPower`, `0x3f` special case) — not on the generic crypto backend; emits `AesParams`; key cache helper by `(password, salt, cycles)`; reader never imports `cryptography`
+- [x] 1.3 Finish `PpmdCodec.open` for PPMd var.H parameters from 7z coder properties
+- [x] 1.4 Update stale "Phase 7" comments in crypto/PPMd paths to Phase 6
 
 ## 2. Native header parser
 
-- [ ] 2.1 Add `sevenzip_parser.py`: signature header, end-header CRC, `HEADER` / `ENCODED_HEADER`
-- [ ] 2.2 Parse `PACK_INFO`, `UNPACK_INFO` (folders, coders, bind pairs), `SUBSTREAMS_INFO`, `FILES_INFO` (names, times, attrs, empty/anti bitmasks, comment)
-- [ ] 2.3 Map files → `(folder_index, file_in_folder)`, sizes/CRCs, `is_solid`, per-folder encryption, `compression` chains
-- [ ] 2.4 Header-encrypted archives: decrypt via candidates + KDF cache before parse; no password → `EncryptionError`
+- [x] 2.1 Add `sevenzip_parser.py`: signature header, end-header CRC, `HEADER` / `ENCODED_HEADER`
+- [x] 2.2 Parse `PACK_INFO`, `UNPACK_INFO` (folders, coders, bind pairs), `SUBSTREAMS_INFO`, `FILES_INFO` (names, times, attrs, empty/anti bitmasks, comment)
+- [x] 2.3 Map files → `(folder_index, file_in_folder)`, sizes/CRCs, `is_solid`, per-folder encryption, `compression` chains
+- [x] 2.4 Header-encrypted archives: decrypt via candidates + KDF cache before parse; no password → `EncryptionError`
 
 ## 3. Reader backend + folder decode
 
-- [ ] 3.1 Implement `SevenZipReader` / `SevenZipReadBackend`; register; require seek; use `SharedSource` for pack views
-- [ ] 3.2 Folder pipeline: compose `compressed-streams` (+ AES stage) in reverse coder order; verify per-member CRC32
-- [ ] 3.3 `stream_members()`: decode each folder once, slice by substream size (pull, no spool)
-- [ ] 3.4 `open()`: re-decode folder from start and skip to member; no disk/RAM decoded-folder cache
-- [ ] 3.5 Reject BCJ2 / unknown IDs / unimplemented combinations (incl. LZMA1+BCJ if not validated) with `UnsupportedFeatureError`
-- [ ] 3.6 Wire password candidates for header + per-folder units; promote known-good; never wrong bytes
-- [ ] 3.7 Populate `ArchiveInfo` (solid, encrypted, comment, multivolume) and `CostReceipt` folder signals
+- [x] 3.1 Implement `SevenZipReader` / `SevenZipReadBackend`; register; require seek; use `SharedSource` for pack views
+- [x] 3.2 Folder pipeline: compose `compressed-streams` (+ AES stage) in reverse coder order; verify per-member CRC32
+- [x] 3.3 `stream_members()`: decode each folder once, slice by substream size (pull, no spool)
+- [x] 3.4 `open()`: re-decode folder from start and skip to member; no disk/RAM decoded-folder cache
+- [x] 3.5 Reject BCJ2 / unknown IDs / unimplemented combinations (incl. LZMA1+BCJ if not validated) with `UnsupportedFeatureError`
+- [x] 3.6 Wire password candidates for header + per-folder units; promote known-good; never wrong bytes
+- [x] 3.7 Populate `ArchiveInfo` (solid, encrypted, comment, multivolume) and `CostReceipt` folder signals
 
 ## 4. Volumes + anti-items + extraction
 
-- [ ] 4.1 Join multi-volume sets (discovered siblings or explicit list) by concatenation; error on incomplete sets
-- [ ] 4.2 Expose anti members with `is_anti=True`; empty payload on open; compute `is_current` from the ANTI bitmask + same-name shadowing (superseded content → `is_current=False`)
-- [ ] 4.3 Extraction: skip `is_current=False` members by default (SKIPPED result; no limit counting); anti-items delete **only** a path this same extraction wrote (`lstat`/`unlink`, file/empty-dir only), never pre-existing/populated/out-of-root data; missing or not-written dest = success no-op
+- [x] 4.1 Join multi-volume sets (discovered siblings or explicit list) by concatenation; error on incomplete sets
+- [x] 4.2 Expose anti members with `is_anti=True`; empty payload on open; compute `is_current` from the ANTI bitmask + same-name shadowing (superseded content → `is_current=False`)
+- [x] 4.3 Extraction: skip `is_current=False` members by default (SKIPPED result; no limit counting); anti-items delete **only** a path this same extraction wrote (`lstat`/`unlink`, file/empty-dir only), never pre-existing/populated/out-of-root data; missing or not-written dest = success no-op
 
 ## 5. Tests, oracles, fuzz
 

--- a/src/archivey/core.py
+++ b/src/archivey/core.py
@@ -80,7 +80,7 @@ __all__ = [
 def _raise_multi_volume_not_supported(
     fmt: ArchiveFormat, archive_name: str | None
 ) -> None:
-    if fmt.container in (ContainerFormat.SEVEN_Z, ContainerFormat.RAR):
+    if fmt.container == ContainerFormat.RAR:
         raise UnsupportedFeatureError(
             f"Multi-volume {fmt.container.value} archives are not supported yet "
             f"(lands in Phase 7).",
@@ -196,7 +196,7 @@ def open_archive(
         detected = detect_format(open_source, collector=collector)
         format = detected.format
 
-    if resolved.volume_count > 1:
+    if resolved.volume_count > 1 and format.container != ContainerFormat.SEVEN_Z:
         _raise_multi_volume_not_supported(format, archive_name)
 
     registry = get_registry()

--- a/src/archivey/internal/backends/__init__.py
+++ b/src/archivey/internal/backends/__init__.py
@@ -8,6 +8,9 @@ from archivey.internal.backends import (
 )
 from archivey.internal.backends import iso_reader as _iso_reader  # noqa: F401
 from archivey.internal.backends import (
+    sevenzip_reader as _sevenzip_reader,  # noqa: F401
+)
+from archivey.internal.backends import (
     single_file_reader as _single_file_reader,  # noqa: F401
 )
 from archivey.internal.backends import tar_reader as _tar_reader  # noqa: F401

--- a/src/archivey/internal/backends/sevenzip_parser.py
+++ b/src/archivey/internal/backends/sevenzip_parser.py
@@ -8,6 +8,7 @@ not import or delegate to ``py7zr``.
 from __future__ import annotations
 
 import io
+import struct
 import zlib
 from collections.abc import Callable
 from dataclasses import dataclass
@@ -114,7 +115,6 @@ class SevenZipFileRecord:
 class SevenZipArchive:
     major_version: int
     minor_version: int
-    after_header: int
     pack_pos: int
     pack_sizes: list[int]
     pack_positions: list[int]
@@ -200,12 +200,13 @@ def parse_sevenzip_archive(
     if _crc32(start_header) != start_header_crc:
         raise CorruptionError("7z signature header CRC mismatch")
 
-    next_header_offset = int.from_bytes(start_header[0:8], "little")
-    next_header_size = int.from_bytes(start_header[8:16], "little")
-    next_header_crc = int.from_bytes(start_header[16:20], "little")
-    after_header = _SIGNATURE_HEADER_SIZE
+    # start_header is 20 bytes: nextHeaderOffset (u64), nextHeaderSize (u64), CRC (u32).
+    next_header_offset, next_header_size, next_header_crc = struct.unpack(
+        "<QQI", start_header
+    )
 
-    fp.seek(after_header + next_header_offset)
+    # Offsets in the header are relative to the end of the 32-byte signature header.
+    fp.seek(_SIGNATURE_HEADER_SIZE + next_header_offset)
     header_data = _read_exact(fp, next_header_size, "7z next header")
     if _crc32(header_data) != next_header_crc:
         raise CorruptionError("7z next header CRC mismatch")
@@ -213,7 +214,6 @@ def parse_sevenzip_archive(
     parsed = _parse_header(
         fp,
         io.BytesIO(header_data),
-        after_header=after_header,
         decode_folder=decode_folder,
     )
 
@@ -224,7 +224,7 @@ def parse_sevenzip_archive(
     num_unpackstreams_folders = streams.num_unpackstreams_folders or []
     unpack_sizes = streams.unpack_sizes or []
     digests = streams.digests or []
-    pack_pos = after_header + streams.pack_pos
+    pack_pos = _SIGNATURE_HEADER_SIZE + streams.pack_pos
 
     files = _map_files_to_folders(
         parsed.files,
@@ -238,7 +238,6 @@ def parse_sevenzip_archive(
     return SevenZipArchive(
         major_version=major_version,
         minor_version=minor_version,
-        after_header=after_header,
         pack_pos=pack_pos,
         pack_sizes=pack_sizes,
         pack_positions=pack_positions,
@@ -288,7 +287,6 @@ def _parse_header(
     archive_fp: BinaryIO,
     buffer: BinaryIO,
     *,
-    after_header: int,
     decode_folder: DecodeFolder,
 ) -> _ParsedHeader:
     prop = _read_property(buffer, "7z header")
@@ -306,13 +304,11 @@ def _parse_header(
     decoded = _decode_encoded_header(
         archive_fp,
         encoded_streams,
-        after_header=after_header,
         decode_folder=decode_folder,
     )
     parsed = _parse_header(
         archive_fp,
         io.BytesIO(decoded),
-        after_header=after_header,
         decode_folder=decode_folder,
     )
     parsed.is_header_encrypted = any(folder_is_encrypted(f) for f in encoded_folders)
@@ -690,7 +686,6 @@ def _decode_encoded_header(
     archive_fp: BinaryIO,
     streams: _StreamsInfo,
     *,
-    after_header: int,
     decode_folder: DecodeFolder,
 ) -> bytes:
     folders = streams.folders or []
@@ -711,7 +706,9 @@ def _decode_encoded_header(
         compressed_size = pack_sizes[pack_stream_index]
         uncompressed_size = _folder_unpack_size(folder)
         absolute_offset = (
-            after_header + streams.pack_pos + pack_positions[pack_stream_index]
+            _SIGNATURE_HEADER_SIZE
+            + streams.pack_pos
+            + pack_positions[pack_stream_index]
         )
         source = SlicingStream(archive_fp, absolute_offset, compressed_size)
         # ``decode_folder`` owns codec/crypto handling and CRC-checks its own output.

--- a/src/archivey/internal/backends/sevenzip_parser.py
+++ b/src/archivey/internal/backends/sevenzip_parser.py
@@ -8,23 +8,15 @@ not import or delegate to ``py7zr``.
 from __future__ import annotations
 
 import io
-import lzma
 import zlib
-from collections.abc import Callable, Iterable
+from collections.abc import Callable
 from dataclasses import dataclass
 from enum import IntEnum
-from typing import BinaryIO, cast
+from typing import BinaryIO
 
 from archivey.exceptions import (
     CorruptionError,
-    EncryptionError,
-    PackageNotInstalledError,
     UnsupportedFeatureError,
-)
-from archivey.internal.streams.codecs import Codec, CodecParams, open_codec_stream
-from archivey.internal.streams.crypto import (
-    SevenZipKeyCache,
-    open_aes_decrypt_stream,
 )
 from archivey.internal.streams.streamtools import SlicingStream, read_exact
 from archivey.types import CompressionAlgorithm, CompressionMethod
@@ -129,15 +121,13 @@ class SevenZipArchive:
     has_encrypted_folders: bool
 
 
-PasswordInput = (
-    str
-    | bytes
-    | Iterable[str | bytes]
-    | Callable[[], str | bytes | Iterable[str | bytes] | None]
-)
-DecodeFolder = Callable[
-    [BinaryIO, SevenZipFolder, int, int, tuple[bytes, ...], SevenZipKeyCache], bytes
-]
+DecodeFolder = Callable[[BinaryIO, SevenZipFolder, int, int], bytes]
+"""Materialize an (encoded) header folder to bytes.
+
+``(source, folder, compressed_size, uncompressed_size) -> decoded``, where ``source`` is
+positioned at the start of the folder's packed data. The reader supplies the shared
+codec/crypto pipeline (``sevenzip_reader.decode_folder_to_bytes``); the parser never
+decodes folders itself."""
 
 
 @dataclass
@@ -181,11 +171,14 @@ class _FileProps:
 def parse_sevenzip_archive(
     fp: BinaryIO,
     *,
-    passwords: PasswordInput | None = None,
-    key_cache: SevenZipKeyCache | None = None,
-    decode_folder: DecodeFolder | None = None,
+    decode_folder: DecodeFolder,
 ) -> SevenZipArchive:
-    """Parse a 7z signature header and main header."""
+    """Parse a 7z signature header and main header.
+
+    ``decode_folder`` materializes an encoded header's folder to bytes (including any
+    password prompting/decryption); the parser only walks structure and never opens a
+    codec or crypto stream itself.
+    """
 
     fp.seek(0)
     signature = _read_exact(fp, _SIGNATURE_HEADER_SIZE, "7z signature header")
@@ -209,13 +202,10 @@ def parse_sevenzip_archive(
     if _crc32(header_data) != next_header_crc:
         raise CorruptionError("7z next header CRC mismatch")
 
-    password_candidates = _password_candidates(passwords)
     parsed = _parse_header(
         fp,
         io.BytesIO(header_data),
         after_header=after_header,
-        passwords=password_candidates,
-        key_cache=key_cache or SevenZipKeyCache(),
         decode_folder=decode_folder,
     )
 
@@ -291,9 +281,7 @@ def _parse_header(
     buffer: BinaryIO,
     *,
     after_header: int,
-    passwords: tuple[bytes, ...],
-    key_cache: SevenZipKeyCache,
-    decode_folder: DecodeFolder | None,
+    decode_folder: DecodeFolder,
 ) -> _ParsedHeader:
     prop = _read_property(buffer, "7z header")
     if prop == _Property.END:
@@ -311,16 +299,12 @@ def _parse_header(
         archive_fp,
         encoded_streams,
         after_header=after_header,
-        passwords=passwords,
-        key_cache=key_cache,
         decode_folder=decode_folder,
     )
     parsed = _parse_header(
         archive_fp,
         io.BytesIO(decoded),
         after_header=after_header,
-        passwords=passwords,
-        key_cache=key_cache,
         decode_folder=decode_folder,
     )
     parsed.is_header_encrypted = any(folder_is_encrypted(f) for f in encoded_folders)
@@ -699,9 +683,7 @@ def _decode_encoded_header(
     streams: _StreamsInfo,
     *,
     after_header: int,
-    passwords: tuple[bytes, ...],
-    key_cache: SevenZipKeyCache,
-    decode_folder: DecodeFolder | None,
+    decode_folder: DecodeFolder,
 ) -> bytes:
     folders = streams.folders or []
     pack_sizes = streams.pack_sizes or []
@@ -724,170 +706,13 @@ def _decode_encoded_header(
             after_header + streams.pack_pos + pack_positions[pack_stream_index]
         )
         source = SlicingStream(archive_fp, absolute_offset, compressed_size)
-        if decode_folder is not None:
-            folder_data = decode_folder(
-                source,
-                folder,
-                compressed_size,
-                uncompressed_size,
-                passwords,
-                key_cache,
-            )
-        else:
-            folder_data = _decode_simple_folder(
-                source,
-                folder,
-                compressed_size=compressed_size,
-                uncompressed_size=uncompressed_size,
-                passwords=passwords,
-                key_cache=key_cache,
-            )
-        if folder.digest_defined and _crc32(folder_data) != folder.crc:
-            raise CorruptionError("Encoded 7z header CRC mismatch")
-        decoded.extend(folder_data)
+        # ``decode_folder`` owns codec/crypto handling and CRC-checks its own output.
+        decoded.extend(
+            decode_folder(source, folder, compressed_size, uncompressed_size)
+        )
         pack_stream_index += pack_count
 
     return bytes(decoded)
-
-
-def _decode_simple_folder(
-    source: BinaryIO,
-    folder: SevenZipFolder,
-    *,
-    compressed_size: int,
-    uncompressed_size: int,
-    passwords: tuple[bytes, ...],
-    key_cache: SevenZipKeyCache,
-) -> bytes:
-    if any(
-        coder.num_in_streams != 1 or coder.num_out_streams != 1
-        for coder in folder.coders
-    ):
-        raise UnsupportedFeatureError(
-            "Encoded 7z headers with complex coder graphs are not supported"
-        )
-
-    if folder_is_encrypted(folder):
-        if not passwords:
-            raise EncryptionError("Password required to decrypt the 7z header")
-        return _try_decode_encrypted_header(
-            source,
-            folder,
-            compressed_size=compressed_size,
-            uncompressed_size=uncompressed_size,
-            passwords=passwords,
-            key_cache=key_cache,
-        )
-
-    return _decode_simple_folder_with_password(
-        source,
-        folder,
-        compressed_size=compressed_size,
-        uncompressed_size=uncompressed_size,
-        password=None,
-        key_cache=key_cache,
-    )
-
-
-def _try_decode_encrypted_header(
-    source: BinaryIO,
-    folder: SevenZipFolder,
-    *,
-    compressed_size: int,
-    uncompressed_size: int,
-    passwords: tuple[bytes, ...],
-    key_cache: SevenZipKeyCache,
-) -> bytes:
-    last_error: Exception | None = None
-    for password in passwords:
-        source.seek(0)
-        try:
-            return _decode_simple_folder_with_password(
-                source,
-                folder,
-                compressed_size=compressed_size,
-                uncompressed_size=uncompressed_size,
-                password=password,
-                key_cache=key_cache,
-            )
-        except (CorruptionError, EncryptionError) as exc:
-            last_error = exc
-
-    raise EncryptionError(
-        "No supplied password could decrypt the 7z header"
-    ) from last_error
-
-
-def _decode_simple_folder_with_password(
-    source: BinaryIO,
-    folder: SevenZipFolder,
-    *,
-    compressed_size: int,
-    uncompressed_size: int,
-    password: bytes | None,
-    key_cache: SevenZipKeyCache,
-) -> bytes:
-    stream: BinaryIO = SlicingStream(source, 0, compressed_size)
-    owned_streams: list[BinaryIO] = [stream]
-    try:
-        for coder in folder.coders:
-            stream = _open_coder_stream(
-                stream, coder, password=password, key_cache=key_cache
-            )
-            owned_streams.append(stream)
-        decoded = _read_exact(stream, uncompressed_size, "decoded 7z header")
-        if len(decoded) != uncompressed_size:
-            raise CorruptionError("Encoded 7z header is truncated after decoding")
-        return decoded
-    finally:
-        for opened in reversed(owned_streams):
-            opened.close()
-
-
-def _open_coder_stream(
-    source: BinaryIO,
-    coder: SevenZipCoder,
-    *,
-    password: bytes | None,
-    key_cache: SevenZipKeyCache,
-) -> BinaryIO:
-    if coder.method == _METHOD_COPY:
-        return source
-    if coder.method == _METHOD_AES:
-        if password is None:
-            raise EncryptionError("Password required to decrypt the 7z header")
-        if coder.properties is None:
-            raise CorruptionError("7z AES coder is missing properties")
-        try:
-            params = key_cache.aes_params_from_properties(password, coder.properties)
-        except ValueError as exc:
-            raise CorruptionError(f"Malformed 7z AES properties: {exc}") from exc
-        try:
-            return open_aes_decrypt_stream(source, params)
-        except PackageNotInstalledError:
-            raise
-    if coder.method in (_METHOD_LZMA, _METHOD_LZMA2):
-        codec = Codec.LZMA if coder.method == _METHOD_LZMA else Codec.LZMA2
-        params = CodecParams(filters=[_lzma_filter(coder)])
-        return open_codec_stream(codec, source, params=params, seekable=False)
-    if coder.method == _METHOD_BCJ2:
-        raise UnsupportedFeatureError("BCJ2-compressed 7z headers are not supported")
-    raise UnsupportedFeatureError(
-        f"Unsupported 7z header coder method {_method_hex(coder.method)}"
-    )
-
-
-def _lzma_filter(coder: SevenZipCoder) -> dict:
-    filter_id = lzma.FILTER_LZMA1 if coder.method == _METHOD_LZMA else lzma.FILTER_LZMA2
-    if coder.properties is None:
-        return {"id": filter_id}
-    try:
-        decode_properties = getattr(lzma, "_decode_filter_properties")
-        return decode_properties(filter_id, coder.properties)
-    except (AttributeError, lzma.LZMAError, ValueError) as exc:
-        raise CorruptionError(
-            f"Malformed 7z LZMA coder properties for {_method_hex(coder.method)}"
-        ) from exc
 
 
 def _read_names(buffer: BinaryIO, files: list[_FileProps]) -> None:
@@ -1021,32 +846,6 @@ def _pack_positions(pack_sizes: list[int]) -> list[int]:
         total += size
         positions.append(total)
     return positions
-
-
-def _password_candidates(passwords: PasswordInput | None) -> tuple[bytes, ...]:
-    if passwords is None:
-        return ()
-    raw: str | bytes | Iterable[str | bytes] | None
-    if isinstance(passwords, str | bytes):
-        raw = passwords
-    elif callable(passwords):
-        provider = cast(
-            Callable[[], str | bytes | Iterable[str | bytes] | None], passwords
-        )
-        raw = provider()
-    else:
-        raw = passwords
-    if raw is None:
-        return ()
-    if isinstance(raw, (str, bytes)):
-        values: Iterable[str | bytes] = (raw,)
-    else:
-        values = raw
-    return tuple(_password_to_kdf_bytes(password) for password in values)
-
-
-def _password_to_kdf_bytes(password: str | bytes) -> bytes:
-    return password.encode("utf-16le") if isinstance(password, str) else password
 
 
 def _read_boolean(

--- a/src/archivey/internal/backends/sevenzip_parser.py
+++ b/src/archivey/internal/backends/sevenzip_parser.py
@@ -27,11 +27,19 @@ _SIGNATURE_HEADER_SIZE = 32
 _MAX_UINT64_ENCODING = 8
 _MAX_UTF16_CHARS = 65536
 _MAX_NUM_STREAMS = 65536
+# 7z coder method IDs. Single source of truth: the reader imports these.
 _METHOD_COPY = b"\x00"
 _METHOD_LZMA = b"\x03\x01\x01"
 _METHOD_LZMA2 = b"\x21"
 _METHOD_AES = b"\x06\xf1\x07\x01"
 _METHOD_BCJ2 = b"\x03\x03\x01\x1b"
+_METHOD_DELTA = b"\x03"
+_METHOD_DEFLATE = b"\x04\x01\x08"
+_METHOD_DEFLATE64 = b"\x04\x01\x09"
+_METHOD_BZIP2 = b"\x04\x02\x02"
+_METHOD_ZSTD = b"\x04\xf7\x11\x01"
+_METHOD_BROTLI = b"\x04\xf7\x11\x02"
+_METHOD_PPMD = b"\x03\x04\x01"
 
 
 class _Property(IntEnum):
@@ -949,7 +957,7 @@ _METHOD_ALGORITHMS: dict[bytes, CompressionAlgorithm] = {
     _METHOD_COPY: CompressionAlgorithm.STORED,
     _METHOD_LZMA: CompressionAlgorithm.LZMA,
     _METHOD_LZMA2: CompressionAlgorithm.LZMA2,
-    b"\x03": CompressionAlgorithm.DELTA,
+    _METHOD_DELTA: CompressionAlgorithm.DELTA,
     b"\x04": CompressionAlgorithm.BCJ,
     b"\x03\x03\x01\x03": CompressionAlgorithm.BCJ,
     b"\x03\x03\x02\x05": CompressionAlgorithm.BCJ,
@@ -958,11 +966,11 @@ _METHOD_ALGORITHMS: dict[bytes, CompressionAlgorithm] = {
     b"\x03\x03\x07\x01": CompressionAlgorithm.BCJ,
     b"\x03\x03\x08\x05": CompressionAlgorithm.BCJ,
     _METHOD_BCJ2: CompressionAlgorithm.BCJ2,
-    b"\x04\x01\x08": CompressionAlgorithm.DEFLATE,
-    b"\x04\x01\x09": CompressionAlgorithm.DEFLATE64,
-    b"\x04\x02\x02": CompressionAlgorithm.BZIP2,
-    b"\x04\xf7\x11\x01": CompressionAlgorithm.ZSTD,
-    b"\x04\xf7\x11\x02": CompressionAlgorithm.BROTLI,
-    b"\x03\x04\x01": CompressionAlgorithm.PPMD,
+    _METHOD_DEFLATE: CompressionAlgorithm.DEFLATE,
+    _METHOD_DEFLATE64: CompressionAlgorithm.DEFLATE64,
+    _METHOD_BZIP2: CompressionAlgorithm.BZIP2,
+    _METHOD_ZSTD: CompressionAlgorithm.ZSTD,
+    _METHOD_BROTLI: CompressionAlgorithm.BROTLI,
+    _METHOD_PPMD: CompressionAlgorithm.PPMD,
     _METHOD_AES: CompressionAlgorithm.UNKNOWN,
 }

--- a/src/archivey/internal/backends/sevenzip_parser.py
+++ b/src/archivey/internal/backends/sevenzip_parser.py
@@ -1,0 +1,1169 @@
+"""Native 7z header parser.
+
+This module reads the 7z signature/end header and turns the main header into small
+data objects the future reader can use to build members and folder streams. It does
+not import or delegate to ``py7zr``.
+"""
+
+from __future__ import annotations
+
+import io
+import lzma
+import zlib
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from enum import IntEnum
+from typing import BinaryIO, cast
+
+from archivey.exceptions import (
+    CorruptionError,
+    EncryptionError,
+    PackageNotInstalledError,
+    UnsupportedFeatureError,
+)
+from archivey.internal.streams.codecs import Codec, CodecParams, open_codec_stream
+from archivey.internal.streams.crypto import (
+    SevenZipKeyCache,
+    open_aes_decrypt_stream,
+)
+from archivey.internal.streams.streamtools import SlicingStream, read_exact
+from archivey.types import CompressionAlgorithm, CompressionMethod
+
+MAGIC_7Z = b"7z\xbc\xaf'\x1c"
+
+_SIGNATURE_HEADER_SIZE = 32
+_MAX_UINT64_ENCODING = 8
+_MAX_UTF16_CHARS = 65536
+_MAX_NUM_STREAMS = 65536
+_METHOD_COPY = b"\x00"
+_METHOD_LZMA = b"\x03\x01\x01"
+_METHOD_LZMA2 = b"\x21"
+_METHOD_AES = b"\x06\xf1\x07\x01"
+_METHOD_BCJ2 = b"\x03\x03\x01\x1b"
+
+
+class _Property(IntEnum):
+    END = 0x00
+    HEADER = 0x01
+    ARCHIVE_PROPERTIES = 0x02
+    ADDITIONAL_STREAMS_INFO = 0x03
+    MAIN_STREAMS_INFO = 0x04
+    FILES_INFO = 0x05
+    PACK_INFO = 0x06
+    UNPACK_INFO = 0x07
+    SUBSTREAMS_INFO = 0x08
+    SIZE = 0x09
+    CRC = 0x0A
+    FOLDER = 0x0B
+    CODERS_UNPACK_SIZE = 0x0C
+    NUM_UNPACK_STREAM = 0x0D
+    EMPTY_STREAM = 0x0E
+    EMPTY_FILE = 0x0F
+    ANTI = 0x10
+    NAME = 0x11
+    CREATION_TIME = 0x12
+    LAST_ACCESS_TIME = 0x13
+    LAST_WRITE_TIME = 0x14
+    ATTRIBUTES = 0x15
+    COMMENT = 0x16
+    ENCODED_HEADER = 0x17
+    START_POS = 0x18
+    DUMMY = 0x19
+
+
+@dataclass
+class SevenZipCoder:
+    method: bytes
+    num_in_streams: int
+    num_out_streams: int
+    properties: bytes | None
+
+
+@dataclass
+class SevenZipFolder:
+    coders: list[SevenZipCoder]
+    bind_pairs: list[tuple[int, int]]
+    packed_indices: list[int]
+    unpack_sizes: list[int]
+    crc: int | None
+    digest_defined: bool
+
+
+@dataclass
+class SevenZipFileRecord:
+    filename: str
+    emptystream: bool
+    is_anti: bool
+    is_directory: bool
+    is_empty_file: bool
+    attributes: int | None
+    creation_time: int | None
+    last_access_time: int | None
+    last_write_time: int | None
+    folder_index: int | None
+    file_in_folder: int | None
+    uncompressed_size: int
+    crc32: int | None
+    compressed_size: int | None
+    is_encrypted: bool
+    is_solid: bool
+    compression_methods: tuple[bytes | CompressionMethod, ...]
+
+
+@dataclass
+class SevenZipArchive:
+    major_version: int
+    minor_version: int
+    after_header: int
+    pack_pos: int
+    pack_sizes: list[int]
+    pack_positions: list[int]
+    folders: list[SevenZipFolder]
+    num_unpackstreams_folders: list[int]
+    unpack_sizes: list[int]
+    digests: list[int | None]
+    files: list[SevenZipFileRecord]
+    comment: str | None
+    is_solid: bool
+    is_header_encrypted: bool
+    has_encrypted_folders: bool
+
+
+PasswordInput = (
+    str
+    | bytes
+    | Iterable[str | bytes]
+    | Callable[[], str | bytes | Iterable[str | bytes] | None]
+)
+DecodeFolder = Callable[
+    [BinaryIO, SevenZipFolder, int, int, tuple[bytes, ...], SevenZipKeyCache], bytes
+]
+
+
+@dataclass
+class _PackInfo:
+    pack_pos: int = 0
+    pack_sizes: list[int] | None = None
+    pack_positions: list[int] | None = None
+
+
+@dataclass
+class _StreamsInfo:
+    pack_pos: int = 0
+    pack_sizes: list[int] | None = None
+    pack_positions: list[int] | None = None
+    folders: list[SevenZipFolder] | None = None
+    num_unpackstreams_folders: list[int] | None = None
+    unpack_sizes: list[int] | None = None
+    digests: list[int | None] | None = None
+
+
+@dataclass
+class _ParsedHeader:
+    streams: _StreamsInfo
+    files: list[SevenZipFileRecord]
+    comment: str | None
+    is_header_encrypted: bool
+
+
+@dataclass
+class _FileProps:
+    filename: str = ""
+    emptystream: bool = False
+    is_anti: bool = False
+    is_empty_file: bool = False
+    attributes: int | None = None
+    creation_time: int | None = None
+    last_access_time: int | None = None
+    last_write_time: int | None = None
+
+
+def parse_sevenzip_archive(
+    fp: BinaryIO,
+    *,
+    passwords: PasswordInput | None = None,
+    key_cache: SevenZipKeyCache | None = None,
+    decode_folder: DecodeFolder | None = None,
+) -> SevenZipArchive:
+    """Parse a 7z signature header and main header."""
+
+    fp.seek(0)
+    signature = _read_exact(fp, _SIGNATURE_HEADER_SIZE, "7z signature header")
+    if signature[: len(MAGIC_7Z)] != MAGIC_7Z:
+        raise CorruptionError("Not a 7z archive: bad magic bytes")
+
+    major_version = signature[6]
+    minor_version = signature[7]
+    start_header_crc = int.from_bytes(signature[8:12], "little")
+    start_header = signature[12:32]
+    if _crc32(start_header) != start_header_crc:
+        raise CorruptionError("7z signature header CRC mismatch")
+
+    next_header_offset = int.from_bytes(start_header[0:8], "little")
+    next_header_size = int.from_bytes(start_header[8:16], "little")
+    next_header_crc = int.from_bytes(start_header[16:20], "little")
+    after_header = _SIGNATURE_HEADER_SIZE
+
+    fp.seek(after_header + next_header_offset)
+    header_data = _read_exact(fp, next_header_size, "7z next header")
+    if _crc32(header_data) != next_header_crc:
+        raise CorruptionError("7z next header CRC mismatch")
+
+    password_candidates = _password_candidates(passwords)
+    parsed = _parse_header(
+        fp,
+        io.BytesIO(header_data),
+        after_header=after_header,
+        passwords=password_candidates,
+        key_cache=key_cache or SevenZipKeyCache(),
+        decode_folder=decode_folder,
+    )
+
+    streams = parsed.streams
+    pack_sizes = streams.pack_sizes or []
+    pack_positions = streams.pack_positions or _pack_positions(pack_sizes)
+    folders = streams.folders or []
+    num_unpackstreams_folders = streams.num_unpackstreams_folders or []
+    unpack_sizes = streams.unpack_sizes or []
+    digests = streams.digests or []
+    pack_pos = after_header + streams.pack_pos
+
+    files = _map_files_to_folders(
+        parsed.files,
+        folders=folders,
+        pack_sizes=pack_sizes,
+        num_unpackstreams_folders=num_unpackstreams_folders,
+        unpack_sizes=unpack_sizes,
+        digests=digests,
+    )
+
+    return SevenZipArchive(
+        major_version=major_version,
+        minor_version=minor_version,
+        after_header=after_header,
+        pack_pos=pack_pos,
+        pack_sizes=pack_sizes,
+        pack_positions=pack_positions,
+        folders=folders,
+        num_unpackstreams_folders=num_unpackstreams_folders,
+        unpack_sizes=unpack_sizes,
+        digests=digests,
+        files=files,
+        comment=parsed.comment,
+        is_solid=any(n > 1 for n in num_unpackstreams_folders),
+        is_header_encrypted=parsed.is_header_encrypted,
+        has_encrypted_folders=any(folder_is_encrypted(folder) for folder in folders),
+    )
+
+
+def compute_is_current(files: list[SevenZipFileRecord]) -> list[bool]:
+    """Last-entry-wins by filename."""
+
+    current = [False] * len(files)
+    seen: set[str] = set()
+    for index in range(len(files) - 1, -1, -1):
+        filename = files[index].filename
+        if filename not in seen:
+            current[index] = True
+            seen.add(filename)
+    return current
+
+
+def folder_is_encrypted(folder: SevenZipFolder) -> bool:
+    """Whether any coder in the folder is 7z AES."""
+
+    return any(coder.method == _METHOD_AES for coder in folder.coders)
+
+
+def compression_method_for_coder(
+    coder: SevenZipCoder,
+) -> CompressionMethod:
+    """Return archivey's compression descriptor for a 7z coder method id."""
+
+    return CompressionMethod(
+        _METHOD_ALGORITHMS.get(coder.method, CompressionAlgorithm.UNKNOWN),
+        properties=coder.properties,
+    )
+
+
+def _parse_header(
+    archive_fp: BinaryIO,
+    buffer: BinaryIO,
+    *,
+    after_header: int,
+    passwords: tuple[bytes, ...],
+    key_cache: SevenZipKeyCache,
+    decode_folder: DecodeFolder | None,
+) -> _ParsedHeader:
+    prop = _read_property(buffer, "7z header")
+    if prop == _Property.END:
+        return _ParsedHeader(_StreamsInfo(), [], None, False)
+    if prop == _Property.HEADER:
+        parsed = _parse_plain_header(buffer)
+        parsed.is_header_encrypted = False
+        return parsed
+    if prop != _Property.ENCODED_HEADER:
+        raise CorruptionError(f"Expected 7z HEADER or ENCODED_HEADER, got 0x{prop:02x}")
+
+    encoded_streams = _read_streams_info(buffer)
+    encoded_folders = encoded_streams.folders or []
+    decoded = _decode_encoded_header(
+        archive_fp,
+        encoded_streams,
+        after_header=after_header,
+        passwords=passwords,
+        key_cache=key_cache,
+        decode_folder=decode_folder,
+    )
+    parsed = _parse_header(
+        archive_fp,
+        io.BytesIO(decoded),
+        after_header=after_header,
+        passwords=passwords,
+        key_cache=key_cache,
+        decode_folder=decode_folder,
+    )
+    parsed.is_header_encrypted = any(folder_is_encrypted(f) for f in encoded_folders)
+    return parsed
+
+
+def _parse_plain_header(buffer: BinaryIO) -> _ParsedHeader:
+    streams = _StreamsInfo()
+    files: list[SevenZipFileRecord] = []
+    comment: str | None = None
+
+    while True:
+        prop = _read_property(buffer, "7z plain header")
+        if prop == _Property.END:
+            return _ParsedHeader(streams, files, comment, False)
+        if prop == _Property.ARCHIVE_PROPERTIES:
+            _skip_archive_properties(buffer)
+        elif prop == _Property.ADDITIONAL_STREAMS_INFO:
+            _skip_streams_info(buffer)
+        elif prop == _Property.MAIN_STREAMS_INFO:
+            streams = _read_streams_info(buffer)
+        elif prop == _Property.FILES_INFO:
+            files, file_comment = _read_files_info(buffer)
+            if file_comment is not None:
+                comment = file_comment
+        else:
+            raise UnsupportedFeatureError(
+                f"Unsupported 7z header property 0x{prop:02x}"
+            )
+
+
+def _read_streams_info(buffer: BinaryIO) -> _StreamsInfo:
+    streams = _StreamsInfo()
+    prop = _read_property(buffer, "7z streams info")
+
+    if prop == _Property.PACK_INFO:
+        pack_info = _read_pack_info(buffer)
+        streams.pack_pos = pack_info.pack_pos
+        streams.pack_sizes = pack_info.pack_sizes
+        streams.pack_positions = pack_info.pack_positions
+        prop = _read_property(buffer, "7z streams info")
+
+    if prop == _Property.UNPACK_INFO:
+        streams.folders = _read_unpack_info(buffer)
+        prop = _read_property(buffer, "7z streams info")
+
+    if prop == _Property.SUBSTREAMS_INFO:
+        if streams.folders is None:
+            raise CorruptionError("7z SUBSTREAMS_INFO appeared before UNPACK_INFO")
+        (
+            streams.num_unpackstreams_folders,
+            streams.unpack_sizes,
+            streams.digests,
+        ) = _read_substreams_info(buffer, streams.folders)
+        prop = _read_property(buffer, "7z streams info")
+    elif streams.folders is not None:
+        streams.num_unpackstreams_folders = [1] * len(streams.folders)
+        streams.unpack_sizes = [
+            _folder_unpack_size(folder) for folder in streams.folders
+        ]
+        streams.digests = [
+            folder.crc if folder.digest_defined else None for folder in streams.folders
+        ]
+
+    if prop != _Property.END:
+        raise CorruptionError(f"Expected END in 7z streams info, got 0x{prop:02x}")
+    return streams
+
+
+def _read_pack_info(buffer: BinaryIO) -> _PackInfo:
+    pack_pos = _read_uint64(buffer)
+    num_streams = _read_uint64(buffer)
+    if num_streams > _MAX_NUM_STREAMS:
+        raise CorruptionError(f"7z pack stream count is too large: {num_streams}")
+
+    pack_sizes: list[int] | None = None
+    prop = _read_property(buffer, "7z PACK_INFO")
+    if prop == _Property.SIZE:
+        pack_sizes = [_read_uint64(buffer) for _ in range(num_streams)]
+        prop = _read_property(buffer, "7z PACK_INFO")
+    if prop == _Property.CRC:
+        _read_digests(buffer, num_streams)
+        prop = _read_property(buffer, "7z PACK_INFO")
+    if prop != _Property.END:
+        raise CorruptionError(f"Expected END in 7z PACK_INFO, got 0x{prop:02x}")
+
+    if pack_sizes is None:
+        pack_sizes = []
+    return _PackInfo(
+        pack_pos=pack_pos,
+        pack_sizes=pack_sizes,
+        pack_positions=_pack_positions(pack_sizes),
+    )
+
+
+def _read_unpack_info(buffer: BinaryIO) -> list[SevenZipFolder]:
+    prop = _read_property(buffer, "7z UNPACK_INFO")
+    if prop != _Property.FOLDER:
+        raise CorruptionError(f"Expected FOLDER in 7z UNPACK_INFO, got 0x{prop:02x}")
+
+    num_folders = _read_uint64(buffer)
+    external = _read_byte(buffer)
+    if external != 0:
+        raise UnsupportedFeatureError(
+            "External 7z folder definitions are not supported"
+        )
+
+    folders = [_read_folder(buffer) for _ in range(num_folders)]
+    prop = _read_property(buffer, "7z UNPACK_INFO")
+    if prop != _Property.CODERS_UNPACK_SIZE:
+        raise CorruptionError(
+            f"Expected CODERS_UNPACK_SIZE in 7z UNPACK_INFO, got 0x{prop:02x}"
+        )
+
+    for folder in folders:
+        folder.unpack_sizes = [
+            _read_uint64(buffer)
+            for coder in folder.coders
+            for _ in range(coder.num_out_streams)
+        ]
+
+    prop = _read_property(buffer, "7z UNPACK_INFO")
+    if prop == _Property.CRC:
+        defined, crcs = _read_digests(buffer, len(folders))
+        for index, folder in enumerate(folders):
+            folder.digest_defined = defined[index]
+            folder.crc = crcs[index]
+        prop = _read_property(buffer, "7z UNPACK_INFO")
+
+    if prop != _Property.END:
+        raise CorruptionError(f"Expected END in 7z UNPACK_INFO, got 0x{prop:02x}")
+    return folders
+
+
+def _read_folder(buffer: BinaryIO) -> SevenZipFolder:
+    num_coders = _read_uint64(buffer)
+    coders: list[SevenZipCoder] = []
+    total_in = 0
+    total_out = 0
+
+    for _ in range(num_coders):
+        flags = _read_byte(buffer)
+        method_size = flags & 0x0F
+        if flags & 0x80:
+            raise UnsupportedFeatureError(
+                "Alternative 7z coder methods are not supported"
+            )
+        method = _read_exact(buffer, method_size, "7z coder method id")
+        if method_size == 0:
+            method = _METHOD_COPY
+
+        if flags & 0x10:
+            num_in_streams = _read_uint64(buffer)
+            num_out_streams = _read_uint64(buffer)
+        else:
+            num_in_streams = 1
+            num_out_streams = 1
+        properties = None
+        if flags & 0x20:
+            prop_size = _read_uint64(buffer)
+            properties = _read_exact(buffer, prop_size, "7z coder properties")
+
+        total_in += num_in_streams
+        total_out += num_out_streams
+        coders.append(
+            SevenZipCoder(
+                method=method,
+                num_in_streams=num_in_streams,
+                num_out_streams=num_out_streams,
+                properties=properties,
+            )
+        )
+
+    num_bind_pairs = total_out - 1
+    bind_pairs = [
+        (_read_uint64(buffer), _read_uint64(buffer)) for _ in range(num_bind_pairs)
+    ]
+    num_packed_streams = total_in - num_bind_pairs
+    if num_packed_streams == 1:
+        bound_in_streams = {in_stream for in_stream, _ in bind_pairs}
+        packed_indices = [
+            index for index in range(total_in) if index not in bound_in_streams
+        ]
+    else:
+        packed_indices = [_read_uint64(buffer) for _ in range(num_packed_streams)]
+
+    return SevenZipFolder(
+        coders=coders,
+        bind_pairs=bind_pairs,
+        packed_indices=packed_indices,
+        unpack_sizes=[],
+        crc=None,
+        digest_defined=False,
+    )
+
+
+def _read_substreams_info(
+    buffer: BinaryIO, folders: list[SevenZipFolder]
+) -> tuple[list[int], list[int], list[int | None]]:
+    prop = _read_property(buffer, "7z SUBSTREAMS_INFO")
+    if prop == _Property.NUM_UNPACK_STREAM:
+        num_unpackstreams_folders = [_read_uint64(buffer) for _ in folders]
+        prop = _read_property(buffer, "7z SUBSTREAMS_INFO")
+    else:
+        num_unpackstreams_folders = [1] * len(folders)
+
+    unpack_sizes: list[int] = []
+    if prop == _Property.SIZE:
+        for folder_index, folder in enumerate(folders):
+            total = 0
+            count = num_unpackstreams_folders[folder_index]
+            for _ in range(max(count - 1, 0)):
+                size = _read_uint64(buffer)
+                unpack_sizes.append(size)
+                total += size
+            if count:
+                last_size = _folder_unpack_size(folder) - total
+                if last_size < 0:
+                    raise CorruptionError(
+                        "7z substream sizes exceed folder unpack size"
+                    )
+                unpack_sizes.append(last_size)
+        prop = _read_property(buffer, "7z SUBSTREAMS_INFO")
+    else:
+        for folder_index, folder in enumerate(folders):
+            count = num_unpackstreams_folders[folder_index]
+            if count == 1:
+                unpack_sizes.append(_folder_unpack_size(folder))
+
+    digest_slots = _substream_digest_slots(folders, num_unpackstreams_folders)
+    digests: list[int | None] = []
+    if prop == _Property.CRC:
+        defined, crcs = _read_digests(buffer, digest_slots)
+        digest_index = 0
+        for folder_index, folder in enumerate(folders):
+            count = num_unpackstreams_folders[folder_index]
+            if count == 1 and folder.digest_defined:
+                digests.append(folder.crc)
+            else:
+                for _ in range(count):
+                    digests.append(
+                        crcs[digest_index] if defined[digest_index] else None
+                    )
+                    digest_index += 1
+        prop = _read_property(buffer, "7z SUBSTREAMS_INFO")
+    else:
+        for folder_index, folder in enumerate(folders):
+            count = num_unpackstreams_folders[folder_index]
+            if count == 1 and folder.digest_defined:
+                digests.append(folder.crc)
+            else:
+                digests.extend([None] * count)
+
+    if prop != _Property.END:
+        raise CorruptionError(f"Expected END in 7z SUBSTREAMS_INFO, got 0x{prop:02x}")
+    return num_unpackstreams_folders, unpack_sizes, digests
+
+
+def _read_files_info(buffer: BinaryIO) -> tuple[list[SevenZipFileRecord], str | None]:
+    num_files = _read_uint64(buffer)
+    files = [_FileProps() for _ in range(num_files)]
+    num_empty_streams = 0
+    comment: str | None = None
+
+    while True:
+        prop = _read_property(buffer, "7z FILES_INFO")
+        if prop == _Property.END:
+            return [_file_record_from_props(props) for props in files], comment
+
+        size = _read_uint64(buffer)
+        payload = io.BytesIO(_read_exact(buffer, size, "7z file property payload"))
+        if prop == _Property.DUMMY:
+            continue
+        if prop == _Property.EMPTY_STREAM:
+            empty_streams = _read_boolean(payload, num_files)
+            for file_props, empty in zip(files, empty_streams, strict=True):
+                file_props.emptystream = empty
+            num_empty_streams = empty_streams.count(True)
+        elif prop == _Property.EMPTY_FILE:
+            _apply_empty_stream_property(
+                files, _read_boolean(payload, num_empty_streams), "is_empty_file"
+            )
+        elif prop == _Property.ANTI:
+            _apply_empty_stream_property(
+                files, _read_boolean(payload, num_empty_streams), "is_anti"
+            )
+        elif prop == _Property.NAME:
+            _read_names(payload, files)
+        elif prop == _Property.CREATION_TIME:
+            _read_times(payload, files, "creation_time")
+        elif prop == _Property.LAST_ACCESS_TIME:
+            _read_times(payload, files, "last_access_time")
+        elif prop == _Property.LAST_WRITE_TIME:
+            _read_times(payload, files, "last_write_time")
+        elif prop == _Property.ATTRIBUTES:
+            _read_attributes(payload, files)
+        elif prop == _Property.COMMENT:
+            comment = _read_comment(payload)
+        elif prop == _Property.START_POS:
+            _skip_start_positions(payload, num_files)
+        else:
+            raise UnsupportedFeatureError(
+                f"Unsupported 7z FILES_INFO property 0x{prop:02x}"
+            )
+
+
+def _file_record_from_props(props: _FileProps) -> SevenZipFileRecord:
+    return SevenZipFileRecord(
+        filename=props.filename,
+        emptystream=props.emptystream,
+        is_anti=props.is_anti,
+        is_directory=props.emptystream
+        and not props.is_empty_file
+        and not props.is_anti,
+        is_empty_file=props.is_empty_file,
+        attributes=props.attributes,
+        creation_time=props.creation_time,
+        last_access_time=props.last_access_time,
+        last_write_time=props.last_write_time,
+        folder_index=None,
+        file_in_folder=None,
+        uncompressed_size=0,
+        crc32=None,
+        compressed_size=None,
+        is_encrypted=False,
+        is_solid=False,
+        compression_methods=(),
+    )
+
+
+def _map_files_to_folders(
+    files: list[SevenZipFileRecord],
+    *,
+    folders: list[SevenZipFolder],
+    pack_sizes: list[int],
+    num_unpackstreams_folders: list[int],
+    unpack_sizes: list[int],
+    digests: list[int | None],
+) -> list[SevenZipFileRecord]:
+    folder_compressed_sizes = _folder_compressed_sizes(folders, pack_sizes)
+    folder_index = 0
+    file_in_folder = 0
+    substream_index = 0
+
+    for file_record in files:
+        if file_record.emptystream:
+            continue
+        if folder_index >= len(folders):
+            raise CorruptionError("7z file table references a missing folder")
+        if substream_index >= len(unpack_sizes):
+            raise CorruptionError("7z file table references a missing substream")
+
+        folder = folders[folder_index]
+        file_record.folder_index = folder_index
+        file_record.file_in_folder = file_in_folder
+        file_record.uncompressed_size = unpack_sizes[substream_index]
+        file_record.crc32 = (
+            digests[substream_index] if substream_index < len(digests) else None
+        )
+        file_record.compressed_size = folder_compressed_sizes[folder_index]
+        file_record.is_encrypted = folder_is_encrypted(folder)
+        file_record.is_solid = num_unpackstreams_folders[folder_index] > 1
+        file_record.compression_methods = tuple(coder.method for coder in folder.coders)
+
+        file_in_folder += 1
+        substream_index += 1
+        if file_in_folder >= num_unpackstreams_folders[folder_index]:
+            folder_index += 1
+            file_in_folder = 0
+
+    return files
+
+
+def _decode_encoded_header(
+    archive_fp: BinaryIO,
+    streams: _StreamsInfo,
+    *,
+    after_header: int,
+    passwords: tuple[bytes, ...],
+    key_cache: SevenZipKeyCache,
+    decode_folder: DecodeFolder | None,
+) -> bytes:
+    folders = streams.folders or []
+    pack_sizes = streams.pack_sizes or []
+    pack_positions = streams.pack_positions or _pack_positions(pack_sizes)
+    pack_stream_index = 0
+    decoded = bytearray()
+
+    for folder in folders:
+        pack_count = len(folder.packed_indices)
+        if pack_count != 1:
+            raise UnsupportedFeatureError(
+                "Encoded 7z headers with multi-pack folders are not supported"
+            )
+        if pack_stream_index >= len(pack_sizes):
+            raise CorruptionError("Encoded 7z header references a missing pack stream")
+
+        compressed_size = pack_sizes[pack_stream_index]
+        uncompressed_size = _folder_unpack_size(folder)
+        absolute_offset = (
+            after_header + streams.pack_pos + pack_positions[pack_stream_index]
+        )
+        source = SlicingStream(archive_fp, absolute_offset, compressed_size)
+        if decode_folder is not None:
+            folder_data = decode_folder(
+                source,
+                folder,
+                compressed_size,
+                uncompressed_size,
+                passwords,
+                key_cache,
+            )
+        else:
+            folder_data = _decode_simple_folder(
+                source,
+                folder,
+                compressed_size=compressed_size,
+                uncompressed_size=uncompressed_size,
+                passwords=passwords,
+                key_cache=key_cache,
+            )
+        if folder.digest_defined and _crc32(folder_data) != folder.crc:
+            raise CorruptionError("Encoded 7z header CRC mismatch")
+        decoded.extend(folder_data)
+        pack_stream_index += pack_count
+
+    return bytes(decoded)
+
+
+def _decode_simple_folder(
+    source: BinaryIO,
+    folder: SevenZipFolder,
+    *,
+    compressed_size: int,
+    uncompressed_size: int,
+    passwords: tuple[bytes, ...],
+    key_cache: SevenZipKeyCache,
+) -> bytes:
+    if any(
+        coder.num_in_streams != 1 or coder.num_out_streams != 1
+        for coder in folder.coders
+    ):
+        raise UnsupportedFeatureError(
+            "Encoded 7z headers with complex coder graphs are not supported"
+        )
+
+    if folder_is_encrypted(folder):
+        if not passwords:
+            raise EncryptionError("Password required to decrypt the 7z header")
+        return _try_decode_encrypted_header(
+            source,
+            folder,
+            compressed_size=compressed_size,
+            uncompressed_size=uncompressed_size,
+            passwords=passwords,
+            key_cache=key_cache,
+        )
+
+    return _decode_simple_folder_with_password(
+        source,
+        folder,
+        compressed_size=compressed_size,
+        uncompressed_size=uncompressed_size,
+        password=None,
+        key_cache=key_cache,
+    )
+
+
+def _try_decode_encrypted_header(
+    source: BinaryIO,
+    folder: SevenZipFolder,
+    *,
+    compressed_size: int,
+    uncompressed_size: int,
+    passwords: tuple[bytes, ...],
+    key_cache: SevenZipKeyCache,
+) -> bytes:
+    last_error: Exception | None = None
+    for password in passwords:
+        source.seek(0)
+        try:
+            return _decode_simple_folder_with_password(
+                source,
+                folder,
+                compressed_size=compressed_size,
+                uncompressed_size=uncompressed_size,
+                password=password,
+                key_cache=key_cache,
+            )
+        except (CorruptionError, EncryptionError) as exc:
+            last_error = exc
+
+    raise EncryptionError(
+        "No supplied password could decrypt the 7z header"
+    ) from last_error
+
+
+def _decode_simple_folder_with_password(
+    source: BinaryIO,
+    folder: SevenZipFolder,
+    *,
+    compressed_size: int,
+    uncompressed_size: int,
+    password: bytes | None,
+    key_cache: SevenZipKeyCache,
+) -> bytes:
+    stream: BinaryIO = SlicingStream(source, 0, compressed_size)
+    owned_streams: list[BinaryIO] = [stream]
+    try:
+        for coder in folder.coders:
+            stream = _open_coder_stream(
+                stream, coder, password=password, key_cache=key_cache
+            )
+            owned_streams.append(stream)
+        decoded = _read_exact(stream, uncompressed_size, "decoded 7z header")
+        if len(decoded) != uncompressed_size:
+            raise CorruptionError("Encoded 7z header is truncated after decoding")
+        return decoded
+    finally:
+        for opened in reversed(owned_streams):
+            opened.close()
+
+
+def _open_coder_stream(
+    source: BinaryIO,
+    coder: SevenZipCoder,
+    *,
+    password: bytes | None,
+    key_cache: SevenZipKeyCache,
+) -> BinaryIO:
+    if coder.method == _METHOD_COPY:
+        return source
+    if coder.method == _METHOD_AES:
+        if password is None:
+            raise EncryptionError("Password required to decrypt the 7z header")
+        if coder.properties is None:
+            raise CorruptionError("7z AES coder is missing properties")
+        try:
+            params = key_cache.aes_params_from_properties(password, coder.properties)
+        except ValueError as exc:
+            raise CorruptionError(f"Malformed 7z AES properties: {exc}") from exc
+        try:
+            return open_aes_decrypt_stream(source, params)
+        except PackageNotInstalledError:
+            raise
+    if coder.method in (_METHOD_LZMA, _METHOD_LZMA2):
+        codec = Codec.LZMA if coder.method == _METHOD_LZMA else Codec.LZMA2
+        params = CodecParams(filters=[_lzma_filter(coder)])
+        return open_codec_stream(codec, source, params=params, seekable=False)
+    if coder.method == _METHOD_BCJ2:
+        raise UnsupportedFeatureError("BCJ2-compressed 7z headers are not supported")
+    raise UnsupportedFeatureError(
+        f"Unsupported 7z header coder method {_method_hex(coder.method)}"
+    )
+
+
+def _lzma_filter(coder: SevenZipCoder) -> dict:
+    filter_id = lzma.FILTER_LZMA1 if coder.method == _METHOD_LZMA else lzma.FILTER_LZMA2
+    if coder.properties is None:
+        return {"id": filter_id}
+    try:
+        decode_properties = getattr(lzma, "_decode_filter_properties")
+        return decode_properties(filter_id, coder.properties)
+    except (AttributeError, lzma.LZMAError, ValueError) as exc:
+        raise CorruptionError(
+            f"Malformed 7z LZMA coder properties for {_method_hex(coder.method)}"
+        ) from exc
+
+
+def _read_names(buffer: BinaryIO, files: list[_FileProps]) -> None:
+    external = _read_byte(buffer)
+    if external != 0:
+        raise UnsupportedFeatureError("External 7z filename data is not supported")
+    for file_props in files:
+        file_props.filename = _read_utf16(buffer).replace("\\", "/")
+
+
+def _read_times(buffer: BinaryIO, files: list[_FileProps], field: str) -> None:
+    defined = _read_boolean(buffer, len(files), check_all=True)
+    external = _read_byte(buffer)
+    if external != 0:
+        raise UnsupportedFeatureError("External 7z timestamp data is not supported")
+    for file_props, is_defined in zip(files, defined, strict=True):
+        if is_defined:
+            setattr(file_props, field, _read_real_uint64(buffer))
+
+
+def _read_attributes(buffer: BinaryIO, files: list[_FileProps]) -> None:
+    defined = _read_boolean(buffer, len(files), check_all=True)
+    external = _read_byte(buffer)
+    if external != 0:
+        raise UnsupportedFeatureError("External 7z attribute data is not supported")
+    for file_props, is_defined in zip(files, defined, strict=True):
+        if is_defined:
+            file_props.attributes = _read_uint32(buffer)
+
+
+def _read_comment(buffer: BinaryIO) -> str | None:
+    data = buffer.read()
+    if not data:
+        return None
+    if data[0] == 0:
+        data = data[1:]
+    data = data.rstrip(b"\x00")
+    if not data:
+        return None
+    try:
+        return data.decode("utf-16le")
+    except UnicodeDecodeError as exc:
+        raise CorruptionError(f"Could not decode 7z comment: {exc!r}") from exc
+
+
+def _skip_start_positions(buffer: BinaryIO, num_files: int) -> None:
+    defined = _read_boolean(buffer, num_files, check_all=True)
+    external = _read_byte(buffer)
+    if external != 0:
+        raise UnsupportedFeatureError(
+            "External 7z start-position data is not supported"
+        )
+    for is_defined in defined:
+        if is_defined:
+            _read_real_uint64(buffer)
+
+
+def _skip_archive_properties(buffer: BinaryIO) -> None:
+    while True:
+        prop = _read_property(buffer, "7z archive properties")
+        if prop == _Property.END:
+            return
+        size = _read_uint64(buffer)
+        _read_exact(buffer, size, "7z archive property payload")
+
+
+def _skip_streams_info(buffer: BinaryIO) -> None:
+    _read_streams_info(buffer)
+
+
+def _apply_empty_stream_property(
+    files: list[_FileProps], values: list[bool], field: str
+) -> None:
+    value_index = 0
+    for file_props in files:
+        if not file_props.emptystream:
+            continue
+        if value_index >= len(values):
+            raise CorruptionError("7z empty-stream property is truncated")
+        setattr(file_props, field, values[value_index])
+        value_index += 1
+
+
+def _read_digests(buffer: BinaryIO, count: int) -> tuple[list[bool], list[int | None]]:
+    defined = _read_boolean(buffer, count, check_all=True)
+    crcs: list[int | None] = []
+    for is_defined in defined:
+        crcs.append(_read_uint32(buffer) if is_defined else None)
+    return defined, crcs
+
+
+def _substream_digest_slots(
+    folders: list[SevenZipFolder], num_unpackstreams_folders: list[int]
+) -> int:
+    slots = 0
+    for folder, count in zip(folders, num_unpackstreams_folders, strict=True):
+        if count != 1 or not folder.digest_defined:
+            slots += count
+    return slots
+
+
+def _folder_unpack_size(folder: SevenZipFolder) -> int:
+    bound_out_streams = {out_stream for _, out_stream in folder.bind_pairs}
+    for index in range(len(folder.unpack_sizes) - 1, -1, -1):
+        if index not in bound_out_streams:
+            return folder.unpack_sizes[index]
+    if folder.unpack_sizes:
+        return folder.unpack_sizes[-1]
+    return 0
+
+
+def _folder_compressed_sizes(
+    folders: list[SevenZipFolder], pack_sizes: list[int]
+) -> list[int | None]:
+    sizes: list[int | None] = []
+    pack_index = 0
+    for folder in folders:
+        pack_count = len(folder.packed_indices)
+        if pack_index + pack_count > len(pack_sizes):
+            sizes.append(None)
+        else:
+            sizes.append(sum(pack_sizes[pack_index : pack_index + pack_count]))
+        pack_index += pack_count
+    return sizes
+
+
+def _pack_positions(pack_sizes: list[int]) -> list[int]:
+    positions = [0]
+    total = 0
+    for size in pack_sizes:
+        total += size
+        positions.append(total)
+    return positions
+
+
+def _password_candidates(passwords: PasswordInput | None) -> tuple[bytes, ...]:
+    if passwords is None:
+        return ()
+    raw: str | bytes | Iterable[str | bytes] | None
+    if isinstance(passwords, str | bytes):
+        raw = passwords
+    elif callable(passwords):
+        provider = cast(
+            Callable[[], str | bytes | Iterable[str | bytes] | None], passwords
+        )
+        raw = provider()
+    else:
+        raw = passwords
+    if raw is None:
+        return ()
+    if isinstance(raw, (str, bytes)):
+        values: Iterable[str | bytes] = (raw,)
+    else:
+        values = raw
+    return tuple(_password_to_kdf_bytes(password) for password in values)
+
+
+def _password_to_kdf_bytes(password: str | bytes) -> bytes:
+    return password.encode("utf-16le") if isinstance(password, str) else password
+
+
+def _read_boolean(
+    buffer: BinaryIO, count: int, *, check_all: bool = False
+) -> list[bool]:
+    if check_all:
+        all_defined = _read_byte(buffer)
+        if all_defined != 0:
+            return [True] * count
+
+    result: list[bool] = []
+    current = 0
+    mask = 0
+    for _ in range(count):
+        if mask == 0:
+            current = _read_byte(buffer)
+            mask = 0x80
+        result.append((current & mask) != 0)
+        mask >>= 1
+    return result
+
+
+def _read_utf16(buffer: BinaryIO) -> str:
+    chunks = bytearray()
+    for _ in range(_MAX_UTF16_CHARS):
+        unit = _read_exact(buffer, 2, "7z UTF-16 name")
+        if unit == b"\x00\x00":
+            return bytes(chunks).decode("utf-16le")
+        chunks.extend(unit)
+    raise CorruptionError("7z UTF-16 string is not null-terminated")
+
+
+def _read_uint64(buffer: BinaryIO) -> int:
+    first = _read_byte(buffer)
+    if first == 0xFF:
+        return _read_real_uint64(buffer)
+
+    mask = 0x80
+    extra_bytes = _MAX_UINT64_ENCODING
+    for limit, length in (
+        (0b01111111, 0),
+        (0b10111111, 1),
+        (0b11011111, 2),
+        (0b11101111, 3),
+        (0b11110111, 4),
+        (0b11111011, 5),
+        (0b11111101, 6),
+        (0b11111110, 7),
+    ):
+        if first <= limit:
+            extra_bytes = length
+            break
+        mask >>= 1
+
+    if extra_bytes == 0:
+        return first & (mask - 1)
+    data = _read_exact(buffer, extra_bytes, "7z UINT64")
+    low = int.from_bytes(data, "little")
+    high = first & (mask - 1)
+    return low + (high << (extra_bytes * 8))
+
+
+def _read_property(buffer: BinaryIO, context: str) -> _Property:
+    value = _read_byte(buffer)
+    try:
+        return _Property(value)
+    except ValueError:
+        raise UnsupportedFeatureError(
+            f"Unsupported 7z property 0x{value:02x} in {context}"
+        ) from None
+
+
+def _read_byte(buffer: BinaryIO) -> int:
+    return _read_exact(buffer, 1, "7z byte")[0]
+
+
+def _read_uint32(buffer: BinaryIO) -> int:
+    return int.from_bytes(_read_exact(buffer, 4, "7z UINT32"), "little")
+
+
+def _read_real_uint64(buffer: BinaryIO) -> int:
+    return int.from_bytes(_read_exact(buffer, 8, "7z real UINT64"), "little")
+
+
+def _read_exact(buffer: BinaryIO, length: int, context: str) -> bytes:
+    data = read_exact(buffer, length)
+    if len(data) != length:
+        raise CorruptionError(f"Truncated {context}: expected {length} bytes")
+    return data
+
+
+def _crc32(data: bytes) -> int:
+    return zlib.crc32(data) & 0xFFFFFFFF
+
+
+def _method_hex(method: bytes) -> str:
+    return "0x" + method.hex()
+
+
+_METHOD_ALGORITHMS: dict[bytes, CompressionAlgorithm] = {
+    _METHOD_COPY: CompressionAlgorithm.STORED,
+    _METHOD_LZMA: CompressionAlgorithm.LZMA,
+    _METHOD_LZMA2: CompressionAlgorithm.LZMA2,
+    b"\x03": CompressionAlgorithm.DELTA,
+    b"\x04": CompressionAlgorithm.BCJ,
+    b"\x03\x03\x01\x03": CompressionAlgorithm.BCJ,
+    b"\x03\x03\x02\x05": CompressionAlgorithm.BCJ,
+    b"\x03\x03\x04\x01": CompressionAlgorithm.BCJ,
+    b"\x03\x03\x05\x01": CompressionAlgorithm.BCJ,
+    b"\x03\x03\x07\x01": CompressionAlgorithm.BCJ,
+    b"\x03\x03\x08\x05": CompressionAlgorithm.BCJ,
+    _METHOD_BCJ2: CompressionAlgorithm.BCJ2,
+    b"\x04\x01\x08": CompressionAlgorithm.DEFLATE,
+    b"\x04\x01\x09": CompressionAlgorithm.DEFLATE64,
+    b"\x04\x02\x02": CompressionAlgorithm.BZIP2,
+    b"\x04\xf7\x11\x01": CompressionAlgorithm.ZSTD,
+    b"\x04\xf7\x11\x02": CompressionAlgorithm.BROTLI,
+    b"\x03\x04\x01": CompressionAlgorithm.PPMD,
+    _METHOD_AES: CompressionAlgorithm.UNKNOWN,
+}

--- a/src/archivey/internal/backends/sevenzip_reader.py
+++ b/src/archivey/internal/backends/sevenzip_reader.py
@@ -23,10 +23,23 @@ from archivey.exceptions import (
     UnsupportedFeatureError,
 )
 from archivey.internal.backends.sevenzip_parser import (
+    _METHOD_AES,
+    _METHOD_BCJ2,
+    _METHOD_BROTLI,
+    _METHOD_BZIP2,
+    _METHOD_COPY,
+    _METHOD_DEFLATE,
+    _METHOD_DEFLATE64,
+    _METHOD_DELTA,
+    _METHOD_LZMA,
+    _METHOD_LZMA2,
+    _METHOD_PPMD,
+    _METHOD_ZSTD,
     SevenZipArchive,
     SevenZipCoder,
     SevenZipFileRecord,
     SevenZipFolder,
+    _method_hex,
     compression_method_for_coder,
     compute_is_current,
     folder_is_encrypted,
@@ -76,19 +89,6 @@ from archivey.types import (
     MemberStreams,
     MemberType,
 )
-
-_METHOD_COPY = b"\x00"
-_METHOD_LZMA = b"\x03\x01\x01"
-_METHOD_LZMA2 = b"\x21"
-_METHOD_AES = b"\x06\xf1\x07\x01"
-_METHOD_BCJ2 = b"\x03\x03\x01\x1b"
-_METHOD_DELTA = b"\x03"
-_METHOD_DEFLATE = b"\x04\x01\x08"
-_METHOD_DEFLATE64 = b"\x04\x01\x09"
-_METHOD_BZIP2 = b"\x04\x02\x02"
-_METHOD_ZSTD = b"\x04\xf7\x11\x01"
-_METHOD_BROTLI = b"\x04\xf7\x11\x02"
-_METHOD_PPMD = b"\x03\x04\x01"
 
 _BCJ_METHODS: dict[bytes, Codec] = {
     b"\x04": Codec.BCJ_X86,
@@ -164,10 +164,6 @@ class _LimitedFolderReader(ReadOnlyIOStream):
             chunk = self.read(min(self._remaining, 1024 * 1024))
             if not chunk:
                 break
-
-
-def _method_hex(method: bytes) -> str:
-    return "0x" + method.hex()
 
 
 def _password_to_kdf_bytes(password: bytes) -> bytes:

--- a/src/archivey/internal/backends/sevenzip_reader.py
+++ b/src/archivey/internal/backends/sevenzip_reader.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import io
 import lzma
 import stat
+import zlib
 from collections.abc import Iterator, Mapping
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -546,15 +547,10 @@ class SevenZipReader(BaseArchiveReader):
                 decoded = read_exact(stream, total)
                 if len(decoded) != total:
                     raise EncryptionError("Wrong password or corrupt 7z folder")
-                if folder.digest_defined:
-                    verifier = VerifyingStream(
-                        io.BytesIO(decoded),
-                        {"crc32": folder.crc if folder.crc is not None else 0},
-                        collector=self._diagnostics_collector,
-                        archive_name=self._archive_name,
-                    )
-                    verifier.read()
-                    verifier.read()
+                # LZMA can occasionally emit the expected length for a wrong key;
+                # require a CRC match before accepting the candidate. Prefer the
+                # folder digest when present; otherwise check per-member digests.
+                self._verify_folder_plaintext(folder_index, decoded)
                 return kdf_password
             except ArchiveyError as exc:
                 raise EncryptionError("Wrong password or corrupt 7z folder") from exc
@@ -569,6 +565,35 @@ class SevenZipReader(BaseArchiveReader):
             ) from exc
         self._folder_passwords[folder_index] = password
         return password
+
+    def _verify_folder_plaintext(self, folder_index: int, decoded: bytes) -> None:
+        """Raise ``EncryptionError`` when decoded folder bytes fail CRC checks."""
+        folder = self._archive.folders[folder_index]
+        if folder.digest_defined:
+            expected = (folder.crc if folder.crc is not None else 0) & 0xFFFFFFFF
+            if zlib.crc32(decoded) & 0xFFFFFFFF != expected:
+                raise EncryptionError("Wrong password or corrupt 7z folder")
+            return
+
+        offset = 0
+        for folder_member in self._folder_members.get(folder_index, []):
+            size = _member_stream_size(folder_member)
+            chunk = decoded[offset : offset + size]
+            offset += size
+            raw_expected = (
+                folder_member.hashes.get("crc32") if folder_member.hashes else None
+            )
+            if raw_expected is None:
+                continue
+            if isinstance(raw_expected, bytes):
+                expected = int.from_bytes(raw_expected, "big") & 0xFFFFFFFF
+            else:
+                expected = raw_expected & 0xFFFFFFFF
+            if zlib.crc32(chunk) & 0xFFFFFFFF != expected:
+                raise EncryptionError("Wrong password or corrupt 7z folder")
+        # When no digests are present we can only rely on the decompressor rejecting
+        # wrong-key ciphertext (same as before); do not treat that as confirmation
+        # failure on its own.
 
     def _open_folder_pipeline(
         self,

--- a/src/archivey/internal/backends/sevenzip_reader.py
+++ b/src/archivey/internal/backends/sevenzip_reader.py
@@ -33,7 +33,11 @@ from archivey.internal.backends.sevenzip_parser import (
     parse_sevenzip_archive,
 )
 from archivey.internal.base_reader import BaseArchiveReader, ReadBackend
-from archivey.internal.config import stream_config_from_archivey
+from archivey.internal.config import (
+    DEFAULT_STREAM_CONFIG,
+    StreamConfig,
+    stream_config_from_archivey,
+)
 from archivey.internal.diagnostics_collector import DiagnosticCollector
 from archivey.internal.naming import emit_member_name_normalized, normalize_member_name
 from archivey.internal.open_site import OpenSite
@@ -227,6 +231,176 @@ def _member_stream_size(member: ArchiveMember) -> int:
     return member.size if member.size is not None else 0
 
 
+def _check_linear_coder_chain(folder: SevenZipFolder) -> None:
+    """Verify the folder's coders form a single linear chain in list order.
+
+    ``open_folder_pipeline`` decodes coders in list order, assuming coder 0 consumes the
+    single packed stream and each coder's output feeds the next coder's input. 7z encoders
+    emit coders in exactly that order (verified against py7zr fixtures: LZMA2, Delta+LZMA2,
+    BCJ+LZMA2, AES+LZMA2 all yield ``packed_indices == [0]`` and ``bind_pairs`` of the form
+    ``(i+1, i)``). That wiring is only *implied* by the bind pairs, though, so we validate
+    it here and raise rather than silently emit wrong bytes for an out-of-order or branching
+    coder graph.
+    """
+    expected_bind = {(i + 1, i) for i in range(len(folder.coders) - 1)}
+    if folder.packed_indices != [0] or set(folder.bind_pairs) != expected_bind:
+        raise UnsupportedFeatureError(
+            "7z folders with non-linear coder wiring are not supported"
+        )
+
+
+def _open_aes_stage(
+    source: BinaryIO,
+    coder: SevenZipCoder,
+    *,
+    password: bytes | None,
+    key_cache: SevenZipKeyCache,
+) -> BinaryIO:
+    if password is None:
+        raise EncryptionError("Password required to decrypt this 7z folder")
+    if coder.properties is None:
+        raise CorruptionError("7z AES coder is missing properties")
+    try:
+        params = key_cache.aes_params_from_properties(password, coder.properties)
+    except ValueError as exc:
+        raise CorruptionError(f"Malformed 7z AES properties: {exc}") from exc
+    return open_aes_decrypt_stream(source, params)
+
+
+def _open_lzma_run(
+    source: BinaryIO,
+    run: list[SevenZipCoder],
+    *,
+    stream_config: StreamConfig,
+    collector: DiagnosticCollector | None,
+) -> BinaryIO:
+    has_lzma1 = any(coder.method == _METHOD_LZMA for coder in run)
+    has_lzma2 = any(coder.method == _METHOD_LZMA2 for coder in run)
+    has_bcj = any(coder.method in _BCJ_METHODS for coder in run)
+    if has_lzma1 and has_lzma2:
+        raise UnsupportedFeatureError(
+            "Mixed LZMA1+LZMA2 7z coder chains are unsupported"
+        )
+    if has_lzma1 and has_bcj:
+        raise UnsupportedFeatureError("LZMA1+BCJ 7z coder chains are unsupported")
+    # A 7z filter run lists coders in decode order (outer filter first); liblzma wants
+    # them in the reverse (encode) order, hence ``reversed(run)``.
+    filters = [_lzma_filter(coder) for coder in reversed(run)]
+    codec = Codec.LZMA if has_lzma1 and not has_lzma2 else Codec.LZMA2
+    return open_codec_stream(
+        codec,
+        source,
+        config=stream_config,
+        params=CodecParams(filters=filters),
+        collector=collector,
+        seekable=False,
+    )
+
+
+def open_folder_pipeline(
+    source: BinaryIO,
+    folder: SevenZipFolder,
+    *,
+    password: bytes | None,
+    key_cache: SevenZipKeyCache,
+    stream_config: StreamConfig | None = None,
+    collector: DiagnosticCollector | None = None,
+) -> BinaryIO:
+    """Compose a folder's coder chain into a single pull stream.
+
+    Only linear 1-in/1-out coder chains are supported; BCJ2 and multi-stream coder
+    graphs raise ``UnsupportedFeatureError``. Consecutive LZMA-family coders (LZMA,
+    LZMA2, Delta, BCJ) collapse into one liblzma filter chain; other codecs and the AES
+    stage each wrap the stream once.
+    """
+    if any(
+        coder.num_in_streams != 1 or coder.num_out_streams != 1
+        for coder in folder.coders
+    ):
+        raise UnsupportedFeatureError(
+            "7z folders with complex coder graphs are not supported"
+        )
+    _check_linear_coder_chain(folder)
+    config = stream_config if stream_config is not None else DEFAULT_STREAM_CONFIG
+    stream: BinaryIO = source
+    index = 0
+    while index < len(folder.coders):
+        coder = folder.coders[index]
+        if coder.method == _METHOD_BCJ2:
+            raise UnsupportedFeatureError(
+                "BCJ2-compressed 7z folders are not supported"
+            )
+        if coder.method == _METHOD_COPY:
+            index += 1
+            continue
+        if coder.method == _METHOD_AES:
+            stream = _open_aes_stage(
+                stream, coder, password=password, key_cache=key_cache
+            )
+            index += 1
+            continue
+        if _is_lzma_family(coder):
+            run: list[SevenZipCoder] = []
+            while index < len(folder.coders) and _is_lzma_family(folder.coders[index]):
+                run.append(folder.coders[index])
+                index += 1
+            stream = _open_lzma_run(
+                stream, run, stream_config=config, collector=collector
+            )
+            continue
+        codec = _SINGLE_STAGE_CODECS.get(coder.method)
+        if codec is None:
+            raise UnsupportedFeatureError(
+                f"Unsupported 7z coder method {_method_hex(coder.method)}"
+            )
+        stream = open_codec_stream(
+            codec,
+            stream,
+            config=config,
+            params=CodecParams(properties=coder.properties),
+            collector=collector,
+            seekable=False,
+        )
+        index += 1
+    return stream
+
+
+def decode_folder_to_bytes(
+    source: BinaryIO,
+    folder: SevenZipFolder,
+    *,
+    compressed_size: int,
+    uncompressed_size: int,
+    password: bytes | None,
+    key_cache: SevenZipKeyCache,
+    stream_config: StreamConfig | None = None,
+    collector: DiagnosticCollector | None = None,
+) -> bytes:
+    """Fully decode one folder's packed stream into memory and CRC-check it.
+
+    Used to materialize the (encoded) 7z header. ``source`` must be positioned at the
+    start of the folder's packed data.
+    """
+    stream = open_folder_pipeline(
+        SlicingStream(source, 0, compressed_size),
+        folder,
+        password=password,
+        key_cache=key_cache,
+        stream_config=stream_config,
+        collector=collector,
+    )
+    try:
+        decoded = read_exact(stream, uncompressed_size)
+        if len(decoded) != uncompressed_size:
+            raise TruncatedError("7z folder is truncated after decoding")
+        if folder.digest_defined and folder.crc is not None:
+            if zlib.crc32(decoded) & 0xFFFFFFFF != folder.crc & 0xFFFFFFFF:
+                raise CorruptionError("Decoded 7z folder CRC mismatch")
+        return decoded
+    finally:
+        stream.close()
+
+
 class SevenZipReader(BaseArchiveReader):
     """Reads 7z archives using the native parser and shared codec streams."""
 
@@ -275,11 +449,6 @@ class SevenZipReader(BaseArchiveReader):
         self._volume_count = getattr(source, "volume_count", 1)
         self._archive = parse_sevenzip_archive(
             self._shared.view(0),
-            passwords=tuple(
-                _password_to_kdf_bytes(password)
-                for password in self._passwords.iter_candidates()
-            ),
-            key_cache=self._key_cache,
             decode_folder=self._decode_header_folder,
         )
         self._folder_pack_starts = self._folder_pack_start_indices(self._archive)
@@ -301,66 +470,28 @@ class SevenZipReader(BaseArchiveReader):
         folder: SevenZipFolder,
         compressed_size: int,
         uncompressed_size: int,
-        passwords: tuple[bytes, ...],
-        key_cache: SevenZipKeyCache,
     ) -> bytes:
-        del passwords, key_cache
-
-        def decrypt(password: bytes) -> bytes:
+        def decode(password: bytes | None) -> bytes:
             source.seek(0)
-            kdf_password = _password_to_kdf_bytes(password)
-            return self._decode_folder_to_bytes(
+            return decode_folder_to_bytes(
                 source,
                 folder,
                 compressed_size=compressed_size,
                 uncompressed_size=uncompressed_size,
-                password=kdf_password,
+                password=password,
+                key_cache=self._key_cache,
+                stream_config=self._stream_config,
+                collector=self._diagnostics_collector,
             )
 
         try:
             if folder_is_encrypted(folder):
-                return self._passwords.attempt(None, decrypt)
-            source.seek(0)
-            return self._decode_folder_to_bytes(
-                source,
-                folder,
-                compressed_size=compressed_size,
-                uncompressed_size=uncompressed_size,
-                password=None,
-            )
+                return self._passwords.attempt(
+                    None, lambda password: decode(_password_to_kdf_bytes(password))
+                )
+            return decode(None)
         except _PasswordCandidatesExhausted as exc:
             raise EncryptionError("Password required to decrypt the 7z header") from exc
-
-    def _decode_folder_to_bytes(
-        self,
-        source: BinaryIO,
-        folder: SevenZipFolder,
-        *,
-        compressed_size: int,
-        uncompressed_size: int,
-        password: bytes | None,
-    ) -> bytes:
-        stream = self._open_folder_pipeline(
-            SlicingStream(source, 0, compressed_size),
-            folder,
-            password=password,
-        )
-        try:
-            decoded = read_exact(stream, uncompressed_size)
-            if len(decoded) != uncompressed_size:
-                raise TruncatedError("7z folder is truncated after decoding")
-            if folder.digest_defined:
-                verifier = VerifyingStream(
-                    io.BytesIO(decoded),
-                    {"crc32": folder.crc if folder.crc is not None else 0},
-                    collector=self._diagnostics_collector,
-                    archive_name=self._archive_name,
-                )
-                verifier.read()
-                verifier.read()
-            return decoded
-        finally:
-            stream.close()
 
     def _build_members(self) -> list[ArchiveMember]:
         current_flags = compute_is_current(self._archive.files)
@@ -602,91 +733,13 @@ class SevenZipReader(BaseArchiveReader):
         *,
         password: bytes | None,
     ) -> BinaryIO:
-        if any(
-            coder.num_in_streams != 1 or coder.num_out_streams != 1
-            for coder in folder.coders
-        ):
-            raise UnsupportedFeatureError(
-                "7z folders with complex coder graphs are not supported"
-            )
-        stream: BinaryIO = source
-        index = 0
-        while index < len(folder.coders):
-            coder = folder.coders[index]
-            if coder.method == _METHOD_BCJ2:
-                raise UnsupportedFeatureError(
-                    "BCJ2-compressed 7z folders are not supported"
-                )
-            if coder.method == _METHOD_COPY:
-                index += 1
-                continue
-            if coder.method == _METHOD_AES:
-                stream = self._open_aes_stage(stream, coder, password=password)
-                index += 1
-                continue
-            if _is_lzma_family(coder):
-                run: list[SevenZipCoder] = []
-                while index < len(folder.coders) and _is_lzma_family(
-                    folder.coders[index]
-                ):
-                    run.append(folder.coders[index])
-                    index += 1
-                stream = self._open_lzma_run(stream, run)
-                continue
-            codec = _SINGLE_STAGE_CODECS.get(coder.method)
-            if codec is None:
-                raise UnsupportedFeatureError(
-                    f"Unsupported 7z coder method {_method_hex(coder.method)}"
-                )
-            stream = open_codec_stream(
-                codec,
-                stream,
-                config=self._stream_config,
-                params=CodecParams(properties=coder.properties),
-                collector=self._diagnostics_collector,
-                seekable=False,
-            )
-            index += 1
-        return stream
-
-    def _open_aes_stage(
-        self,
-        source: BinaryIO,
-        coder: SevenZipCoder,
-        *,
-        password: bytes | None,
-    ) -> BinaryIO:
-        if password is None:
-            raise EncryptionError("Password required to decrypt this 7z folder")
-        if coder.properties is None:
-            raise CorruptionError("7z AES coder is missing properties")
-        try:
-            params = self._key_cache.aes_params_from_properties(
-                password, coder.properties
-            )
-        except ValueError as exc:
-            raise CorruptionError(f"Malformed 7z AES properties: {exc}") from exc
-        return open_aes_decrypt_stream(source, params)
-
-    def _open_lzma_run(self, source: BinaryIO, run: list[SevenZipCoder]) -> BinaryIO:
-        has_lzma1 = any(coder.method == _METHOD_LZMA for coder in run)
-        has_lzma2 = any(coder.method == _METHOD_LZMA2 for coder in run)
-        has_bcj = any(coder.method in _BCJ_METHODS for coder in run)
-        if has_lzma1 and has_lzma2:
-            raise UnsupportedFeatureError(
-                "Mixed LZMA1+LZMA2 7z coder chains are unsupported"
-            )
-        if has_lzma1 and has_bcj:
-            raise UnsupportedFeatureError("LZMA1+BCJ 7z coder chains are unsupported")
-        filters = [_lzma_filter(coder) for coder in reversed(run)]
-        codec = Codec.LZMA if has_lzma1 and not has_lzma2 else Codec.LZMA2
-        return open_codec_stream(
-            codec,
+        return open_folder_pipeline(
             source,
-            config=self._stream_config,
-            params=CodecParams(filters=filters),
+            folder,
+            password=password,
+            key_cache=self._key_cache,
+            stream_config=self._stream_config,
             collector=self._diagnostics_collector,
-            seekable=False,
         )
 
     def _member_stream_from_folder(

--- a/src/archivey/internal/backends/sevenzip_reader.py
+++ b/src/archivey/internal/backends/sevenzip_reader.py
@@ -1,0 +1,803 @@
+"""Native 7z reader backend."""
+
+from __future__ import annotations
+
+import io
+import lzma
+import stat
+from collections.abc import Iterator, Mapping
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import BinaryIO
+
+from archivey.config import ArchiveyConfig
+from archivey.cost import AccessCost, CostReceipt, ListingCost, StreamCapability
+from archivey.exceptions import (
+    ArchiveyError,
+    CorruptionError,
+    EncryptionError,
+    StreamNotSeekableError,
+    TruncatedError,
+    UnsupportedFeatureError,
+)
+from archivey.internal.backends.sevenzip_parser import (
+    SevenZipArchive,
+    SevenZipCoder,
+    SevenZipFileRecord,
+    SevenZipFolder,
+    compression_method_for_coder,
+    compute_is_current,
+    folder_is_encrypted,
+    parse_sevenzip_archive,
+)
+from archivey.internal.base_reader import BaseArchiveReader, ReadBackend
+from archivey.internal.config import stream_config_from_archivey
+from archivey.internal.diagnostics_collector import DiagnosticCollector
+from archivey.internal.naming import emit_member_name_normalized, normalize_member_name
+from archivey.internal.open_site import OpenSite
+from archivey.internal.password import (
+    _PasswordCandidates,
+    _PasswordCandidatesExhausted,
+)
+from archivey.internal.registry import register_reader
+from archivey.internal.streams.archive_stream import ArchiveStream
+from archivey.internal.streams.codecs import (
+    LZMA_FILTER_IDS,
+    Codec,
+    CodecParams,
+    open_codec_stream,
+)
+from archivey.internal.streams.crypto import (
+    SevenZipKeyCache,
+    open_aes_decrypt_stream,
+)
+from archivey.internal.streams.streamtools import (
+    ReadOnlyIOStream,
+    SharedSource,
+    SlicingStream,
+    is_seekable,
+    is_stream,
+    read_exact,
+)
+from archivey.internal.streams.verify import VerifyingStream
+from archivey.types import (
+    ArchiveFormat,
+    ArchiveInfo,
+    ArchiveMember,
+    CompressionAlgorithm,
+    CreateSystem,
+    MagicSignature,
+    MemberStreams,
+    MemberType,
+)
+
+_METHOD_COPY = b"\x00"
+_METHOD_LZMA = b"\x03\x01\x01"
+_METHOD_LZMA2 = b"\x21"
+_METHOD_AES = b"\x06\xf1\x07\x01"
+_METHOD_BCJ2 = b"\x03\x03\x01\x1b"
+_METHOD_DELTA = b"\x03"
+_METHOD_DEFLATE = b"\x04\x01\x08"
+_METHOD_DEFLATE64 = b"\x04\x01\x09"
+_METHOD_BZIP2 = b"\x04\x02\x02"
+_METHOD_ZSTD = b"\x04\xf7\x11\x01"
+_METHOD_BROTLI = b"\x04\xf7\x11\x02"
+_METHOD_PPMD = b"\x03\x04\x01"
+
+_BCJ_METHODS: dict[bytes, Codec] = {
+    b"\x04": Codec.BCJ_X86,
+    b"\x05": Codec.BCJ_PPC,
+    b"\x06": Codec.BCJ_IA64,
+    b"\x07": Codec.BCJ_ARM,
+    b"\x08": Codec.BCJ_ARMT,
+    b"\x09": Codec.BCJ_SPARC,
+    b"\x03\x03\x01\x03": Codec.BCJ_X86,
+    b"\x03\x03\x02\x05": Codec.BCJ_PPC,
+    b"\x03\x03\x04\x01": Codec.BCJ_IA64,
+    b"\x03\x03\x05\x01": Codec.BCJ_ARM,
+    b"\x03\x03\x07\x01": Codec.BCJ_ARMT,
+    b"\x03\x03\x08\x05": Codec.BCJ_SPARC,
+}
+
+_SINGLE_STAGE_CODECS: dict[bytes, Codec] = {
+    _METHOD_DEFLATE: Codec.DEFLATE,
+    _METHOD_DEFLATE64: Codec.DEFLATE64,
+    _METHOD_BZIP2: Codec.BZIP2,
+    _METHOD_ZSTD: Codec.ZSTD,
+    _METHOD_BROTLI: Codec.BROTLI,
+    _METHOD_PPMD: Codec.PPMD,
+}
+
+_WINDOWS_FILE_ATTRIBUTE_REPARSE_POINT = 0x400
+_NTFS_EPOCH_OFFSET = 11_644_473_600
+
+
+@dataclass(frozen=True)
+class _MemberRaw:
+    record: SevenZipFileRecord
+    folder_index: int | None
+    file_in_folder: int | None
+
+
+class _LimitedFolderReader(ReadOnlyIOStream):
+    """A non-owning limited view over a decoded folder stream."""
+
+    def __init__(
+        self, source: BinaryIO, length: int, *, close_source: bool = False
+    ) -> None:
+        super().__init__()
+        self._source = source
+        self._length = length
+        self._remaining = length
+        self._close_source = close_source
+
+    def read(self, n: int = -1, /) -> bytes:
+        if self._remaining <= 0:
+            return b""
+        if n < 0 or n > self._remaining:
+            n = self._remaining
+        data = self._source.read(n)
+        self._remaining -= len(data)
+        return data
+
+    def tell(self) -> int:
+        return self._length - self._remaining
+
+    def close(self) -> None:
+        if self.closed:
+            return
+        try:
+            self.drain()
+        finally:
+            if self._close_source:
+                self._source.close()
+            super().close()
+
+    def drain(self) -> None:
+        while self._remaining > 0:
+            chunk = self.read(min(self._remaining, 1024 * 1024))
+            if not chunk:
+                break
+
+
+def _method_hex(method: bytes) -> str:
+    return "0x" + method.hex()
+
+
+def _password_to_kdf_bytes(password: bytes) -> bytes:
+    try:
+        return password.decode("utf-8").encode("utf-16le")
+    except UnicodeDecodeError:
+        return password
+
+
+def _filetime_to_datetime(value: int | None) -> datetime | None:
+    if value is None or value == 0:
+        return None
+    try:
+        return datetime.fromtimestamp(
+            value / 10_000_000 - _NTFS_EPOCH_OFFSET,
+            tz=timezone.utc,
+        )
+    except (ValueError, OverflowError, OSError):
+        return None
+
+
+def _is_lzma_family(coder: SevenZipCoder) -> bool:
+    return (
+        coder.method in (_METHOD_LZMA, _METHOD_LZMA2, _METHOD_DELTA)
+        or coder.method in _BCJ_METHODS
+    )
+
+
+def _decode_lzma_properties(coder: SevenZipCoder, filter_id: int) -> dict:
+    if coder.properties is None:
+        return {"id": filter_id}
+    try:
+        decode_properties = getattr(lzma, "_decode_filter_properties")
+        return decode_properties(filter_id, coder.properties)
+    except (AttributeError, lzma.LZMAError, ValueError) as exc:
+        raise CorruptionError(
+            f"Malformed 7z LZMA coder properties for {_method_hex(coder.method)}"
+        ) from exc
+
+
+def _lzma_filter(coder: SevenZipCoder) -> dict:
+    if coder.method == _METHOD_LZMA:
+        return _decode_lzma_properties(coder, lzma.FILTER_LZMA1)
+    if coder.method == _METHOD_LZMA2:
+        return _decode_lzma_properties(coder, lzma.FILTER_LZMA2)
+    if coder.method == _METHOD_DELTA:
+        if coder.properties is None:
+            return {"id": lzma.FILTER_DELTA}
+        if len(coder.properties) != 1:
+            raise CorruptionError("Malformed 7z Delta coder properties")
+        return {"id": lzma.FILTER_DELTA, "dist": coder.properties[0] + 1}
+    bcj_codec = _BCJ_METHODS.get(coder.method)
+    if bcj_codec is not None:
+        return {"id": LZMA_FILTER_IDS[bcj_codec]}
+    raise UnsupportedFeatureError(
+        f"Unsupported 7z LZMA-family coder {_method_hex(coder.method)}"
+    )
+
+
+def _member_stream_size(member: ArchiveMember) -> int:
+    return member.size if member.size is not None else 0
+
+
+class SevenZipReader(BaseArchiveReader):
+    """Reads 7z archives using the native parser and shared codec streams."""
+
+    _SUPPORTS_RANDOM_ACCESS = True
+    _MEMBER_LIST_UPFRONT = True
+
+    def __init__(
+        self,
+        source: Path | BinaryIO,
+        streaming: bool,
+        passwords: _PasswordCandidates | None,
+        encoding: str | None,
+        archive_name: str | None,
+        config: ArchiveyConfig,
+        collector: DiagnosticCollector | None = None,
+        member_streams: MemberStreams = MemberStreams(0),
+        open_site: OpenSite | None = None,
+    ) -> None:
+        super().__init__(
+            ArchiveFormat.SEVEN_Z,
+            streaming,
+            archive_name,
+            config,
+            collector=collector,
+            member_streams=member_streams,
+            open_site=open_site,
+        )
+        del encoding  # 7z stores names as UTF-16LE.
+        self._source = source
+        self._passwords = passwords or _PasswordCandidates()
+        self._key_cache = SevenZipKeyCache()
+        self._folder_passwords: dict[int, bytes | None] = {}
+        self._stream_config = stream_config_from_archivey(
+            self._config,
+            streaming=streaming,
+            seekable=MemberStreams.SEEKABLE in member_streams,
+        )
+        if is_stream(source) and not is_seekable(source):
+            raise StreamNotSeekableError(
+                "7z archives require a seekable source: the header and packed streams "
+                "are addressed by offsets.",
+                archive_name=archive_name,
+                source_format=ArchiveFormat.SEVEN_Z,
+            )
+        self._shared = SharedSource(source)
+        self._volume_count = getattr(source, "volume_count", 1)
+        self._archive = parse_sevenzip_archive(
+            self._shared.view(0),
+            passwords=tuple(
+                _password_to_kdf_bytes(password)
+                for password in self._passwords.iter_candidates()
+            ),
+            key_cache=self._key_cache,
+            decode_folder=self._decode_header_folder,
+        )
+        self._folder_pack_starts = self._folder_pack_start_indices(self._archive)
+        self._members = self._build_members()
+        self._folder_members = self._members_by_folder()
+
+    @staticmethod
+    def _folder_pack_start_indices(archive: SevenZipArchive) -> list[int]:
+        starts: list[int] = []
+        index = 0
+        for folder in archive.folders:
+            starts.append(index)
+            index += len(folder.packed_indices)
+        return starts
+
+    def _decode_header_folder(
+        self,
+        source: BinaryIO,
+        folder: SevenZipFolder,
+        compressed_size: int,
+        uncompressed_size: int,
+        passwords: tuple[bytes, ...],
+        key_cache: SevenZipKeyCache,
+    ) -> bytes:
+        del passwords, key_cache
+
+        def decrypt(password: bytes) -> bytes:
+            source.seek(0)
+            kdf_password = _password_to_kdf_bytes(password)
+            return self._decode_folder_to_bytes(
+                source,
+                folder,
+                compressed_size=compressed_size,
+                uncompressed_size=uncompressed_size,
+                password=kdf_password,
+            )
+
+        try:
+            if folder_is_encrypted(folder):
+                return self._passwords.attempt(None, decrypt)
+            source.seek(0)
+            return self._decode_folder_to_bytes(
+                source,
+                folder,
+                compressed_size=compressed_size,
+                uncompressed_size=uncompressed_size,
+                password=None,
+            )
+        except _PasswordCandidatesExhausted as exc:
+            raise EncryptionError("Password required to decrypt the 7z header") from exc
+
+    def _decode_folder_to_bytes(
+        self,
+        source: BinaryIO,
+        folder: SevenZipFolder,
+        *,
+        compressed_size: int,
+        uncompressed_size: int,
+        password: bytes | None,
+    ) -> bytes:
+        stream = self._open_folder_pipeline(
+            SlicingStream(source, 0, compressed_size),
+            folder,
+            password=password,
+        )
+        try:
+            decoded = read_exact(stream, uncompressed_size)
+            if len(decoded) != uncompressed_size:
+                raise TruncatedError("7z folder is truncated after decoding")
+            if folder.digest_defined:
+                verifier = VerifyingStream(
+                    io.BytesIO(decoded),
+                    {"crc32": folder.crc if folder.crc is not None else 0},
+                    collector=self._diagnostics_collector,
+                    archive_name=self._archive_name,
+                )
+                verifier.read()
+                verifier.read()
+            return decoded
+        finally:
+            stream.close()
+
+    def _build_members(self) -> list[ArchiveMember]:
+        current_flags = compute_is_current(self._archive.files)
+        members: list[ArchiveMember] = []
+        for record, is_current in zip(self._archive.files, current_flags, strict=True):
+            members.append(self._to_member(record, is_current=is_current))
+        return members
+
+    def _members_by_folder(self) -> dict[int, list[ArchiveMember]]:
+        grouped: dict[int, list[ArchiveMember]] = {}
+        for member in self._members:
+            raw = member._raw
+            assert isinstance(raw, _MemberRaw)
+            if raw.folder_index is not None:
+                grouped.setdefault(raw.folder_index, []).append(member)
+        return grouped
+
+    def _iter_members(self) -> Iterator[ArchiveMember]:
+        yield from self._members
+
+    def _iter_with_data(self) -> Iterator[tuple[ArchiveMember, ArchiveStream | None]]:
+        current_folder: int | None = None
+        folder_stream: BinaryIO | None = None
+        previous: ArchiveStream | None = None
+        try:
+            for member in self._members:
+                if previous is not None:
+                    previous.close()
+                    previous = None
+                if not member.is_file:
+                    yield member, None
+                    continue
+                raw = member._raw
+                assert isinstance(raw, _MemberRaw)
+                if raw.folder_index is None:
+                    stream = self._wrap_member_stream(
+                        io.BytesIO(b""), member.name, size=member.size
+                    )
+                    previous = stream
+                    yield member, stream
+                    continue
+                if raw.folder_index != current_folder:
+                    if folder_stream is not None:
+                        folder_stream.close()
+                    current_folder = raw.folder_index
+                    folder_stream = self._open_folder_stream(raw.folder_index, member)
+                assert folder_stream is not None
+                member_stream = self._member_stream_from_folder(folder_stream, member)
+                previous = member_stream
+                yield member, member_stream
+        finally:
+            if previous is not None:
+                previous.close()
+            if folder_stream is not None:
+                folder_stream.close()
+
+    def _to_member(
+        self, record: SevenZipFileRecord, *, is_current: bool
+    ) -> ArchiveMember:
+        member_type = self._member_type(record)
+        name = normalize_member_name(
+            record.filename,
+            member_type,
+            backslash_is_separator=True,
+        )
+        raw_name = record.filename.encode("utf-16le", errors="surrogateescape")
+        compression = tuple(
+            method
+            for method in (
+                compression_method_for_coder(coder)
+                for coder in self._folder_coders(record)
+                if coder.method != _METHOD_AES
+            )
+            if method.algo is not CompressionAlgorithm.UNKNOWN
+        )
+        hashes: dict[str, int] = {}
+        if record.crc32 is not None:
+            hashes["crc32"] = record.crc32
+        attrs = record.attributes
+        unix_mode = (attrs >> 16) if attrs is not None and attrs >> 16 else None
+        mode = stat.S_IMODE(unix_mode) if unix_mode is not None else None
+        extra: dict[str, object] = {}
+        if record.folder_index is not None:
+            extra["7z.folder_index"] = record.folder_index
+        if record.file_in_folder is not None:
+            extra["7z.file_in_folder"] = record.file_in_folder
+        member = ArchiveMember(
+            type=member_type,
+            name=name,
+            raw_name=raw_name,
+            size=record.uncompressed_size,
+            compressed_size=record.compressed_size,
+            modified=_filetime_to_datetime(record.last_write_time),
+            accessed=_filetime_to_datetime(record.last_access_time),
+            created=_filetime_to_datetime(record.creation_time),
+            mode=mode,
+            compression=compression,
+            is_encrypted=record.is_encrypted,
+            is_anti=record.is_anti,
+            is_current=is_current,
+            create_system=CreateSystem.UNIX
+            if unix_mode is not None
+            else CreateSystem.WINDOWS_NTFS,
+            windows_attrs=attrs & 0xFFFF if attrs is not None else None,
+            hashes=hashes,
+            extra=extra,
+            _raw=_MemberRaw(record, record.folder_index, record.file_in_folder),
+        )
+        emit_member_name_normalized(
+            self._diagnostics_collector,
+            member=member,
+            presented_name=record.filename,
+            archive_name=self._archive_name,
+        )
+        return member
+
+    def _member_type(self, record: SevenZipFileRecord) -> MemberType:
+        attrs = record.attributes
+        if attrs is not None:
+            unix_mode = attrs >> 16
+            if unix_mode:
+                if stat.S_ISLNK(unix_mode):
+                    return MemberType.SYMLINK
+                if stat.S_ISDIR(unix_mode):
+                    return MemberType.DIRECTORY
+            if attrs & _WINDOWS_FILE_ATTRIBUTE_REPARSE_POINT:
+                return MemberType.SYMLINK
+        if record.is_directory:
+            return MemberType.DIRECTORY
+        return MemberType.FILE
+
+    def _folder_coders(self, record: SevenZipFileRecord) -> tuple[SevenZipCoder, ...]:
+        if record.folder_index is None:
+            return ()
+        return tuple(self._archive.folders[record.folder_index].coders)
+
+    def _folder_pack_view(self, folder_index: int) -> BinaryIO:
+        folder = self._archive.folders[folder_index]
+        pack_count = len(folder.packed_indices)
+        if pack_count != 1:
+            raise UnsupportedFeatureError(
+                "7z folders with multiple packed streams are not supported"
+            )
+        pack_index = self._folder_pack_starts[folder_index]
+        if pack_index >= len(self._archive.pack_sizes):
+            raise CorruptionError("7z folder references a missing packed stream")
+        pack_offset = self._archive.pack_pos + self._archive.pack_positions[pack_index]
+        pack_size = self._archive.pack_sizes[pack_index]
+        return self._shared.view(pack_offset, pack_size)
+
+    def _folder_unpack_size(self, folder_index: int) -> int:
+        members = self._folder_members.get(folder_index, [])
+        return sum(_member_stream_size(member) for member in members)
+
+    def _open_folder_stream(
+        self, folder_index: int, member: ArchiveMember | None
+    ) -> BinaryIO:
+        folder = self._archive.folders[folder_index]
+        password = self._password_for_folder(folder_index, member)
+        return self._open_folder_pipeline(
+            self._folder_pack_view(folder_index),
+            folder,
+            password=password,
+        )
+
+    def _password_for_folder(
+        self, folder_index: int, member: ArchiveMember | None
+    ) -> bytes | None:
+        folder = self._archive.folders[folder_index]
+        if not folder_is_encrypted(folder):
+            return None
+        if folder_index in self._folder_passwords:
+            return self._folder_passwords[folder_index]
+
+        def confirm(password: bytes) -> bytes:
+            kdf_password = _password_to_kdf_bytes(password)
+            stream = self._open_folder_pipeline(
+                self._folder_pack_view(folder_index),
+                folder,
+                password=kdf_password,
+            )
+            try:
+                total = self._folder_unpack_size(folder_index)
+                decoded = read_exact(stream, total)
+                if len(decoded) != total:
+                    raise EncryptionError("Wrong password or corrupt 7z folder")
+                if folder.digest_defined:
+                    verifier = VerifyingStream(
+                        io.BytesIO(decoded),
+                        {"crc32": folder.crc if folder.crc is not None else 0},
+                        collector=self._diagnostics_collector,
+                        archive_name=self._archive_name,
+                    )
+                    verifier.read()
+                    verifier.read()
+                return kdf_password
+            except ArchiveyError as exc:
+                raise EncryptionError("Wrong password or corrupt 7z folder") from exc
+            finally:
+                stream.close()
+
+        try:
+            password = self._passwords.attempt(member, confirm)
+        except _PasswordCandidatesExhausted as exc:
+            raise EncryptionError(
+                "Password required to decrypt this 7z member"
+            ) from exc
+        self._folder_passwords[folder_index] = password
+        return password
+
+    def _open_folder_pipeline(
+        self,
+        source: BinaryIO,
+        folder: SevenZipFolder,
+        *,
+        password: bytes | None,
+    ) -> BinaryIO:
+        if any(
+            coder.num_in_streams != 1 or coder.num_out_streams != 1
+            for coder in folder.coders
+        ):
+            raise UnsupportedFeatureError(
+                "7z folders with complex coder graphs are not supported"
+            )
+        stream: BinaryIO = source
+        index = 0
+        while index < len(folder.coders):
+            coder = folder.coders[index]
+            if coder.method == _METHOD_BCJ2:
+                raise UnsupportedFeatureError(
+                    "BCJ2-compressed 7z folders are not supported"
+                )
+            if coder.method == _METHOD_COPY:
+                index += 1
+                continue
+            if coder.method == _METHOD_AES:
+                stream = self._open_aes_stage(stream, coder, password=password)
+                index += 1
+                continue
+            if _is_lzma_family(coder):
+                run: list[SevenZipCoder] = []
+                while index < len(folder.coders) and _is_lzma_family(
+                    folder.coders[index]
+                ):
+                    run.append(folder.coders[index])
+                    index += 1
+                stream = self._open_lzma_run(stream, run)
+                continue
+            codec = _SINGLE_STAGE_CODECS.get(coder.method)
+            if codec is None:
+                raise UnsupportedFeatureError(
+                    f"Unsupported 7z coder method {_method_hex(coder.method)}"
+                )
+            stream = open_codec_stream(
+                codec,
+                stream,
+                config=self._stream_config,
+                params=CodecParams(properties=coder.properties),
+                collector=self._diagnostics_collector,
+                seekable=False,
+            )
+            index += 1
+        return stream
+
+    def _open_aes_stage(
+        self,
+        source: BinaryIO,
+        coder: SevenZipCoder,
+        *,
+        password: bytes | None,
+    ) -> BinaryIO:
+        if password is None:
+            raise EncryptionError("Password required to decrypt this 7z folder")
+        if coder.properties is None:
+            raise CorruptionError("7z AES coder is missing properties")
+        try:
+            params = self._key_cache.aes_params_from_properties(
+                password, coder.properties
+            )
+        except ValueError as exc:
+            raise CorruptionError(f"Malformed 7z AES properties: {exc}") from exc
+        return open_aes_decrypt_stream(source, params)
+
+    def _open_lzma_run(self, source: BinaryIO, run: list[SevenZipCoder]) -> BinaryIO:
+        has_lzma1 = any(coder.method == _METHOD_LZMA for coder in run)
+        has_lzma2 = any(coder.method == _METHOD_LZMA2 for coder in run)
+        has_bcj = any(coder.method in _BCJ_METHODS for coder in run)
+        if has_lzma1 and has_lzma2:
+            raise UnsupportedFeatureError(
+                "Mixed LZMA1+LZMA2 7z coder chains are unsupported"
+            )
+        if has_lzma1 and has_bcj:
+            raise UnsupportedFeatureError("LZMA1+BCJ 7z coder chains are unsupported")
+        filters = [_lzma_filter(coder) for coder in reversed(run)]
+        codec = Codec.LZMA if has_lzma1 and not has_lzma2 else Codec.LZMA2
+        return open_codec_stream(
+            codec,
+            source,
+            config=self._stream_config,
+            params=CodecParams(filters=filters),
+            collector=self._diagnostics_collector,
+            seekable=False,
+        )
+
+    def _member_stream_from_folder(
+        self,
+        folder_stream: BinaryIO,
+        member: ArchiveMember,
+        *,
+        close_folder: bool = False,
+    ) -> ArchiveStream:
+        limited: BinaryIO = _LimitedFolderReader(
+            folder_stream,
+            _member_stream_size(member),
+            close_source=close_folder,
+        )
+        if member.hashes:
+            limited = VerifyingStream(
+                limited,
+                member.hashes,
+                collector=self._diagnostics_collector,
+                member=member,
+                archive_name=self._archive_name,
+            )
+        return self._wrap_member_stream(limited, member.name, size=member.size)
+
+    def _skip_folder_prefix(
+        self, folder_stream: BinaryIO, member: ArchiveMember
+    ) -> None:
+        raw = member._raw
+        assert isinstance(raw, _MemberRaw)
+        if raw.folder_index is None or raw.file_in_folder is None:
+            return
+        offset = 0
+        for prior in self._folder_members.get(raw.folder_index, [])[
+            : raw.file_in_folder
+        ]:
+            offset += _member_stream_size(prior)
+        while offset:
+            chunk = folder_stream.read(min(offset, 1024 * 1024))
+            if not chunk:
+                raise TruncatedError("7z folder ended before the requested member")
+            offset -= len(chunk)
+
+    def _ensure_link_target(self, member: ArchiveMember) -> None:
+        if member.type != MemberType.SYMLINK or member.link_target is not None:
+            return
+        try:
+            with self._open_member(member) as stream:
+                member.link_target = stream.read().decode(
+                    "utf-8", errors="surrogateescape"
+                )
+        except EncryptionError:
+            return
+
+    def _open_member(self, member: ArchiveMember) -> ArchiveStream:
+        raw = member._raw
+        assert isinstance(raw, _MemberRaw)
+        if member.is_anti or raw.folder_index is None:
+            return self._wrap_member_stream(
+                io.BytesIO(b""), member.name, size=member.size
+            )
+        folder_stream = self._open_folder_stream(raw.folder_index, member)
+        try:
+            self._skip_folder_prefix(folder_stream, member)
+            return self._member_stream_from_folder(
+                folder_stream, member, close_folder=True
+            )
+        except Exception:
+            folder_stream.close()
+            raise
+
+    def _get_archive_info(self) -> ArchiveInfo:
+        solid_blocks = sum(
+            1 for members in self._folder_members.values() if len(members) > 1
+        )
+        cost = CostReceipt(
+            listing_cost=ListingCost.INDEXED,
+            access_cost=AccessCost.SOLID
+            if self._archive.is_solid
+            else AccessCost.DIRECT,
+            stream_capability=StreamCapability.SEEKABLE,
+            solid_block_count=solid_blocks if self._archive.is_solid else None,
+        )
+        return ArchiveInfo(
+            format=ArchiveFormat.SEVEN_Z,
+            format_version=f"{self._archive.major_version}.{self._archive.minor_version}",
+            is_solid=self._archive.is_solid,
+            member_count=len(self._members),
+            comment=self._archive.comment,
+            is_encrypted=self._archive.is_header_encrypted
+            or self._archive.has_encrypted_folders,
+            is_multivolume=self._volume_count > 1,
+            cost=cost,
+            extra={"7z.volume_count": self._volume_count},
+        )
+
+    def _close_archive(self) -> None:
+        self._shared.close()
+
+
+class SevenZipReadBackend(ReadBackend):
+    """Backend factory for 7z archives."""
+
+    FORMATS: tuple[ArchiveFormat, ...] = (ArchiveFormat.SEVEN_Z,)
+    EXTENSIONS: Mapping[str, ArchiveFormat] = {".7z": ArchiveFormat.SEVEN_Z}
+    MAGIC: tuple[MagicSignature, ...] = (
+        MagicSignature(0, b"7z\xbc\xaf'\x1c", ArchiveFormat.SEVEN_Z),
+    )
+    SUPPORTS_PASSWORD = True
+    SUPPORTS_STREAMING_NON_SEEKABLE = False
+    OPTIONAL_DEPENDENCY = None
+
+    def open_read(
+        self,
+        source: Path | BinaryIO,
+        format: ArchiveFormat,
+        streaming: bool,
+        passwords: _PasswordCandidates | None,
+        encoding: str | None,
+        archive_name: str | None,
+        config: ArchiveyConfig,
+        collector: DiagnosticCollector | None = None,
+        member_streams: MemberStreams = MemberStreams(0),
+        open_site: OpenSite | None = None,
+    ) -> SevenZipReader:
+        del format
+        return SevenZipReader(
+            source,
+            streaming,
+            passwords,
+            encoding,
+            archive_name,
+            config,
+            collector=collector,
+            member_streams=member_streams,
+            open_site=open_site,
+        )
+
+
+register_reader(SevenZipReadBackend)

--- a/src/archivey/internal/backends/sevenzip_reader.py
+++ b/src/archivey/internal/backends/sevenzip_reader.py
@@ -14,6 +14,7 @@ from typing import BinaryIO
 
 from archivey.config import ArchiveyConfig
 from archivey.cost import AccessCost, CostReceipt, ListingCost, StreamCapability
+from archivey.diagnostics import DiagnosticCode, MemberTimestampContext
 from archivey.exceptions import (
     ArchiveyError,
     CorruptionError,
@@ -52,6 +53,7 @@ from archivey.internal.config import (
     stream_config_from_archivey,
 )
 from archivey.internal.diagnostics_collector import DiagnosticCollector
+from archivey.internal.logs import backends as logger
 from archivey.internal.naming import emit_member_name_normalized, normalize_member_name
 from archivey.internal.open_site import OpenSite
 from archivey.internal.password import (
@@ -133,16 +135,34 @@ def _password_to_kdf_bytes(password: bytes) -> bytes:
         return password
 
 
-def _filetime_to_datetime(value: int | None) -> datetime | None:
+@dataclass(frozen=True)
+class _TimestampIssue:
+    field: str
+    value_repr: str
+    message: str
+
+
+def _filetime_to_datetime(
+    value: int | None, filename: str, *, field: str
+) -> tuple[datetime | None, _TimestampIssue | None]:
+    """An NTFS FILETIME (100 ns ticks since 1601 UTC) as a datetime; 0/None means "unset"."""
     if value is None or value == 0:
-        return None
+        return None, None
     try:
-        return datetime.fromtimestamp(
-            value / 10_000_000 - _NTFS_EPOCH_OFFSET,
-            tz=timezone.utc,
+        return (
+            datetime.fromtimestamp(
+                value / 10_000_000 - _NTFS_EPOCH_OFFSET, tz=timezone.utc
+            ),
+            None,
         )
     except (ValueError, OverflowError, OSError):
-        return None
+        # fromtimestamp rejects out-of-range values with ValueError/OverflowError, and on
+        # some platforms (notably Windows) with OSError for negative/huge inputs.
+        return None, _TimestampIssue(
+            field=field,
+            value_repr=repr(value),
+            message=f"Invalid NTFS timestamp for {filename!r}: {value!r}",
+        )
 
 
 def _is_lzma_family(coder: SevenZipCoder) -> bool:
@@ -550,15 +570,27 @@ class SevenZipReader(BaseArchiveReader):
             extra["7z.folder_index"] = record.folder_index
         if record.file_in_folder is not None:
             extra["7z.file_in_folder"] = record.file_in_folder
+        ts_issues: list[_TimestampIssue] = []
+        timestamps: dict[str, datetime | None] = {}
+        for field, value in (
+            ("modified", record.last_write_time),
+            ("accessed", record.last_access_time),
+            ("created", record.creation_time),
+        ):
+            timestamps[field], issue = _filetime_to_datetime(
+                value, record.filename, field=field
+            )
+            if issue is not None:
+                ts_issues.append(issue)
         member = ArchiveMember(
             type=member_type,
             name=name,
             raw_name=raw_name,
             size=record.uncompressed_size,
             compressed_size=record.compressed_size,
-            modified=_filetime_to_datetime(record.last_write_time),
-            accessed=_filetime_to_datetime(record.last_access_time),
-            created=_filetime_to_datetime(record.creation_time),
+            modified=timestamps["modified"],
+            accessed=timestamps["accessed"],
+            created=timestamps["created"],
             mode=mode,
             compression=compression,
             is_encrypted=record.is_encrypted,
@@ -578,6 +610,22 @@ class SevenZipReader(BaseArchiveReader):
             presented_name=record.filename,
             archive_name=self._archive_name,
         )
+        for issue in ts_issues:
+            self._diagnostics_collector.emit(
+                code=DiagnosticCode.MEMBER_TIMESTAMP_INVALID,
+                message=issue.message,
+                context=MemberTimestampContext(
+                    archive_name=self._archive_name,
+                    member_name=member.name,
+                    member_id=member._member_id,
+                    field=issue.field,
+                    source="ntfs",
+                    value_repr=issue.value_repr,
+                ),
+                member=member,
+                attach_to_member=True,
+                logger=logger,
+            )
         return member
 
     def _member_type(self, record: SevenZipFileRecord) -> MemberType:

--- a/src/archivey/internal/backends/sevenzip_reader.py
+++ b/src/archivey/internal/backends/sevenzip_reader.py
@@ -71,12 +71,13 @@ from archivey.internal.streams.crypto import (
     open_aes_decrypt_stream,
 )
 from archivey.internal.streams.streamtools import (
-    ReadOnlyIOStream,
     SharedSource,
     SlicingStream,
+    SolidBlockReader,
     is_seekable,
     is_stream,
     read_exact,
+    skip_forward,
 )
 from archivey.internal.streams.verify import VerifyingStream
 from archivey.types import (
@@ -123,47 +124,6 @@ class _MemberRaw:
     record: SevenZipFileRecord
     folder_index: int | None
     file_in_folder: int | None
-
-
-class _LimitedFolderReader(ReadOnlyIOStream):
-    """A non-owning limited view over a decoded folder stream."""
-
-    def __init__(
-        self, source: BinaryIO, length: int, *, close_source: bool = False
-    ) -> None:
-        super().__init__()
-        self._source = source
-        self._length = length
-        self._remaining = length
-        self._close_source = close_source
-
-    def read(self, n: int = -1, /) -> bytes:
-        if self._remaining <= 0:
-            return b""
-        if n < 0 or n > self._remaining:
-            n = self._remaining
-        data = self._source.read(n)
-        self._remaining -= len(data)
-        return data
-
-    def tell(self) -> int:
-        return self._length - self._remaining
-
-    def close(self) -> None:
-        if self.closed:
-            return
-        try:
-            self.drain()
-        finally:
-            if self._close_source:
-                self._source.close()
-            super().close()
-
-    def drain(self) -> None:
-        while self._remaining > 0:
-            chunk = self.read(min(self._remaining, 1024 * 1024))
-            if not chunk:
-                break
 
 
 def _password_to_kdf_bytes(password: bytes) -> bytes:
@@ -269,6 +229,7 @@ def _open_lzma_run(
     *,
     stream_config: StreamConfig,
     collector: DiagnosticCollector | None,
+    seekable: bool,
 ) -> BinaryIO:
     has_lzma1 = any(coder.method == _METHOD_LZMA for coder in run)
     has_lzma2 = any(coder.method == _METHOD_LZMA2 for coder in run)
@@ -289,7 +250,7 @@ def _open_lzma_run(
         config=stream_config,
         params=CodecParams(filters=filters),
         collector=collector,
-        seekable=False,
+        seekable=seekable,
     )
 
 
@@ -301,6 +262,7 @@ def open_folder_pipeline(
     key_cache: SevenZipKeyCache,
     stream_config: StreamConfig | None = None,
     collector: DiagnosticCollector | None = None,
+    seekable: bool = False,
 ) -> BinaryIO:
     """Compose a folder's coder chain into a single pull stream.
 
@@ -308,6 +270,11 @@ def open_folder_pipeline(
     graphs raise ``UnsupportedFeatureError``. Consecutive LZMA-family coders (LZMA,
     LZMA2, Delta, BCJ) collapse into one liblzma filter chain; other codecs and the AES
     stage each wrap the stream once.
+
+    ``seekable`` requests a seekable decode (backward seeks re-decode from the folder
+    start, O(n)); it is the ArchiveStream seekability hint for the codec streams. Note an
+    AES stage yields a non-seekable stream regardless, so encrypted folders stay
+    forward-only — the caller checks ``is_seekable`` on the result.
     """
     if any(
         coder.num_in_streams != 1 or coder.num_out_streams != 1
@@ -341,7 +308,11 @@ def open_folder_pipeline(
                 run.append(folder.coders[index])
                 index += 1
             stream = _open_lzma_run(
-                stream, run, stream_config=config, collector=collector
+                stream,
+                run,
+                stream_config=config,
+                collector=collector,
+                seekable=seekable,
             )
             continue
         codec = _SINGLE_STAGE_CODECS.get(coder.method)
@@ -355,7 +326,7 @@ def open_folder_pipeline(
             config=config,
             params=CodecParams(properties=coder.properties),
             collector=collector,
-            seekable=False,
+            seekable=seekable,
         )
         index += 1
     return stream
@@ -509,8 +480,11 @@ class SevenZipReader(BaseArchiveReader):
         yield from self._members
 
     def _iter_with_data(self) -> Iterator[tuple[ArchiveMember, ArchiveStream | None]]:
+        # Solid folders decode once into a single forward-only stream; SolidBlockReader
+        # slices it into consecutive members and skips a prior member's unread tail
+        # lazily when the next member is opened (see streamtools/solid.py).
         current_folder: int | None = None
-        folder_stream: BinaryIO | None = None
+        solid: SolidBlockReader | None = None
         previous: ArchiveStream | None = None
         try:
             for member in self._members:
@@ -530,19 +504,21 @@ class SevenZipReader(BaseArchiveReader):
                     yield member, stream
                     continue
                 if raw.folder_index != current_folder:
-                    if folder_stream is not None:
-                        folder_stream.close()
+                    if solid is not None:
+                        solid.close()
                     current_folder = raw.folder_index
-                    folder_stream = self._open_folder_stream(raw.folder_index, member)
-                assert folder_stream is not None
-                member_stream = self._member_stream_from_folder(folder_stream, member)
+                    solid = SolidBlockReader(
+                        self._open_folder_stream(raw.folder_index, member)
+                    )
+                assert solid is not None
+                member_stream = self._member_stream_from_solid(solid, member)
                 previous = member_stream
                 yield member, member_stream
         finally:
             if previous is not None:
                 previous.close()
-            if folder_stream is not None:
-                folder_stream.close()
+            if solid is not None:
+                solid.close()
 
     def _to_member(
         self, record: SevenZipFileRecord, *, is_current: bool
@@ -643,7 +619,11 @@ class SevenZipReader(BaseArchiveReader):
         return sum(_member_stream_size(member) for member in members)
 
     def _open_folder_stream(
-        self, folder_index: int, member: ArchiveMember | None
+        self,
+        folder_index: int,
+        member: ArchiveMember | None,
+        *,
+        seekable: bool = False,
     ) -> BinaryIO:
         folder = self._archive.folders[folder_index]
         password = self._password_for_folder(folder_index, member)
@@ -651,6 +631,7 @@ class SevenZipReader(BaseArchiveReader):
             self._folder_pack_view(folder_index),
             folder,
             password=password,
+            seekable=seekable,
         )
 
     def _password_for_folder(
@@ -728,6 +709,7 @@ class SevenZipReader(BaseArchiveReader):
         folder: SevenZipFolder,
         *,
         password: bytes | None,
+        seekable: bool = False,
     ) -> BinaryIO:
         return open_folder_pipeline(
             source,
@@ -736,47 +718,41 @@ class SevenZipReader(BaseArchiveReader):
             key_cache=self._key_cache,
             stream_config=self._stream_config,
             collector=self._diagnostics_collector,
+            seekable=seekable,
         )
 
-    def _member_stream_from_folder(
-        self,
-        folder_stream: BinaryIO,
-        member: ArchiveMember,
-        *,
-        close_folder: bool = False,
+    def _member_prefix(self, member: ArchiveMember) -> int:
+        """Cumulative decoded size of the members preceding ``member`` in its folder."""
+        raw = member._raw
+        assert isinstance(raw, _MemberRaw)
+        if raw.folder_index is None or raw.file_in_folder is None:
+            return 0
+        prior = self._folder_members.get(raw.folder_index, [])[: raw.file_in_folder]
+        return sum(_member_stream_size(p) for p in prior)
+
+    def _wrap_folder_member(
+        self, inner: BinaryIO, member: ArchiveMember
     ) -> ArchiveStream:
-        limited: BinaryIO = _LimitedFolderReader(
-            folder_stream,
-            _member_stream_size(member),
-            close_source=close_folder,
-        )
         if member.hashes:
-            limited = VerifyingStream(
-                limited,
+            inner = VerifyingStream(
+                inner,
                 member.hashes,
                 collector=self._diagnostics_collector,
                 member=member,
                 archive_name=self._archive_name,
             )
-        return self._wrap_member_stream(limited, member.name, size=member.size)
+        return self._wrap_member_stream(inner, member.name, size=member.size)
 
-    def _skip_folder_prefix(
-        self, folder_stream: BinaryIO, member: ArchiveMember
-    ) -> None:
-        raw = member._raw
-        assert isinstance(raw, _MemberRaw)
-        if raw.folder_index is None or raw.file_in_folder is None:
-            return
-        offset = 0
-        for prior in self._folder_members.get(raw.folder_index, [])[
-            : raw.file_in_folder
-        ]:
-            offset += _member_stream_size(prior)
-        while offset:
-            chunk = folder_stream.read(min(offset, 1024 * 1024))
-            if not chunk:
-                raise TruncatedError("7z folder ended before the requested member")
-            offset -= len(chunk)
+    def _member_stream_from_solid(
+        self, solid: SolidBlockReader, member: ArchiveMember
+    ) -> ArchiveStream:
+        try:
+            inner = solid.open_member(
+                self._member_prefix(member), _member_stream_size(member)
+            )
+        except EOFError as exc:
+            raise TruncatedError("7z folder ended before the requested member") from exc
+        return self._wrap_folder_member(inner, member)
 
     def _ensure_link_target(self, member: ArchiveMember) -> None:
         if member.type != MemberType.SYMLINK or member.link_target is not None:
@@ -796,14 +772,36 @@ class SevenZipReader(BaseArchiveReader):
             return self._wrap_member_stream(
                 io.BytesIO(b""), member.name, size=member.size
             )
-        folder_stream = self._open_folder_stream(raw.folder_index, member)
+        # Random access re-decodes the folder from its start and slices out the member. The
+        # SlicingStream owns its private decoder (``own_source``) so closing the member stream
+        # closes the decoder. With MemberStreams.SEEKABLE and a seekable codec chain, hand back
+        # a seekable slice positioned at the member (backward seeks re-decode from the folder
+        # start, O(n)); otherwise skip forward and return a forward-only slice. VerifyingStream
+        # still checks the CRC on a pure forward read and disables itself once the caller seeks.
+        want_seekable = self._stream_config.seekable
+        prefix = self._member_prefix(member)
+        size = _member_stream_size(member)
+        folder_stream = self._open_folder_stream(
+            raw.folder_index, member, seekable=want_seekable
+        )
         try:
-            self._skip_folder_prefix(folder_stream, member)
-            return self._member_stream_from_folder(
-                folder_stream, member, close_folder=True
-            )
-        except Exception:
+            if want_seekable and is_seekable(folder_stream):
+                inner: BinaryIO = SlicingStream(
+                    folder_stream, start=prefix, length=size, own_source=True
+                )
+            else:
+                skip_forward(folder_stream, prefix)
+                inner = SlicingStream(folder_stream, length=size, own_source=True)
+        except EOFError as exc:
             folder_stream.close()
+            raise TruncatedError("7z folder ended before the requested member") from exc
+        except BaseException:
+            folder_stream.close()
+            raise
+        try:
+            return self._wrap_folder_member(inner, member)
+        except BaseException:
+            inner.close()
             raise
 
     def _get_archive_info(self) -> ArchiveInfo:

--- a/src/archivey/internal/base_reader.py
+++ b/src/archivey/internal/base_reader.py
@@ -832,6 +832,10 @@ class BaseArchiveReader(ArchiveReader):
         finally:
             self._state.release_pass(token)
 
+    def get_members(self) -> list[ArchiveMember]:
+        """Compatibility alias for callers expecting the v1-style member-list method."""
+        return self.members()
+
     def scan_members(self) -> list[ArchiveMember]:
         self._state.require_open("scan_members()")
         token = self._state.acquire_pass("scan_members")

--- a/src/archivey/internal/base_reader.py
+++ b/src/archivey/internal/base_reader.py
@@ -86,7 +86,7 @@ class ReadBackend(ABC):
     # Whether this backend's format has encryption a password could unlock. Checked
     # centrally by open_archive(): a password passed for a format that cannot use one is
     # API misuse and is rejected uniformly (backends never see it). ZIP sets this True;
-    # the native 7z/RAR readers (Phase 7) will too.
+    # the native 7z/RAR readers will too.
     SUPPORTS_PASSWORD: bool = False
     # Name of the optional dependency this backend needs (e.g. "pycdlib"); the registry
     # derives availability centrally from whether it imports. ``None`` for core backends.

--- a/src/archivey/internal/base_reader.py
+++ b/src/archivey/internal/base_reader.py
@@ -832,10 +832,6 @@ class BaseArchiveReader(ArchiveReader):
         finally:
             self._state.release_pass(token)
 
-    def get_members(self) -> list[ArchiveMember]:
-        """Compatibility alias for callers expecting the v1-style member-list method."""
-        return self.members()
-
     def scan_members(self) -> list[ArchiveMember]:
         self._state.require_open("scan_members()")
         token = self._state.acquire_pass("scan_members")

--- a/src/archivey/internal/extraction.py
+++ b/src/archivey/internal/extraction.py
@@ -25,6 +25,7 @@ import errno
 import logging
 import os
 import shutil
+import stat
 import tempfile
 import uuid
 from dataclasses import dataclass
@@ -279,13 +280,38 @@ class ExtractionCoordinator:
         results: list[ExtractionResult] = []
         # source member_id -> list of on-disk paths holding that source's content.
         source_paths: dict[int, list[Path]] = {}
+        written_paths: set[Path] = set()
         orphans: list[_Orphan] = []
         members_done = 0
 
         for original, stream in reader.stream_members(stream_selector):
             try:
+                if not original.is_current:
+                    results.append(
+                        ExtractionResult(original, None, ExtractionStatus.SKIPPED, None)
+                    )
+                    continue
                 transformed = self._transform(original, dest_root)
                 if transformed is not None:
+                    result_index = len(results)
+                    results.append(
+                        ExtractionResult(original, None, ExtractionStatus.FAILED, None)
+                    )
+                    if original.is_anti:
+                        results[result_index] = self._write_member(
+                            original,
+                            transformed,
+                            stream,
+                            dest,
+                            dest_root,
+                            tracker,
+                            source_paths,
+                            written_paths,
+                            orphans,
+                            forward_only,
+                            result_index,
+                        )
+                        continue
                     # Entry-count guard + ratio bookkeeping. Counted only once the
                     # selector and user filter have accepted the member (and the
                     # universal check inside _transform has passed), immediately before
@@ -294,10 +320,6 @@ class ExtractionCoordinator:
                     # (resolved 2026-07 decision).
                     tracker.start_member(original)
 
-                    result_index = len(results)
-                    results.append(
-                        ExtractionResult(original, None, ExtractionStatus.FAILED, None)
-                    )
                     results[result_index] = self._write_member(
                         original,
                         transformed,
@@ -306,6 +328,7 @@ class ExtractionCoordinator:
                         dest_root,
                         tracker,
                         source_paths,
+                        written_paths,
                         orphans,
                         forward_only,
                         result_index,
@@ -410,26 +433,36 @@ class ExtractionCoordinator:
         dest_root: Path,
         tracker: BombTracker,
         source_paths: dict[int, list[Path]],
+        written_paths: set[Path],
         orphans: list[_Orphan],
         forward_only: bool,
         result_index: int,
     ) -> ExtractionResult:
         dest_path = dest / transformed.name
 
+        if original.is_anti:
+            return self._apply_anti_item(original, dest_path, written_paths)
+
         if transformed.type == MemberType.DIRECTORY:
+            existed = os.path.lexists(dest_path)
             if not self._prepare_destination(transformed, dest_path):
                 return ExtractionResult(original, None, ExtractionStatus.SKIPPED, None)
             os.makedirs(dest_path, exist_ok=True)
             self._apply_metadata(dest_path, transformed)
+            if not existed:
+                written_paths.add(dest_path)
             return ExtractionResult(
                 original, dest_path, ExtractionStatus.EXTRACTED, None
             )
 
         if transformed.type == MemberType.SYMLINK:
-            return self._write_symlink(original, transformed, dest_root, dest_path)
+            result = self._write_symlink(original, transformed, dest_root, dest_path)
+            if result.status is ExtractionStatus.EXTRACTED and result.path is not None:
+                written_paths.add(result.path)
+            return result
 
         if transformed.type == MemberType.HARDLINK:
-            return self._write_hardlink(
+            result = self._write_hardlink(
                 original,
                 transformed,
                 dest_path,
@@ -438,16 +471,46 @@ class ExtractionCoordinator:
                 forward_only,
                 result_index,
             )
+            if result.status is ExtractionStatus.EXTRACTED and result.path is not None:
+                written_paths.add(result.path)
+            return result
 
         if transformed.type == MemberType.FILE:
-            return self._write_file(
+            result = self._write_file(
                 original, transformed, stream, dest_path, tracker, source_paths
             )
+            if result.status is ExtractionStatus.EXTRACTED and result.path is not None:
+                written_paths.add(result.path)
+            return result
 
         # MemberType.OTHER is rejected by check_universal; nothing else should reach here.
         raise ExtractionError(
             f"Unsupported member type {transformed.type!r} for {transformed.name!r}"
         )
+
+    def _apply_anti_item(
+        self,
+        original: ArchiveMember,
+        dest_path: Path,
+        written_paths: set[Path],
+    ) -> ExtractionResult:
+        if dest_path not in written_paths:
+            return ExtractionResult(
+                original, dest_path, ExtractionStatus.EXTRACTED, None
+            )
+        try:
+            st = os.lstat(dest_path)
+        except FileNotFoundError:
+            written_paths.discard(dest_path)
+            return ExtractionResult(
+                original, dest_path, ExtractionStatus.EXTRACTED, None
+            )
+        if stat.S_ISDIR(st.st_mode):
+            os.rmdir(dest_path)
+        else:
+            os.unlink(dest_path)
+        written_paths.discard(dest_path)
+        return ExtractionResult(original, dest_path, ExtractionStatus.EXTRACTED, None)
 
     def _write_file(
         self,

--- a/src/archivey/internal/registry.py
+++ b/src/archivey/internal/registry.py
@@ -84,6 +84,12 @@ class FormatAvailability:
 # This table describes the intended post-Phase-7 composition, where the codec layer is
 # wired into ZIP member reads (see ``format-zip`` / ``compressed-streams``).
 _CONTAINER_OPTIONAL_CODECS: dict[ContainerFormat, tuple[Codec, ...]] = {
+    ContainerFormat.SEVEN_Z: (
+        Codec.PPMD,
+        Codec.DEFLATE64,
+        Codec.ZSTD,
+        Codec.BROTLI,
+    ),
     ContainerFormat.ZIP: (Codec.DEFLATE64, Codec.ZSTD, Codec.PPMD),
 }
 

--- a/src/archivey/internal/streams/codecs.py
+++ b/src/archivey/internal/streams/codecs.py
@@ -45,6 +45,7 @@ from archivey.internal.streams.archive_stream import (
 )
 from archivey.internal.streams.decompress import (
     BrotliDecompressorStream,
+    Deflate64DecompressorStream,
     PpmdDecompressorStream,
     ZlibDecompressorStream,
 )
@@ -1023,7 +1024,7 @@ class Deflate64Codec(StreamCodec):
                 "The 'inflate64' package is required for Deflate64 streams "
                 "(install the '7z' extra)."
             )
-        return ensure_binaryio(_inflate64.Inflate64File(ensure_bufferedio(source)))
+        return Deflate64DecompressorStream(source)
 
     def translate(self, exc: Exception) -> ArchiveyError | None:
         if isinstance(exc, EOFError):

--- a/src/archivey/internal/streams/codecs.py
+++ b/src/archivey/internal/streams/codecs.py
@@ -45,6 +45,7 @@ from archivey.internal.streams.archive_stream import (
 )
 from archivey.internal.streams.decompress import (
     BrotliDecompressorStream,
+    PpmdDecompressorStream,
     ZlibDecompressorStream,
 )
 from archivey.internal.streams.lzip import LzipDecompressorStream
@@ -158,7 +159,7 @@ class Codec(Enum):
 
     Single-file/TAR stream formats and 7z/ZIP folder coders both resolve to these.
     Filter-only entries (Delta, the BCJ family) are not opened standalone — they compose
-    into a raw-LZMA filter chain (built by the 7z reader in Phase 7); their LZMA filter ids
+    into a raw-LZMA filter chain (built by the 7z reader); their LZMA filter ids
     are recorded in :data:`LZMA_FILTER_IDS`.
     """
 
@@ -205,9 +206,11 @@ class CodecParams:
 
     - ``filters`` — the ``lzma`` raw filter chain (required for raw LZMA1/LZMA2; this is
       where Delta/BCJ stages and the coder properties enter).
+    - ``properties`` — raw coder properties blob (e.g. 7z PPMd var.H parameters).
     """
 
     filters: list[dict] | None = None
+    properties: bytes | None = None
 
 
 _DEFAULT_PARAMS = CodecParams()
@@ -959,6 +962,23 @@ class UnixCompressCodec(StreamCodec):
         return None
 
 
+def _parse_ppmd_var_h_properties(properties: bytes | None) -> tuple[int, int]:
+    """Parse 7z PPMd var.H coder properties → ``(order, mem_size)``."""
+    import struct
+
+    if properties is None:
+        raise ValueError("PPMd requires coder properties (order + mem size)")
+    if len(properties) == 5:
+        order, mem = struct.unpack("<BL", properties)
+    elif len(properties) == 7:
+        order, mem, _, _ = struct.unpack("<BLBB", properties)
+    else:
+        raise ValueError(
+            f"unsupported PPMd properties length {len(properties)} (expected 5 or 7)"
+        )
+    return int(order), int(mem)
+
+
 class PpmdCodec(StreamCodec):
     codec = Codec.PPMD
     requirement = MissingComponent("pyppmd", "pip install archivey[7z]", ("ppmd",))
@@ -973,16 +993,15 @@ class PpmdCodec(StreamCodec):
             raise PackageNotInstalledError(
                 "The 'pyppmd' package is required for PPMd streams (install the '7z' extra)."
             )
-        # The concrete PPMd stream construction (var.H parameters from the 7z coder) lands with
-        # the native 7z reader in Phase 7; the resolver + missing-backend gating are complete.
-        raise NotImplementedError(
-            "PPMd decoding is implemented in Phase 7 (native 7z reader)"
-        )
+        order, mem_size = _parse_ppmd_var_h_properties(params.properties)
+        return PpmdDecompressorStream(source, order=order, mem_size=mem_size)
 
     def translate(self, exc: Exception) -> ArchiveyError | None:
         if isinstance(exc, EOFError):
             return TruncatedError(f"PPMd stream is truncated: {exc!r}")
         if isinstance(exc, ValueError):
+            return CorruptionError(f"Error reading PPMd stream: {exc!r}")
+        if _pyppmd is not None and isinstance(exc, getattr(_pyppmd, "PpmdError", ())):
             return CorruptionError(f"Error reading PPMd stream: {exc!r}")
         return None
 

--- a/src/archivey/internal/streams/crypto.py
+++ b/src/archivey/internal/streams/crypto.py
@@ -143,7 +143,9 @@ class AesDecryptStream(ReadOnlyIOStream):
         if size == 0:
             return b""
         while not self._eof and (size < 0 or len(self._buf) < size):
-            chunk = self._source.read(65536 if size < 0 else max(size - len(self._buf), 1))
+            chunk = self._source.read(
+                65536 if size < 0 else max(size - len(self._buf), 1)
+            )
             if not chunk:
                 self._buf.extend(self._stage.finalize())
                 self._eof = True
@@ -171,9 +173,7 @@ def open_aes_decrypt_stream(source: BinaryIO, params: AesParams) -> BinaryIO:
 # --- 7z-local KDF (not on the generic CryptoBackend surface) ---------------------------
 
 
-def derive_sevenzip_aes_key(
-    password: bytes, *, salt: bytes, cycles: int
-) -> bytes:
+def derive_sevenzip_aes_key(password: bytes, *, salt: bytes, cycles: int) -> bytes:
     """Derive a 32-byte AES-256 key with the 7z SHA-256 scheme.
 
     ``password`` is the raw password bytes already encoded as UTF-16LE (callers that

--- a/src/archivey/internal/streams/crypto.py
+++ b/src/archivey/internal/streams/crypto.py
@@ -184,8 +184,8 @@ def derive_sevenzip_aes_key(password: bytes, *, salt: bytes, cycles: int) -> byt
     if cycles < 0 or cycles > 0x3F:
         raise ValueError(f"NumCyclesPower out of range: {cycles}")
     if cycles == 0x3F:
-        ba = bytearray(salt + password + bytes(32))
-        return bytes(ba[:32])
+        # The 0x3f sentinel means "no hashing": key = (salt + password), zero-padded to 32.
+        return (salt + password + bytes(32))[:32]
     # Batch rounds to cut hashlib.update call overhead (same approach as py7zr).
     cat_cycle = 6
     if cycles > cat_cycle:

--- a/src/archivey/internal/streams/crypto.py
+++ b/src/archivey/internal/streams/crypto.py
@@ -6,21 +6,22 @@ internal abstraction so format parsers never import ``cryptography`` directly an
 backend stays swappable. AES decryption is modelled as a *stage* that composes ahead of a
 decompressor in a pipeline (e.g. AES → LZMA2 for an encrypted 7z folder).
 
-Phase 2 builds the **interface** and the missing-dependency behaviour only. The concrete
-AES-CBC decryptor (and the 7z/RAR key derivation that feeds it) lands in Phase 7, where it
-is exercised end-to-end; until then ``AesParams``-driven decryption raises a clear
-"not yet implemented" error while the wrapper boundary and the ``[crypto]`` gating are
-already real and tested.
+The format-agnostic AES-CBC decrypt stage lives here. The 7z SHA-256 KDF is 7z-specific
+(RAR and WinZip-AES derive keys differently), so it lives as a local helper beside this
+module rather than on the generic ``CryptoBackend`` surface — see
+:func:`derive_sevenzip_aes_key` and :class:`SevenZipKeyCache`.
 """
 
 from __future__ import annotations
 
+import hashlib
 import importlib.util
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
-from typing import Protocol
+from dataclasses import dataclass, field
+from typing import BinaryIO, Protocol
 
 from archivey.exceptions import PackageNotInstalledError
+from archivey.internal.streams.streamtools import ReadOnlyIOStream
 
 # The package name surfaced to users (matches the [crypto] extra).
 CRYPTO_PACKAGE = "cryptography"
@@ -52,16 +53,52 @@ class CryptoBackend(ABC):
         ...
 
 
+class _CryptographyDecryptStage:
+    """AES-256-CBC decrypt stage backed by ``cryptography`` Cipher."""
+
+    def __init__(self, params: AesParams) -> None:
+        # Local import: format parsers never import cryptography; only this wrapper does.
+        from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+
+        if len(params.key) not in (16, 24, 32):
+            raise ValueError(
+                f"AES key must be 16, 24, or 32 bytes, got {len(params.key)}"
+            )
+        if len(params.iv) != 16:
+            raise ValueError(f"AES-CBC IV must be 16 bytes, got {len(params.iv)}")
+        cipher = Cipher(algorithms.AES(params.key), modes.CBC(params.iv))
+        self._decryptor = cipher.decryptor()
+        self._buf = bytearray()
+
+    def update(self, data: bytes) -> bytes:
+        if not data:
+            return b""
+        self._buf.extend(data)
+        # CBC requires 16-byte blocks; hold a partial trailing block until finalize.
+        n = len(self._buf) & ~0x0F
+        if n == 0:
+            return b""
+        block = bytes(self._buf[:n])
+        del self._buf[:n]
+        return self._decryptor.update(block)
+
+    def finalize(self) -> bytes:
+        if self._buf:
+            # Pad remaining ciphertext to a full block with zeros (7z AES convention).
+            padlen = (-len(self._buf)) & 15
+            self._buf.extend(bytes(padlen))
+            out = self._decryptor.update(bytes(self._buf))
+            self._buf.clear()
+            out += self._decryptor.finalize()
+            return out
+        return self._decryptor.finalize()
+
+
 class _CryptographyBackend(CryptoBackend):
     name = CRYPTO_PACKAGE
 
     def aes_cbc_decrypt_stage(self, params: AesParams) -> DecryptStage:
-        # Deferred to Phase 7 (native 7z/RAR), where the key derivation that produces
-        # AesParams also lands and the stage is exercised end-to-end. The wrapper and the
-        # [crypto] gating below are complete now.
-        raise NotImplementedError(
-            "AES decryption is implemented in Phase 7 (native 7z/RAR readers)"
-        )
+        return _CryptographyDecryptStage(params)
 
 
 def _crypto_available() -> bool:
@@ -90,3 +127,134 @@ def get_crypto_backend() -> CryptoBackend:
 def open_aes_decrypt_stage(params: AesParams) -> DecryptStage:
     """Convenience: resolve the crypto backend and build an AES-CBC decrypt stage."""
     return get_crypto_backend().aes_cbc_decrypt_stage(params)
+
+
+class AesDecryptStream(ReadOnlyIOStream):
+    """Pull ``BinaryIO`` that decrypts an underlying ciphertext stream via AES-CBC."""
+
+    def __init__(self, source: BinaryIO, stage: DecryptStage) -> None:
+        super().__init__()
+        self._source = source
+        self._stage = stage
+        self._buf = bytearray()
+        self._eof = False
+
+    def read(self, size: int = -1) -> bytes:
+        if size == 0:
+            return b""
+        while not self._eof and (size < 0 or len(self._buf) < size):
+            chunk = self._source.read(65536 if size < 0 else max(size - len(self._buf), 1))
+            if not chunk:
+                self._buf.extend(self._stage.finalize())
+                self._eof = True
+                break
+            self._buf.extend(self._stage.update(chunk))
+        if size < 0:
+            out = bytes(self._buf)
+            self._buf.clear()
+            return out
+        out = bytes(self._buf[:size])
+        del self._buf[:size]
+        return out
+
+    def close(self) -> None:
+        if not self.closed:
+            self._source.close()
+        super().close()
+
+
+def open_aes_decrypt_stream(source: BinaryIO, params: AesParams) -> BinaryIO:
+    """Wrap ``source`` in an AES-CBC decrypt stream using the shared crypto backend."""
+    return AesDecryptStream(source, open_aes_decrypt_stage(params))
+
+
+# --- 7z-local KDF (not on the generic CryptoBackend surface) ---------------------------
+
+
+def derive_sevenzip_aes_key(
+    password: bytes, *, salt: bytes, cycles: int
+) -> bytes:
+    """Derive a 32-byte AES-256 key with the 7z SHA-256 scheme.
+
+    ``password`` is the raw password bytes already encoded as UTF-16LE (callers that
+    hold a ``str`` should encode first). ``cycles`` is ``NumCyclesPower`` from the AES
+    coder properties (``0..0x3f``). The ``0x3f`` special case copies salt+password into
+    a 32-byte key without hashing.
+    """
+    if cycles < 0 or cycles > 0x3F:
+        raise ValueError(f"NumCyclesPower out of range: {cycles}")
+    if cycles == 0x3F:
+        ba = bytearray(salt + password + bytes(32))
+        return bytes(ba[:32])
+    # Batch rounds to cut hashlib.update call overhead (same approach as py7zr).
+    cat_cycle = 6
+    if cycles > cat_cycle:
+        rounds = 1 << cat_cycle
+        stages = 1 << (cycles - cat_cycle)
+    else:
+        rounds = 1 << cycles
+        stages = 1
+    digest = hashlib.sha256()
+    salt_password = salt + password
+    s = 0
+    for _ in range(stages):
+        digest.update(
+            b"".join(
+                salt_password + (s + i).to_bytes(8, "little") for i in range(rounds)
+            )
+        )
+        s += rounds
+    return digest.digest()
+
+
+def parse_sevenzip_aes_properties(properties: bytes) -> tuple[int, bytes, bytes]:
+    """Parse 7z AES coder properties → ``(num_cycles_power, salt, iv)``.
+
+    Raises ``ValueError`` when the property blob is malformed.
+    """
+    if not properties:
+        raise ValueError("empty 7z AES properties")
+    first = properties[0]
+    cycles = first & 0x3F
+    if first & 0xC0 == 0:
+        raise ValueError("7z AES properties missing salt/IV flags")
+    salt_size = (first >> 7) & 1
+    iv_size = (first >> 6) & 1
+    if len(properties) < 2:
+        raise ValueError("truncated 7z AES properties")
+    second = properties[1]
+    salt_size += second >> 4
+    iv_size += second & 0x0F
+    expected = 2 + salt_size + iv_size
+    if len(properties) != expected:
+        raise ValueError(
+            f"7z AES properties length {len(properties)} != expected {expected}"
+        )
+    salt = properties[2 : 2 + salt_size]
+    iv = properties[2 + salt_size : 2 + salt_size + iv_size]
+    if len(iv) < 16:
+        iv = iv + bytes(16 - len(iv))
+    return cycles, salt, iv
+
+
+@dataclass
+class SevenZipKeyCache:
+    """Cache derived 7z AES keys keyed by ``(password, salt, cycles)`` for one reader."""
+
+    _cache: dict[tuple[bytes, bytes, int], bytes] = field(default_factory=dict)
+
+    def derive(self, password: bytes, *, salt: bytes, cycles: int) -> bytes:
+        key = (password, salt, cycles)
+        cached = self._cache.get(key)
+        if cached is not None:
+            return cached
+        derived = derive_sevenzip_aes_key(password, salt=salt, cycles=cycles)
+        self._cache[key] = derived
+        return derived
+
+    def aes_params_from_properties(
+        self, password: bytes, properties: bytes
+    ) -> AesParams:
+        cycles, salt, iv = parse_sevenzip_aes_properties(properties)
+        key = self.derive(password, salt=salt, cycles=cycles)
+        return AesParams(key=key, iv=iv)

--- a/src/archivey/internal/streams/decompress.py
+++ b/src/archivey/internal/streams/decompress.py
@@ -70,3 +70,41 @@ class BrotliDecompressorStream(DecompressorStream[Any]):
 
     def _is_decompressor_finished(self) -> bool:
         return self._decompressor.is_finished()
+
+
+class PpmdDecompressorStream(DecompressorStream[Any]):
+    """Decode a PPMd var.H stream via ``pyppmd.Ppmd7Decoder``.
+
+    Forward-only. ``order`` / ``mem_size`` come from the 7z coder properties blob
+    (5 or 7 bytes). The ``pyppmd`` import is local — the codec layer gates presence
+    before constructing this stream.
+    """
+
+    def __init__(
+        self,
+        path: str | os.PathLike[str] | BinaryIO,
+        *,
+        order: int,
+        mem_size: int,
+    ) -> None:
+        self._order = order
+        self._mem_size = mem_size
+        super().__init__(path, codec_name="ppmd")
+
+    def _create_decompressor(self, point: SeekPoint) -> Any:
+        import pyppmd
+
+        return pyppmd.Ppmd7Decoder(self._order, self._mem_size)
+
+    def _decompress_chunk(self, chunk: bytes) -> bytes:
+        return self._decompressor.decode(chunk)
+
+    def _flush_decompressor(self) -> bytes:
+        # 7z PPMd streams sometimes need a trailing NUL to finish when the decoder
+        # still reports needs_input at EOF (mirrors py7zr's PpmdDecompressor).
+        if getattr(self._decompressor, "needs_input", False) and not self._decompressor.eof:
+            return self._decompressor.decode(b"\0")
+        return b""
+
+    def _is_decompressor_finished(self) -> bool:
+        return bool(self._decompressor.eof)

--- a/src/archivey/internal/streams/decompress.py
+++ b/src/archivey/internal/streams/decompress.py
@@ -102,7 +102,10 @@ class PpmdDecompressorStream(DecompressorStream[Any]):
     def _flush_decompressor(self) -> bytes:
         # 7z PPMd streams sometimes need a trailing NUL to finish when the decoder
         # still reports needs_input at EOF (mirrors py7zr's PpmdDecompressor).
-        if getattr(self._decompressor, "needs_input", False) and not self._decompressor.eof:
+        if (
+            getattr(self._decompressor, "needs_input", False)
+            and not self._decompressor.eof
+        ):
             return self._decompressor.decode(b"\0")
         return b""
 

--- a/src/archivey/internal/streams/decompress.py
+++ b/src/archivey/internal/streams/decompress.py
@@ -111,3 +111,28 @@ class PpmdDecompressorStream(DecompressorStream[Any]):
 
     def _is_decompressor_finished(self) -> bool:
         return bool(self._decompressor.eof)
+
+
+class Deflate64DecompressorStream(DecompressorStream[Any]):
+    """Decode a Deflate64 stream via ``inflate64.Inflater``.
+
+    Forward-only. The ``inflate64`` package exposes an incremental ``Inflater``
+    (``inflate()`` / ``eof``) with no file-like open — same shape as Brotli/PPMd.
+    """
+
+    def _create_decompressor(self, point: SeekPoint) -> Any:
+        import inflate64
+
+        return inflate64.Inflater()
+
+    def _decompress_chunk(self, chunk: bytes) -> bytes:
+        return self._decompressor.inflate(chunk)
+
+    def _flush_decompressor(self) -> bytes:
+        # Flush remaining state with an empty feed (mirrors py7zr's Deflate64Decompressor).
+        if self._decompressor.eof:
+            return b""
+        return self._decompressor.inflate(b"")
+
+    def _is_decompressor_finished(self) -> bool:
+        return bool(self._decompressor.eof)

--- a/src/archivey/internal/streams/decompress.py
+++ b/src/archivey/internal/streams/decompress.py
@@ -97,7 +97,7 @@ class PpmdDecompressorStream(DecompressorStream[Any]):
         return pyppmd.Ppmd7Decoder(self._order, self._mem_size)
 
     def _decompress_chunk(self, chunk: bytes) -> bytes:
-        return self._decompressor.decode(chunk)
+        return self._decompressor.decode(chunk, -1)
 
     def _flush_decompressor(self) -> bytes:
         # 7z PPMd streams sometimes need a trailing NUL to finish when the decoder
@@ -106,7 +106,7 @@ class PpmdDecompressorStream(DecompressorStream[Any]):
             getattr(self._decompressor, "needs_input", False)
             and not self._decompressor.eof
         ):
-            return self._decompressor.decode(b"\0")
+            return self._decompressor.decode(b"\0", -1)
         return b""
 
     def _is_decompressor_finished(self) -> bool:

--- a/src/archivey/internal/streams/streamtools/__init__.py
+++ b/src/archivey/internal/streams/streamtools/__init__.py
@@ -33,6 +33,10 @@ from archivey.internal.streams.streamtools.slice import (
     SlicingStream,
     fix_stream_start_position,
 )
+from archivey.internal.streams.streamtools.solid import (
+    SolidBlockReader,
+    skip_forward,
+)
 
 __all__ = [
     "BinaryIOWrapper",
@@ -42,6 +46,7 @@ __all__ = [
     "ReadableStream",
     "SharedSource",
     "SlicingStream",
+    "SolidBlockReader",
     "ensure_binaryio",
     "ensure_bufferedio",
     "fix_stream_start_position",
@@ -49,6 +54,7 @@ __all__ = [
     "is_seekable",
     "is_stream",
     "read_exact",
+    "skip_forward",
     "source_byte_size",
     "source_name",
 ]

--- a/src/archivey/internal/streams/streamtools/slice.py
+++ b/src/archivey/internal/streams/streamtools/slice.py
@@ -49,10 +49,12 @@ class SlicingStream(ReadOnlyIOStream):
 
     It is a :class:`ReadOnlyIOStream`, not a :class:`DelegatingStream`: every operation is
     *transformed*, not forwarded — ``read`` clamps to the slice bounds, and ``seek``/``tell``
-    are relative to the slice start, not the underlying offset. And critically it is a
-    *non-owning view*: it must NOT close the underlying stream (the container owns it), whereas
+    are relative to the slice start, not the underlying offset. And by default it is a
+    *non-owning view*: it does NOT close the underlying stream (the container owns it), whereas
     ``DelegatingStream.close`` closes its inner. So delegation would be both useless (almost
-    everything is overridden) and unsafe (the close default).
+    everything is overridden) and unsafe (the close default). The opt-in ``own_source`` flag
+    flips just the close behaviour for the case where the view is the sole owner of a private
+    underlying stream (e.g. a per-member decoder); it never applies to a ``SharedSource`` view.
 
     It also does not expose ``name``: a slice view remaps the origin, so forwarding the
     underlying path would mislead libraries that reopen or stat by ``stream.name``.
@@ -66,9 +68,15 @@ class SlicingStream(ReadOnlyIOStream):
         *,
         lock: ContextManager[object] | None = None,
         check_open: Callable[[], None] | None = None,
+        own_source: bool = False,
     ) -> None:
         super().__init__()
         self._stream = stream
+        # A view is non-owning by default (never closes the underlying — the container
+        # owns it). ``own_source=True`` is the opt-in for the case where this view is the
+        # sole owner of a private underlying stream (e.g. a per-member decoder opened just
+        # for this slice) that should be closed together with the view.
+        self._own_source = own_source
         self._seekable = is_seekable(stream)
         # Split lock into the I/O guard and the re-seek policy so the latter can later
         # be engaged without a lock (e.g. a single-consumer view that still re-seeks).
@@ -175,8 +183,11 @@ class SlicingStream(ReadOnlyIOStream):
         return self._seekable
 
     def close(self) -> None:
-        # Non-owning: mark this view closed only; never close the underlying stream.
+        # Non-owning by default: mark this view closed only. With ``own_source`` the view
+        # owns a private underlying stream and closes it too.
         if not self.closed:
+            if self._own_source:
+                self._stream.close()
             super().close()
 
     @property

--- a/src/archivey/internal/streams/streamtools/solid.py
+++ b/src/archivey/internal/streams/streamtools/solid.py
@@ -1,0 +1,120 @@
+"""Demultiplex one forward-only decoded stream into consecutive member sub-streams.
+
+A *solid block* — a 7z folder, or a RAR ``unrar p`` pipe — decodes to a single
+forward-only (often non-seekable) byte stream whose members occupy consecutive,
+known-size ranges. :class:`SolidBlockReader` owns that stream and hands out one member
+sub-stream at a time, skipping forward **lazily**: the gap before a member (a preceding
+member's unread tail, or an inter-member gap) is consumed only when the *next* member is
+opened, so closing a member the caller never advances past costs nothing. Closing the
+reader closes the block without draining.
+
+This is the sequential/iteration primitive. Random access into a solid block is served
+differently (a seekable slice over a seekable decode), so this class is deliberately
+forward-only and does not seek.
+
+Like the rest of ``streamtools`` this module knows nothing about archivey's error
+hierarchy: a truncated block surfaces as a plain :class:`EOFError` for the caller to
+translate into a format-specific error.
+"""
+
+from __future__ import annotations
+
+from typing import BinaryIO
+
+from archivey.internal.streams.streamtools.base import ReadOnlyIOStream
+
+_SKIP_CHUNK = 1 << 20  # 1 MiB
+
+
+def skip_forward(stream: BinaryIO, count: int) -> None:
+    """Read and discard exactly ``count`` bytes from a forward-only ``stream``.
+
+    Raises :class:`EOFError` if the stream ends before ``count`` bytes are consumed.
+    """
+    while count > 0:
+        chunk = stream.read(min(count, _SKIP_CHUNK))
+        if not chunk:
+            raise EOFError("stream ended before the requested position")
+        count -= len(chunk)
+
+
+class _MemberSlice(ReadOnlyIOStream):
+    """One member's forward-only view over its owning reader's block stream.
+
+    Non-owning: closing a member slice never closes the shared block — the
+    :class:`SolidBlockReader` owns that. Reads are bounded to the member's declared size
+    and flow through the reader so it always knows the block's position.
+    """
+
+    def __init__(self, reader: SolidBlockReader, size: int) -> None:
+        super().__init__()
+        self._reader = reader
+        self._size = size
+        self._remaining = size
+
+    def read(self, n: int = -1, /) -> bytes:
+        if self._remaining <= 0:
+            return b""
+        if n < 0 or n > self._remaining:
+            n = self._remaining
+        data = self._reader._consume(n)
+        self._remaining -= len(data)
+        return data
+
+    def tell(self) -> int:
+        return self._size - self._remaining
+
+
+class SolidBlockReader:
+    """Vend consecutive member sub-streams over one forward-only decoded block.
+
+    ``open_member(offset, size)`` returns a forward-only stream for the member occupying
+    ``[offset, offset + size)`` of the decoded block. Members must be opened in
+    non-decreasing ``offset`` order; the reader skips forward from its current position to
+    ``offset`` lazily, at open time, so a partially-read (or unread) member costs nothing
+    until the next one is requested. Only one member is active at a time.
+    """
+
+    def __init__(self, block: BinaryIO, *, close_block: bool = True) -> None:
+        self._block = block
+        self._close_block = close_block
+        self._pos = 0  # bytes consumed from the block so far
+        self._current: _MemberSlice | None = None
+        self._closed = False
+
+    def open_member(self, offset: int, size: int) -> BinaryIO:
+        if self._closed:
+            raise ValueError("SolidBlockReader is closed")
+        if offset < self._pos:
+            raise ValueError(
+                f"solid members must be opened in order: offset {offset} < position "
+                f"{self._pos}"
+            )
+        # Finalize the previous member and jump the gap in one forward skip. This is where
+        # a prior member's unread tail is actually consumed (lazy drain).
+        self._current = None
+        skip_forward(self._block, offset - self._pos)
+        self._pos = offset
+        slice_ = _MemberSlice(self, size)
+        self._current = slice_
+        return slice_
+
+    def _consume(self, n: int) -> bytes:
+        data = self._block.read(n)
+        self._pos += len(data)
+        return data
+
+    def close(self) -> None:
+        # No draining: whatever is left in the block is discarded with it.
+        if self._closed:
+            return
+        self._closed = True
+        self._current = None
+        if self._close_block:
+            self._block.close()
+
+    def __enter__(self) -> SolidBlockReader:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()

--- a/src/archivey/internal/streams/verify.py
+++ b/src/archivey/internal/streams/verify.py
@@ -161,6 +161,9 @@ class VerifyingStream(ReadOnlyIOStream):
     def seekable(self) -> bool:
         return False
 
+    def tell(self) -> int:
+        return self._inner.tell()
+
     def close(self) -> None:
         if not self.closed:
             self._inner.close()

--- a/src/archivey/internal/streams/verify.py
+++ b/src/archivey/internal/streams/verify.py
@@ -14,6 +14,9 @@ digests (``ArchiveMember.hashes``) against the bytes actually read. Per the
 - An algorithm whose backend is missing (or that is unknown) is **skipped with a
   ``DIGEST_UNVERIFIABLE`` diagnostic** rather than failing the read; algorithms that can
   be computed (always including CRC32 via stdlib) are still verified.
+- ``close()`` also verifies when the inner stream is already at clean EOF, so a single
+  ``read()`` that consumed the whole member (as ``ArchiveReader.read`` does) still
+  checks digests.
 
 This is distinct from a codec's own internal integrity check (gzip trailer CRC, xz stream
 check) — those are surfaced by the codec backend; this verifies the *container's* digest
@@ -166,5 +169,10 @@ class VerifyingStream(ReadOnlyIOStream):
 
     def close(self) -> None:
         if not self.closed:
+            # ``archive.read()`` often does a single ``read()`` that returns all
+            # bytes without a follow-up empty read, so verify here when the inner
+            # stream is already at clean EOF (partial reads still skip verification).
+            if not self._verified and not self._inner.read(1):
+                self._verify()
             self._inner.close()
             super().close()

--- a/src/archivey/internal/streams/verify.py
+++ b/src/archivey/internal/streams/verify.py
@@ -7,6 +7,11 @@ digests (``ArchiveMember.hashes``) against the bytes actually read. Per the
 - Verification runs **only on a full sequential read to clean EOF**. A partial read is
   never verified (the digest of partial content is undefined), so this stage applies to
   the sequential read path, not to random-access reads.
+- The stage is transparent to seeking: it delegates ``seek``/``seekable`` to the inner
+  stream, but a seek that moves off the sequential frontier disables verification for the
+  rest of the stream's life (the running digest is then incomplete). So a member opened
+  ``MemberStreams.SEEKABLE`` is still verified if the caller only reads forward, and simply
+  skips the check once it seeks — mirroring the gzip truncation backstop in ``codecs.py``.
 - The mismatch is raised from the terminal read — the call that would return ``b""`` —
   *after* every data chunk (including the last) has already been delivered. A
   ``while chunk := f.read(n)`` consumer thus receives all bytes, then gets
@@ -36,7 +41,7 @@ from archivey.internal.diagnostics_collector import (
     resolve_collector,
 )
 from archivey.internal.logs import integrity as logger
-from archivey.internal.streams.streamtools import ReadOnlyIOStream
+from archivey.internal.streams.streamtools import ReadOnlyIOStream, is_seekable
 
 if TYPE_CHECKING:
     from archivey.types import ArchiveMember
@@ -97,8 +102,11 @@ def _expected_as_bytes(value: int | bytes, hasher: _IncrementalHasher) -> bytes:
 class VerifyingStream(ReadOnlyIOStream):
     """Wrap ``inner`` and verify ``expected`` digests at clean end-of-stream.
 
-    Sequential-only: ``read`` hashes the bytes it returns; ``readinto``/``readall`` come from
-    :class:`ReadOnlyIOStream` (built on this ``read``, so they hash too).
+    ``read`` hashes the bytes it returns (``readinto``/``readall`` come from
+    :class:`ReadOnlyIOStream`, built on this ``read``, so they hash too) and checks the
+    digests once the stream reaches clean EOF. ``seek``/``seekable`` delegate to ``inner``;
+    a seek off the sequential frontier disables verification for the rest of the stream's
+    life, since the running digest can no longer cover the whole member.
     """
 
     def __init__(
@@ -140,6 +148,8 @@ class VerifyingStream(ReadOnlyIOStream):
             self._hashers[algorithm] = hasher
             self._expected[algorithm] = _expected_as_bytes(value, hasher)
         self._verified = False
+        self._pos = 0  # bytes read so far — the sequential verification frontier
+        self._verify_enabled = True  # cleared by a seek off the frontier
 
     def _verify(self) -> None:
         """Check every computable digest; raise on the first mismatch."""
@@ -154,15 +164,26 @@ class VerifyingStream(ReadOnlyIOStream):
     def read(self, n: int = -1, /) -> bytes:
         data = self._inner.read(n)
         if data:
-            for hasher in self._hashers.values():
-                hasher.update(data)
+            self._pos += len(data)
+            if self._verify_enabled:
+                for hasher in self._hashers.values():
+                    hasher.update(data)
             return data
-        if not self._verified:
+        if self._verify_enabled and not self._verified:
             self._verify()
         return data
 
     def seekable(self) -> bool:
-        return False
+        return is_seekable(self._inner)
+
+    def seek(self, offset: int, whence: int = 0, /) -> int:
+        result = self._inner.seek(offset, whence)
+        # A seek off the sequential frontier makes the running digest incomplete; give up
+        # on verification (a no-op seek to the current position keeps it armed).
+        if result != self._pos:
+            self._verify_enabled = False
+        self._pos = result
+        return result
 
     def tell(self) -> int:
         return self._inner.tell()
@@ -172,7 +193,7 @@ class VerifyingStream(ReadOnlyIOStream):
             # ``archive.read()`` often does a single ``read()`` that returns all
             # bytes without a follow-up empty read, so verify here when the inner
             # stream is already at clean EOF (partial reads still skip verification).
-            if not self._verified and not self._inner.read(1):
+            if self._verify_enabled and not self._verified and not self._inner.read(1):
                 self._verify()
             self._inner.close()
             super().close()

--- a/src/archivey/internal/volumes.py
+++ b/src/archivey/internal/volumes.py
@@ -1,4 +1,4 @@
-"""Multi-volume path discovery (Phase 5 plumbing; joining lands in Phase 7)."""
+"""Multi-volume path discovery and joining (7z concatenation; RAR join later)."""
 
 from __future__ import annotations
 

--- a/src/archivey/internal/volumes.py
+++ b/src/archivey/internal/volumes.py
@@ -2,12 +2,16 @@
 
 from __future__ import annotations
 
+import bisect
+import io
+import os
 import re
 from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 from typing import BinaryIO, TypeGuard
 
+from archivey.exceptions import TruncatedError
 from archivey.internal.streams.streamtools import is_stream, source_name
 
 SourceItem = str | Path | BinaryIO
@@ -117,6 +121,123 @@ def discover_volume_siblings(path: Path) -> list[Path] | None:
     return None
 
 
+class ConcatenatedFile(io.RawIOBase, BinaryIO):
+    """Seekable read-only concatenation of volume streams."""
+
+    def __init__(self, sources: Sequence[Path | BinaryIO]) -> None:
+        super().__init__()
+        if not sources:
+            raise ValueError("at least one volume is required")
+        self._streams: list[BinaryIO] = []
+        self._owned: list[BinaryIO] = []
+        offsets = [0]
+        total = 0
+        for source in sources:
+            if isinstance(source, Path):
+                stream = open(source, "rb")
+                self._owned.append(stream)
+            else:
+                stream = source
+            try:
+                pos = stream.tell()
+                size = stream.seek(0, os.SEEK_END)
+                stream.seek(pos)
+            except (OSError, AttributeError, io.UnsupportedOperation) as exc:
+                raise ValueError("all volume streams must be seekable") from exc
+            self._streams.append(stream)
+            total += size
+            offsets.append(total)
+        self._offsets = offsets
+        self._size = total
+        self._pos = 0
+        self.volume_count = len(sources)
+
+    @property
+    def size(self) -> int:
+        return self._size
+
+    def readable(self) -> bool:
+        return True
+
+    def writable(self) -> bool:
+        return False
+
+    def seekable(self) -> bool:
+        return True
+
+    def tell(self) -> int:
+        return self._pos
+
+    def seek(self, offset: int, whence: int = os.SEEK_SET) -> int:
+        if whence == os.SEEK_SET:
+            new_pos = offset
+        elif whence == os.SEEK_CUR:
+            new_pos = self._pos + offset
+        elif whence == os.SEEK_END:
+            new_pos = self._size + offset
+        else:
+            raise ValueError(f"Invalid whence: {whence}")
+        if new_pos < 0:
+            raise ValueError("Negative seek position")
+        self._pos = new_pos
+        return self._pos
+
+    def read(self, n: int = -1) -> bytes:
+        if self._pos >= self._size:
+            return b""
+        if n is None or n < 0:
+            n = self._size - self._pos
+        else:
+            n = min(n, self._size - self._pos)
+        out = bytearray()
+        while n > 0 and self._pos < self._size:
+            index = bisect.bisect_right(self._offsets, self._pos) - 1
+            stream = self._streams[index]
+            volume_offset = self._pos - self._offsets[index]
+            available = self._offsets[index + 1] - self._pos
+            to_read = min(n, available)
+            stream.seek(volume_offset)
+            chunk = stream.read(to_read)
+            if not chunk:
+                break
+            out.extend(chunk)
+            self._pos += len(chunk)
+            n -= len(chunk)
+        return bytes(out)
+
+    def close(self) -> None:
+        if self.closed:
+            return
+        try:
+            for stream in self._owned:
+                stream.close()
+        finally:
+            super().close()
+
+
+def _validate_7z_volume_sequence(paths: Sequence[Path]) -> None:
+    numbered: list[int] = []
+    for path in paths:
+        match = _7Z_VOLUME_RE.match(path.name)
+        if match is None:
+            return
+        numbered.append(int(match.group("part")))
+    expected = list(range(1, len(numbered) + 1))
+    if numbered != expected:
+        raise TruncatedError(
+            f"Incomplete 7z multi-volume set: expected parts {expected}, got {numbered}"
+        )
+
+
+def join_volumes(paths: Sequence[Path]) -> BinaryIO:
+    """Concatenate an ordered volume set into one seekable file-like object."""
+
+    if not paths:
+        raise ValueError("volume path sequence must not be empty")
+    _validate_7z_volume_sequence(paths)
+    return ConcatenatedFile(paths)
+
+
 OpenSourceInput = SourceItem | SourceSequence
 
 
@@ -152,7 +273,10 @@ def resolve_source(source: OpenSourceInput) -> ResolvedSource:
         if len(items) == 1:
             return _resolve_single(items[0])
         first = items[0]
-        return ResolvedSource(first, source_name(first), len(items))
+        if all(isinstance(item, Path) for item in items):
+            paths = [item for item in items if isinstance(item, Path)]
+            return ResolvedSource(join_volumes(paths), source_name(first), len(paths))
+        return ResolvedSource(ConcatenatedFile(items), source_name(first), len(items))
     if isinstance(source, str):
         return _resolve_single(Path(source))
     if isinstance(source, Path):
@@ -168,6 +292,10 @@ def _resolve_single(source: Path | BinaryIO) -> ResolvedSource:
             return ResolvedSource(source, str(source), 1)
         siblings = discover_volume_siblings(source)
         if siblings is not None:
+            if _7Z_VOLUME_RE.match(siblings[0].name):
+                return ResolvedSource(
+                    join_volumes(siblings), source_name(siblings[0]), len(siblings)
+                )
             return ResolvedSource(siblings[0], source_name(siblings[0]), len(siblings))
         return ResolvedSource(source, source_name(source), 1)
     return ResolvedSource(source, source_name(source), 1)

--- a/src/archivey/types.py
+++ b/src/archivey/types.py
@@ -306,6 +306,12 @@ class ArchiveMember:
     is_encrypted: bool = False
     """Whether this member's data is encrypted."""
 
+    is_anti: bool = False
+    """Whether this member is a format-level deletion marker (7z ANTI bit)."""
+
+    is_current: bool = True
+    """Whether this member is the live final state of its path (last-entry-wins)."""
+
     is_sparse: bool = False
     """Whether this member is stored as a sparse file."""
 

--- a/tests/fuzz_sevenzip_parser.py
+++ b/tests/fuzz_sevenzip_parser.py
@@ -1,0 +1,70 @@
+"""Env-gated mutation harness for the native 7z header parser.
+
+Run locally with::
+
+    ARCHIVEY_FUZZ=1 uv run --no-sync pytest tests/fuzz_sevenzip_parser.py
+"""
+
+from __future__ import annotations
+
+import io
+import os
+from collections.abc import Iterable
+from pathlib import Path
+from random import Random
+
+import pytest
+
+from archivey import ArchiveyError
+from archivey.internal.backends.sevenzip_parser import MAGIC_7Z, parse_sevenzip_archive
+from tests.sample_archives import CORPUS, CorpusEntry, corpus_archive_path
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("ARCHIVEY_FUZZ") != "1",
+    reason="set ARCHIVEY_FUZZ=1 to run the 7z parser fuzz harness",
+)
+
+_HARNESS_VERSION = 1
+_SEED_ENTRY_IDS = {"basic", "encoding", "large"}
+
+
+def _corpus_seed_entries() -> Iterable[CorpusEntry]:
+    for entry in CORPUS:
+        if entry.id in _SEED_ENTRY_IDS and "7z" in entry.formats:
+            yield entry
+
+
+def _seed_bytes(tmp_path: Path) -> list[bytes]:
+    pytest.importorskip("py7zr")
+    seeds = [
+        b"",
+        MAGIC_7Z,
+        MAGIC_7Z + bytes(26),
+        b"not a 7z archive",
+        MAGIC_7Z + b"\x00\x04" + b"\xff" * 24,
+    ]
+    for entry in _corpus_seed_entries():
+        seeds.append(corpus_archive_path(entry, "7z", tmp_path).read_bytes())
+    return seeds
+
+
+def _mutations(seed: bytes, label: str) -> Iterable[bytes]:
+    yield seed
+    if seed:
+        yield seed[: max(1, len(seed) // 2)]
+        yield seed + b"\x00" * 32
+        rng = Random(f"sevenzip-parser|{label}|v{_HARNESS_VERSION}")
+        for _ in range(8):
+            data = bytearray(seed)
+            offset = rng.randrange(len(data))
+            data[offset] ^= 1 << rng.randrange(8)
+            yield bytes(data)
+
+
+def test_parse_sevenzip_archive_fuzz_harness(tmp_path: Path) -> None:
+    for index, seed in enumerate(_seed_bytes(tmp_path)):
+        for mutated in _mutations(seed, str(index)):
+            try:
+                parse_sevenzip_archive(io.BytesIO(mutated))
+            except ArchiveyError:
+                pass

--- a/tests/fuzz_sevenzip_parser.py
+++ b/tests/fuzz_sevenzip_parser.py
@@ -12,11 +12,18 @@ import os
 from collections.abc import Iterable
 from pathlib import Path
 from random import Random
+from typing import BinaryIO
 
 import pytest
 
 from archivey import ArchiveyError
-from archivey.internal.backends.sevenzip_parser import MAGIC_7Z, parse_sevenzip_archive
+from archivey.internal.backends.sevenzip_parser import (
+    MAGIC_7Z,
+    SevenZipFolder,
+    parse_sevenzip_archive,
+)
+from archivey.internal.backends.sevenzip_reader import decode_folder_to_bytes
+from archivey.internal.streams.crypto import SevenZipKeyCache
 from tests.sample_archives import CORPUS, CorpusEntry, corpus_archive_path
 
 pytestmark = pytest.mark.skipif(
@@ -61,10 +68,29 @@ def _mutations(seed: bytes, label: str) -> Iterable[bytes]:
             yield bytes(data)
 
 
+def _decode_folder(
+    source: BinaryIO,
+    folder: SevenZipFolder,
+    compressed_size: int,
+    uncompressed_size: int,
+) -> bytes:
+    # Reuse the reader's real codec/crypto pipeline (unencrypted only: no passwords).
+    return decode_folder_to_bytes(
+        source,
+        folder,
+        compressed_size=compressed_size,
+        uncompressed_size=uncompressed_size,
+        password=None,
+        key_cache=SevenZipKeyCache(),
+    )
+
+
 def test_parse_sevenzip_archive_fuzz_harness(tmp_path: Path) -> None:
     for index, seed in enumerate(_seed_bytes(tmp_path)):
         for mutated in _mutations(seed, str(index)):
             try:
-                parse_sevenzip_archive(io.BytesIO(mutated))
+                parse_sevenzip_archive(
+                    io.BytesIO(mutated), decode_folder=_decode_folder
+                )
             except ArchiveyError:
                 pass

--- a/tests/sample_archives.py
+++ b/tests/sample_archives.py
@@ -10,8 +10,9 @@ conformance sweep).
 The shapes are ported from the DEV declarative corpus (``archivey-dev``
 ``tests/archivey/sample_archives.py`` @ 730275b7a755f8b5b8d08d3d4d9b267b5bdadb0d),
 re-expressed in the v2 idiom; v1-API creation plumbing was deliberately not carried
-over. 7z/RAR entries are present but inactive until the Phase 6 native readers land
-(the sweep skips them via the registry's format-availability guard).
+over. RAR entries are present but inactive until the Phase 7 native reader lands
+(the sweep skips it via the registry's format-availability guard); 7z entries run
+when the native reader and py7zr fixture builder are available.
 
 Generation is on-demand with a content-keyed cache under ``ARCHIVEY_TEST_CACHE``
 (atomic ``os.replace`` writes, safe for parallel runs; no binaries are committed).
@@ -38,8 +39,8 @@ from archivey.types import ArchiveFormat, ContainerFormat, MemberType, StreamFor
 from tests.conftest import ARCHIVEY_TEST_CACHE
 
 # Bump when any builder's output changes, so cached archives regenerate.
-# v2: the ZIP builder's Windows output changed (backslash names are now preserved).
-GENERATOR_VERSION = 2
+# v3: the 7z builder now writes relative members and honors single-password fixtures.
+GENERATOR_VERSION = 3
 
 
 # ---------------------------------------------------------------------------
@@ -158,9 +159,9 @@ FORMAT_KEYS: dict[str, ArchiveFormat] = {
     "lz": ArchiveFormat.LZIP,
     "zz": ArchiveFormat.ZLIB,
     "br": ArchiveFormat.BROTLI,
-    # Inactive until the Phase 6 native readers register these formats; the sweep's
-    # registry-driven availability guard skips them automatically until then.
     "7z": ArchiveFormat.SEVEN_Z,
+    # Inactive until the Phase 7 native RAR reader registers this format; the sweep's
+    # registry-driven availability guard skips it automatically until then.
     "rar": ArchiveFormat.RAR,
 }
 
@@ -533,14 +534,20 @@ def _iso_build(entry: CorpusEntry, path: Path) -> None:
     path.write_bytes(out.getvalue())
 
 
-def _7z_build(entry: CorpusEntry, path: Path) -> None:  # pragma: no cover - Phase 6
+def _7z_build(entry: CorpusEntry, path: Path) -> None:
     import py7zr
 
+    if len(entry.passwords) > 1:
+        raise ValueError(
+            "the py7zr corpus builder supports one 7z password per archive"
+        )
     with tempfile.TemporaryDirectory() as td:
         tmp = Path(td)
         _dir_build(entry, tmp)
-        with py7zr.SevenZipFile(path, "w") as zf:
-            zf.writeall(tmp, arcname="")
+        password = entry.passwords[0] if entry.passwords else None
+        with py7zr.SevenZipFile(path, "w", password=password) as zf:
+            for item in sorted(tmp.rglob("*")):
+                zf.write(item, arcname=item.relative_to(tmp).as_posix())
 
 
 def _rar_build(entry: CorpusEntry, path: Path) -> None:  # pragma: no cover - Phase 6

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -159,11 +159,35 @@ def test_crypto_reachable_only_through_wrapper() -> None:
     """With [crypto] present, the backend is reached via the wrapper (not a direct import)."""
     backend = crypto.get_crypto_backend()
     assert backend.name == crypto.CRYPTO_PACKAGE
-    # The concrete AES stage is deferred to Phase 7; the wrapper boundary is what's real now.
-    with pytest.raises(NotImplementedError):
-        backend.aes_cbc_decrypt_stage(
-            crypto.AesParams(key=b"\x00" * 32, iv=b"\x00" * 16)
-        )
+    stage = backend.aes_cbc_decrypt_stage(
+        crypto.AesParams(key=b"\x00" * 32, iv=b"\x00" * 16)
+    )
+    # Round-trip one AES block through the shared stage (format parsers never import
+    # cryptography directly — they go through this wrapper).
+    from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+
+    encryptor = Cipher(algorithms.AES(b"\x00" * 32), modes.CBC(b"\x00" * 16)).encryptor()
+    plaintext = b"0123456789abcdef"
+    ciphertext = encryptor.update(plaintext) + encryptor.finalize()
+    assert stage.update(ciphertext) + stage.finalize() == plaintext
+
+
+@pytest.mark.skipif(
+    importlib.util.find_spec("cryptography") is None,
+    reason="cryptography is not installed (core-only leg); the present-path cannot run",
+)
+def test_sevenzip_kdf_cache_reuses_derived_keys() -> None:
+    password = "secret".encode("utf-16le")
+    salt = b"salt"
+    cache = crypto.SevenZipKeyCache()
+    first = cache.derive(password, salt=salt, cycles=1)
+    second = cache.derive(password, salt=salt, cycles=1)
+    assert first == second
+    assert first is second  # same cached object
+    # 0x3f special case: salt+password copied into 32-byte key (no hashing).
+    special = crypto.derive_sevenzip_aes_key(password, salt=salt, cycles=0x3F)
+    assert len(special) == 32
+    assert special == bytes(bytearray(salt + password + bytes(32))[:32])
 
 
 # --- exception translation -------------------------------------------------------------

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -361,6 +361,14 @@ def test_verify_partial_read_is_not_verified() -> None:
     stream.close()  # abandoned before EOF — must not raise
 
 
+def test_verify_on_close_after_full_single_read() -> None:
+    """A single read()-to-end must still verify when the stream is closed."""
+    stream = VerifyingStream(io.BytesIO(CONTENT), {"crc32": _crc32(CONTENT) ^ 0xFFFF})
+    assert stream.read() == CONTENT
+    with pytest.raises(CorruptionError, match="crc32"):
+        stream.close()
+
+
 def test_verify_unverifiable_algorithm_skipped_with_warning(
     caplog: pytest.LogCaptureFixture,
 ) -> None:

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -166,7 +166,9 @@ def test_crypto_reachable_only_through_wrapper() -> None:
     # cryptography directly — they go through this wrapper).
     from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
-    encryptor = Cipher(algorithms.AES(b"\x00" * 32), modes.CBC(b"\x00" * 16)).encryptor()
+    encryptor = Cipher(
+        algorithms.AES(b"\x00" * 32), modes.CBC(b"\x00" * 16)
+    ).encryptor()
     plaintext = b"0123456789abcdef"
     ciphertext = encryptor.update(plaintext) + encryptor.finalize()
     assert stage.update(ciphertext) + stage.finalize() == plaintext

--- a/tests/test_corpus_sweep.py
+++ b/tests/test_corpus_sweep.py
@@ -86,9 +86,9 @@ def _skip_unless_runnable(entry: CorpusEntry, key: str) -> None:
         if shutil.which(binary) is None:
             pytest.skip(f"builder needs binary {binary!r}")
     if (
-        key == "dir"
-        and os.name == "nt"
+        os.name == "nt"
         and any(m.type is MemberType.SYMLINK for m in entry.members)
+        and key in ("dir", "7z")
     ):
         pytest.skip("creating symlinks on Windows needs privileges")
 

--- a/tests/test_corpus_sweep.py
+++ b/tests/test_corpus_sweep.py
@@ -5,7 +5,7 @@ corpus describes, in every format it is built in, must open, list members matchi
 declared expectations, read back the declared contents (following links per the
 link-resolution contract), and extract safely — with adversarial members rejected and
 encrypted members unreadable without their password. Formats whose reader is not
-available (missing optional dependency, or the 7z/RAR readers before Phase 6) are
+available (missing optional dependency, or the RAR reader before Phase 7) are
 skipped via the registry's availability guard, so enabling a format activates its
 entries with no test changes.
 """
@@ -77,7 +77,12 @@ def _skip_unless_runnable(entry: CorpusEntry, key: str) -> None:
                 pytest.skip("no zstd backend to build with")
         elif importlib.util.find_spec(package) is None:
             pytest.skip(f"builder needs package {package!r}")
-    for binary in (*BUILDER_BINARIES.get(key, ()), *entry.requires_binaries):
+    entry_binaries = entry.requires_binaries
+    if key == "7z":
+        # Encrypted ZIP corpus entries need the 7z CLI builder, but encrypted 7z entries
+        # are written directly by py7zr with a single archive password.
+        entry_binaries = tuple(b for b in entry_binaries if b != "7z")
+    for binary in (*BUILDER_BINARIES.get(key, ()), *entry_binaries):
         if shutil.which(binary) is None:
             pytest.skip(f"builder needs binary {binary!r}")
     if (

--- a/tests/test_data_model.py
+++ b/tests/test_data_model.py
@@ -99,6 +99,20 @@ def test_equality_excludes_hashes_and_extra() -> None:
     assert a == b
 
 
+def test_anti_and_current_defaults_and_equality() -> None:
+    # Defaults: ordinary members are non-anti and current.
+    default = ArchiveMember(type=MemberType.FILE, name="a.txt")
+    assert default.is_anti is False
+    assert default.is_current is True
+
+    # Both flags participate in equality.
+    anti = ArchiveMember(type=MemberType.FILE, name="a.txt", is_anti=True)
+    assert anti != default
+    superseded = ArchiveMember(type=MemberType.FILE, name="a.txt", is_current=False)
+    assert superseded != default
+    assert anti == ArchiveMember(type=MemberType.FILE, name="a.txt", is_anti=True)
+
+
 def test_single_codec_member_compression_shape() -> None:
     m = ArchiveMember(
         type=MemberType.FILE,

--- a/tests/test_member_stream_contract.py
+++ b/tests/test_member_stream_contract.py
@@ -82,6 +82,15 @@ def _gzip(tmp_path: Path) -> tuple[Path, str]:
     return path, MEMBER  # single-file member name inferred from the source filename
 
 
+def _sevenzip(tmp_path: Path) -> tuple[Path, str]:
+    import py7zr
+
+    path = tmp_path / "a.7z"
+    with py7zr.SevenZipFile(path, "w") as z:
+        z.writestr(CONTENT, MEMBER)
+    return path, MEMBER
+
+
 def _iso(tmp_path: Path) -> tuple[Path, str]:
     import pycdlib
 
@@ -102,6 +111,7 @@ def _iso(tmp_path: Path) -> tuple[Path, str]:
         pytest.param(_tar, id="tar"),
         pytest.param(_tar_gz, id="tar_gz"),
         pytest.param(_gzip, id="gzip"),
+        pytest.param(_sevenzip, id="sevenzip", marks=requires("py7zr")),
         pytest.param(_iso, id="iso", marks=requires("pycdlib")),
     ]
 )
@@ -154,8 +164,33 @@ def test_piecewise_read_then_eof(member: tuple[Path, str]) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Seeking (only when the member stream reports seekable)
+# Seekability capability: off by default, on (and working) with MemberStreams.SEEKABLE
 # ---------------------------------------------------------------------------
+
+
+def test_default_open_is_not_seekable(member: tuple[Path, str]) -> None:
+    # Without the SEEKABLE capability every backend hands out a forward-only stream.
+    source, name = member
+    with open_archive(source) as ar, ar.open(name) as f:
+        assert f.seekable() is False
+        with pytest.raises((io.UnsupportedOperation, ValueError)):
+            f.seek(0)
+
+
+def test_seekable_flag_enables_forward_and_backward_seek(
+    member: tuple[Path, str],
+) -> None:
+    # With the capability the stream reports seekable and seeking actually works both
+    # ways (backward seeks may re-decode from the start; the caller accepted that cost).
+    source, name = member
+    with open_archive(source, member_streams=_SEEKABLE) as ar, ar.open(name) as f:
+        assert f.seekable() is True
+        assert f.read() == CONTENT
+        f.seek(0)  # backward to the start
+        assert f.read() == CONTENT
+        f.seek(10)  # forward into the middle
+        assert f.read() == CONTENT[10:]
+        assert f.tell() == len(CONTENT)
 
 
 def test_seek_past_end_then_read_returns_empty(member: tuple[Path, str]) -> None:

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -45,7 +45,7 @@ class _CoreBackend(ReadBackend):
 
 
 class _OptionalPresentBackend(ReadBackend):
-    FORMATS = (ArchiveFormat.SEVEN_Z,)
+    FORMATS = (ArchiveFormat.RAR,)
     OPTIONAL_DEPENDENCY = "io"  # a module that always imports
     INSTALL_HINT = "pip install archivey[present]"
 
@@ -95,10 +95,10 @@ def test_optional_missing_backend_is_known_but_unavailable(
 
 
 def test_optional_present_backend_is_full(registry: BackendRegistry) -> None:
-    avail = registry.format_availability(ArchiveFormat.SEVEN_Z)
+    avail = registry.format_availability(ArchiveFormat.RAR)
     assert avail.support is FormatSupport.FULL
     assert avail.missing == ()
-    assert ArchiveFormat.SEVEN_Z in registry.list_supported_formats()
+    assert ArchiveFormat.RAR in registry.list_supported_formats()
 
 
 def test_core_backend_is_full(registry: BackendRegistry) -> None:
@@ -107,7 +107,7 @@ def test_core_backend_is_full(registry: BackendRegistry) -> None:
 
 
 def test_unknown_format_is_none(registry: BackendRegistry) -> None:
-    avail = registry.format_availability(ArchiveFormat.RAR)
+    avail = registry.format_availability(ArchiveFormat.SEVEN_Z)
     assert avail.support is FormatSupport.NONE
     assert avail.missing == ()
 
@@ -124,7 +124,7 @@ def test_reader_for_missing_dependency_raises_with_hint(
 
 def test_reader_for_unknown_format_raises(registry: BackendRegistry) -> None:
     with pytest.raises(UnsupportedFormatError):
-        registry.reader_for_format(ArchiveFormat.RAR)
+        registry.reader_for_format(ArchiveFormat.SEVEN_Z)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_sevenzip_oracle.py
+++ b/tests/test_sevenzip_oracle.py
@@ -1,0 +1,58 @@
+"""Native 7z reader cross-checks against py7zr."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from archivey import MemberType, open_archive
+from tests.sample_archives import CORPUS, CorpusEntry, corpus_archive_path
+
+_ORACLE_ENTRY_IDS = {"basic", "encoding", "permissions", "large", "encrypted"}
+_PARAMS = [
+    pytest.param(entry, id=entry.id)
+    for entry in CORPUS
+    if entry.id in _ORACLE_ENTRY_IDS and "7z" in entry.formats
+]
+
+
+def _py7zr():
+    return pytest.importorskip("py7zr")
+
+
+def _password(entry: CorpusEntry) -> str | None:
+    return entry.passwords[0] if entry.passwords else None
+
+
+@pytest.mark.parametrize("entry", _PARAMS)
+def test_native_sevenzip_matches_py7zr_metadata_and_bytes(
+    entry: CorpusEntry, tmp_path: Path
+) -> None:
+    py7zr = _py7zr()
+    archive = corpus_archive_path(entry, "7z", tmp_path)
+    password = _password(entry)
+
+    with py7zr.SevenZipFile(archive, "r", password=password) as oracle:
+        oracle_infos = {
+            info.filename: info
+            for info in oracle.list()
+            if not getattr(info, "is_directory", False)
+        }
+        oracle_dir = tmp_path / f"{entry.id}-py7zr"
+        oracle.extractall(oracle_dir)
+
+    with open_archive(archive, password=password) as native:
+        native_members = {
+            member.name: member
+            for member in native.members()
+            if member.type is MemberType.FILE
+        }
+        assert set(native_members) == set(oracle_infos)
+        for name, oracle_info in oracle_infos.items():
+            member = native_members[name]
+            assert member.size == oracle_info.uncompressed
+            if oracle_info.compressed is not None:
+                assert member.compressed_size == oracle_info.compressed
+            assert member.hashes.get("crc32") == oracle_info.crc32
+            assert native.read(member) == (oracle_dir / name).read_bytes()

--- a/tests/test_sevenzip_reader.py
+++ b/tests/test_sevenzip_reader.py
@@ -168,6 +168,7 @@ def test_7z_cli_deflate64_fixture_roundtrip(tmp_path: Path) -> None:
 
 
 @requires_binary("7z")
+@requires("cryptography")
 def test_7z_cli_multi_password_archive_roundtrip(tmp_path: Path) -> None:
     first = tmp_path / "first.txt"
     second = tmp_path / "second.txt"

--- a/tests/test_sevenzip_reader.py
+++ b/tests/test_sevenzip_reader.py
@@ -388,12 +388,58 @@ def test_synthetic_anti_item_lists_and_extracts_safely(tmp_path: Path) -> None:
 
 @requires_binary("7z")
 def test_anti_item_fresh_extract_matches_7z_cli(tmp_path: Path) -> None:
-    archive = tmp_path / "anti.7z"
-    archive.write_bytes(_anti_item_archive())
+    """Build a real anti-item archive with the 7z CLI and compare fresh-dest trees.
+
+    Recipe: archive keep.txt + gone.txt, delete gone.txt on disk, then ``7z u`` with
+    anti-item update options into a new archive. Fresh ``7z x`` and archivey extract
+    must both leave keep.txt and omit gone.txt.
+    """
+    work = tmp_path / "work"
+    work.mkdir()
+    (work / "keep.txt").write_text("keep\n", encoding="utf-8")
+    (work / "gone.txt").write_text("gone\n", encoding="utf-8")
+    base = tmp_path / "base.7z"
+    archive = tmp_path / "with_anti.7z"
+    create = subprocess.run(
+        ["7z", "a", "-t7z", str(base), "keep.txt", "gone.txt", "-y"],
+        cwd=work,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if create.returncode != 0:
+        pytest.skip(f"7z CLI cannot build base archive: {create.stderr}")
+    (work / "gone.txt").unlink()
+    update = subprocess.run(
+        [
+            "7z",
+            "u",
+            str(base),
+            "-u-",
+            f"-up0q3x2y2z1!{archive}",
+            "keep.txt",
+            "gone.txt",
+            "-y",
+        ],
+        cwd=work,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if update.returncode != 0 or not archive.is_file():
+        pytest.skip(f"7z CLI cannot build anti-item update archive: {update.stderr}")
+
+    with open_archive(archive) as reader:
+        members = reader.members()
+        by_name = {m.name: m for m in members}
+        assert by_name["gone.txt"].is_anti is True
+        assert by_name["gone.txt"].is_current is True
+        assert by_name["keep.txt"].is_anti is False
+        assert by_name["keep.txt"].is_current is True
+
     archivey_dest = tmp_path / "archivey"
     cli_dest = tmp_path / "cli"
     cli_dest.mkdir()
-
     with open_archive(archive) as reader:
         reader.extract_all(archivey_dest)
     subprocess.run(
@@ -403,6 +449,10 @@ def test_anti_item_fresh_extract_matches_7z_cli(tmp_path: Path) -> None:
     )
 
     assert sorted(
-        p.relative_to(archivey_dest) for p in archivey_dest.rglob("*")
-    ) == sorted(p.relative_to(cli_dest) for p in cli_dest.rglob("*"))
-    assert not any(path.is_file() for path in archivey_dest.rglob("*"))
+        p.relative_to(archivey_dest) for p in archivey_dest.rglob("*") if p.is_file()
+    ) == sorted(p.relative_to(cli_dest) for p in cli_dest.rglob("*") if p.is_file())
+    assert (archivey_dest / "keep.txt").read_bytes() == (
+        cli_dest / "keep.txt"
+    ).read_bytes()
+    assert not (archivey_dest / "gone.txt").exists()
+    assert not (cli_dest / "gone.txt").exists()

--- a/tests/test_sevenzip_reader.py
+++ b/tests/test_sevenzip_reader.py
@@ -222,7 +222,7 @@ def test_7z_multi_password_rejects_wrong_candidate_via_crc(
     first_kdf = "first".encode("utf-16le")
     garbage = b"\x05\x7f\xc6\x01\xebI\x03j\x88\x93\x8e\xe5\xb5"
 
-    def pipeline_with_wrong_first(self, source, folder, *, password):
+    def pipeline_with_wrong_first(self, source, folder, *, password, seekable=False):
         # After the first folder unlocks, known-good "first" is tried on the second
         # folder. Simulate a decompressor that yields plausible garbage of the
         # expected length instead of raising, so only the CRC confirm rejects it.
@@ -232,7 +232,9 @@ def test_7z_multi_password_rejects_wrong_candidate_via_crc(
                     garbage
                 ):
                     return io.BytesIO(garbage)
-        return original_pipeline(self, source, folder, password=password)
+        return original_pipeline(
+            self, source, folder, password=password, seekable=seekable
+        )
 
     monkeypatch.setattr(
         SevenZipReader, "_open_folder_pipeline", pipeline_with_wrong_first

--- a/tests/test_sevenzip_reader.py
+++ b/tests/test_sevenzip_reader.py
@@ -1,0 +1,408 @@
+"""Native 7z reader fixture coverage."""
+
+from __future__ import annotations
+
+import io
+import struct
+import subprocess
+import zlib
+from pathlib import Path
+
+import pytest
+
+from archivey import ExtractionStatus, open_archive
+from archivey.exceptions import (
+    EncryptionError,
+    PackageNotInstalledError,
+    UnsupportedFeatureError,
+)
+from archivey.internal.backends.sevenzip_parser import SevenZipCoder, SevenZipFolder
+from archivey.internal.backends.sevenzip_reader import SevenZipReader
+from archivey.internal.config import DEFAULT_STREAM_CONFIG
+from archivey.internal.streams import codecs, crypto
+from tests.conftest import requires, requires_binary, requires_zstd
+
+_FILES = {
+    "alpha.txt": b"alpha\n" * 100,
+    "nested/beta.bin": bytes(range(64)) * 16,
+}
+
+
+def _py7zr():
+    return pytest.importorskip("py7zr")
+
+
+def _py7zr_version() -> tuple[int, ...]:
+    raw = getattr(_py7zr(), "__version__", "0")
+    return tuple(int(part) for part in raw.split(".") if part.isdigit())
+
+
+def _filters(*names: str) -> list[dict[str, int]]:
+    py7zr = _py7zr()
+    return [{"id": getattr(py7zr, f"FILTER_{name}")} for name in names]
+
+
+def _write_py7zr_archive(
+    path: Path,
+    files: dict[str, bytes],
+    *,
+    filters: list[dict[str, int]] | None = None,
+    password: str | None = None,
+    header_encryption: bool = False,
+) -> None:
+    py7zr = _py7zr()
+    source = path.parent / f"{path.stem}-src"
+    for name, data in files.items():
+        target = source / name
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(data)
+    with py7zr.SevenZipFile(
+        path,
+        "w",
+        filters=filters,
+        password=password,
+        header_encryption=header_encryption,
+    ) as archive:
+        for name in sorted(files):
+            archive.write(source / name, arcname=name)
+
+
+def _assert_roundtrip(
+    path: Path, files: dict[str, bytes], *, password: str | list[str] | None = None
+) -> None:
+    with open_archive(path, password=password) as archive:
+        members = {
+            member.name: member for member in archive.members() if member.is_file
+        }
+        assert set(members) == set(files)
+        for name, expected in files.items():
+            assert archive.read(members[name]) == expected
+
+
+@pytest.mark.parametrize(
+    ("label", "filter_names"),
+    [
+        pytest.param("stored", ("COPY",), id="stored"),
+        pytest.param("lzma2", ("LZMA2",), id="lzma2"),
+        pytest.param("lzma2-bcj", ("X86", "LZMA2"), id="lzma2-bcj"),
+        pytest.param("lzma2-delta", ("DELTA", "LZMA2"), id="lzma2-delta"),
+        pytest.param("deflate", ("DEFLATE",), id="deflate"),
+        pytest.param("bzip2", ("BZIP2",), id="bzip2"),
+        pytest.param("zstd", ("ZSTD",), marks=requires_zstd(), id="zstd"),
+        pytest.param("brotli", ("BROTLI",), marks=requires("brotli"), id="brotli"),
+        pytest.param("ppmd", ("PPMD",), marks=requires("pyppmd"), id="ppmd"),
+    ],
+)
+def test_py7zr_codec_fixtures_roundtrip(
+    tmp_path: Path, label: str, filter_names: tuple[str, ...]
+) -> None:
+    if label == "ppmd" and _py7zr_version() < (1, 1):
+        pytest.skip("py7zr < 1.1 cannot build reliable PPMd 7z fixtures")
+    archive = tmp_path / f"{label}.7z"
+    _write_py7zr_archive(archive, _FILES, filters=_filters(*filter_names))
+
+    _assert_roundtrip(archive, _FILES)
+
+
+def test_solid_archive_stream_and_random_access(tmp_path: Path) -> None:
+    archive = tmp_path / "solid.7z"
+    _write_py7zr_archive(archive, _FILES, filters=_filters("LZMA2"))
+
+    with open_archive(archive) as reader:
+        assert reader.info.is_solid is True
+        streamed = {
+            member.name: stream.read()
+            for member, stream in reader.stream_members()
+            if member.is_file and stream is not None
+        }
+        assert streamed == _FILES
+        assert reader.read("nested/beta.bin") == _FILES["nested/beta.bin"]
+
+
+def test_aes_encrypted_archive_roundtrip(tmp_path: Path) -> None:
+    archive = tmp_path / "aes.7z"
+    _write_py7zr_archive(archive, _FILES, password="secret")
+
+    _assert_roundtrip(archive, _FILES, password="secret")
+    with open_archive(archive) as reader:
+        encrypted = next(member for member in reader.members() if member.is_file)
+        with pytest.raises(EncryptionError):
+            reader.read(encrypted)
+
+
+def test_header_encrypted_archive_requires_password(tmp_path: Path) -> None:
+    archive = tmp_path / "header-encrypted.7z"
+    _write_py7zr_archive(archive, _FILES, password="secret", header_encryption=True)
+
+    with pytest.raises(EncryptionError, match="header"):
+        open_archive(archive).close()
+    _assert_roundtrip(archive, _FILES, password="secret")
+
+
+def test_lzma1_bcj_fixture_is_rejected(tmp_path: Path) -> None:
+    archive = tmp_path / "lzma1-bcj.7z"
+    _write_py7zr_archive(archive, _FILES, filters=_filters("X86", "LZMA"))
+
+    with open_archive(archive) as reader:
+        with pytest.raises(UnsupportedFeatureError, match=r"LZMA1\+BCJ"):
+            reader.read("alpha.txt")
+
+
+@requires_binary("7z")
+@requires("inflate64")
+def test_7z_cli_deflate64_fixture_roundtrip(tmp_path: Path) -> None:
+    payload = tmp_path / "payload.bin"
+    payload.write_bytes(bytes(range(251)) * 200)
+    archive = tmp_path / "deflate64.7z"
+    result = subprocess.run(
+        ["7z", "a", "-t7z", "-m0=Deflate64", str(archive), payload.name, "-y"],
+        cwd=tmp_path,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        pytest.skip(f"7z CLI cannot write Deflate64 7z fixtures: {result.stderr}")
+
+    _assert_roundtrip(archive, {payload.name: payload.read_bytes()})
+
+
+@requires_binary("7z")
+def test_7z_cli_multi_password_archive_roundtrip(tmp_path: Path) -> None:
+    first = tmp_path / "first.txt"
+    second = tmp_path / "second.txt"
+    first.write_bytes(b"first secret")
+    second.write_bytes(b"second secret")
+    archive = tmp_path / "multi-password.7z"
+    commands = (
+        ["7z", "a", "-t7z", str(archive), first.name, "-pfirst", "-y"],
+        ["7z", "a", "-t7z", str(archive), second.name, "-psecond", "-y"],
+    )
+    for command in commands:
+        result = subprocess.run(
+            command, cwd=tmp_path, check=False, capture_output=True, text=True
+        )
+        if result.returncode != 0:
+            pytest.skip(
+                f"7z CLI cannot build multi-password 7z fixture: {result.stderr}"
+            )
+
+    _assert_roundtrip(
+        archive,
+        {first.name: first.read_bytes(), second.name: second.read_bytes()},
+        password=["first", "second"],
+    )
+
+
+@requires_binary("7z")
+def test_7z_cli_multi_volume_archive_roundtrip(tmp_path: Path) -> None:
+    payload = tmp_path / "large.bin"
+    payload.write_bytes(bytes(range(256)) * 1200)
+    result = subprocess.run(
+        ["7z", "a", "-t7z", "-v100k", str(tmp_path / "vol.7z"), payload.name, "-y"],
+        cwd=tmp_path,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        pytest.skip(f"7z CLI cannot build multi-volume 7z fixture: {result.stderr}")
+    first_volume = tmp_path / "vol.7z.001"
+    if not first_volume.exists() or not (tmp_path / "vol.7z.002").exists():
+        pytest.skip("7z CLI did not split the fixture into multiple volumes")
+
+    _assert_roundtrip(first_volume, {payload.name: payload.read_bytes()})
+
+
+def _reader_for_unit_tests() -> SevenZipReader:
+    reader = object.__new__(SevenZipReader)
+    reader._stream_config = DEFAULT_STREAM_CONFIG  # noqa: SLF001 - focused unit test
+    reader._diagnostics_collector = None  # noqa: SLF001 - focused unit test
+    reader._key_cache = crypto.SevenZipKeyCache()  # noqa: SLF001 - focused unit test
+    return reader
+
+
+def _folder(method: bytes, properties: bytes | None = None) -> SevenZipFolder:
+    return SevenZipFolder(
+        coders=[
+            SevenZipCoder(
+                method=method,
+                num_in_streams=1,
+                num_out_streams=1,
+                properties=properties,
+            )
+        ],
+        bind_pairs=[],
+        packed_indices=[0],
+        unpack_sizes=[0],
+        crc=None,
+        digest_defined=False,
+    )
+
+
+def test_bcj2_folder_is_rejected() -> None:
+    reader = _reader_for_unit_tests()
+
+    with pytest.raises(UnsupportedFeatureError, match="BCJ2"):
+        reader._open_folder_pipeline(  # noqa: SLF001 - focused reader unit test
+            io.BytesIO(b""), _folder(b"\x03\x03\x01\x1b"), password=None
+        )
+
+
+def test_unknown_folder_method_is_rejected() -> None:
+    reader = _reader_for_unit_tests()
+
+    with pytest.raises(UnsupportedFeatureError, match="0x99"):
+        reader._open_folder_pipeline(  # noqa: SLF001 - focused reader unit test
+            io.BytesIO(b""), _folder(b"\x99"), password=None
+        )
+
+
+def test_ppmd_without_pyppmd_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    reader = _reader_for_unit_tests()
+    monkeypatch.setattr(codecs, "_pyppmd", None)
+    properties = struct.pack("<BL", 6, 1 << 20)
+
+    with pytest.raises(PackageNotInstalledError, match="pyppmd"):
+        reader._open_folder_pipeline(  # noqa: SLF001 - focused reader unit test
+            io.BytesIO(b""), _folder(b"\x03\x04\x01", properties), password=None
+        )
+
+
+def test_aes_without_crypto_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    reader = _reader_for_unit_tests()
+    monkeypatch.setattr(crypto, "_crypto_available", lambda: False)
+    properties = b"\xc0\x00\x00\x00"  # one-byte salt, one-byte IV, both zero
+
+    with pytest.raises(PackageNotInstalledError, match="cryptography"):
+        reader._open_folder_pipeline(  # noqa: SLF001 - focused reader unit test
+            io.BytesIO(b""), _folder(b"\x06\xf1\x07\x01", properties), password=b"pw"
+        )
+
+
+def _u64(value: int) -> bytes:
+    assert 0 <= value < 0x80
+    return bytes([value])
+
+
+def _bools(values: list[bool]) -> bytes:
+    out = bytearray()
+    current = 0
+    mask = 0x80
+    for value in values:
+        if value:
+            current |= mask
+        mask >>= 1
+        if mask == 0:
+            out.append(current)
+            current = 0
+            mask = 0x80
+    if mask != 0x80:
+        out.append(current)
+    return bytes(out)
+
+
+def _property(prop: int, payload: bytes) -> bytes:
+    return bytes([prop]) + _u64(len(payload)) + payload
+
+
+def _names_payload(names: list[str]) -> bytes:
+    encoded = bytearray(b"\x00")
+    for name in names:
+        encoded.extend(name.encode("utf-16le"))
+        encoded.extend(b"\x00\x00")
+    return bytes(encoded)
+
+
+def _anti_item_archive(payload: bytes = b"obsolete") -> bytes:
+    crc = zlib.crc32(payload) & 0xFFFFFFFF
+    pack_info = b"\x06" + _u64(0) + _u64(1) + b"\x09" + _u64(len(payload)) + b"\x00"
+    folder = _u64(1) + b"\x00"  # one COPY coder
+    unpack_info = (
+        b"\x07\x0b"
+        + _u64(1)
+        + b"\x00"
+        + folder
+        + b"\x0c"
+        + _u64(len(payload))
+        + b"\x0a"
+        + b"\x01"
+        + crc.to_bytes(4, "little")
+        + b"\x00"
+    )
+    streams_info = b"\x04" + pack_info + unpack_info + b"\x00"
+    files_info = (
+        b"\x05"
+        + _u64(2)
+        + _property(0x0E, _bools([False, True]))
+        + _property(0x10, _bools([True]))
+        + _property(0x11, _names_payload(["gone.txt", "gone.txt"]))
+        + b"\x00"
+    )
+    header = b"\x01" + streams_info + files_info + b"\x00"
+    start_header = (
+        len(payload).to_bytes(8, "little")
+        + len(header).to_bytes(8, "little")
+        + (zlib.crc32(header) & 0xFFFFFFFF).to_bytes(4, "little")
+    )
+    signature = (
+        b"7z\xbc\xaf'\x1c\x00\x04"
+        + (zlib.crc32(start_header) & 0xFFFFFFFF).to_bytes(4, "little")
+        + start_header
+    )
+    return signature + payload + header
+
+
+def test_synthetic_anti_item_lists_and_extracts_safely(tmp_path: Path) -> None:
+    archive = tmp_path / "anti.7z"
+    archive.write_bytes(_anti_item_archive())
+
+    with open_archive(archive) as reader:
+        content, anti = reader.members()
+        assert content.name == "gone.txt"
+        assert content.is_anti is False
+        assert content.is_current is False
+        assert anti.name == "gone.txt"
+        assert anti.is_anti is True
+        assert anti.is_current is True
+        assert reader.read(content) == b"obsolete"
+        assert reader.read(anti) == b""
+
+    fresh = tmp_path / "fresh"
+    with open_archive(archive) as reader:
+        results = reader.extract_all(fresh).results
+    assert [result.status for result in results] == [
+        ExtractionStatus.SKIPPED,
+        ExtractionStatus.EXTRACTED,
+    ]
+    assert not (fresh / "gone.txt").exists()
+
+    existing = tmp_path / "existing"
+    existing.mkdir()
+    preexisting = existing / "gone.txt"
+    preexisting.write_bytes(b"keep me")
+    with open_archive(archive) as reader:
+        reader.extract_all(existing)
+    assert preexisting.read_bytes() == b"keep me"
+
+
+@requires_binary("7z")
+def test_anti_item_fresh_extract_matches_7z_cli(tmp_path: Path) -> None:
+    archive = tmp_path / "anti.7z"
+    archive.write_bytes(_anti_item_archive())
+    archivey_dest = tmp_path / "archivey"
+    cli_dest = tmp_path / "cli"
+    cli_dest.mkdir()
+
+    with open_archive(archive) as reader:
+        reader.extract_all(archivey_dest)
+    subprocess.run(
+        ["7z", "x", str(archive), f"-o{cli_dest}", "-y"],
+        check=True,
+        capture_output=True,
+    )
+
+    assert sorted(
+        p.relative_to(archivey_dest) for p in archivey_dest.rglob("*")
+    ) == sorted(p.relative_to(cli_dest) for p in cli_dest.rglob("*"))
+    assert not any(path.is_file() for path in archivey_dest.rglob("*"))

--- a/tests/test_sevenzip_reader.py
+++ b/tests/test_sevenzip_reader.py
@@ -506,3 +506,21 @@ def test_anti_item_fresh_extract_matches_7z_cli(tmp_path: Path) -> None:
     ).read_bytes()
     assert not (archivey_dest / "gone.txt").exists()
     assert not (cli_dest / "gone.txt").exists()
+
+
+def test_filetime_conversion_and_invalid_timestamp_issue() -> None:
+    from archivey.internal.backends.sevenzip_reader import _filetime_to_datetime
+
+    # A normal FILETIME converts with no issue; 0/None mean "unset" (no value, no issue).
+    dt, issue = _filetime_to_datetime(
+        132_000_000_000_000_000, "a.txt", field="modified"
+    )
+    assert dt is not None and issue is None
+    assert _filetime_to_datetime(0, "a.txt", field="modified") == (None, None)
+    assert _filetime_to_datetime(None, "a.txt", field="modified") == (None, None)
+
+    # An out-of-range value yields no datetime and a reported issue (surfaced as a
+    # MEMBER_TIMESTAMP_INVALID diagnostic rather than being swallowed silently).
+    dt, issue = _filetime_to_datetime(0xFFFFFFFFFFFFFFFF, "a.txt", field="created")
+    assert dt is None
+    assert issue is not None and issue.field == "created"

--- a/tests/test_sevenzip_reader.py
+++ b/tests/test_sevenzip_reader.py
@@ -196,6 +196,55 @@ def test_7z_cli_multi_password_archive_roundtrip(tmp_path: Path) -> None:
 
 
 @requires_binary("7z")
+@requires("cryptography")
+def test_7z_multi_password_rejects_wrong_candidate_via_crc(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Wrong keys that decompress to the right length must still lose on CRC."""
+    first = tmp_path / "first.txt"
+    second = tmp_path / "second.txt"
+    first.write_bytes(b"first secret")
+    second.write_bytes(b"second secret")
+    archive = tmp_path / "multi-password-crc.7z"
+    for command in (
+        ["7z", "a", "-t7z", str(archive), first.name, "-pfirst", "-y"],
+        ["7z", "a", "-t7z", str(archive), second.name, "-psecond", "-y"],
+    ):
+        result = subprocess.run(
+            command, cwd=tmp_path, check=False, capture_output=True, text=True
+        )
+        if result.returncode != 0:
+            pytest.skip(
+                f"7z CLI cannot build multi-password 7z fixture: {result.stderr}"
+            )
+
+    original_pipeline = SevenZipReader._open_folder_pipeline
+    first_kdf = "first".encode("utf-16le")
+    garbage = b"\x05\x7f\xc6\x01\xebI\x03j\x88\x93\x8e\xe5\xb5"
+
+    def pipeline_with_wrong_first(self, source, folder, *, password):
+        # After the first folder unlocks, known-good "first" is tried on the second
+        # folder. Simulate a decompressor that yields plausible garbage of the
+        # expected length instead of raising, so only the CRC confirm rejects it.
+        if password == first_kdf:
+            for index, candidate in enumerate(self._archive.folders):
+                if candidate is folder and self._folder_unpack_size(index) == len(
+                    garbage
+                ):
+                    return io.BytesIO(garbage)
+        return original_pipeline(self, source, folder, password=password)
+
+    monkeypatch.setattr(
+        SevenZipReader, "_open_folder_pipeline", pipeline_with_wrong_first
+    )
+
+    with open_archive(archive, password=["first", "second"]) as reader:
+        members = {member.name: member for member in reader.members() if member.is_file}
+        assert reader.read(members["first.txt"]) == b"first secret"
+        assert reader.read(members["second.txt"]) == b"second secret"
+
+
+@requires_binary("7z")
 def test_7z_cli_multi_volume_archive_roundtrip(tmp_path: Path) -> None:
     payload = tmp_path / "large.bin"
     payload.write_bytes(bytes(range(256)) * 1200)

--- a/tests/test_slice.py
+++ b/tests/test_slice.py
@@ -198,3 +198,22 @@ class TestSlicingStreamSize:
     def test_size_none_when_underlying_unknowable(self) -> None:
         sliced = SlicingStream(NonSeekableBytesIO(DATA), length=None)
         assert sliced.size is None
+
+
+class TestSlicingStreamOwnSource:
+    class _Tracked(io.BytesIO):
+        closed_flag = False
+
+        def close(self) -> None:
+            self.closed_flag = True
+            super().close()
+
+    def test_default_is_non_owning(self) -> None:
+        underlying = self._Tracked(DATA)
+        SlicingStream(underlying, start=0, length=5).close()
+        assert underlying.closed_flag is False
+
+    def test_own_source_closes_underlying(self) -> None:
+        underlying = self._Tracked(DATA)
+        SlicingStream(underlying, start=0, length=5, own_source=True).close()
+        assert underlying.closed_flag is True

--- a/tests/test_solid.py
+++ b/tests/test_solid.py
@@ -1,0 +1,99 @@
+"""Contract for :class:`SolidBlockReader` — the sequential solid-block demux.
+
+This primitive backs 7z solid-folder iteration and is intended for RAR's ``unrar p``
+pipe too, so its lazy-skip / no-drain-on-close behaviour is pinned here directly rather
+than only through the 7z reader.
+"""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+
+from archivey.internal.streams.streamtools import SolidBlockReader, skip_forward
+
+
+class _CountingBlock(io.BytesIO):
+    """A BytesIO that records how many bytes were read and whether it was closed."""
+
+    def __init__(self, data: bytes) -> None:
+        super().__init__(data)
+        self.bytes_read = 0
+        self.was_closed = False
+
+    def read(self, n: int = -1, /) -> bytes:
+        data = super().read(n)
+        self.bytes_read += len(data)
+        return data
+
+    def close(self) -> None:
+        self.was_closed = True
+        super().close()
+
+
+def test_consecutive_members_read_in_order() -> None:
+    block = _CountingBlock(b"AAAABBBBBCC")
+    reader = SolidBlockReader(block)
+    assert reader.open_member(0, 4).read() == b"AAAA"
+    assert reader.open_member(4, 5).read() == b"BBBBB"
+    assert reader.open_member(9, 2).read() == b"CC"
+
+
+def test_partial_read_then_next_member_lazily_skips_tail() -> None:
+    block = _CountingBlock(b"AAAABBBB")
+    reader = SolidBlockReader(block)
+    first = reader.open_member(0, 4)
+    assert first.read(1) == b"A"  # only one byte consumed from the first member
+    # Opening the next member skips the first member's unread tail (the lazy drain).
+    assert reader.open_member(4, 4).read() == b"BBBB"
+
+
+def test_close_does_not_drain_the_block() -> None:
+    block = _CountingBlock(b"AAAABBBB")
+    reader = SolidBlockReader(block)
+    reader.open_member(0, 4).read(1)  # read a single byte, leave the rest
+    reader.close()
+    # Only the one requested byte was ever read; close discards the block without draining.
+    assert block.bytes_read == 1
+    assert block.was_closed is True
+
+
+def test_out_of_order_open_raises() -> None:
+    block = _CountingBlock(b"AAAABBBB")
+    reader = SolidBlockReader(block)
+    reader.open_member(4, 4).read()
+    with pytest.raises(ValueError, match="in order"):
+        reader.open_member(0, 4)
+
+
+def test_gap_between_members_is_skipped() -> None:
+    block = _CountingBlock(b"AA__BB")  # bytes 2..4 belong to no member
+    reader = SolidBlockReader(block)
+    assert reader.open_member(0, 2).read() == b"AA"
+    assert reader.open_member(4, 2).read() == b"BB"
+
+
+def test_truncated_block_raises_eof_on_skip() -> None:
+    block = _CountingBlock(b"AAAA")  # only 4 bytes, second member starts past the end
+    reader = SolidBlockReader(block)
+    reader.open_member(0, 4).read(1)
+    with pytest.raises(EOFError):
+        reader.open_member(8, 2)  # skip of 7 bytes over a 3-byte remainder
+
+
+def test_close_block_false_leaves_block_open() -> None:
+    block = _CountingBlock(b"AAAA")
+    reader = SolidBlockReader(block, close_block=False)
+    reader.open_member(0, 4).read()
+    reader.close()
+    assert block.was_closed is False
+
+
+def test_skip_forward_helper_raises_on_short_stream() -> None:
+    stream = io.BytesIO(b"1234")
+    skip_forward(stream, 4)
+    assert stream.read() == b""
+    stream.seek(0)
+    with pytest.raises(EOFError):
+        skip_forward(stream, 5)

--- a/tests/test_volumes.py
+++ b/tests/test_volumes.py
@@ -9,8 +9,8 @@ from pathlib import Path
 import pytest
 
 from archivey import extract, open_archive
-from archivey.exceptions import UnsupportedFeatureError
-from archivey.internal.volumes import discover_volume_siblings
+from archivey.exceptions import CorruptionError, TruncatedError, UnsupportedFeatureError
+from archivey.internal.volumes import discover_volume_siblings, join_volumes
 from archivey.types import ArchiveFormat
 
 _7Z_MAGIC = bytes.fromhex("377abcaf271c")
@@ -55,11 +55,21 @@ def test_discover_rnn_without_first_volume_is_not_a_set(tmp_path: Path) -> None:
     assert discover_volume_siblings(tmp_path / "archive.r01") is None
 
 
-def test_multi_volume_7z_raises_phase7_message(tmp_path: Path) -> None:
+def test_multi_volume_7z_is_joined_before_parse(tmp_path: Path) -> None:
     for name in ("vol.7z.001", "vol.7z.002"):
         (tmp_path / name).write_bytes(_7Z_MAGIC)
-    with pytest.raises(UnsupportedFeatureError, match="Phase 7"):
+    with pytest.raises(CorruptionError, match="signature header"):
         open_archive(tmp_path / "vol.7z.002", format=ArchiveFormat.SEVEN_Z)
+
+
+def test_join_7z_volumes_rejects_numbering_gaps(tmp_path: Path) -> None:
+    paths = []
+    for name in ("vol.7z.001", "vol.7z.003"):
+        path = tmp_path / name
+        path.write_bytes(b"")
+        paths.append(path)
+    with pytest.raises(TruncatedError, match="Incomplete 7z multi-volume set"):
+        join_volumes(paths)
 
 
 def test_multi_volume_rar_raises_phase7_message(tmp_path: Path) -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements OpenSpec change `native-7z-reader`: a zero-dependency native 7z reader (header parse, codecs, AES, multi-volume, anti-items).

## CI fix (this push)

`test_7z_cli_multi_password_archive_roundtrip` failed on Ubuntu/py3.12 when a wrong known-good password decompressed to the expected length and was accepted because folder digests were absent and per-member CRCs were not checked during password confirmation. `archive.read()` also skipped `VerifyingStream` checks (verification only ran on an empty EOF read).

- Confirm encrypted 7z folders against folder or per-member CRC before caching a password
- Verify digests on `VerifyingStream.close()` when the inner stream is already at EOF
- Regression coverage for wrong-candidate CRC rejection and close-after-full-read verification

## Test plan

- [x] `pytest tests/test_sevenzip_reader.py tests/test_codecs.py`
- [ ] Full CI matrix (`[all]`, `[all-lowest]`, `[core-only]`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-03a970fe-6c7a-4a85-892c-fb56f9999ed1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-03a970fe-6c7a-4a85-892c-fb56f9999ed1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

