### PR TITLE
Native 7z cleanup + review follow-ups: shared solid streaming, seekable members, dedup

### DIFF
--- a/src/archivey/internal/backends/sevenzip_parser.py
+++ b/src/archivey/internal/backends/sevenzip_parser.py
@@ -8,23 +8,15 @@ not import or delegate to ``py7zr``.
 from __future__ import annotations
 
 import io
-import lzma
 import zlib
-from collections.abc import Callable, Iterable
+from collections.abc import Callable
 from dataclasses import dataclass
 from enum import IntEnum
-from typing import BinaryIO, cast
+from typing import BinaryIO
 
 from archivey.exceptions import (
     CorruptionError,
-    EncryptionError,
-    PackageNotInstalledError,
     UnsupportedFeatureError,
-)
-from archivey.internal.streams.codecs import Codec, CodecParams, open_codec_stream
-from archivey.internal.streams.crypto import (
-    SevenZipKeyCache,
-    open_aes_decrypt_stream,
 )
 from archivey.internal.streams.streamtools import SlicingStream, read_exact
 from archivey.types import CompressionAlgorithm, CompressionMethod
@@ -129,15 +121,13 @@ class SevenZipArchive:
     has_encrypted_folders: bool
 
 
-PasswordInput = (
-    str
-    | bytes
-    | Iterable[str | bytes]
-    | Callable[[], str | bytes | Iterable[str | bytes] | None]
-)
-DecodeFolder = Callable[
-    [BinaryIO, SevenZipFolder, int, int, tuple[bytes, ...], SevenZipKeyCache], bytes
-]
+DecodeFolder = Callable[[BinaryIO, SevenZipFolder, int, int], bytes]
+"""Materialize an (encoded) header folder to bytes.
+
+``(source, folder, compressed_size, uncompressed_size) -> decoded``, where ``source`` is
+positioned at the start of the folder's packed data. The reader supplies the shared
+codec/crypto pipeline (``sevenzip_reader.decode_folder_to_bytes``); the parser never
+decodes folders itself."""
 
 
 @dataclass
@@ -181,11 +171,14 @@ class _FileProps:
 def parse_sevenzip_archive(
     fp: BinaryIO,
     *,
-    passwords: PasswordInput | None = None,
-    key_cache: SevenZipKeyCache | None = None,
-    decode_folder: DecodeFolder | None = None,
+    decode_folder: DecodeFolder,
 ) -> SevenZipArchive:
-    """Parse a 7z signature header and main header."""
+    """Parse a 7z signature header and main header.
+
+    ``decode_folder`` materializes an encoded header's folder to bytes (including any
+    password prompting/decryption); the parser only walks structure and never opens a
+    codec or crypto stream itself.
+    """
 
     fp.seek(0)
     signature = _read_exact(fp, _SIGNATURE_HEADER_SIZE, "7z signature header")
@@ -209,13 +202,10 @@ def parse_sevenzip_archive(
     if _crc32(header_data) != next_header_crc:
         raise CorruptionError("7z next header CRC mismatch")
 
-    password_candidates = _password_candidates(passwords)
     parsed = _parse_header(
         fp,
         io.BytesIO(header_data),
         after_header=after_header,
-        passwords=password_candidates,
-        key_cache=key_cache or SevenZipKeyCache(),
         decode_folder=decode_folder,
     )
 
@@ -291,9 +281,7 @@ def _parse_header(
     buffer: BinaryIO,
     *,
     after_header: int,
-    passwords: tuple[bytes, ...],
-    key_cache: SevenZipKeyCache,
-    decode_folder: DecodeFolder | None,
+    decode_folder: DecodeFolder,
 ) -> _ParsedHeader:
     prop = _read_property(buffer, "7z header")
     if prop == _Property.END:
@@ -311,16 +299,12 @@ def _parse_header(
         archive_fp,
         encoded_streams,
         after_header=after_header,
-        passwords=passwords,
-        key_cache=key_cache,
         decode_folder=decode_folder,
     )
     parsed = _parse_header(
         archive_fp,
         io.BytesIO(decoded),
         after_header=after_header,
-        passwords=passwords,
-        key_cache=key_cache,
         decode_folder=decode_folder,
     )
     parsed.is_header_encrypted = any(folder_is_encrypted(f) for f in encoded_folders)
@@ -699,9 +683,7 @@ def _decode_encoded_header(
     streams: _StreamsInfo,
     *,
     after_header: int,
-    passwords: tuple[bytes, ...],
-    key_cache: SevenZipKeyCache,
-    decode_folder: DecodeFolder | None,
+    decode_folder: DecodeFolder,
 ) -> bytes:
     folders = streams.folders or []
     pack_sizes = streams.pack_sizes or []
@@ -724,170 +706,13 @@ def _decode_encoded_header(
             after_header + streams.pack_pos + pack_positions[pack_stream_index]
         )
         source = SlicingStream(archive_fp, absolute_offset, compressed_size)
-        if decode_folder is not None:
-            folder_data = decode_folder(
-                source,
-                folder,
-                compressed_size,
-                uncompressed_size,
-                passwords,
-                key_cache,
-            )
-        else:
-            folder_data = _decode_simple_folder(
-                source,
-                folder,
-                compressed_size=compressed_size,
-                uncompressed_size=uncompressed_size,
-                passwords=passwords,
-                key_cache=key_cache,
-            )
-        if folder.digest_defined and _crc32(folder_data) != folder.crc:
-            raise CorruptionError("Encoded 7z header CRC mismatch")
-        decoded.extend(folder_data)
+        # ``decode_folder`` owns codec/crypto handling and CRC-checks its own output.
+        decoded.extend(
+            decode_folder(source, folder, compressed_size, uncompressed_size)
+        )
         pack_stream_index += pack_count
 
     return bytes(decoded)
-
-
-def _decode_simple_folder(
-    source: BinaryIO,
-    folder: SevenZipFolder,
-    *,
-    compressed_size: int,
-    uncompressed_size: int,
-    passwords: tuple[bytes, ...],
-    key_cache: SevenZipKeyCache,
-) -> bytes:
-    if any(
-        coder.num_in_streams != 1 or coder.num_out_streams != 1
-        for coder in folder.coders
-    ):
-        raise UnsupportedFeatureError(
-            "Encoded 7z headers with complex coder graphs are not supported"
-        )
-
-    if folder_is_encrypted(folder):
-        if not passwords:
-            raise EncryptionError("Password required to decrypt the 7z header")
-        return _try_decode_encrypted_header(
-            source,
-            folder,
-            compressed_size=compressed_size,
-            uncompressed_size=uncompressed_size,
-            passwords=passwords,
-            key_cache=key_cache,
-        )
-
-    return _decode_simple_folder_with_password(
-        source,
-        folder,
-        compressed_size=compressed_size,
-        uncompressed_size=uncompressed_size,
-        password=None,
-        key_cache=key_cache,
-    )
-
-
-def _try_decode_encrypted_header(
-    source: BinaryIO,
-    folder: SevenZipFolder,
-    *,
-    compressed_size: int,
-    uncompressed_size: int,
-    passwords: tuple[bytes, ...],
-    key_cache: SevenZipKeyCache,
-) -> bytes:
-    last_error: Exception | None = None
-    for password in passwords:
-        source.seek(0)
-        try:
-            return _decode_simple_folder_with_password(
-                source,
-                folder,
-                compressed_size=compressed_size,
-                uncompressed_size=uncompressed_size,
-                password=password,
-                key_cache=key_cache,
-            )
-        except (CorruptionError, EncryptionError) as exc:
-            last_error = exc
-
-    raise EncryptionError(
-        "No supplied password could decrypt the 7z header"
-    ) from last_error
-
-
-def _decode_simple_folder_with_password(
-    source: BinaryIO,
-    folder: SevenZipFolder,
-    *,
-    compressed_size: int,
-    uncompressed_size: int,
-    password: bytes | None,
-    key_cache: SevenZipKeyCache,
-) -> bytes:
-    stream: BinaryIO = SlicingStream(source, 0, compressed_size)
-    owned_streams: list[BinaryIO] = [stream]
-    try:
-        for coder in folder.coders:
-            stream = _open_coder_stream(
-                stream, coder, password=password, key_cache=key_cache
-            )
-            owned_streams.append(stream)
-        decoded = _read_exact(stream, uncompressed_size, "decoded 7z header")
-        if len(decoded) != uncompressed_size:
-            raise CorruptionError("Encoded 7z header is truncated after decoding")
-        return decoded
-    finally:
-        for opened in reversed(owned_streams):
-            opened.close()
-
-
-def _open_coder_stream(
-    source: BinaryIO,
-    coder: SevenZipCoder,
-    *,
-    password: bytes | None,
-    key_cache: SevenZipKeyCache,
-) -> BinaryIO:
-    if coder.method == _METHOD_COPY:
-        return source
-    if coder.method == _METHOD_AES:
-        if password is None:
-            raise EncryptionError("Password required to decrypt the 7z header")
-        if coder.properties is None:
-            raise CorruptionError("7z AES coder is missing properties")
-        try:
-            params = key_cache.aes_params_from_properties(password, coder.properties)
-        except ValueError as exc:
-            raise CorruptionError(f"Malformed 7z AES properties: {exc}") from exc
-        try:
-            return open_aes_decrypt_stream(source, params)
-        except PackageNotInstalledError:
-            raise
-    if coder.method in (_METHOD_LZMA, _METHOD_LZMA2):
-        codec = Codec.LZMA if coder.method == _METHOD_LZMA else Codec.LZMA2
-        params = CodecParams(filters=[_lzma_filter(coder)])
-        return open_codec_stream(codec, source, params=params, seekable=False)
-    if coder.method == _METHOD_BCJ2:
-        raise UnsupportedFeatureError("BCJ2-compressed 7z headers are not supported")
-    raise UnsupportedFeatureError(
-        f"Unsupported 7z header coder method {_method_hex(coder.method)}"
-    )
-
-
-def _lzma_filter(coder: SevenZipCoder) -> dict:
-    filter_id = lzma.FILTER_LZMA1 if coder.method == _METHOD_LZMA else lzma.FILTER_LZMA2
-    if coder.properties is None:
-        return {"id": filter_id}
-    try:
-        decode_properties = getattr(lzma, "_decode_filter_properties")
-        return decode_properties(filter_id, coder.properties)
-    except (AttributeError, lzma.LZMAError, ValueError) as exc:
-        raise CorruptionError(
-            f"Malformed 7z LZMA coder properties for {_method_hex(coder.method)}"
-        ) from exc
 
 
 def _read_names(buffer: BinaryIO, files: list[_FileProps]) -> None:
@@ -1021,32 +846,6 @@ def _pack_positions(pack_sizes: list[int]) -> list[int]:
         total += size
         positions.append(total)
     return positions
-
-
-def _password_candidates(passwords: PasswordInput | None) -> tuple[bytes, ...]:
-    if passwords is None:
-        return ()
-    raw: str | bytes | Iterable[str | bytes] | None
-    if isinstance(passwords, str | bytes):
-        raw = passwords
-    elif callable(passwords):
-        provider = cast(
-            Callable[[], str | bytes | Iterable[str | bytes] | None], passwords
-        )
-        raw = provider()
-    else:
-        raw = passwords
-    if raw is None:
-        return ()
-    if isinstance(raw, (str, bytes)):
-        values: Iterable[str | bytes] = (raw,)
-    else:
-        values = raw
-    return tuple(_password_to_kdf_bytes(password) for password in values)
-
-
-def _password_to_kdf_bytes(password: str | bytes) -> bytes:
-    return password.encode("utf-16le") if isinstance(password, str) else password
 
 
 def _read_boolean(

--- a/src/archivey/internal/backends/sevenzip_parser.py
+++ b/src/archivey/internal/backends/sevenzip_parser.py
@@ -27,11 +27,19 @@ _SIGNATURE_HEADER_SIZE = 32
 _MAX_UINT64_ENCODING = 8
 _MAX_UTF16_CHARS = 65536
 _MAX_NUM_STREAMS = 65536
+# 7z coder method IDs. Single source of truth: the reader imports these.
 _METHOD_COPY = b"\x00"
 _METHOD_LZMA = b"\x03\x01\x01"
 _METHOD_LZMA2 = b"\x21"
 _METHOD_AES = b"\x06\xf1\x07\x01"
 _METHOD_BCJ2 = b"\x03\x03\x01\x1b"
+_METHOD_DELTA = b"\x03"
+_METHOD_DEFLATE = b"\x04\x01\x08"
+_METHOD_DEFLATE64 = b"\x04\x01\x09"
+_METHOD_BZIP2 = b"\x04\x02\x02"
+_METHOD_ZSTD = b"\x04\xf7\x11\x01"
+_METHOD_BROTLI = b"\x04\xf7\x11\x02"
+_METHOD_PPMD = b"\x03\x04\x01"
 
 
 class _Property(IntEnum):
@@ -949,7 +957,7 @@ _METHOD_ALGORITHMS: dict[bytes, CompressionAlgorithm] = {
     _METHOD_COPY: CompressionAlgorithm.STORED,
     _METHOD_LZMA: CompressionAlgorithm.LZMA,
     _METHOD_LZMA2: CompressionAlgorithm.LZMA2,
-    b"\x03": CompressionAlgorithm.DELTA,
+    _METHOD_DELTA: CompressionAlgorithm.DELTA,
     b"\x04": CompressionAlgorithm.BCJ,
     b"\x03\x03\x01\x03": CompressionAlgorithm.BCJ,
     b"\x03\x03\x02\x05": CompressionAlgorithm.BCJ,
@@ -958,11 +966,11 @@ _METHOD_ALGORITHMS: dict[bytes, CompressionAlgorithm] = {
     b"\x03\x03\x07\x01": CompressionAlgorithm.BCJ,
     b"\x03\x03\x08\x05": CompressionAlgorithm.BCJ,
     _METHOD_BCJ2: CompressionAlgorithm.BCJ2,
-    b"\x04\x01\x08": CompressionAlgorithm.DEFLATE,
-    b"\x04\x01\x09": CompressionAlgorithm.DEFLATE64,
-    b"\x04\x02\x02": CompressionAlgorithm.BZIP2,
-    b"\x04\xf7\x11\x01": CompressionAlgorithm.ZSTD,
-    b"\x04\xf7\x11\x02": CompressionAlgorithm.BROTLI,
-    b"\x03\x04\x01": CompressionAlgorithm.PPMD,
+    _METHOD_DEFLATE: CompressionAlgorithm.DEFLATE,
+    _METHOD_DEFLATE64: CompressionAlgorithm.DEFLATE64,
+    _METHOD_BZIP2: CompressionAlgorithm.BZIP2,
+    _METHOD_ZSTD: CompressionAlgorithm.ZSTD,
+    _METHOD_BROTLI: CompressionAlgorithm.BROTLI,
+    _METHOD_PPMD: CompressionAlgorithm.PPMD,
     _METHOD_AES: CompressionAlgorithm.UNKNOWN,
 }

--- a/src/archivey/internal/backends/sevenzip_reader.py
+++ b/src/archivey/internal/backends/sevenzip_reader.py
@@ -23,10 +23,23 @@ from archivey.exceptions import (
     UnsupportedFeatureError,
 )
 from archivey.internal.backends.sevenzip_parser import (
+    _METHOD_AES,
+    _METHOD_BCJ2,
+    _METHOD_BROTLI,
+    _METHOD_BZIP2,
+    _METHOD_COPY,
+    _METHOD_DEFLATE,
+    _METHOD_DEFLATE64,
+    _METHOD_DELTA,
+    _METHOD_LZMA,
+    _METHOD_LZMA2,
+    _METHOD_PPMD,
+    _METHOD_ZSTD,
     SevenZipArchive,
     SevenZipCoder,
     SevenZipFileRecord,
     SevenZipFolder,
+    _method_hex,
     compression_method_for_coder,
     compute_is_current,
     folder_is_encrypted,
@@ -76,19 +89,6 @@ from archivey.types import (
     MemberStreams,
     MemberType,
 )
-
-_METHOD_COPY = b"\x00"
-_METHOD_LZMA = b"\x03\x01\x01"
-_METHOD_LZMA2 = b"\x21"
-_METHOD_AES = b"\x06\xf1\x07\x01"
-_METHOD_BCJ2 = b"\x03\x03\x01\x1b"
-_METHOD_DELTA = b"\x03"
-_METHOD_DEFLATE = b"\x04\x01\x08"
-_METHOD_DEFLATE64 = b"\x04\x01\x09"
-_METHOD_BZIP2 = b"\x04\x02\x02"
-_METHOD_ZSTD = b"\x04\xf7\x11\x01"
-_METHOD_BROTLI = b"\x04\xf7\x11\x02"
-_METHOD_PPMD = b"\x03\x04\x01"
 
 _BCJ_METHODS: dict[bytes, Codec] = {
     b"\x04": Codec.BCJ_X86,
@@ -164,10 +164,6 @@ class _LimitedFolderReader(ReadOnlyIOStream):
             chunk = self.read(min(self._remaining, 1024 * 1024))
             if not chunk:
                 break
-
-
-def _method_hex(method: bytes) -> str:
-    return "0x" + method.hex()
 
 
 def _password_to_kdf_bytes(password: bytes) -> bytes:

--- a/src/archivey/internal/backends/sevenzip_reader.py
+++ b/src/archivey/internal/backends/sevenzip_reader.py
@@ -33,7 +33,11 @@ from archivey.internal.backends.sevenzip_parser import (
     parse_sevenzip_archive,
 )
 from archivey.internal.base_reader import BaseArchiveReader, ReadBackend
-from archivey.internal.config import stream_config_from_archivey
+from archivey.internal.config import (
+    DEFAULT_STREAM_CONFIG,
+    StreamConfig,
+    stream_config_from_archivey,
+)
 from archivey.internal.diagnostics_collector import DiagnosticCollector
 from archivey.internal.naming import emit_member_name_normalized, normalize_member_name
 from archivey.internal.open_site import OpenSite
@@ -227,6 +231,176 @@ def _member_stream_size(member: ArchiveMember) -> int:
     return member.size if member.size is not None else 0
 
 
+def _check_linear_coder_chain(folder: SevenZipFolder) -> None:
+    """Verify the folder's coders form a single linear chain in list order.
+
+    ``open_folder_pipeline`` decodes coders in list order, assuming coder 0 consumes the
+    single packed stream and each coder's output feeds the next coder's input. 7z encoders
+    emit coders in exactly that order (verified against py7zr fixtures: LZMA2, Delta+LZMA2,
+    BCJ+LZMA2, AES+LZMA2 all yield ``packed_indices == [0]`` and ``bind_pairs`` of the form
+    ``(i+1, i)``). That wiring is only *implied* by the bind pairs, though, so we validate
+    it here and raise rather than silently emit wrong bytes for an out-of-order or branching
+    coder graph.
+    """
+    expected_bind = {(i + 1, i) for i in range(len(folder.coders) - 1)}
+    if folder.packed_indices != [0] or set(folder.bind_pairs) != expected_bind:
+        raise UnsupportedFeatureError(
+            "7z folders with non-linear coder wiring are not supported"
+        )
+
+
+def _open_aes_stage(
+    source: BinaryIO,
+    coder: SevenZipCoder,
+    *,
+    password: bytes | None,
+    key_cache: SevenZipKeyCache,
+) -> BinaryIO:
+    if password is None:
+        raise EncryptionError("Password required to decrypt this 7z folder")
+    if coder.properties is None:
+        raise CorruptionError("7z AES coder is missing properties")
+    try:
+        params = key_cache.aes_params_from_properties(password, coder.properties)
+    except ValueError as exc:
+        raise CorruptionError(f"Malformed 7z AES properties: {exc}") from exc
+    return open_aes_decrypt_stream(source, params)
+
+
+def _open_lzma_run(
+    source: BinaryIO,
+    run: list[SevenZipCoder],
+    *,
+    stream_config: StreamConfig,
+    collector: DiagnosticCollector | None,
+) -> BinaryIO:
+    has_lzma1 = any(coder.method == _METHOD_LZMA for coder in run)
+    has_lzma2 = any(coder.method == _METHOD_LZMA2 for coder in run)
+    has_bcj = any(coder.method in _BCJ_METHODS for coder in run)
+    if has_lzma1 and has_lzma2:
+        raise UnsupportedFeatureError(
+            "Mixed LZMA1+LZMA2 7z coder chains are unsupported"
+        )
+    if has_lzma1 and has_bcj:
+        raise UnsupportedFeatureError("LZMA1+BCJ 7z coder chains are unsupported")
+    # A 7z filter run lists coders in decode order (outer filter first); liblzma wants
+    # them in the reverse (encode) order, hence ``reversed(run)``.
+    filters = [_lzma_filter(coder) for coder in reversed(run)]
+    codec = Codec.LZMA if has_lzma1 and not has_lzma2 else Codec.LZMA2
+    return open_codec_stream(
+        codec,
+        source,
+        config=stream_config,
+        params=CodecParams(filters=filters),
+        collector=collector,
+        seekable=False,
+    )
+
+
+def open_folder_pipeline(
+    source: BinaryIO,
+    folder: SevenZipFolder,
+    *,
+    password: bytes | None,
+    key_cache: SevenZipKeyCache,
+    stream_config: StreamConfig | None = None,
+    collector: DiagnosticCollector | None = None,
+) -> BinaryIO:
+    """Compose a folder's coder chain into a single pull stream.
+
+    Only linear 1-in/1-out coder chains are supported; BCJ2 and multi-stream coder
+    graphs raise ``UnsupportedFeatureError``. Consecutive LZMA-family coders (LZMA,
+    LZMA2, Delta, BCJ) collapse into one liblzma filter chain; other codecs and the AES
+    stage each wrap the stream once.
+    """
+    if any(
+        coder.num_in_streams != 1 or coder.num_out_streams != 1
+        for coder in folder.coders
+    ):
+        raise UnsupportedFeatureError(
+            "7z folders with complex coder graphs are not supported"
+        )
+    _check_linear_coder_chain(folder)
+    config = stream_config if stream_config is not None else DEFAULT_STREAM_CONFIG
+    stream: BinaryIO = source
+    index = 0
+    while index < len(folder.coders):
+        coder = folder.coders[index]
+        if coder.method == _METHOD_BCJ2:
+            raise UnsupportedFeatureError(
+                "BCJ2-compressed 7z folders are not supported"
+            )
+        if coder.method == _METHOD_COPY:
+            index += 1
+            continue
+        if coder.method == _METHOD_AES:
+            stream = _open_aes_stage(
+                stream, coder, password=password, key_cache=key_cache
+            )
+            index += 1
+            continue
+        if _is_lzma_family(coder):
+            run: list[SevenZipCoder] = []
+            while index < len(folder.coders) and _is_lzma_family(folder.coders[index]):
+                run.append(folder.coders[index])
+                index += 1
+            stream = _open_lzma_run(
+                stream, run, stream_config=config, collector=collector
+            )
+            continue
+        codec = _SINGLE_STAGE_CODECS.get(coder.method)
+        if codec is None:
+            raise UnsupportedFeatureError(
+                f"Unsupported 7z coder method {_method_hex(coder.method)}"
+            )
+        stream = open_codec_stream(
+            codec,
+            stream,
+            config=config,
+            params=CodecParams(properties=coder.properties),
+            collector=collector,
+            seekable=False,
+        )
+        index += 1
+    return stream
+
+
+def decode_folder_to_bytes(
+    source: BinaryIO,
+    folder: SevenZipFolder,
+    *,
+    compressed_size: int,
+    uncompressed_size: int,
+    password: bytes | None,
+    key_cache: SevenZipKeyCache,
+    stream_config: StreamConfig | None = None,
+    collector: DiagnosticCollector | None = None,
+) -> bytes:
+    """Fully decode one folder's packed stream into memory and CRC-check it.
+
+    Used to materialize the (encoded) 7z header. ``source`` must be positioned at the
+    start of the folder's packed data.
+    """
+    stream = open_folder_pipeline(
+        SlicingStream(source, 0, compressed_size),
+        folder,
+        password=password,
+        key_cache=key_cache,
+        stream_config=stream_config,
+        collector=collector,
+    )
+    try:
+        decoded = read_exact(stream, uncompressed_size)
+        if len(decoded) != uncompressed_size:
+            raise TruncatedError("7z folder is truncated after decoding")
+        if folder.digest_defined and folder.crc is not None:
+            if zlib.crc32(decoded) & 0xFFFFFFFF != folder.crc & 0xFFFFFFFF:
+                raise CorruptionError("Decoded 7z folder CRC mismatch")
+        return decoded
+    finally:
+        stream.close()
+
+
 class SevenZipReader(BaseArchiveReader):
     """Reads 7z archives using the native parser and shared codec streams."""
 
@@ -275,11 +449,6 @@ class SevenZipReader(BaseArchiveReader):
         self._volume_count = getattr(source, "volume_count", 1)
         self._archive = parse_sevenzip_archive(
             self._shared.view(0),
-            passwords=tuple(
-                _password_to_kdf_bytes(password)
-                for password in self._passwords.iter_candidates()
-            ),
-            key_cache=self._key_cache,
             decode_folder=self._decode_header_folder,
         )
         self._folder_pack_starts = self._folder_pack_start_indices(self._archive)
@@ -301,66 +470,28 @@ class SevenZipReader(BaseArchiveReader):
         folder: SevenZipFolder,
         compressed_size: int,
         uncompressed_size: int,
-        passwords: tuple[bytes, ...],
-        key_cache: SevenZipKeyCache,
     ) -> bytes:
-        del passwords, key_cache
-
-        def decrypt(password: bytes) -> bytes:
+        def decode(password: bytes | None) -> bytes:
             source.seek(0)
-            kdf_password = _password_to_kdf_bytes(password)
-            return self._decode_folder_to_bytes(
+            return decode_folder_to_bytes(
                 source,
                 folder,
                 compressed_size=compressed_size,
                 uncompressed_size=uncompressed_size,
-                password=kdf_password,
+                password=password,
+                key_cache=self._key_cache,
+                stream_config=self._stream_config,
+                collector=self._diagnostics_collector,
             )
 
         try:
             if folder_is_encrypted(folder):
-                return self._passwords.attempt(None, decrypt)
-            source.seek(0)
-            return self._decode_folder_to_bytes(
-                source,
-                folder,
-                compressed_size=compressed_size,
-                uncompressed_size=uncompressed_size,
-                password=None,
-            )
+                return self._passwords.attempt(
+                    None, lambda password: decode(_password_to_kdf_bytes(password))
+                )
+            return decode(None)
         except _PasswordCandidatesExhausted as exc:
             raise EncryptionError("Password required to decrypt the 7z header") from exc
-
-    def _decode_folder_to_bytes(
-        self,
-        source: BinaryIO,
-        folder: SevenZipFolder,
-        *,
-        compressed_size: int,
-        uncompressed_size: int,
-        password: bytes | None,
-    ) -> bytes:
-        stream = self._open_folder_pipeline(
-            SlicingStream(source, 0, compressed_size),
-            folder,
-            password=password,
-        )
-        try:
-            decoded = read_exact(stream, uncompressed_size)
-            if len(decoded) != uncompressed_size:
-                raise TruncatedError("7z folder is truncated after decoding")
-            if folder.digest_defined:
-                verifier = VerifyingStream(
-                    io.BytesIO(decoded),
-                    {"crc32": folder.crc if folder.crc is not None else 0},
-                    collector=self._diagnostics_collector,
-                    archive_name=self._archive_name,
-                )
-                verifier.read()
-                verifier.read()
-            return decoded
-        finally:
-            stream.close()
 
     def _build_members(self) -> list[ArchiveMember]:
         current_flags = compute_is_current(self._archive.files)
@@ -602,91 +733,13 @@ class SevenZipReader(BaseArchiveReader):
         *,
         password: bytes | None,
     ) -> BinaryIO:
-        if any(
-            coder.num_in_streams != 1 or coder.num_out_streams != 1
-            for coder in folder.coders
-        ):
-            raise UnsupportedFeatureError(
-                "7z folders with complex coder graphs are not supported"
-            )
-        stream: BinaryIO = source
-        index = 0
-        while index < len(folder.coders):
-            coder = folder.coders[index]
-            if coder.method == _METHOD_BCJ2:
-                raise UnsupportedFeatureError(
-                    "BCJ2-compressed 7z folders are not supported"
-                )
-            if coder.method == _METHOD_COPY:
-                index += 1
-                continue
-            if coder.method == _METHOD_AES:
-                stream = self._open_aes_stage(stream, coder, password=password)
-                index += 1
-                continue
-            if _is_lzma_family(coder):
-                run: list[SevenZipCoder] = []
-                while index < len(folder.coders) and _is_lzma_family(
-                    folder.coders[index]
-                ):
-                    run.append(folder.coders[index])
-                    index += 1
-                stream = self._open_lzma_run(stream, run)
-                continue
-            codec = _SINGLE_STAGE_CODECS.get(coder.method)
-            if codec is None:
-                raise UnsupportedFeatureError(
-                    f"Unsupported 7z coder method {_method_hex(coder.method)}"
-                )
-            stream = open_codec_stream(
-                codec,
-                stream,
-                config=self._stream_config,
-                params=CodecParams(properties=coder.properties),
-                collector=self._diagnostics_collector,
-                seekable=False,
-            )
-            index += 1
-        return stream
-
-    def _open_aes_stage(
-        self,
-        source: BinaryIO,
-        coder: SevenZipCoder,
-        *,
-        password: bytes | None,
-    ) -> BinaryIO:
-        if password is None:
-            raise EncryptionError("Password required to decrypt this 7z folder")
-        if coder.properties is None:
-            raise CorruptionError("7z AES coder is missing properties")
-        try:
-            params = self._key_cache.aes_params_from_properties(
-                password, coder.properties
-            )
-        except ValueError as exc:
-            raise CorruptionError(f"Malformed 7z AES properties: {exc}") from exc
-        return open_aes_decrypt_stream(source, params)
-
-    def _open_lzma_run(self, source: BinaryIO, run: list[SevenZipCoder]) -> BinaryIO:
-        has_lzma1 = any(coder.method == _METHOD_LZMA for coder in run)
-        has_lzma2 = any(coder.method == _METHOD_LZMA2 for coder in run)
-        has_bcj = any(coder.method in _BCJ_METHODS for coder in run)
-        if has_lzma1 and has_lzma2:
-            raise UnsupportedFeatureError(
-                "Mixed LZMA1+LZMA2 7z coder chains are unsupported"
-            )
-        if has_lzma1 and has_bcj:
-            raise UnsupportedFeatureError("LZMA1+BCJ 7z coder chains are unsupported")
-        filters = [_lzma_filter(coder) for coder in reversed(run)]
-        codec = Codec.LZMA if has_lzma1 and not has_lzma2 else Codec.LZMA2
-        return open_codec_stream(
-            codec,
+        return open_folder_pipeline(
             source,
-            config=self._stream_config,
-            params=CodecParams(filters=filters),
+            folder,
+            password=password,
+            key_cache=self._key_cache,
+            stream_config=self._stream_config,
             collector=self._diagnostics_collector,
-            seekable=False,
         )
 
     def _member_stream_from_folder(

--- a/src/archivey/internal/streams/crypto.py
+++ b/src/archivey/internal/streams/crypto.py
@@ -184,8 +184,8 @@ def derive_sevenzip_aes_key(password: bytes, *, salt: bytes, cycles: int) -> byt
     if cycles < 0 or cycles > 0x3F:
         raise ValueError(f"NumCyclesPower out of range: {cycles}")
     if cycles == 0x3F:
-        ba = bytearray(salt + password + bytes(32))
-        return bytes(ba[:32])
+        # The 0x3f sentinel means "no hashing": key = (salt + password), zero-padded to 32.
+        return (salt + password + bytes(32))[:32]
     # Batch rounds to cut hashlib.update call overhead (same approach as py7zr).
     cat_cycle = 6
     if cycles > cat_cycle:

--- a/tests/fuzz_sevenzip_parser.py
+++ b/tests/fuzz_sevenzip_parser.py
@@ -12,11 +12,18 @@ import os
 from collections.abc import Iterable
 from pathlib import Path
 from random import Random
+from typing import BinaryIO
 
 import pytest
 
 from archivey import ArchiveyError
-from archivey.internal.backends.sevenzip_parser import MAGIC_7Z, parse_sevenzip_archive
+from archivey.internal.backends.sevenzip_parser import (
+    MAGIC_7Z,
+    SevenZipFolder,
+    parse_sevenzip_archive,
+)
+from archivey.internal.backends.sevenzip_reader import decode_folder_to_bytes
+from archivey.internal.streams.crypto import SevenZipKeyCache
 from tests.sample_archives import CORPUS, CorpusEntry, corpus_archive_path
 
 pytestmark = pytest.mark.skipif(
@@ -61,10 +68,29 @@ def _mutations(seed: bytes, label: str) -> Iterable[bytes]:
             yield bytes(data)
 
 
+def _decode_folder(
+    source: BinaryIO,
+    folder: SevenZipFolder,
+    compressed_size: int,
+    uncompressed_size: int,
+) -> bytes:
+    # Reuse the reader's real codec/crypto pipeline (unencrypted only: no passwords).
+    return decode_folder_to_bytes(
+        source,
+        folder,
+        compressed_size=compressed_size,
+        uncompressed_size=uncompressed_size,
+        password=None,
+        key_cache=SevenZipKeyCache(),
+    )
+
+
 def test_parse_sevenzip_archive_fuzz_harness(tmp_path: Path) -> None:
     for index, seed in enumerate(_seed_bytes(tmp_path)):
         for mutated in _mutations(seed, str(index)):
             try:
-                parse_sevenzip_archive(io.BytesIO(mutated))
+                parse_sevenzip_archive(
+                    io.BytesIO(mutated), decode_folder=_decode_folder
+                )
             except ArchiveyError:
                 pass


### PR DESCRIPTION
Follow-up cleanup on the native 7z reader (#66), applied as separate commits on top of that branch so the original implementation and these changes stay reviewable in isolation. Base is the #66 head branch, so this PR's diff is **only** these commits.

## Commits

**Initial review cleanup**
1. `328764a` **Consolidate 7z folder-decode into one shared pipeline** — the parser carried a second, complete folder-decode implementation plus a flexible password-input system, all bypassed in production (the reader always injects its own `decode_folder`). Extracted `open_folder_pipeline()` / `decode_folder_to_bytes()` as shared functions; made `decode_folder` required; deleted the duplicate decoder + dead password machinery (parser −201 net lines). Also simplified the header CRC to a direct `zlib.crc32` and added a guard against non-linear coder wiring (was silent-wrong-bytes territory).
2. `8747379` **De-duplicate method-ID constants and `_method_hex`** — parser is now the single source of truth.
3. `5fa3e15` **Simplify the KDF `0x3f` branch.**

**From the PR review comments**
4. `b64e19a` **Reusable solid-block streaming + seekable 7z member streams** — replaces the 7z-local `_LimitedFolderReader`/`_skip_folder_prefix` with a reusable `streamtools.SolidBlockReader` (owns one forward-only decoded block, vends consecutive member slices, skips a prior member's unread tail *lazily* on the next open, and closes the block without draining) so RAR's `unrar p` pipe can reuse it. Random `open()` now goes through `SlicingStream` with an opt-in `own_source` flag; with `MemberStreams.SEEKABLE` and a seekable codec chain the member stream is seekable (backward seeks re-decode from the folder start, O(n)). `VerifyingStream` became seek-transparent — it delegates seek/seekable to its inner and disables verification once a seek moves off the sequential frontier (mirroring the gzip truncation backstop), so a SEEKABLE member is still CRC-checked on a pure forward read.
5. `8b33709` **Address the remaining review comments** — parse the start header with `struct.unpack`; drop the always-constant `after_header` threading and the unused `SevenZipArchive.after_header` field; emit `MEMBER_TIMESTAMP_INVALID` for out-of-range NTFS FILETIMEs instead of swallowing them (matching zip/tar); remove the unused `get_members()` v1-compat alias.

## Tests added
- `SolidBlockReader` contract (lazy skip, ordering, no-drain-on-close, EOF) and `SlicingStream.own_source`.
- Cross-format member-stream seekability in `test_member_stream_contract.py` — **not** seekable by default, seekable with working forward/backward seeks under `MemberStreams.SEEKABLE`, now covering all formats including 7z.
- 7z invalid-timestamp → issue unit test.

## Deliberately left for later (flagged, not done)
- The "verify anyway if the underlying stream had to be fully decoded" optimization for seeked streams — a separate, more complex change.
- The over-strict `parse_sevenzip_aes_properties` `0xC0==0` check (no fixture to validate a new path; real 7z always emits an IV).

## Test plan
- [x] Full `pytest` suite green in all three dependency legs: `[all]` (1339), `[all-lowest]` (1338), `[core-only]` (1136).
- [x] `ARCHIVEY_FUZZ=1` 7z parser fuzz harness (now exercises the shared pipeline).
- [x] `pyrefly` + `ty` clean; `ruff check`/`format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pv35e2eAyd9ZmG6YNS27Jr