### PR TITLE
Deep review round 2: reports + fixes for the concurrency, timestamp, and error-boundary findings

### DIFF
--- a/docs/formats.md
+++ b/docs/formats.md
@@ -41,6 +41,14 @@ Recommended installs: `archivey[recommended]` or `archivey[recommended-lite]` (n
 - Hardlinks are first-class at extraction; unfiltered `extract_all` resolves them in one
   pass.
 - `MemberStreams.CONCURRENT` uses a per-reader shared-handle lock (same shape as ISO).
+- **Mid-archive corruption can silently shorten the listing.** Stdlib `tarfile` treats a
+  corrupt member header *after the first* as a clean end of archive — no exception is
+  raised; iteration just stops early. Archivey backstops this with its end-of-archive
+  marker check: a listing cut short by corruption almost never lands on a valid
+  two-block null trailer, so it surfaces as the `ARCHIVE_EOF_MARKER_MISSING` diagnostic
+  (a warning by default). When a provably complete listing matters (inventory/dedupe
+  sweeps), set `ArchiveyConfig(strict_archive_eof=True)` to escalate that diagnostic to
+  `TruncatedError`.
 
 ## 7z
 

--- a/docs/internal/known-issues.md
+++ b/docs/internal/known-issues.md
@@ -4,6 +4,21 @@
 > codec and why — including why `rapidgzip` is the single accelerator library (the issue below)
 > and why an `indexed_zstd` zstd accelerator would face the same constraint.
 
+## stdlib `tarfile` treats a corrupt non-first header as clean end-of-archive
+
+`tarfile.TarFile.next()` re-raises `InvalidHeaderError` only when it occurs at offset 0;
+a corrupt member header anywhere later is swallowed and iteration simply ends — so
+mid-archive corruption produces a **silently shortened listing**, never a
+`CorruptionError`. Confirmed against a corrupted-checksum fixture and a corrupted
+`.tar.gz` whose garbage decode parses as an invalid header (deep review W1). Archivey's
+backstop is the end-of-archive marker check in `TarReader._verify_tar_eof`: a
+corruption-shortened listing almost never sits on a valid two-block null trailer, so it
+fires `ARCHIVE_EOF_MARKER_MISSING` (WARNING by default; `strict_archive_eof=True`
+escalates to `TruncatedError`). The diagnostic message names both possibilities. A
+native TAR header walker (the 7z/RAR strategy applied to TAR) would make this
+archivey's own decision instead of tarfile's; until then the leniency is documented in
+`docs/formats.md`.
+
 ## Importing the ISO backend patches pycdlib process-globally (by design)
 
 `import archivey` eagerly imports the ISO backend to register it, and that import installs a

--- a/docs/safe-extraction.md
+++ b/docs/safe-extraction.md
@@ -19,6 +19,12 @@ archivey.extract("archive.zip", "out/")
 - **Decompression bombs** — cumulative bytes, per-member and archive ratios, entry cap
 - **Permission hygiene** — setuid/setgid/sticky stripped except under `TRUSTED`
 
+Atomic file writes stage into temp siblings named `.archivey-tmp-<random>` inside the
+destination directory. Any Python-level failure removes them; only a hard kill
+(SIGKILL, power loss) can leave one behind. Leftover `.archivey-tmp-*` files in an
+extraction destination are archivey's staging files and are safe to delete before
+re-running the extraction.
+
 Full trust boundaries and open gaps: [threat model](internal/threat-model.md).
 
 ## Policies

--- a/review/deep-concurrency.md
+++ b/review/deep-concurrency.md
@@ -1,0 +1,477 @@
+# Deep pass 1 — Concurrency correctness
+
+Second-pass review on branch `claude/deep-review-concurrency-structure-ldkxms`, HEAD `7786fda`
+(post-PR-#73, so C1/C2/C3 fixes are in the tree — confirmed: `base_reader.py:519-528` catches
+`BaseException`, `directory_reader.py:63` sets `_MEMBER_LIST_UPFRONT = False`).
+
+Method: every mechanism gets (a) the guarantee it is meant to provide, (b) either a proof
+naming the ordering/atomicity/exclusion property and where it is enforced, or (c) a concrete
+violating execution. "Appears correct" is not used. Findings **N1–N7** are new; corrections to
+`review/concurrency.md` and `review/00-recon-map.md` are called out inline and collected at
+the end.
+
+## Corrected invariants and shared-state map
+
+The first review's invariants I1–I6 need three corrections:
+
+- **I1/I2 (single root pass / single live stream) are not enforced during library-internal
+  open windows.** The exemption that admits extract_all's own internal opens is a
+  reader-wide *depth counter*, not a thread- or token-scoped grant, so it admits **any**
+  thread's `open()` during those windows (finding N3). I1/I2 as stated hold only outside
+  `extract_all()` and outside first-touch link resolution.
+- **I3 (snapshot "published exactly once … immutable after publication")** is right about
+  once-ness but wrong about atomicity: the snapshot is two separate attribute stores with an
+  unlocked fast path keyed on only the first (finding N2). Also, the code comment's claim of
+  "tuple + frozen name map copy" (`base_reader.py:515`) is inaccurate — the *mutable* list
+  and dict are published directly; immutability is by convention (callers get copies via
+  `list(...)`, but internal readers share the mutable objects).
+- **I5 (streaming reader is single-owner)** holds, but not by anything in `ReaderState` —
+  it holds because `core.py:167-172` rejects `streaming=True` + `CONCURRENT` at open. The
+  enforcement lives two modules away from the state it protects; a future entry point that
+  skips `open_archive` (a backend constructed directly, as tests do) gets no protection.
+
+Shared-state additions the recon map missed:
+
+- `SevenZipKeyCache._cache` (`crypto.py:240-253`) — unlocked dict, written from worker
+  threads under CONCURRENT.
+- `ArchiveMember._member_id` / `_archive_id` are stamped from **two** unsynchronized paths
+  when `_MEMBER_LIST_UPFRONT` is set: `_get_members_registered` (under the materialization
+  election) and `get_members_if_available()` → `_get_members_index_only`
+  (`base_reader.py:905-910` — **no token, no election**). For 7z/single-file, which yield
+  cached member objects, both paths mutate the *same* objects concurrently. Benign because
+  both write identical positional values (see the CPython-reliance section), but it is a
+  data race in the ISO-C sense on free-threaded builds, and it double-runs
+  `_warn_for_bidirectional_controls`.
+- The finalizer capture in `_register_public_stream` (`base_reader.py:272-282`): the
+  finalizer closure captures `self._on_close` **at attach time** (`archive_stream.py:111`),
+  so correctness depends on the assignment at `base_reader.py:280` preceding
+  `_attach_finalizer()` at `:281`. Currently ordered correctly; nothing enforces it.
+
+## Mechanism-by-mechanism verdicts
+
+### M1. Operation tokens (`ReaderState.acquire_pass/acquire_worker/…`)
+
+**Guarantee (from docstrings `reader_state.py:41-50,154-160`):** without CONCURRENT, a
+reader-wide pass excludes other passes and workers, and workers exclude passes; overlap is
+rejected loudly (`ArchiveyUsageError`/`ConcurrentAccessError`), never served silently.
+
+**Verdict: does NOT hold — the internal-opens exemption is a hole (N3, VERIFIED, medium-high).**
+
+`begin_internal_opens()` (`reader_state.py:93-96`) increments two plain reader-wide counters.
+While `extract_all()` holds them (`base_reader.py:1108-1110`) — or while first-touch
+materialization resolves link targets (`base_reader.py:504-513`) — the admission rules change
+for **every thread**:
+
+- `acquire_worker` (`reader_state.py:170-173`): root active + `_internal_open_depth > 0` →
+  the foreign thread's `open()` is admitted as a *child of extract_all's root* instead of
+  raising.
+- `acquire_live_stream` (`reader_state.py:236-239`): `_gate_exempt_depth > 0` → the
+  single-live-stream gate is bypassed, so the foreign stream is registered as live.
+
+Concrete execution, plain GIL build, **no CONCURRENT declared**:
+
+1. Thread A: `reader.extract_all(dest)` on a random-access TAR (no `_handle_lock`:
+   `tar_reader.py:170-175` takes a lock only under CONCURRENT or streaming).
+2. Thread B (a caller bug the gate exists to catch): `reader.open("x").read()`.
+3. B is admitted (child token + gate exemption). Both A's coordinator stream and B's stream
+   are tarfile `ExFileObject`s over the **same** `fileobj`. `tarfile._FileInFile.read` is a
+   separate `seek()` then `read()`; the GIL can switch threads between them. A seeks to
+   offset₁ → switch → B seeks to offset₂, reads → switch → A reads **at offset₂**.
+4. Observable consequence: **wrong member bytes written into A's extraction output** (or
+   returned from B), silently — the exact failure the gate promises to convert into a loud
+   `ConcurrentAccessError`. ISO under the same conditions is equally exposed (pycdlib has no
+   internal fp lock); ZIP survives *by accident* because stdlib `_SharedFile` takes
+   `ZipFile._lock` per read.
+
+The exemption is meant for the coordinator's *own* opens (hardlink recovery through public
+`open()`, link-target reads), and those all run on the owning thread. Scoping the exemption
+to the thread that called `begin_internal_opens()` (store `threading.get_ident()`; exempt
+only matching threads) closes the hole without changing any supported behavior. I did not
+apply this (maintainer rule: concurrency mechanisms get a decision first).
+
+**Where the guarantee otherwise holds:** every admission decision and token release runs
+under the single `self._lock`; release is idempotent via `token._released`
+(`reader_state.py:125-135`); a root release clears stale children. The check-then-act shape
+of `open()` (token acquired, released, *then* backend work) is safe because the token is a
+reservation recorded in state, not a held lock — overlap detection only needs the
+membership sets, which are lock-protected.
+
+### M2. Materialization election (`begin/complete/fail_materialization`)
+
+**Guarantee:** first-touch member-list construction runs at most once at a time; under
+CONCURRENT, overlapping callers block and then observe the fully published snapshot; a
+failed attempt re-opens the election. (`reader_state.py:190-230`.)
+
+**Verdict: the election itself holds; the *publication* does not (N2, VERIFIED, medium).**
+
+The election is a correct monitor: the wait loop `begin_materialization` re-checks its
+predicate after every wake (`reader_state.py:205-219`), `complete/fail` notify under the
+same lock, and the C1 fix (`base_reader.py:519-528`) resets the election on `BaseException`.
+Waiters that return `False` from `begin_materialization` are ordered after
+`complete_materialization` by the lock, which is after both publication stores — that path
+is sound.
+
+The unlocked **fast path** is not. `_get_members_registered` publishes two fields in
+sequence (`base_reader.py:516-517`):
+
+```python
+self._members_cache = members            # (1)
+self._members_by_name_lists = by_name_lists  # (2)
+```
+
+and the fast path (`base_reader.py:481-482`) returns as soon as (1) is visible, **without
+the lock**. Two consumers then immediately dereference the *second* field:
+
+- `get()` — `base_reader.py:933`: `assert self._members_by_name_lists is not None`
+- `open(name)` — `base_reader.py:960-961`: same assert.
+
+Concrete execution (CONCURRENT reader, plain GIL build — no free-threading needed):
+thread W (owner, holding a *worker* token per `members()` at `base_reader.py:864-869`)
+executes store (1); the GIL switches before (2); thread B calls `reader.get("x")`, acquires
+its own worker token (workers don't exclude workers), hits the fast path, returns, and the
+assert fires → **`AssertionError` from a public API** (with `python -O`: `AttributeError:
+'NoneType' object has no attribute 'get'` inside `_last_by_exact_name`). Both are
+untranslated internal errors leaking from a correct program.
+
+Fix is one line: swap (1) and (2) so the sentinel everything keys on is stored last (plus a
+comment making the ordering load-bearing). On free-threaded builds the fast path then
+additionally relies on attribute store/load atomicity with acquire/release ordering — see
+the CPython-reliance section.
+
+**Re-entrancy: the election can self-deadlock through a diagnostic callback (N4a, VERIFIED,
+low-medium).** Materialization emits diagnostics with no lock held (correct), but a user
+`on_diagnostic` callback that calls back into the same reader deadlocks *its own thread* on
+a CONCURRENT reader:
+
+1. Owner thread, inside `_iter_members()` during first-touch, emits (say)
+   `MEMBER_TIMESTAMP_INVALID`; the collector delivers the callback outside its lock
+   (`diagnostics_collector.py:224-234`).
+2. Callback calls `reader.members()` → worker token admitted (no root) →
+   `_get_members_registered` → cache still `None` → `begin_materialization` → state is
+   MATERIALIZING → CONCURRENT branch → `self._materialization_cv.wait()`
+   (`reader_state.py:215`) — waiting for a notify that only *this same thread* can issue.
+   Permanent single-thread hang; no second thread required.
+
+The collector's `_emitting_threads` guard (`diagnostics_collector.py:184-189`) is aimed at
+exactly this class but only trips when the re-entered operation *itself emits*; a
+non-emitting `members()` sails past it. Non-CONCURRENT readers get the (misleading but loud)
+"another materialization is already in progress" error instead. Cheap fix: record the
+electing thread id in `ReaderState`; `begin_materialization` raises `ArchiveyUsageError` when
+the waiter *is* the owner. Same pattern closes the sibling deadlock N4b below.
+
+### M3. Progressive pass (`_ProgressivePassIterator`, `_begin_forward_pass`)
+
+**Guarantee:** one instance-held forward pass; early exit survivable so `scan_members()` can
+finish it; on completion the resolved list is published. Single-owner (caller-synchronized
+per stream; cross-thread overlap excluded by pass tokens).
+
+**Verdict: does NOT hold under exception unwind — a failed pass converts to silent partial
+success (N1, VERIFIED with repro, medium-high).**
+
+`_ProgressivePassIterator.__next__` (`base_reader.py:1177-1189`) treats `StopIteration` from
+`self._members_source` as clean EOF and publishes the cache via `_finalize_pass_links()`.
+But a generator that *raised* is thereafter **closed**, and PEP-479 semantics make every
+subsequent `next()` on it raise `StopIteration`. So:
+
+1. Streaming pass raises mid-scan (any error: codec `CorruptionError`, `TruncatedError`,
+   a RAISE-disposition diagnostic). The exception propagates to the caller — correct so far.
+2. Caller catches it and calls `scan_members()` (the method the error messages themselves
+   recommend: "Call scan_members() for the resolved member list").
+3. `scan_members` drains the same iterator (`base_reader.py:887-891`); the first `next()`
+   hits the closed generator → `StopIteration` → `_exhausted = True` →
+   `_finalize_pass_links()` **publishes the partial `_pass_scanned` as the complete,
+   resolved `_members_cache`** — and returns it with no error.
+
+Reproduced deterministically (TAR, `MEMBER_TIMESTAMP_INVALID` set to RAISE on the third of
+six members):
+
+```
+iterated: ['a.bin', 'b.bin'] | error: DiagnosticRaisedError
+scan_members: ['a.bin', 'b.bin'] -- NO ERROR (published as resolved cache)
+get_members_if_available: ['a.bin', 'b.bin']
+```
+
+The same happens for a corrupt `.tar.gz` whose decode error surfaces mid-walk. Observable
+consequence: after an error the reader **lies** — `scan_members()`/`get_members_if_available()`
+present a truncated listing as complete and resolved, and a subsequent `extract_all` on a
+non-streaming reader materialized the same way would extract the subset "successfully". For
+the founding dedupe/inventory use case, a silent partial listing is the worst failure shape.
+Fix direction: record the escaped exception on the iterator (wrap `next(self._members_source)`
+in `except BaseException: self._broken = exc; raise`) and have subsequent `__next__` re-raise
+a `ReadError` ("pass previously failed") instead of finalizing; `fail`-not-`finalize` on any
+non-StopIteration unwind.
+
+(Related but distinct, filed in deep-unknown-unknowns.md: `tarfile` itself treats a corrupt
+*non-first* header as clean end-of-archive, so some corruption never raises at all — the
+listing just ends early with only the EOF-marker diagnostic as a WARNING.)
+
+**Where the mechanism otherwise holds:** the instance-held iterator surviving `break` is
+correct (the `__iter__` generator's `finally` releases the pass token on early exit via
+generator close; the *iterator* keeps its position); token release on abandonment without
+close relies on refcounting GC — see CPython-reliance R4.
+
+### M4. Live-stream gate + lifecycle leases + teardown
+
+**Guarantee:** without CONCURRENT at most one live public stream (modulo N3); reader starts
+with one lease, each live stream holds one; `_close_archive` runs exactly once, only after
+READER_CLOSED and the last lease drop; double close and stream-close/finalizer races are
+idempotent.
+
+**Verdict: holds (with one BaseException caveat).** Argument:
+
+- Lease accounting is single-writer-per-transition: every mutation of `_lease_count`,
+  `_live_streams`, `_teardown_claimed`, `lifecycle` happens inside `ReaderState._lock`
+  (`reader_state.py:252-337`). The teardown trigger (`_release_lease_locked`) computes
+  "should run teardown" *in the same lock hold* as the decrement, so exactly one releaser
+  observes the 0-and-closed-and-unclaimed conjunction.
+- `claim_teardown` re-checks all three conditions and flips `_teardown_claimed` atomically
+  (`reader_state.py:303-316`), so even if two callers somehow both got `True` (they cannot,
+  per the previous point) only one runs `_close_archive`.
+- Double release of one stream is idempotent through set membership: the second
+  `release_live_stream` finds `id(stream)` absent and returns `False`
+  (`reader_state.py:255-258`). This is what makes the explicit-close vs GC-finalizer race
+  benign: both funnel into the same idempotent release. The finalizer never runs while a
+  strong reference exists, so it cannot race a *concurrent* `close()` on the same object;
+  and after `close()`, `_detach_finalizer` disarms it (`archive_stream.py:348`).
+- Caveat (accepted): `_maybe_teardown` catches `Exception`, not `BaseException`
+  (`base_reader.py:312`). A `KeyboardInterrupt` inside `_close_archive` leaves lifecycle at
+  TEARDOWN_RUNNING with `_teardown_claimed=True`; teardown is never retried (by design) and
+  never marked complete, so backend handles leak silently after a Ctrl-C-during-teardown.
+  For KI that is a reasonable trade; noting so it is a choice, not an oversight.
+- Dead mechanism: `take_teardown_error` (`reader_state.py:324-328`) has **zero callers**
+  (grepped src + tests). Either wire it up (e.g. surface a deferred-teardown failure on the
+  next public call) or delete it; a stored-but-never-read error is a silent-swallow path.
+
+### M5. Draining close (`mark_reader_closed`)
+
+**Guarantee:** under CONCURRENT, `close()` blocks new admissions, waits for in-flight
+workers, and transitions once; concurrent double-close is idempotent; an interrupted closer
+doesn't wedge others.
+
+**Verdict: holds, with the same re-entrancy exception as M2 (N4b, VERIFIED, low).**
+The monitor is correct: `_closing` is set under the lock before waiting; admissions check it
+(`reader_state.py:346-351`); the drain loop's predicate is re-checked per wake; the
+`except BaseException` arm resets `_closing` and re-notifies (`reader_state.py:298-301`) so
+an interrupted closer leaves the door open for others. Waiting closers use a proper
+predicate loop on `_close_cv` (`reader_state.py:277-280`).
+
+The exception: `close()` called *from the same thread that holds a worker token* — the
+realistic route is again a diagnostic/progress callback fired during a worker operation —
+finds `_workers` non-empty and waits on `_workers_cv` for its own token: single-thread
+deadlock on a CONCURRENT reader (`reader_state.py:293-294`). Non-CONCURRENT raises instead
+(`:286-290`). Same owner-thread-check fix as N4a.
+
+### M6. Backend shared-handle locks
+
+**Guarantee:** all positioned operations on one shared OS-level handle are mutually
+exclusive, so seek→read pairs are atomic per consumer.
+
+**Verdicts:**
+
+- **TAR `LockedStream` — holds under CONCURRENT/streaming.** Every public op holds the lock
+  across the whole call (`locked.py:32-68`); crucially tarfile's internal
+  `_FileInFile.read` (seek+read) executes entirely *inside* `LockedStream.read`'s lock
+  hold, so the pair is atomic. Open/EOF-check/close/progressive-`next()` all take the same
+  lock (`tar_reader.py:178,270,296,324,361,501,551`). Holds **only when the lock exists** —
+  the default random-access reader has none and depends on single-owner usage, which N3
+  punctures.
+- **ZIP `CloseLockedStream` — holds, but by pinned-stdlib audit, not by construction.**
+  Reads are deliberately not serialized by archivey; data integrity rests on
+  `zipfile._SharedFile.read` taking `ZipFile._lock` around its seek+read (verified in
+  CPython 3.11–3.13 sources), and the archivey lock covers only open/close where
+  `_fileRefCnt` is unlocked. The ZipCrypto side-channel reads (`_ciphertext_body_stream`,
+  `_read_zipcrypto_header`, `zip_reader.py:526-579`) hold `ZipFile._lock` across their whole
+  save/seek/read/restore window, which is the *same* lock `_SharedFile` uses — so they
+  mutually exclude member reads correctly. This is reliance R2 below.
+- **ISO — holds under CONCURRENT modulo the pinned-pycdlib audit.** `open_file_from_iso` +
+  `_PyCdlibStream` construction under the lock, all subsequent ops via `LockedStream`
+  (`iso_reader.py:477-484`); `walk()`/`get_record()` are audited as not touching `_cdfp`
+  (`iso_reader.py:346-350`). Reliance R3.
+- **`SharedSource`/`SlicingStream` re-seek views — holds.** The seek+read pair runs under
+  `_io_guard` (`slice.py:124-134`); `seek()` only moves the private `_pos`; construction
+  never moves the shared handle in re-seek mode (`slice.py:93-97`); the SEEK_END probe is
+  also guarded (`slice.py:156-158`). One near-miss: `SlicingStream.size`
+  (`slice.py:193-208`) calls `source_byte_size(self._stream)`, which for whitelisted types
+  does an **unguarded** tell/SEEK_END/restore on the shared handle
+  (`binaryio.py:210-217`) — that would corrupt a concurrent locked read. It is unreachable
+  today only because `SharedSource.view()` resolves `length` to a concrete int whenever the
+  source size is knowable (`shared.py:108-117`), and when it is *not* knowable
+  `source_byte_size` returns `None` for the same object without seeking. Correct by
+  coincidence of the two call sites sharing one function; nothing local to
+  `SlicingStream.size` prevents a future caller from creating an open-ended locked view.
+  Cheap hardening: take `_io_guard` around the probe, or forbid `length=None` when a lock is
+  supplied.
+
+### M7. `ArchiveStream` one-shot open + close
+
+**Guarantee:** `open_fn` runs at most once, never under the stream lock; open-vs-close race
+never leaks an inner stream; close is idempotent and translates inner-close errors.
+
+**Verdict: holds.** The claim is an ownership transfer under `_open_lock`
+(`archive_stream.py:190-204`): exactly one caller swaps `_open_fn` to `None`; losers get a
+typed error rather than blocking (documented caller-synchronization contract). `open_fn`
+runs lock-free (so a backend handle lock never nests under stream state), and the publish
+step re-checks `closed` and closes the freshly opened inner if a close won the race
+(`archive_stream.py:211-219`). Concurrent `close()`+`close()` on one stream can both enter
+the body (the `closed` check at `:328` is unlocked), can both invoke `_on_close`, and can
+double-release the lease at the *stream* layer — but M4's set-membership idempotence absorbs
+it, and same-stream concurrency is explicitly the caller's to synchronize. No violation of
+the reader's invariants is reachable through this window.
+
+### M8. `DiagnosticCollector`
+
+**Guarantee:** counters/retention consistent under concurrent emits; delivery (log +
+callback) outside the lock; same-thread reentrancy through emit detected loudly.
+
+**Verdict: holds for what it claims; the claim is narrower than the docstring implies.**
+All counter/retention mutations are under the RLock; delivery happens after the `with`
+block exits (`diagnostics_collector.py:184-238`); the per-thread reentrancy set correctly
+distinguishes parallel emits from same-thread re-entry, and the `finally` clears the id even
+when the callback raises. But the error message ("cannot drive another operation on the same
+reader/stream while a diagnostic is being emitted") promises more than is enforced — only
+*emitting* re-entry is caught; non-emitting re-entry reaches the reader and can hit N4a/N4b.
+`_attach_diagnostic`'s tuple read-modify-write (`:242-245`) is exclusive because each member
+belongs to one reader with one collector, and the replacement is a single reference store —
+readers of `member.diagnostics` see the old or new tuple, never a torn one.
+
+### M9. `_PasswordCandidates` / `SevenZipKeyCache` / `_folder_passwords`
+
+**Guarantee:** provider invoked with no archivey lock held; same-reader provider re-entry
+raises; concurrent first-touch may duplicate attempts but converges; known-good promotion
+is synchronized.
+
+**Verdict: holds as documented.** Promotion and snapshots take `_state_lock`
+(`password.py:139-153`); the provider depth guard increments/decrements under
+`_provider_lock` with the callback outside both (`password.py:117-137`); `_provider` is
+immutable after construction so its unlocked reads in `attempt` are safe. Duplicated
+expensive work is explicitly documented as the accepted cost (`password.py:39-44`), and 7z's
+`_folder_passwords` check-then-act (`sevenzip_reader.py:794-825`) can at worst run the full
+folder-confirm decode once per racing thread and call the provider more than once —
+convergent because all writers store the same confirmed value. The dict writes themselves
+are reliance R1 (per-object dict atomicity), not corruption under either build. The one
+sharp edge: `iter_candidates` in ZIP's stored-password path plus a *stateful* provider can
+interleave with another thread's attempt so the provider is asked with non-monotonic
+`attempt` numbers — cosmetic, the API makes no ordering promise across threads.
+
+### M10. Single-file reader's `_pending_stream` (non-seekable one-shot)
+
+**Guarantee:** the single forward pass is handed out exactly once; a second open fails
+loudly (`single_file_reader.py:279-290`).
+
+**Verdict: holds, but only via a distant invariant.** The `if/read/None` sequence is a
+textbook check-then-act; two concurrent `open()` calls would both receive the *same* stream.
+It is unreachable because a non-seekable source forces `streaming=True`
+(`core.py:219-227`), and `streaming=True` + CONCURRENT is rejected (`core.py:167-172`), so
+`_open_member` on a non-seekable source can never be entered from two threads through the
+public API. The proof spans three files; a one-line comment at the check-then-act site (or
+an assert `self._handle_lock is None`-style guard) would keep a future
+non-seekable-random-access change from silently landing on the race.
+
+### M11. Process-global installs (pycdlib cycle guard, codec module sentinels)
+
+**Verdict: holds.** Both are performed at module import under the import lock; the deque
+subclass keeps its visited-set per *instance*, so concurrent ISO walks don't share state
+(`iso_reader.py:115-178`); codec sentinels (`codecs.py:95-107`) are written once at import
+and only read thereafter.
+
+## Lock ordering — correction to the first review
+
+`review/concurrency.md` ("Lock-ordering / deadlock check") claims ReaderState's lock and a
+backend handle lock "can be held simultaneously … ReaderState-outer, handle-inner". **That is
+wrong, and the truth is stronger:** no code path holds `ReaderState._lock` while acquiring
+any other lock. Every `ReaderState` method takes and releases the lock internally (the CV
+waits release it), and token "holding" is a state entry, not a held lock — by the time
+`_open_member` takes a handle lock, the state lock is long released.
+
+The actual nesting pairs in the tree, each one-directional and therefore acyclic:
+
+| Outer | Inner | Where |
+|---|---|---|
+| backend `_handle_lock` | `ZipFile._lock` | `_zip_open_raw` → `zipfile.open` → `_SharedFile` (`zip_reader.py:635-640`) |
+| backend `_handle_lock` | (tarfile/pycdlib internals, lock-free) | `tar_reader.py:501`, `iso_reader.py:477` |
+| `SharedSource._lock` | — (leaf; raw file/BytesIO/ConcatenatedFile ops) | `slice.py:124` |
+| `DiagnosticCollector._lock` | — (leaf; delivery runs outside it) | `diagnostics_collector.py:224` |
+| `_provider_lock` / `_state_lock` | — (leaves; callback runs outside) | `password.py:121-134` |
+| `ArchiveStream._open_lock` | — (leaf; `open_fn` runs outside) | `archive_stream.py:190-205` |
+
+TAR's `_open_member` additionally keeps `emit()` outside the handle lock on purpose
+(`tar_reader.py:495-513`), so collector-lock-under-handle-lock doesn't occur either. With no
+lock ever taken while another archivey lock is held, deadlock requires a *condition wait*
+whose fulfiller is blocked — which is exactly the N4 self-deadlocks, the only deadlocks
+found.
+
+## Interpreter shutdown
+
+- `_AcceleratorStream`'s `weakref.finalize` guard is the load-bearing one and is built
+  correctly (staticmethod callback, strong ref to the raw inner only) — it runs via
+  finalize's atexit hook before module teardown, closing rapidgzip's C++ threads. Holds.
+- **N5 (SUSPECTED, exotic): the `ArchiveStream` lease finalizer can hang shutdown.** Its
+  callback calls `release_live_stream` → `ReaderState._lock`
+  (`archive_stream.py:113-117` → `reader_state.py:253`). At interpreter shutdown, daemon
+  threads are frozen (3.9–3.11: hang on GIL; 3.12+: exit at next GIL acquire) — a daemon
+  thread parked *inside* a `ReaderState` critical section never releases the lock, and the
+  atexit-driven finalizer then blocks forever → the process hangs instead of exiting. The
+  window is a handful of bytecodes wide and requires daemon threads driving a reader at
+  exit; standard for lock-taking finalizers, but worth a line in the concurrency docs since
+  the library otherwise makes strong shutdown claims (the rapidgzip SIGABRT work).
+- The finalizer's `sys.unraisablehook` usage is itself guarded against raising. Holds.
+
+## Where correctness relies on CPython implementation details (inventory)
+
+The task asked for *every* such place. These are the ones that survive scrutiny as real
+load-bearing reliances (each is fine today; the point is they are guarantees the code
+assumes rather than enforces):
+
+- **R1 — per-object dict/attribute atomicity for benign-race caches.** `SevenZipKeyCache._cache`,
+  `_folder_passwords`, and the double-stamping of `_member_id` are unlocked concurrent
+  writes that are safe under the GIL and, on 3.13t, safe only because PEP 703 gives
+  individual dict/attribute operations per-object locking. Any port (PyPy without such
+  guarantees, subinterpreters with shared objects) or any refactor to a fancier cache
+  structure inherits a real race. One `threading.Lock` per cache would make it explicit for
+  ~0 cost.
+- **R2 — `zipfile` internals.** The entire CONCURRENT-ZIP design rests on the audited claims
+  that `_SharedFile.read` holds `ZipFile._lock` and that only `_fileRefCnt` open/close is
+  unlocked (`zip_reader.py:306-312`, `locked.py:71-78`); plus direct use of private
+  `ZipFile._lock` (`zip_reader.py:522-524`, loud `AttributeError` if renamed) and private
+  `ZipInfo._raw_time` (`zip_reader.py:514-520`, **silent** `getattr(..., 0)` fallback —
+  filed in deep-unknown-unknowns as a should-fail-loud).
+- **R3 — pycdlib walk/get_record not touching the shared fp** — pinned-version audit,
+  documented at the call site (`iso_reader.py:346-350`). Good hygiene; still a reliance.
+- **R4 — refcounting promptness for pass-token release.** An abandoned `__iter__`/
+  `stream_members` generator releases its pass token in a `finally` that runs at generator
+  close — immediate under refcounting, arbitrarily delayed under 3.13t's deferred refcounts
+  / any tracing GC. Until then the reader rejects all other operations ("another reader
+  operation is already active") with no hint that the owner is garbage. Not a corruption,
+  but a usability trap unique to non-refcounted builds.
+- **R5 — GIL switch granularity for the unlocked fast paths.** `_members_cache` (N2),
+  `BaseArchiveReader._closed`, `ArchiveStream.closed` are read unlocked; on GIL builds these
+  are single-reference reads (atomic by bytecode granularity), on 3.13t they are atomic by
+  PEP 703 attribute semantics. Fine — but N2 shows that *pairs* of such fields need explicit
+  ordering, which no build guarantees across two separate stores.
+- **R6 — `lzma._decode_filter_properties`** — already converted to a loud import-time bind
+  (`sevenzip_reader.py:169-184`) after the first review; the model to copy for R2's
+  `_raw_time`.
+
+## Findings summary
+
+| # | Sev | Status | What | Where |
+|---|-----|--------|------|-------|
+| N1 | Med-High | VERIFIED (repro) | Exception mid streaming pass → `scan_members()`/`get_members_if_available()` silently publish the partial list as complete+resolved | `base_reader.py:1177-1189`, `:692-703` |
+| N2 | Med | VERIFIED (interleaving) | Two-store snapshot publication + unlocked fast path → `AssertionError`/`AttributeError` from `get()`/`open(name)` racing first-touch under CONCURRENT | `base_reader.py:481,516-517,933,960` |
+| N3 | Med-High | VERIFIED (code) | Internal-opens exemption is depth-scoped, not thread-scoped → foreign-thread `open()` silently admitted during `extract_all`/link-reads on a non-CONCURRENT reader; wrong bytes on unlocked TAR/ISO handles instead of the promised loud error | `reader_state.py:93-101,170-173,236-239` |
+| N4 | Low-Med | VERIFIED (argument) | Same-thread CV deadlocks via non-emitting reader calls from `on_diagnostic`: (a) `begin_materialization` waits on own election, (b) `close()` drains own worker | `reader_state.py:215,293` |
+| N5 | Very low | SUSPECTED | Lease finalizer takes `ReaderState._lock` at shutdown → hang if a daemon thread died holding it | `archive_stream.py:113`, `reader_state.py:253` |
+| N6 | Trivial | VERIFIED | `take_teardown_error` is dead code; deferred-teardown errors stored, never read | `reader_state.py:324-328` |
+| N7 | Trivial | VERIFIED | "Publish an immutable snapshot (tuple + frozen …)" comment describes code that publishes the mutable list/dict | `base_reader.py:516` |
+
+## Corrections to the first review
+
+1. **Lock-ordering section of `concurrency.md` is wrong** — ReaderState's lock and handle
+   locks are never held simultaneously; see the table above. The conclusion (no deadlock
+   cycle) stands, for a stronger reason; the deadlocks that do exist are CV self-waits (N4),
+   which that section's method (lock-pair enumeration) could not find.
+2. **Invariant I2/I3/I5 as stated are inaccurate** — see the corrected map (N3, N2, and the
+   core.py-enforced I5).
+3. **"DiagnosticCollector … Correct"** — correct for emit-vs-emit, but its guard does not
+   deliver the promise in its own error message; N4 passes through it.
+4. **C1/C2/C3 post-review statuses confirmed accurate** in the current tree.

--- a/review/deep-concurrency.md
+++ b/review/deep-concurrency.md
@@ -1,5 +1,12 @@
 # Deep pass 1 — Concurrency correctness
 
+> **Post-review status (this PR, round 2):** maintainer approved implementing the fixes.
+> **N1, N2, N3, N4, N6, N7 are FIXED** on this branch, with regression tests
+> (N1: contract + end-to-end TAR repro; N3: ReaderState unit + foreign-thread-during-
+> extract_all; N4: both callback-re-entry deadlocks now raise `ArchiveyUsageError`).
+> N5 is documented in `_attach_finalizer`'s docstring (accepted risk). The R-inventory
+> items are documentation of reliances, not defects — unchanged.
+
 Second-pass review on branch `claude/deep-review-concurrency-structure-ldkxms`, HEAD `7786fda`
 (post-PR-#73, so C1/C2/C3 fixes are in the tree — confirmed: `base_reader.py:519-528` catches
 `BaseException`, `directory_reader.py:63` sets `_MEMBER_LIST_UPFRONT = False`).
@@ -86,8 +93,9 @@ Concrete execution, plain GIL build, **no CONCURRENT declared**:
 The exemption is meant for the coordinator's *own* opens (hardlink recovery through public
 `open()`, link-target reads), and those all run on the owning thread. Scoping the exemption
 to the thread that called `begin_internal_opens()` (store `threading.get_ident()`; exempt
-only matching threads) closes the hole without changing any supported behavior. I did not
-apply this (maintainer rule: concurrency mechanisms get a decision first).
+only matching threads) closes the hole without changing any supported behavior. **Applied
+in this PR** after maintainer approval: `_internal_open_threads` is a per-thread depth map
+and both exemption checks go through `_internal_opens_active_locked()`.
 
 **Where the guarantee otherwise holds:** every admission decision and token release runs
 under the single `self._lock`; release is idempotent via `token._released`

--- a/review/deep-simplification.md
+++ b/review/deep-simplification.md
@@ -1,0 +1,209 @@
+# Deep pass 2 — Structural simplification
+
+Question posed: not "where is code duplicated" (the first pass's X1–X5, all fixed) but
+"which abstraction, if adopted, deletes a *category* of code — and is the half-size,
+strictly-no-weaker version of this library real?"
+
+Baseline: `src/archivey` is ~16.5k lines. Verdict up front: **the half-size version does not
+exist** (argued at the end), but three category-deleting changes do, worth roughly 8–12% of
+the tree and — more importantly — each deletes a *recurring failure mode*, not just lines.
+They are ordered by (category deleted ÷ disruption).
+
+## S1 — One error boundary: backends stop writing translate/stamp/raise code at all
+
+**The category:** hand-rolled exception translation at backend call sites. The prior pass
+saw one symptom (X3, ZIP's thrice-repeated tuple) and fixed it locally with
+`_reraise_member_error`. The disease is tree-wide: the pattern
+
+```python
+except <raw errors> as exc:
+    translated = self._translate_exception(exc)
+    if translated is not None:
+        self._stamp_error_context(translated, ...)
+        raise translated from exc
+    raise
+```
+
+exists at **10 sites today** (`tar_reader.py:245,274,305,336,509`,
+`iso_reader.py:292,358,490`, `zip_reader.py:628,733`) plus the per-backend helper variants
+(`_translate_open_error`, `_reraise_member_error`) — and this is *after* X3 was fixed. Every
+site is a place to forget a member-name stamp, to catch too narrow a tuple (the exact bug X3
+documented), or to run diagnostics under a handle lock (which `tar_reader.py:495-513`
+carefully hand-avoids, once, with a comment).
+
+**The observation that deletes it:** this logic already exists, once, finished, in
+`ArchiveStream._fail` (`archive_stream.py:221-243`) — translate via the backend's hook,
+stamp, chain, pass ArchiveyError through, re-raise unrecognized. Backends re-implement it
+only because they call raw libraries *outside* an ArchiveStream: at archive-open time, at
+member-open time, and during metadata passes.
+
+**The change:** give `BaseArchiveReader` one context manager that *is* the error boundary —
+
+```python
+@contextmanager
+def _translated_errors(self, member_name: str | None = None):
+    try:
+        yield
+    except ArchiveyError as exc:
+        self._stamp_error_context(exc, member_name); raise
+    except Exception as exc:
+        translated = self._translate_exception(exc)
+        if translated is None: raise
+        self._stamp_error_context(translated, member_name)
+        raise translated from exc
+```
+
+and make it the *only* sanctioned way for a backend to touch its underlying library. Every
+one of the 10 sites collapses to `with self._translated_errors(name):`. The per-backend
+raw-exception tuples (`_ZIP_MEMBER_READ_ERRORS`, `_PYCDLIB_ERRORS`, the tarfile catches)
+stop being *catch* lists at N sites and become what they already are conceptually: input to
+the one `_translate_exception` hook. Two structural consequences beyond line count:
+
+- The "unrecognized exceptions propagate raw" contract (CONTRIBUTING's no-catch-all rule) is
+  enforced by the boundary's shape instead of re-earned at every site.
+- The ZipCrypto special case (EncryptionError must not get member-stamped,
+  `zip_reader.py:626-633`) becomes a keyword on the boundary instead of a divergent helper.
+
+Estimated deletion: ~120–150 lines of live code, and the entire "site drifted" bug class.
+This is the change X3 was a local instance of; adopting it retires X3's fix too.
+
+**Not weaker because:** the boundary is behavior-identical at each site (same translate, same
+stamp, same chaining); the only sites that can't use it verbatim are the ones that must
+capture-then-translate to keep `emit()` outside a lock — and those become
+`with self._handle_guard(): ...` *inside* `with self._translated_errors(...)`, which orders
+correctly by construction.
+
+## S2 — One member-list pipeline instead of two
+
+**The category:** the parallel materialized/progressive machinery in `BaseArchiveReader`.
+Today there are two complete pipelines that both produce "the resolved member list +
+name index":
+
+| concern | random-access pipeline | streaming pipeline |
+|---|---|---|
+| state | `_members_cache`, `_members_by_name_lists` | `_pass_scanned`, `_pass_by_name_lists`, `_progressive_gen`, `_forward_pass_started` |
+| id stamping | `_get_members_registered` loop (`base_reader.py:490-494`) | `_stamp_progressive_member` (`:705-719`) |
+| link resolution | inline second phase (`:496-513`) | `_finalize_pass_links` (`:692-703`) |
+| completion | `complete_materialization` | `_ProgressivePassIterator.__next__` EOF arm |
+| plus | `_get_members_index_only` (`:531-536`), a third id-stamping loop for `get_members_if_available` | |
+
+Three id-stamping loops, two name-index builders, two link-resolution drivers, two
+completion protocols — and the deep-concurrency findings N1 (partial-list publication) and
+N2 (two-store snapshot race) each live in exactly one of the two pipelines, which is the
+tell: state that exists twice gets its invariants enforced once.
+
+**The unifying observation:** materialization *is* a drained forward pass. The random-access
+pipeline is "run the progressive pass to completion eagerly, then do the link-read phase".
+If `_get_members_registered` were implemented as
+
+```python
+def _get_members_registered(self):
+    if snapshot := self._snapshot: return snapshot
+    if owner := self._state.begin_materialization():
+        for _ in self._begin_forward_pass(): pass      # same iterator, drained
+        ... link-read phase over the pass's output ...
+        publish(one Snapshot object)                    # single-field, fixes N2
+```
+
+then `_pass_scanned`/`_pass_by_name_lists` *are* the only accumulation state,
+`_stamp_progressive_member` is the only id-stamper, and `_finalize_pass_links` merges into
+the one publication point. Publishing a single `_Snapshot(members, by_name)` object (one
+attribute store) makes the N2 fix structural instead of ordering-by-comment, and making the
+pass iterator remember a mid-pass failure (the N1 fix) then protects *both* access modes,
+because there is only one pass.
+
+Estimated deletion: ~100–130 lines net, minus one whole class of "which pipeline stamped
+this member" questions. `_get_members_index_only` stays (it is genuinely different: no
+registration cost for index-only peeks) but shrinks to a pure enumeration.
+
+**Not weaker because:** observable behavior is unchanged for every documented contract —
+same election, same laziness, same streaming semantics (`_begin_forward_pass` is already
+shared); the only behavior changes are the two bug fixes.
+
+## S3 — One pass driver: `_iter_with_data` stops being an override point
+
+**The category:** the "close previous / open current / yield / cleanup tail" loop skeleton
+exists three times — base default (`base_reader.py:355-373`), TAR override
+(`tar_reader.py:312-340`), 7z override (`sevenzip_reader.py:604-643`) — each with its own
+subtly-commented invariant about the last yielded stream staying open, each with its own
+error-translation wrapper (S1 again), and each a place where the previous-close invariant
+can regress independently. The RAR reader (Phase 7, imminent per PLAN) would add a fourth.
+
+**The change:** the base owns the single driver loop; backends override a narrow hook —
+"give me this member's stream within the current pass":
+
+```python
+def _pass_open_member(self, member, ctx) -> ArchiveStream | None: ...
+```
+
+where `ctx` is per-pass state the base threads through (TAR: nothing — it opens via
+`extractfile` under the handle guard; 7z: the current `SolidBlockReader`, swapped when
+`folder_index` changes; base default: `_lazy_member_stream`). The 7z solid-block swap
+(`close old block, open new`) fits as a second tiny hook (`_pass_advance(ctx, member)`), or
+7z keeps a generator-based ctx. The driver enforces close-previous-on-advance,
+close-current-on-finally, and skip-costs-nothing exactly once.
+
+Estimated deletion: ~60–80 lines now, plus every future backend's copy; more valuable, the
+`stream_members` ownership contract (the docstring at `base_reader.py:337-353`, currently a
+"MUST override correctly" instruction to backend authors) becomes machinery instead of
+documentation. This directly serves the stated plan: native RAR is next, and its
+`unrar p`-pipe pass is exactly this shape.
+
+## S4 — (Flagged, not recommended now) ReaderState's five overlapping admission mechanisms
+
+`ReaderState` enforces "one pass XOR many workers, with internal exceptions" via five
+interacting mechanisms: root tokens, child tokens, worker tokens, `_internal_open_depth`,
+and `_gate_exempt_depth`. The deep-concurrency findings N3 and N4 are both artifacts of this
+shape: the depth counters erase *who* is exempt, and the token sets erase *which thread*
+owns what. A single explicit mode machine —
+
+```
+mode: IDLE | PASS(owner_token, owner_thread, internal_depth) | WORKERS(count)
+```
+
+— expresses the same admission table in one match statement, makes thread-scoped exemption
+(the N3 fix) and owner-thread re-entry detection (the N4 fix) fall out of stored fields
+rather than new bookkeeping, and would likely *shrink* `reader_state.py`. I flag rather than
+recommend it because the first review's advice ("the ReaderState machine's complexity is
+essential — don't simplify it") is half right: the *rules* are essential, but the current
+*encoding* of the rules is where N3/N4 hid. If N3/N4 are fixed by patching the existing
+counters, expect this file to accrete a sixth mechanism; if the maintainer is touching it
+anyway, the mode machine is the version worth writing. Decision-sized, so it goes to
+QUESTIONS rather than a recommendation.
+
+## What is NOT worth abstracting (checked and rejected)
+
+- **The accelerator exception-message tables** (`codecs.py:562-713`): irreducible essential
+  knowledge about rapidgzip's per-platform error strings. Any abstraction would just move
+  the strings.
+- **The codec descriptor table itself**: already the exemplar (one subclass per codec); the
+  first review was right to protect it.
+- **`_zip_timestamps` / 7z timestamp handling**: post-X2 the FILETIME math is shared
+  (`internal/timestamps.py`); what remains per-backend is genuinely per-format field layout.
+- **The two `LockedStream` variants**: 20 lines each, deliberately different lock scopes
+  with a documented reason (`locked.py:71-78`). Merging them behind a flag would obscure the
+  one design fact that matters.
+- **`streamtools`**: clean, dependency-free, correctly layered. Leave it alone.
+
+## The half-size question, answered honestly
+
+No — there is no strictly-no-weaker archivey at ~8k lines. The mass breaks down roughly as:
+format parsers and per-format metadata fidelity (7z parser ~1k, ZIP ~1k, TAR/ISO/single-file
+~1.3k), the codec layer including per-library error taxonomies (~2.5k), extraction safety
+(~1.2k), streams/streamtools plumbing (~1.7k), and the public data model / config /
+diagnostics surface (~2k). Almost all of that is *knowledge* — hostile-input hardening,
+library quirks, platform divergence — that a smaller library would simply not have, i.e.
+would be weaker in exactly the dimensions VISION stakes out (hostile input as first-class,
+uniform error contract, honest cost signals). S1–S3 above total maybe 300–350 net lines
+(~2%… but the deletions are concentrated in `base_reader.py` + backends, where they remove
+perhaps a quarter of the *coordination* code, which is where the review findings cluster).
+The honest framing: this library's size is in its knowledge, its risk is in its
+coordination, and the simplifications worth doing are the ones that shrink coordination —
+S1/S2/S3 do, a generic "make it smaller" pass would not.
+
+## Correction to the first review
+
+`complexity.md` X3's fix (`_reraise_member_error` + the shared tuple) treated a tree-wide
+pattern as a ZIP-local one; the same drift hazard it closed in ZIP remains open at 8 sites
+in TAR/ISO today (list under S1). Not wrong, but under-scoped — S1 is the finish of that
+thought.

--- a/review/deep-simplification.md
+++ b/review/deep-simplification.md
@@ -1,5 +1,12 @@
 # Deep pass 2 — Structural simplification
 
+> **Post-review status (this PR, round 2):** **S1 is APPLIED** (`_raise_translated` +
+> `_translated_errors` on `BaseArchiveReader`; the 10 hand-rolled sites in TAR/ISO/ZIP
+> converted; ZIP's `_reraise_member_error` now delegates). **S2/S3 deliberately deferred**:
+> they restructure exactly the code the N1/N2 point-fixes just touched, and are better done
+> as their own change once this lands (S2 would subsume the N1/N2 fixes structurally).
+> S4 remains flagged for a decision, as written.
+
 Question posed: not "where is code duplicated" (the first pass's X1–X5, all fixed) but
 "which abstraction, if adopted, deletes a *category* of code — and is the half-size,
 strictly-no-weaker version of this library real?"

--- a/review/deep-unknown-unknowns.md
+++ b/review/deep-unknown-unknowns.md
@@ -1,0 +1,193 @@
+# Deep pass 3 — Unknown unknowns, round two
+
+Assumption per the brief: the first pass (`unknown-unknowns.md`, U1–U6) found the obvious
+ones. This pass hunted in four places: stdlib *leniency* (not just stdlib errors), platform
+divergence in timestamp/paths, private-API reliance beyond the one already fixed, and
+guarantees we hold but don't exploit. Items W1–W9; corrections to the first review inline.
+Threat-model items already registered (O1–O7) are acknowledged, not re-reported.
+
+## Wrong (or unstated) assumptions
+
+### W1 — "Corruption raises." For TAR, mid-archive corruption is a *silent clean EOF* (VERIFIED, repro)
+
+The error-handling story assumes corrupt structure surfaces as `CorruptionError`. For TAR
+that is false in the most common corruption position: **stdlib `tarfile.next()` treats an
+`InvalidHeaderError` on any header after the first as end-of-archive** — no exception, the
+iterator just stops (CPython `tarfile.py`, the `except InvalidHeaderError` arm re-raises
+only `if self.offset == 0`). Reproduced against this tree:
+
+- 6-member tar, second member's header checksum corrupted → iteration yields **1 member,
+  no error**; `scan_members()` returns 1 member; the only signal is
+  `ARCHIVE_EOF_MARKER_MISSING` at WARNING (default `strict_archive_eof=False`,
+  `config.py:81`).
+- 6-member `.tar.gz`, 64 bytes zeroed mid-deflate → decodes to garbage that parses as an
+  invalid header → iteration yields **2 members, no error**, same warning-only signal.
+
+So for the flagship "inventory a million archives" use case, a bit-rotted TAR produces a
+*short listing that looks complete*. The EOF-marker check (`tar_reader.py:342-396`) is the
+only backstop and it is (a) WARNING-severity by default and (b) semantically mislabeled for
+this case — the diagnostic and the strict escalation both say *truncated*, but the archive
+is corrupt-in-the-middle; a user investigating "truncated" will look at the wrong end of the
+file. The `format-tar` spec's EOF matrix (spec.md:145-153) documents the missing-marker
+case but nowhere states "a corrupt non-first header silently ends the listing" — that
+behavior is currently an undocumented consequence of tarfile internals.
+
+Directions (maintainer decision, QUESTIONS-worthy): (1) document the leniency in
+`format-tar` + `docs/formats.md` explicitly; (2) consider defaulting `strict_archive_eof`
+to True for *random-access* readers (a seekable source can verify cheaply; the lenient
+default mainly serves pipes); (3) longer term, the native-reader strategy (7z/RAR) applied
+to TAR's 512-byte headers would make this class of leniency archivey's own decision instead
+of tarfile's.
+
+### W2 — "Every `datetime.fromtimestamp` is guarded" (first review U3) — false at two sites, one attacker-reachable (VERIFIED code / platform-conditional)
+
+`internal/timestamps.py:6-8` states the lesson precisely: "the out-of-range guard is the
+load-bearing part … OSError on Windows … must degrade to None + a reported issue, never sink
+the whole listing." Two sites in the tree don't follow it:
+
+- **ZIP Extended Timestamp (0x5455), attacker-controlled** — `zip_reader.py:261-264`:
+  `ts` is read as a **signed** 32-bit value and passed to
+  `datetime.fromtimestamp(ts, tz=timezone.utc)` naked. On Windows, tz-aware
+  `fromtimestamp` still routes through `gmtime()` (both the C and Python implementations),
+  which fails with `OSError` for negative inputs. A ZIP whose UT field carries any pre-1970
+  time — hostile, or a genuinely old file — makes `members()` raise a **raw, untranslated
+  OSError** on Windows while working fine on Linux. That is exactly the
+  hostile-input-crashes-the-listing class the same function's NTFS branch (via the shared
+  guarded helper, `timestamps.py:44-59`) was hardened against, three lines above. Fix is
+  mechanical: same try/except + `TimestampIssue` as its siblings. A CI job on Windows would
+  have caught it only with a pre-1970 UT fixture — worth adding one.
+- **Directory reader** — `directory_reader.py:198-207`: `st_mtime`/`st_atime`/`st_birthtime`
+  converted unguarded. Not attacker-controlled in the archive sense, but network/FUSE
+  filesystems do return garbage timestamps, and one bad file then sinks the whole walk on
+  Windows (SUSPECTED severity, low).
+
+**Correction to the first review:** U3's "the code correctly wraps *every*
+`datetime.fromtimestamp`" was an over-claim; it checked the three backends it cites and
+generalized. (Checked the remaining sites: `_pax_time` guarded, gzip header mtime is
+unsigned-32 so its max is year 2106 — inside range on all platforms — and detection has no
+timestamp path. These are fine.)
+
+### W3 — `ZipInfo._raw_time`: the same hazard class as the lzma one, still silent (VERIFIED)
+
+The first review's D1 (private `lzma._decode_filter_properties`) was fixed by binding at
+import and failing loud (`sevenzip_reader.py:169-184`). The tree has a second private-stdlib
+dependency with a *worse* failure mode that wasn't inventoried:
+`zip_reader.py:514-520` reads `getattr(info, "_raw_time", 0)` to derive the ZipCrypto check
+byte for data-descriptor members. If a future CPython renames `_raw_time`, the fallback `0`
+makes the check byte `0x00` for every such member — so **every candidate password fails the
+1-byte check and the library reports "Wrong password" for correct passwords**, silently,
+only for flag-bit-3 ZipCrypto members. Apply the D1 recipe: resolve once at import (or
+first use) and raise a loud "archivey needs updating" error when absent, instead of
+defaulting. Related but lower risk, for the inventory: `ZipFile._lock`
+(`zip_reader.py:522-524`, fails loud with AttributeError), the `_SharedFile`-locking audit
+that `CloseLockedStream` rests on (`locked.py:71-78`, behavioral — silent if it changes;
+already pinned-version-audited), and `ZipInfo.orig_filename` (undocumented but stable
+attribute; loud if removed).
+
+### W4 — Member identity is *positional*, and two enumerations must agree (VERIFIED reliance, currently sound)
+
+Selection-by-member and extraction progress both key on `(archive_id, member_id)`
+(`selection.py:24-37`), and `member_id` is a stamp of enumeration position. The extraction
+coordinator gets its totals/selector list from `get_members_if_available()` →
+`_get_members_index_only()` — which for ZIP and ISO builds **fresh member objects by
+re-enumerating** — and then matches them against the members yielded by
+`stream_members()`, which come from the *separately enumerated* materialized cache
+(`extraction.py:259-287`). The whole scheme works only because `_iter_members()` yields in
+identical order every call. True today for every backend that has `_MEMBER_LIST_UPFRONT`
+(zipfile infolist order, 7z/single-file yield cached objects, pycdlib walk order), and the
+one backend where it could genuinely break — a directory on a live filesystem — was moved
+off this path by the C2/C3 fix. But nothing states the invariant; a future backend whose
+enumeration order depends on anything mutable (or a cache-refresh feature) would corrupt
+selection *silently* (wrong members extracted). Worth one sentence in the
+`_iter_members` contract in `base_reader.py:153-156`: "must yield the same members in the
+same order on every call."
+
+Two adjacent behavioral quirks of the same path, worth knowing: every
+`get_members_if_available()` call on ZIP/ISO re-runs `_to_member`, so (a) per-member
+diagnostics (name-normalization, bad timestamps) are **re-emitted and re-counted** on every
+call — `reader.diagnostics` counts inflate by calling a documented "cheap, safe" method —
+and (b) the returned objects are distinct from the ones `members()` yields, so callers
+comparing them by identity get surprises. Both disappear if the index-only peek caches (or
+if it reuses the materialized cache when present — which it already prefers).
+
+### W5 — `os.replace`-based atomicity leaves `.archivey-tmp-*` orphans on hard kill (VERIFIED, minor)
+
+`_write_file_atomic` (`extraction.py:879-907`) cleans its temp on any Python-level failure
+(`BaseException` arm), but SIGKILL/power-loss leaves `.archivey-tmp-<random>` files in the
+destination — and nothing in the library or docs names the prefix as safe to sweep. Since
+partial-extraction recovery is exactly when a user re-runs extraction into the same dest,
+either export the prefix as a documented constant or note in `safe-extraction` docs that
+`.archivey-tmp-*` files in the destination are archivey's and are safe to delete. (First
+review U2 covered `os.replace` semantics themselves; this is the operational leftover.)
+
+### W6 — Free-threading correctness rests on PEP 703 per-object atomicity in four places (cross-ref)
+
+Inventoried in deep-concurrency.md ("R1/R5"): `SevenZipKeyCache._cache`,
+`_folder_passwords`, double member-id stamping, and the unlocked snapshot fast path. Under
+the GIL these are bytecode-atomicity assumptions; under 3.13t they are PEP 703
+per-object-lock assumptions. Both are *real* guarantees today, but they are the kind that
+silently stops holding on PyPy/GraalPy or if a cache becomes a two-step structure. One lock
+each makes the assumption explicit; noted here because "which builds are we actually
+promising?" is a packaging/docs question as much as a concurrency one — the README/docs
+currently don't state a position on free-threaded support even though CI tests it.
+
+## Guaranteed and unexploited
+
+### W7 — `os.pread`: the OS already provides what `SharedSource`'s lock simulates (POSIX)
+
+`SharedSource` views do lock→seek→read to fake positioned reads on one fd
+(`slice.py:124-134`). POSIX guarantees `pread(2)` is atomic at a given offset with **no
+shared file position mutation** — for a path-backed `SharedSource` (the common case: every
+7z open, single-file path sources), each view could issue `os.pread(fd, n, abs_offset)`
+with *no lock at all and one syscall instead of two*. This is strictly stronger than the
+dormant `independent_handles` seam (`shared.py:19-22`): no extra fds, no per-view open
+cost, true parallelism for the future parallel-extraction work. Windows keeps the locked
+path (`os.pread` is POSIX-only). Contained change: `SharedSource` grows a
+"positioned-read" strategy when `_owns_handle` and the handle has a real fd;
+`SlicingStream` already isolates the re-seek policy behind `_seek_before_read`
+(`slice.py:82-87`), which is exactly the seam to hang it on.
+
+### W8 — Extraction copies allocate a fresh 1 MiB `bytes` per chunk
+
+`_copy_to_fileobj` (`extraction.py:909-931`) is `read(1 MiB)` → `write()`, allocating and
+discarding a megabyte `bytes` per iteration for the entire extraction volume. Every
+`ArchiveStream` supports `readinto` (`archive_stream.py:255-266`), so a reusable
+`bytearray`/`memoryview` loop halves allocator traffic on the hottest byte path in the
+library, with the bomb-tracker `count()` unchanged. (First review E3 pointed at
+`posix_fadvise`; this one is bigger and portable. Both belong with the benchmark-gate work
+— measured, not assumed.)
+
+### W9 — `zipfile.ZipFile` already accepts our `SharedSource` discipline for free
+
+Noting the positive: the choice to let stdlib zipfile keep owning ZIP's shared-handle
+serialization (rather than re-plumbing ZIP through `SharedSource`) exploits `_SharedFile`'s
+per-read locking that CPython already maintains — one of the few places the tree leans on
+an implementation detail *and* has the audit + pinned note + free-threaded stress test
+(`test_multithread_zip_open_close_refcnt_stress`) to justify it. This is the pattern W3
+should be brought up to.
+
+## Acknowledged, already registered — not re-reported
+
+- Windows reserved names / trailing dots+spaces (threat model **O3**), NTFS ADS via `:` in
+  names (**O4**), case/Unicode collision bookkeeping (**O2**, first review U4), metadata
+  bombs (**O1**, U1 — the 7z count bound is in and correct: `sevenzip_parser.py:578-592`;
+  spot-checked the remaining loops: every unbounded count is consumed against the bounded,
+  size-checked header buffer, so reads fail before allocation can run away), names
+  unrepresentable on the target FS (**O7**, with the EILSEQ translation in
+  `extraction.py:352-358` already landed).
+- `os.replace` Windows sharing-violation semantics (U2), surrogateescape round-trip
+  asymmetry (U5), GC/finalizer-vs-reader interleaving (U6 — now sharpened into
+  deep-concurrency N5 and R4).
+
+## Corrections to the first review
+
+1. **U3 over-claimed** — "wraps every `datetime.fromtimestamp`" is false; see W2 (ZIP UT
+   field is the attacker-reachable one).
+2. **U1's "general lesson" was applied but framed too narrowly** — count fields were
+   bounded, but the *silent-leniency* sibling (W1: tarfile swallowing corrupt headers) is
+   the same "the parser trusts the container more than it should" class on the read path,
+   and the first review's fuzzing/mutation framing (corruption ⇒ exception) missed the
+   corruption-⇒-*silence* outcome entirely.
+3. **D1's recipe (bind private stdlib API loud) was treated as complete after one instance**
+   — the inventory in W3 shows at least one more silent-failure instance (`_raw_time`) that
+   should have been swept in the same pass.

--- a/review/deep-unknown-unknowns.md
+++ b/review/deep-unknown-unknowns.md
@@ -1,5 +1,15 @@
 # Deep pass 3 — Unknown unknowns, round two
 
+> **Post-review status (this PR, round 2):** **W1** documented (`docs/formats.md`,
+> `docs/internal/known-issues.md`) + the EOF diagnostic message now names the
+> corrupt-header cause; the `strict_archive_eof` default is unchanged (behavior change —
+> flag it separately if wanted). **W2 FIXED** (ZIP UT field guarded + `TimestampIssue`,
+> directory `_stat_datetime` guard; tests incl. a simulated-Windows monkeypatch).
+> **W3 FIXED** (`_raw_time` raises loud; test). **W4** documented in the
+> `_iter_members` contract. **W5** documented (`_TMP_PREFIX` constant +
+> `docs/safe-extraction.md`). **W7/W8 deferred** — perf changes the report itself gates
+> on benchmarks. W6/W9 are inventory, no action.
+
 Assumption per the brief: the first pass (`unknown-unknowns.md`, U1–U6) found the obvious
 ones. This pass hunted in four places: stdlib *leniency* (not just stdlib errors), platform
 divergence in timestamp/paths, private-API reliance beyond the one already fixed, and

--- a/src/archivey/internal/backends/directory_reader.py
+++ b/src/archivey/internal/backends/directory_reader.py
@@ -41,6 +41,19 @@ from archivey.types import (
 )
 
 
+def _stat_datetime(ts: float) -> datetime | None:
+    """A stat timestamp as an aware UTC datetime, or ``None`` when out of range.
+
+    ``datetime.fromtimestamp`` raises ``ValueError``/``OverflowError`` on POSIX and
+    ``OSError`` on Windows (its ``gmtime()`` rejects pre-1970/huge values) for
+    out-of-range inputs, which a network/FUSE filesystem can genuinely report.
+    """
+    try:
+        return datetime.fromtimestamp(ts, tz=timezone.utc)
+    except (ValueError, OverflowError, OSError):
+        return None
+
+
 def _is_junction(entry: os.DirEntry[str]) -> bool:
     """True if a scandir entry is a Windows NTFS junction.
 
@@ -195,17 +208,18 @@ class DirectoryReader(BaseArchiveReader):
         # "."/".."/leading-slash components), so it is normalize_member_name()-clean by
         # construction — unlike names decoded from an archive, which every real backend
         # must route through that helper.
-        modified = datetime.fromtimestamp(st.st_mtime, tz=timezone.utc)
-        accessed = datetime.fromtimestamp(st.st_atime, tz=timezone.utc)
+        #
+        # Timestamps are guarded like every backend's (see internal/timestamps.py): a
+        # network/FUSE filesystem can report out-of-range values, and on Windows even
+        # tz-aware fromtimestamp raises OSError for them — one bad file must not sink
+        # the whole walk.
+        modified = _stat_datetime(st.st_mtime)
+        accessed = _stat_datetime(st.st_atime)
         # st_birthtime is the true creation time but only exists on some platforms
         # (macOS/BSD, Windows, recent Linux); st_ctime is metadata-change time on
         # Unix, NOT creation, so we never use it for `created`. Hence the getattr.
         birthtime = getattr(st, "st_birthtime", None)
-        created = (
-            datetime.fromtimestamp(birthtime, tz=timezone.utc)
-            if birthtime is not None
-            else None
-        )
+        created = _stat_datetime(birthtime) if birthtime is not None else None
 
         # os.stat_result always defines st_uid/st_gid (both 0 on Windows), so no
         # getattr guard is needed.

--- a/src/archivey/internal/backends/iso_reader.py
+++ b/src/archivey/internal/backends/iso_reader.py
@@ -282,18 +282,14 @@ class IsoReader(BaseArchiveReader):
             )
 
         self._iso = pycdlib.PyCdlib()
-        try:
+        # Boundary outside the guard; an exception the translator does not recognize
+        # (a genuine OSError from the handle) propagates unchanged.
+        with self._translated_errors():
             with self._handle_guard():
                 if isinstance(source, Path):
                     self._iso.open(str(source))
                 else:
                     self._iso.open_fp(source)
-        except _PYCDLIB_ERRORS as exc:
-            translated = self._translate_exception(exc)
-            if translated is not None:
-                self._stamp_error_context(translated)
-                raise translated from exc
-            raise
 
         # Auto-select the richest namespace: Rock Ridge > Joliet > plain ISO 9660.
         if self._iso.has_rock_ridge():
@@ -348,18 +344,12 @@ class IsoReader(BaseArchiveReader):
         # walk()/get_record() traverse in-memory parsed catalog records and do not touch
         # _cdfp. Only open_file_from_iso / PyCdlibIO I/O need the handle lock. If a future
         # pycdlib version gains handle access here, lock the complete call.
-        try:
+        with self._translated_errors():
             for dirpath, dirnames, filenames in self._iso.walk(**{self._path_kw: "/"}):
                 for name in dirnames:
                     yield self._make_member(self._join(dirpath, name))
                 for name in filenames:
                     yield self._make_member(self._join(dirpath, name))
-        except _PYCDLIB_ERRORS as exc:
-            translated = self._translate_exception(exc)
-            if translated is not None:
-                self._stamp_error_context(translated)
-                raise translated from exc
-            raise
 
     def _make_member(self, ns_path: str) -> ArchiveMember:
         record: Any = self._iso.get_record(**{self._path_kw: ns_path})
@@ -473,7 +463,9 @@ class IsoReader(BaseArchiveReader):
     def _open_member(self, member: ArchiveMember) -> ArchiveStream:
         ns_path = member._raw
         assert isinstance(ns_path, str), "ISO member is missing its namespace path"
-        try:
+        # Boundary outside the lock; _PyCdlibStream construction stays inside it so any
+        # enter-time pycdlib seek/error is covered by both.
+        with self._translated_errors(member.name):
             if self._handle_lock is not None:
                 with self._handle_lock:
                     raw = self._iso.open_file_from_iso(**{self._path_kw: ns_path})
@@ -483,15 +475,8 @@ class IsoReader(BaseArchiveReader):
                     )
                 return self._wrap_member_stream(locked, member.name, size=member.size)
             raw = self._iso.open_file_from_iso(**{self._path_kw: ns_path})
-            # Construct inside the try so any enter-time pycdlib error is translated too;
             # _PyCdlibStream enters the PyCdlibIO context in its __init__.
             stream = _PyCdlibStream(raw)
-        except _PYCDLIB_ERRORS as exc:
-            translated = self._translate_exception(exc)
-            if translated is not None:
-                self._stamp_error_context(translated, member.name)
-                raise translated from exc
-            raise
         return self._wrap_member_stream(stream, member.name, size=member.size)
 
     def _get_archive_info(self) -> ArchiveInfo:

--- a/src/archivey/internal/backends/tar_reader.py
+++ b/src/archivey/internal/backends/tar_reader.py
@@ -264,18 +264,14 @@ class TarReader(BaseArchiveReader):
         if self._streaming:
             yield from self._iter_members_progressive()
             return
-        try:
+        # The error boundary sits OUTSIDE the handle guard, so translation/stamping
+        # never run under the shared-fileobj lock. An exception the translator does
+        # not recognize (a genuine OSError from the source) propagates unchanged.
+        with self._translated_errors():
             # Pinned-library audit: TarFile.getmembers() drives seek/tell/read through
             # _load()/next() on the shared fileobj — must run under the handle lock.
             with self._handle_guard():
                 members = self._tar.getmembers()  # forces the full header scan
-        except tarfile.TarError as exc:
-            # A genuine OSError from the source is not caught here, so it propagates unchanged.
-            translated = self._translate_exception(exc)
-            if translated is not None:
-                self._stamp_error_context(translated)
-                raise translated from exc
-            raise
         for info in members:
             yield self._to_member(info)
         self._verify_tar_eof()
@@ -286,7 +282,7 @@ class TarReader(BaseArchiveReader):
         Yields bare members; the base's shared progressive pass stamps ids and resolves
         backward links. Shared-handle ops run under ``_handle_lock`` when present.
         """
-        try:
+        with self._translated_errors():
             if self._handle_lock is not None:
                 # Hold the lock only around each next() so a yielded consumer can open
                 # the current member without deadlock (streaming is single-owner).
@@ -301,12 +297,6 @@ class TarReader(BaseArchiveReader):
             else:
                 for info in self._tar:
                     yield self._to_member(info)
-        except tarfile.TarError as exc:
-            translated = self._translate_exception(exc)
-            if translated is not None:
-                self._stamp_error_context(translated)
-                raise translated from exc
-            raise
         self._verify_tar_eof()
 
     def _iter_with_data(self) -> Iterator[tuple[ArchiveMember, ArchiveStream | None]]:
@@ -315,7 +305,7 @@ class TarReader(BaseArchiveReader):
             return
         # Pull from the shared instance-held progressive pass so __iter__,
         # stream_members, and scan_members share one cursor and finalization.
-        try:
+        with self._translated_errors():
             for member in self._begin_forward_pass():
                 if member.is_file:
                     info = cast("tarfile.TarInfo", member._raw)
@@ -332,12 +322,6 @@ class TarReader(BaseArchiveReader):
                     )
                 else:
                     yield member, None
-        except tarfile.TarError as exc:
-            translated = self._translate_exception(exc)
-            if translated is not None:
-                self._stamp_error_context(translated)
-                raise translated from exc
-            raise
 
     def _verify_tar_eof(self) -> None:
         """Verify the two-block null end-of-archive marker.
@@ -363,8 +347,10 @@ class TarReader(BaseArchiveReader):
         if len(chunk) == 512 and chunk == b"\x00" * 512:
             return
         msg = (
-            "TAR archive may be truncated: missing or invalid "
-            "end-of-archive marker block(s)"
+            "TAR archive may be truncated or corrupt: missing or invalid "
+            "end-of-archive marker block(s). Note that stdlib tarfile treats a "
+            "corrupt member header after the first as a clean end of archive, so a "
+            "silently shortened listing can also surface only here."
         )
         if len(chunk) == 0:
             observed_kind: Literal["absent", "short", "nonzero"] = "absent"
@@ -493,24 +479,13 @@ class TarReader(BaseArchiveReader):
         assert isinstance(info, tarfile.TarInfo), (
             "TAR member is missing its TarInfo handle"
         )
-        # Capture under the handle lock; translate/stamp only after release so diagnostics
-        # and callbacks never run while the shared-fileobj lock is held.
-        raw_exc: tarfile.TarError | None = None
-        raw: BinaryIO | None
-        try:
+        # Boundary outside the guard: translation/stamping never run while the
+        # shared-fileobj lock is held.
+        with self._translated_errors(member.name):
             with self._handle_guard():
                 extracted = self._tar.extractfile(info)
-            # tarfile stubs ``extractfile`` as ``IO[bytes] | None``; we need BinaryIO.
-            raw = cast(BinaryIO | None, extracted)
-        except tarfile.TarError as exc:
-            raw_exc = exc
-            raw = None
-        if raw_exc is not None:
-            translated = self._translate_exception(raw_exc)
-            if translated is not None:
-                self._stamp_error_context(translated, member.name)
-                raise translated from raw_exc
-            raise raw_exc
+        # tarfile stubs ``extractfile`` as ``IO[bytes] | None``; we need BinaryIO.
+        raw = cast(BinaryIO | None, extracted)
         if raw is None:
             # Only FILE members reach here (the base follows links/skips non-data members),
             # so a None stream means a zero-length or special entry; present an empty stream.

--- a/src/archivey/internal/backends/zip_reader.py
+++ b/src/archivey/internal/backends/zip_reader.py
@@ -256,19 +256,38 @@ def _zip_timestamps(
     if ut_field is not None:
         flags = ut_field[0]
         cursor = 1
-        for bit in (0x01, 0x02, 0x04):  # mtime, atime, ctime, in order
+        for bit, ut_name in ((0x01, "mtime"), (0x02, "atime"), (0x04, "ctime")):
             if flags & bit and cursor + 4 <= len(ut_field):
                 ts = int.from_bytes(
                     ut_field[cursor : cursor + 4], "little", signed=True
                 )
-                when = datetime.fromtimestamp(ts, tz=timezone.utc)
+                cursor += 4
+                try:
+                    when = datetime.fromtimestamp(ts, tz=timezone.utc)
+                except (ValueError, OverflowError, OSError):
+                    # Same out-of-range guard as the DOS/NTFS fields above: on Windows
+                    # even tz-aware fromtimestamp routes through gmtime(), which raises
+                    # OSError for pre-1970 values — a signed field an archive (hostile
+                    # or merely old) can legitimately carry. Degrade to an issue, never
+                    # sink the listing with a raw platform error.
+                    issues.append(
+                        _TimestampIssue(
+                            field=ut_name,
+                            source="extended",
+                            value_repr=repr(ts),
+                            message=(
+                                f"Invalid ZIP extended timestamp for "
+                                f"{info.filename!r}: {ts!r}"
+                            ),
+                        )
+                    )
+                    continue
                 if bit == 0x01:
                     modified = when
                 elif bit == 0x02:
                     accessed = when
                 else:
                     created = when
-                cursor += 4
 
     return modified, accessed, created, issues
 
@@ -515,8 +534,19 @@ class ZipReader(BaseArchiveReader):
         if info.flag_bits & _ZIP_MASK_USE_DATA_DESCRIPTOR:
             # zipfile stores the DOS time in the private ``_raw_time`` attribute and uses
             # its high byte as the ZipCrypto check byte when a data descriptor is present.
-            raw_time = int(getattr(info, "_raw_time", 0))
-            return (raw_time >> 8) & 0xFF
+            # Fail LOUD if a future Python drops the attribute: a silent 0 fallback would
+            # make every candidate fail the 1-byte check, misreporting correct passwords
+            # as wrong for data-descriptor members (same policy as the loud import-time
+            # bind of lzma._decode_filter_properties in the 7z reader).
+            raw_time = getattr(info, "_raw_time", None)
+            if raw_time is None:
+                raise RuntimeError(
+                    "This Python's `zipfile` no longer exposes `ZipInfo._raw_time`, "
+                    "which archivey needs to verify ZipCrypto passwords for "
+                    "data-descriptor members. Please report this to archivey "
+                    "(with your Python version)."
+                )
+            return (int(raw_time) >> 8) & 0xFF
         return (info.CRC >> 24) & 0xFF
 
     def _zipfile_lock(self) -> Any:
@@ -620,17 +650,12 @@ class ZipReader(BaseArchiveReader):
     def _reraise_member_error(self, exc: Exception, member_name: str) -> NoReturn:
         """Translate a raw member-read error, stamp it with member context, and raise.
 
-        An unrecognized exception (``_translate_exception`` returns ``None``) is re-raised
-        unchanged. An ``EncryptionError`` is raised without member stamping (it carries its
-        own message and must not be reclassified). Shared by the member-open and
-        compressed-confirm decrypt paths so their translate/stamp/raise tail stays identical.
+        Thin wrapper over the shared base boundary: an ``EncryptionError`` is raised
+        without member stamping (it carries its own message and must not be
+        reclassified). Shared by the member-open and compressed-confirm decrypt paths
+        so their translate/stamp/raise tail stays identical.
         """
-        translated = self._translate_exception(exc)
-        if translated is not None:
-            if not isinstance(translated, EncryptionError):
-                self._stamp_error_context(translated, member_name)
-            raise translated from exc
-        raise
+        self._raise_translated(exc, member_name, stamp_encryption=False)
 
     def _zip_open_raw(
         self, info: zipfile.ZipInfo, *, password: bytes | None
@@ -727,14 +752,8 @@ class ZipReader(BaseArchiveReader):
         check_byte = self._zipcrypto_check_byte(info)
         expected_crc = info.CRC & 0xFFFFFFFF
 
-        try:
+        with self._translated_errors(member_name):
             header = self._read_zipcrypto_header(info)
-        except zipfile.BadZipFile as exc:
-            translated = self._translate_exception(exc)
-            if translated is not None:
-                self._stamp_error_context(translated, member_name)
-                raise translated from exc
-            raise
 
         def weak_ok(password: bytes) -> bool:
             return password_matches_check_byte(password, header, check_byte)

--- a/src/archivey/internal/base_reader.py
+++ b/src/archivey/internal/base_reader.py
@@ -7,7 +7,15 @@ import uuid
 from abc import ABC, abstractmethod
 from contextlib import nullcontext
 from pathlib import Path
-from typing import TYPE_CHECKING, BinaryIO, Callable, ContextManager, Iterator, Mapping
+from typing import (
+    TYPE_CHECKING,
+    BinaryIO,
+    Callable,
+    ContextManager,
+    Iterator,
+    Mapping,
+    NoReturn,
+)
 
 if TYPE_CHECKING:
     from archivey.internal.password import _PasswordCandidates
@@ -18,6 +26,7 @@ from archivey.diagnostics import DiagnosticSummary, ExtractionReport
 from archivey.exceptions import (
     ArchiveyError,
     ArchiveyUsageError,
+    EncryptionError,
     LinkTargetNotFoundError,
     ReadError,
     UnsupportedOperationError,
@@ -261,6 +270,50 @@ class BaseArchiveReader(ArchiveReader):
         """
         return self._handle_lock if self._handle_lock is not None else nullcontext()
 
+    def _raise_translated(
+        self,
+        exc: Exception,
+        member_name: str | None = None,
+        *,
+        stamp_encryption: bool = True,
+    ) -> NoReturn:
+        """Translate ``exc`` via ``_translate_exception``, stamp context, and raise.
+
+        The single backend-side error boundary (the out-of-stream counterpart of
+        ``ArchiveStream._fail``): an already-typed ``ArchiveyError`` is stamped and
+        re-raised as-is; a raw exception the translator recognizes is stamped and raised
+        chained to the original; an unrecognized exception propagates unchanged (the
+        catch-all-free rule in CONTRIBUTING). ``stamp_encryption=False`` skips member
+        stamping for ``EncryptionError`` (ZIP's password errors carry their own message
+        and must not be reattributed).
+        """
+        if isinstance(exc, ArchiveyError):
+            self._stamp_error_context(exc, member_name)
+            raise exc
+        translated = self._translate_exception(exc)
+        if translated is None:
+            raise exc
+        if stamp_encryption or not isinstance(translated, EncryptionError):
+            self._stamp_error_context(translated, member_name)
+        raise translated from exc
+
+    def _translated_errors(
+        self,
+        member_name: str | None = None,
+        *,
+        stamp_encryption: bool = True,
+    ) -> ContextManager[None]:
+        """Context manager routing any exception from the body through ``_raise_translated``.
+
+        Backends wrap every direct call into their underlying library with this instead
+        of hand-rolling the translate/stamp/raise tail per site — the pattern that
+        repeatedly drifted (one site catching a narrower tuple than its siblings).
+        Take the boundary OUTSIDE ``_handle_guard()`` so translation and stamping never
+        run while a shared-handle lock is held. ``BaseException`` (KeyboardInterrupt,
+        GeneratorExit) passes through untouched.
+        """
+        return _TranslatedErrorBoundary(self, member_name, stamp_encryption)
+
     @property
     def member_streams(self) -> MemberStreams:
         """Declared member-stream capabilities for this reader."""
@@ -311,7 +364,7 @@ class BaseArchiveReader(ArchiveReader):
             self._close_archive()
         except Exception as exc:  # noqa: BLE001 - combine with pending stream-close failure
             teardown_exc = exc
-            self._state.complete_teardown(exc)
+            self._state.complete_teardown()
         else:
             self._state.complete_teardown()
         if pending is not None and teardown_exc is not None:
@@ -325,7 +378,17 @@ class BaseArchiveReader(ArchiveReader):
             raise teardown_exc
 
     @abstractmethod
-    def _iter_members(self) -> Iterator[ArchiveMember]: ...
+    def _iter_members(self) -> Iterator[ArchiveMember]:
+        """Yield every member once, in archive order.
+
+        **Order stability is load-bearing:** repeated calls MUST yield the same members
+        in the same order. ``member_id`` is a stamp of enumeration position, and
+        selection/extraction match members from *separate* enumerations by
+        ``(archive_id, member_id)`` (``get_members_if_available()`` re-enumerates for
+        some backends while ``stream_members()`` serves the materialized cache) — an
+        order that varies between calls would silently select the wrong members.
+        """
+        ...
 
     def _iter_with_data(self) -> Iterator[tuple[ArchiveMember, ArchiveStream | None]]:
         """Yield (member, stream) pairs in archive order; backs ``stream_members``.
@@ -512,9 +575,13 @@ class BaseArchiveReader(ArchiveReader):
                 if child is not None:
                     self._state.release_child(child)
 
-            # Publish an immutable snapshot (tuple + frozen name map copy).
-            self._members_cache = members
+            # Publish the snapshot (the list and name map are never mutated after this
+            # point; callers get copies). ORDER IS LOAD-BEARING: `_members_cache` is the
+            # sentinel the lock-free fast path above keys on, and `get()`/`open(name)`
+            # dereference `_members_by_name_lists` immediately after that check — so the
+            # name map must be visible before the sentinel, i.e. stored first.
             self._members_by_name_lists = by_name_lists
+            self._members_cache = members
             self._state.complete_materialization()
         except BaseException:
             # MUST be BaseException, not Exception: a KeyboardInterrupt/MemoryError/
@@ -699,8 +766,11 @@ class BaseArchiveReader(ArchiveReader):
         for member in self._pass_scanned:
             if member.is_link and member.link_target:
                 self._resolve_link(member, self._pass_by_name_lists)
-        self._members_cache = self._pass_scanned
+        # Same publication order as _get_members_registered: name map before the
+        # `_members_cache` sentinel (streaming passes are single-owner, so this is
+        # consistency rather than a live race here).
         self._members_by_name_lists = self._pass_by_name_lists
+        self._members_cache = self._pass_scanned
 
     def _stamp_progressive_member(self, idx: int, member: ArchiveMember) -> None:
         self._register_member(idx, member)
@@ -1170,11 +1240,24 @@ class _ProgressivePassIterator(Iterator[ArchiveMember]):
         self._members_source = reader._iter_members()
         self._next_id = 0
         self._exhausted = False
+        self._error: BaseException | None = None
 
     def __iter__(self) -> _ProgressivePassIterator:
         return self
 
     def __next__(self) -> ArchiveMember:
+        if self._error is not None:
+            # The pass previously failed. Its generator is closed, so a plain retry
+            # would see StopIteration and finalize the PARTIAL scan as the complete,
+            # resolved member cache — scan_members() would then silently return a
+            # truncated listing after the caller caught the original error. Fail loud
+            # and keep the cache unpublished instead.
+            err = ReadError(
+                "The archive scan previously failed "
+                f"({type(self._error).__name__}); the member list is incomplete and "
+                "cannot be resumed. Reopen the archive to retry."
+            )
+            raise err from self._error
         if self._exhausted:
             raise StopIteration
         try:
@@ -1183,7 +1266,65 @@ class _ProgressivePassIterator(Iterator[ArchiveMember]):
             self._exhausted = True
             self._reader._finalize_pass_links()
             raise
+        except BaseException as exc:
+            self._error = exc
+            raise
         idx = self._next_id
         self._next_id += 1
-        self._reader._stamp_progressive_member(idx, member)
+        try:
+            self._reader._stamp_progressive_member(idx, member)
+        except BaseException as exc:
+            # Registration/link bookkeeping failed mid-pass (e.g. a RAISE-disposition
+            # diagnostic): the pass state is inconsistent, so poison it the same way.
+            self._error = exc
+            raise
         return member
+
+
+class _TranslatedErrorBoundary:
+    """``with``-boundary that applies ``_raise_translated`` to an escaping exception.
+
+    A plain ``__exit__`` class (not a ``@contextmanager`` generator) so the exception
+    handling is explicit: ``BaseException`` that is not an ``Exception`` always passes
+    through untouched; an exception ``_raise_translated`` re-raises *unchanged* (already
+    typed, or unrecognized by the translator) propagates as the original — with context
+    stamped where applicable — and only a genuinely translated exception replaces it,
+    chained via ``from``.
+    """
+
+    __slots__ = ("_reader", "_member_name", "_stamp_encryption")
+
+    def __init__(
+        self,
+        reader: BaseArchiveReader,
+        member_name: str | None,
+        stamp_encryption: bool,
+    ) -> None:
+        self._reader = reader
+        self._member_name = member_name
+        self._stamp_encryption = stamp_encryption
+
+    def __enter__(self) -> None:
+        return None
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: object,
+    ) -> bool:
+        if exc is None or not isinstance(exc, Exception):
+            return False
+        try:
+            self._reader._raise_translated(
+                exc,
+                self._member_name,
+                stamp_encryption=self._stamp_encryption,
+            )
+        except BaseException as raised:
+            if raised is exc:
+                # Already typed (stamped in place) or unrecognized: let the ORIGINAL
+                # propagate from the with-body rather than re-raising from here, which
+                # would tack an extra frame onto its traceback.
+                return False
+            raise

--- a/src/archivey/internal/extraction.py
+++ b/src/archivey/internal/extraction.py
@@ -64,6 +64,13 @@ logger = logging.getLogger("archivey.extraction")
 
 _CHUNK = 1024 * 1024  # 1 MiB copy chunk
 
+# Prefix of the temp files atomic FILE writes stage in the destination directory
+# (mkstemp appends a random suffix). Python-level failures always unlink them, but a
+# hard kill (SIGKILL, power loss) cannot: leftover ``.archivey-tmp-*`` files in an
+# extraction destination are archivey's and are safe to delete. Documented in
+# docs/safe-extraction.md; keep the value and that doc in sync.
+_TMP_PREFIX = ".archivey-tmp-"
+
 # Defaults (see the safe-extraction spec); callers override via extract()/extract_all().
 DEFAULT_MAX_EXTRACTED_BYTES = 2 * 2**30  # 2 GiB
 DEFAULT_MAX_RATIO = 1000.0
@@ -891,7 +898,7 @@ class ExtractionCoordinator:
         when materializing an orphaned hardlink source's content (it applies no metadata; the
         links each carry their own)."""
         # mkstemp hands back an already-open fd; write straight into it (no close+reopen).
-        fd, tmp_name = tempfile.mkstemp(dir=dest_path.parent, prefix=".archivey-tmp-")
+        fd, tmp_name = tempfile.mkstemp(dir=dest_path.parent, prefix=_TMP_PREFIX)
         tmp = Path(tmp_name)
         try:
             with os.fdopen(fd, "wb") as dst:

--- a/src/archivey/internal/reader_state.py
+++ b/src/archivey/internal/reader_state.py
@@ -35,6 +35,10 @@ class OperationToken:
     name: str
     parent: OperationToken | None = None
     kind: str = "root"  # "root" | "child" | "worker"
+    # The thread that acquired the token. Used to detect same-thread re-entry (a
+    # diagnostic/progress callback driving the reader that is mid-operation on this very
+    # thread), which must raise a usage error instead of deadlocking on a wait for itself.
+    thread_id: int = field(default_factory=threading.get_ident, repr=False)
     _released: bool = field(default=False, repr=False)
 
 
@@ -70,9 +74,17 @@ class ReaderState:
         self._live_streams: set[int] = set()
         self._lease_count = 1  # reader itself holds one lease until close
         self._teardown_claimed = False
-        self._teardown_error: BaseException | None = None
-        self._gate_exempt_depth = 0
-        self._internal_open_depth = 0
+        # Library-internal open windows (extract_all's coordinator, first-touch link
+        # reads), keyed BY THREAD: the exemption from the live-stream gate and from
+        # worker rejection applies only to the thread that entered the window. A plain
+        # reader-wide depth counter would silently admit a *foreign* thread's open()
+        # during extract_all on a non-CONCURRENT reader — and on backends without a
+        # shared-handle lock the interleaved seek+read pairs then serve wrong member
+        # bytes instead of the loud error this gate exists to raise (deep review N3).
+        self._internal_open_threads: dict[int, int] = {}
+        # The thread that currently owns the materialization election, for same-thread
+        # re-entry detection (deep review N4a).
+        self._materializing_thread: int | None = None
 
     @property
     def concurrent(self) -> bool:
@@ -91,20 +103,30 @@ class ReaderState:
             return self._root
 
     def begin_internal_opens(self) -> None:
+        tid = threading.get_ident()
         with self._lock:
-            self._internal_open_depth += 1
-            self._gate_exempt_depth += 1
+            self._internal_open_threads[tid] = (
+                self._internal_open_threads.get(tid, 0) + 1
+            )
 
     def end_internal_opens(self) -> None:
+        tid = threading.get_ident()
         with self._lock:
-            self._internal_open_depth = max(0, self._internal_open_depth - 1)
-            self._gate_exempt_depth = max(0, self._gate_exempt_depth - 1)
+            depth = self._internal_open_threads.get(tid, 0) - 1
+            if depth > 0:
+                self._internal_open_threads[tid] = depth
+            else:
+                self._internal_open_threads.pop(tid, None)
+
+    def _internal_opens_active_locked(self) -> bool:
+        """Whether the CURRENT thread is inside a library-internal open window."""
+        return self._internal_open_threads.get(threading.get_ident(), 0) > 0
 
     def acquire_pass(self, name: str) -> OperationToken:
         """Acquire a data-pass token: root when free, else a child under an internal owner."""
         with self._lock:
             self._require_admissible_locked(name)
-            if self._root is not None and self._internal_open_depth > 0:
+            if self._root is not None and self._internal_opens_active_locked():
                 child = OperationToken(name=name, parent=self._root, kind="child")
                 self._children.add(child)
                 return child
@@ -160,14 +182,16 @@ class ReaderState:
         """
         with self._lock:
             self._require_admissible_locked(name)
-            if self._root is not None and self._internal_open_depth == 0:
+            internal = self._internal_opens_active_locked()
+            if self._root is not None and not internal:
                 raise ArchiveyUsageError(
                     f"Cannot call {name!r}: another reader operation "
                     f"({self._root.name!r}) is already active."
                 )
-            # Under an internal library owner (extract_all), worker opens are admitted as
-            # children of that root.
-            if self._root is not None and self._internal_open_depth > 0:
+            # Under an internal library owner (extract_all), the OWNING THREAD's worker
+            # opens are admitted as children of that root; other threads are rejected
+            # above like during any root pass.
+            if self._root is not None and internal:
                 token = OperationToken(name=name, parent=self._root, kind="child")
                 self._children.add(token)
                 return token
@@ -207,6 +231,18 @@ class ReaderState:
                 if self.cache_state is CacheState.MATERIALIZED:
                     return False
                 if self.cache_state is CacheState.MATERIALIZING:
+                    if self._materializing_thread == threading.get_ident():
+                        # Same-thread re-entry: a diagnostic/progress callback fired
+                        # during materialization called back into the reader. Waiting
+                        # would deadlock this thread on a notify only it can send
+                        # (deep review N4a); a non-CONCURRENT reader would raise the
+                        # generic message below, which misdiagnoses the situation.
+                        raise ArchiveyUsageError(
+                            "Reader re-entered while it is materializing its member "
+                            "list on this same thread (e.g. from a diagnostic or "
+                            "progress callback). Callbacks must not call back into "
+                            "the reader that triggered them."
+                        )
                     if not self.concurrent:
                         raise ArchiveyUsageError(
                             "Cannot start materialization: another materialization is "
@@ -216,24 +252,27 @@ class ReaderState:
                     continue
                 # UNMATERIALIZED — elect this caller.
                 self.cache_state = CacheState.MATERIALIZING
+                self._materializing_thread = threading.get_ident()
                 return True
 
     def complete_materialization(self) -> None:
         with self._lock:
             self.cache_state = CacheState.MATERIALIZED
+            self._materializing_thread = None
             self._materialization_cv.notify_all()
 
     def fail_materialization(self) -> None:
         with self._lock:
             if self.cache_state is CacheState.MATERIALIZING:
                 self.cache_state = CacheState.UNMATERIALIZED
+                self._materializing_thread = None
                 self._materialization_cv.notify_all()
 
     def acquire_live_stream(self, stream: ArchiveStream) -> None:
         """Register a public member stream; enforce the single-live-stream gate."""
         with self._lock:
             self._require_lifecycle_open_locked("open()")
-            if self.concurrent or self._gate_exempt_depth > 0:
+            if self.concurrent or self._internal_opens_active_locked():
                 self._live_streams.add(id(stream))
                 self._lease_count += 1
                 return
@@ -288,6 +327,18 @@ class ReaderState:
                     "Cannot close the archive reader while an open()/read() call is "
                     "still in progress."
                 )
+            tid = threading.get_ident()
+            if any(worker.thread_id == tid for worker in self._workers):
+                # This thread is closing from INSIDE one of its own worker calls (a
+                # diagnostic/progress callback calling close()). Draining would wait
+                # forever for a worker that cannot return until close() does (deep
+                # review N4b).
+                raise ArchiveyUsageError(
+                    "Cannot close the archive reader from inside one of its own "
+                    "open()/read()/members() calls (e.g. from a diagnostic or "
+                    "progress callback). Callbacks must not close the reader that "
+                    "triggered them."
+                )
             self._closing = True
             try:
                 while self._workers:
@@ -315,17 +366,13 @@ class ReaderState:
             self.lifecycle = LifecycleState.TEARDOWN_RUNNING
             return True
 
-    def complete_teardown(self, error: BaseException | None = None) -> None:
+    def complete_teardown(self) -> None:
+        """Mark teardown finished. A teardown failure is the caller's to propagate
+        (``_maybe_teardown`` raises it, alone or in an ``ExceptionGroup``); the state
+        machine keeps no copy — a stored-but-never-surfaced error would be a silent
+        swallow path."""
         with self._lock:
-            if error is not None and self._teardown_error is None:
-                self._teardown_error = error
             self.lifecycle = LifecycleState.TEARDOWN_COMPLETE
-
-    def take_teardown_error(self) -> BaseException | None:
-        with self._lock:
-            err = self._teardown_error
-            self._teardown_error = None
-            return err
 
     def _release_lease_locked(self) -> bool:
         if self._lease_count > 0:

--- a/src/archivey/internal/streams/archive_stream.py
+++ b/src/archivey/internal/streams/archive_stream.py
@@ -105,6 +105,17 @@ class ArchiveStream(ReadOnlyIOStream):
         """Safety-net finalizer: release the lease if the caller never closed us.
 
         Never raises; reports via ``sys.unraisablehook`` if release fails.
+
+        Shutdown caveat: the release path takes ``ReaderState``'s lock. At interpreter
+        exit, ``weakref.finalize``'s atexit hook runs while daemon threads are frozen —
+        a daemon thread that died *inside* a reader-state critical section leaves the
+        lock held forever and this finalizer would then hang shutdown. The window is a
+        few bytecodes wide and requires daemon threads driving a reader at exit; noted
+        so a future refactor doesn't widen it (e.g. by making the finalizer wait on a
+        condition).
+
+        Ordering note: this must be called AFTER ``_on_close`` is assigned — the
+        callback captures ``self._on_close`` at attach time, not at fire time.
         """
         if self._finalizer is not None:
             return

--- a/tests/test_concurrent_cooperative.py
+++ b/tests/test_concurrent_cooperative.py
@@ -241,3 +241,70 @@ def test_stream_members_abandon_releases_pass(tmp_path: Path) -> None:
         # Pass released: a new open is allowed.
         with reader.open("a.txt") as s:
             assert s.read() == b"aaa"
+
+
+# --- Same-thread re-entry from callbacks must raise, not deadlock (deep N4) -------------
+
+
+def _zip_with_bad_dos_date(tmp_path: Path) -> Path:
+    """A ZIP whose materialization emits MEMBER_TIMESTAMP_INVALID (invalid DOS day)."""
+    import zipfile
+
+    path = tmp_path / "bad-date.zip"
+    with zipfile.ZipFile(path, "w") as zf:
+        info = zipfile.ZipInfo("bad.txt", date_time=(2021, 2, 31, 0, 0, 0))
+        zf.writestr(info, b"x")
+    return path
+
+
+def test_reader_reentry_from_diagnostic_callback_raises_not_deadlocks(
+    tmp_path: Path,
+) -> None:
+    """A diagnostic callback calling back into the reader mid-materialization would
+    wait on the materialization condition for a notify only its own thread can send.
+    It must be rejected loudly instead (the pre-fix behavior was a permanent
+    single-thread hang; pytest-timeout would trip on a regression)."""
+    from archivey import ArchiveyConfig
+
+    path = _zip_with_bad_dos_date(tmp_path)
+    reader = None
+
+    def on_diagnostic(diagnostic: object) -> None:
+        assert reader is not None
+        reader.members()  # re-enter the reader that is mid-materialization
+
+    config = ArchiveyConfig(on_diagnostic=on_diagnostic)
+    with open_archive(
+        path, member_streams=MemberStreams.CONCURRENT, config=config
+    ) as opened:
+        reader = opened
+        with pytest.raises(ArchiveyUsageError, match="re-entered"):
+            reader.members()
+        # The failed election rolled back; the reader stays usable once the callback
+        # behaves (subsequent emit re-fires the callback, so swap it off first).
+        reader = None
+
+
+def test_close_from_diagnostic_callback_raises_not_deadlocks(tmp_path: Path) -> None:
+    """close() from inside one of the reader's own worker calls (via a callback) would
+    drain-wait forever for a worker that cannot return until close() does."""
+    from archivey import ArchiveyConfig
+
+    path = _zip_with_bad_dos_date(tmp_path)
+    reader = None
+
+    def on_diagnostic(diagnostic: object) -> None:
+        assert reader is not None
+        reader.close()
+
+    config = ArchiveyConfig(on_diagnostic=on_diagnostic)
+    reader_cm = open_archive(
+        path, member_streams=MemberStreams.CONCURRENT, config=config
+    )
+    try:
+        reader = reader_cm
+        with pytest.raises(ArchiveyUsageError, match="from inside one of its own"):
+            reader.members()
+    finally:
+        reader = None
+        reader_cm.close()

--- a/tests/test_concurrent_multithread.py
+++ b/tests/test_concurrent_multithread.py
@@ -432,3 +432,78 @@ def test_concurrent_double_close_exception_group_on_dual_failure(
     with pytest.raises(ExceptionGroup) as exc_info:
         stream.close()
     assert "member-stream close and archive teardown both failed" in str(exc_info.value)
+
+
+# --- Internal-open exemption is thread-scoped (deep N3) ---------------------------------
+
+
+def test_internal_open_exemption_is_thread_scoped() -> None:
+    """extract_all's internal-open window admits the owning thread's opens as children
+    of its root pass; a FOREIGN thread's open must still be rejected (pre-fix it was
+    silently admitted, and unlocked shared handles then served wrong bytes)."""
+    from archivey.internal.reader_state import ReaderState
+
+    state = ReaderState(member_streams=MemberStreams(0), open_site=None)
+    root = state.acquire_pass("extract_all")
+    state.begin_internal_opens()
+    try:
+        # Owning thread: admitted as a child of the root.
+        token = state.acquire_worker("open")
+        assert token.parent is root
+        state.release_worker(token)
+
+        # Foreign thread: rejected like during any active root pass.
+        outcome: list[object] = []
+
+        def foreign() -> None:
+            try:
+                outcome.append(state.acquire_worker("open"))
+            except ArchiveyUsageError as exc:
+                outcome.append(exc)
+
+        thread = threading.Thread(target=foreign)
+        thread.start()
+        thread.join(timeout=10)
+        assert not thread.is_alive()
+        assert len(outcome) == 1 and isinstance(outcome[0], ArchiveyUsageError)
+    finally:
+        state.end_internal_opens()
+        state.release_pass(root)
+
+
+@pytest.mark.concurrent_reader
+def test_foreign_thread_open_rejected_during_extract_all(tmp_path: Path) -> None:
+    """End-to-end N3: while extract_all runs on thread A (no CONCURRENT declared), a
+    second thread's reader.open() must raise instead of being silently admitted under
+    extract_all's internal-open exemption."""
+    archive = _make_tar(tmp_path / "a.tar")
+    dest = tmp_path / "out"
+    with open_archive(archive) as reader:
+        in_extract = threading.Event()
+        proceed = threading.Event()
+        outcome: list[str] = []
+
+        def on_progress(progress: object) -> None:
+            if not in_extract.is_set():
+                in_extract.set()
+                # Hold the extraction mid-pass until the foreign open has resolved.
+                assert proceed.wait(timeout=30)
+
+        def foreign_open() -> None:
+            try:
+                assert in_extract.wait(timeout=30)
+                try:
+                    with reader.open("f0.txt") as stream:
+                        stream.read()
+                    outcome.append("admitted")
+                except ArchiveyUsageError:
+                    outcome.append("rejected")
+            finally:
+                proceed.set()
+
+        thread = threading.Thread(target=foreign_open)
+        thread.start()
+        reader.extract_all(dest, on_progress=on_progress)
+        thread.join(timeout=30)
+        assert not thread.is_alive()
+        assert outcome == ["rejected"]

--- a/tests/test_directory.py
+++ b/tests/test_directory.py
@@ -548,3 +548,19 @@ def test_subdirectory_vanishing_mid_walk_is_skipped(
     assert "sub/" in names  # the dir entry itself was listed before it vanished
     assert not any(n.startswith("sub/") and n != "sub/" for n in names)
     assert any("vanished" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# stat timestamps are guarded like every backend's (deep W2)
+# ---------------------------------------------------------------------------
+
+
+def test_stat_datetime_guards_out_of_range_values() -> None:
+    # A network/FUSE filesystem can report garbage timestamps; one bad file must not
+    # sink the whole walk (on Windows even tz-aware fromtimestamp raises OSError).
+    from datetime import datetime, timezone
+
+    from archivey.internal.backends.directory_reader import _stat_datetime
+
+    assert _stat_datetime(0) == datetime(1970, 1, 1, tzinfo=timezone.utc)
+    assert _stat_datetime(2**62) is None

--- a/tests/test_reader_contract.py
+++ b/tests/test_reader_contract.py
@@ -280,3 +280,58 @@ def test_baseexception_during_materialization_does_not_wedge_reader() -> None:
     # UNMATERIALIZED, so a retry re-elects and succeeds instead of raising a
     # misleading "materialization already in progress".
     assert [m.name for m in reader.members()] == ["a.txt"]
+
+
+# --- A failed streaming pass must not publish a partial member list (deep N1) --------
+
+
+class _FailingScanReader(BaseArchiveReader):
+    """Streaming reader whose scan raises after yielding its first member."""
+
+    _SUPPORTS_RANDOM_ACCESS = False
+    _MEMBER_LIST_UPFRONT = False
+
+    def _iter_members(self) -> Iterator[ArchiveMember]:
+        yield ArchiveMember(type=MemberType.FILE, name="a.txt", size=1)
+        raise archivey.CorruptionError("scan failed mid-pass")
+
+    def _open_member(self, member: ArchiveMember) -> ArchiveStream:
+        return self._wrap_member_stream(io.BytesIO(b"x"), member.name, size=member.size)
+
+    def _get_archive_info(self) -> ArchiveInfo:
+        return _info(
+            ArchiveFormat.TAR,
+            ListingCost.REQUIRES_SCANNING,
+            StreamCapability.FORWARD_ONLY,
+        )
+
+    def _close_archive(self) -> None:
+        pass
+
+
+def test_failed_streaming_pass_does_not_publish_partial_list() -> None:
+    # An exception escaping the forward pass leaves its generator closed; a plain
+    # retry would see StopIteration and finalize the PARTIAL scan as the complete
+    # resolved cache — scan_members() would then silently return a truncated listing.
+    reader = _FailingScanReader(ArchiveFormat.TAR, True, "x.tar")
+    it = iter(reader)
+    assert next(it).name == "a.txt"
+    with pytest.raises(archivey.CorruptionError):
+        next(it)
+    # The resolved-list methods must fail loud, not serve the partial scan as complete.
+    with pytest.raises(archivey.ReadError, match="previously failed"):
+        reader.scan_members()
+    # And the partial scan must never be published as an available cache.
+    assert reader.get_members_if_available() is None
+
+
+def test_failed_streaming_pass_stays_poisoned_on_reiteration() -> None:
+    reader = _FailingScanReader(ArchiveFormat.TAR, True, "x.tar")
+    with pytest.raises(archivey.CorruptionError):
+        list(reader)
+    # scan_members() may finish an interrupted pass, so it reaches the poisoned
+    # iterator — and must keep failing loud on every retry, chained to the original.
+    for _ in range(2):
+        with pytest.raises(archivey.ReadError, match="previously failed") as excinfo:
+            reader.scan_members()
+        assert isinstance(excinfo.value.__cause__, archivey.CorruptionError)

--- a/tests/test_tar.py
+++ b/tests/test_tar.py
@@ -956,3 +956,50 @@ def test_chain_through_same_named_members_not_false_cycle() -> None:
     )
     with reader._open_with_link_follow(start, set()) as stream:
         assert stream.read() == b"payload"
+
+
+# ---------------------------------------------------------------------------
+# A failed streaming pass must not publish a partial member list (deep N1)
+# ---------------------------------------------------------------------------
+
+
+def test_error_mid_streaming_pass_poisons_scan_members() -> None:
+    """End-to-end N1 repro: a RAISE-disposition diagnostic fires mid-pass; the caller
+    catches it; ``scan_members()`` must then fail loud instead of silently returning
+    the two-member prefix as the complete resolved list."""
+    from archivey.diagnostics import (
+        DiagnosticCode,
+        DiagnosticDisposition,
+        DiagnosticPolicy,
+    )
+    from archivey.exceptions import DiagnosticRaisedError
+
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w") as tf:
+        for name in ("a", "b", "c", "d"):
+            data = b"x" * 100
+            info = tarfile.TarInfo(name + ".bin")
+            info.size = len(data)
+            if name == "c":
+                info.mtime = 2**62  # out of range -> MEMBER_TIMESTAMP_INVALID
+            tf.addfile(info, io.BytesIO(data))
+    buf.seek(0)
+
+    config = ArchiveyConfig(
+        diagnostic_policy=DiagnosticPolicy(
+            overrides={
+                DiagnosticCode.MEMBER_TIMESTAMP_INVALID: DiagnosticDisposition.RAISE
+            }
+        )
+    )
+    with open_archive(
+        buf, streaming=True, format=ArchiveFormat.TAR, config=config
+    ) as reader:
+        seen: list[str] = []
+        with pytest.raises(DiagnosticRaisedError):
+            for member in reader:
+                seen.append(member.name)
+        assert seen == ["a.bin", "b.bin"]
+        with pytest.raises(ReadError, match="previously failed"):
+            reader.scan_members()
+        assert reader.get_members_if_available() is None

--- a/tests/test_zip.py
+++ b/tests/test_zip.py
@@ -768,3 +768,80 @@ def test_backslash_kept_literal_for_unix_entry() -> None:
     with open_archive(_ZIP_BACKSLASH_DIR / "unix_backslash.zip") as ar:
         names = [m.name for m in ar.members()]
     assert names == ["weird\\name.txt"]
+
+
+# ---------------------------------------------------------------------------
+# Extended Timestamp out-of-range guard (deep W2)
+# ---------------------------------------------------------------------------
+
+
+def test_extended_timestamp_pre_epoch(tmp_path: Path) -> None:
+    # A signed pre-1970 Extended Timestamp is legitimate data. On POSIX it converts
+    # cleanly; on Windows the conversion raises OSError and must degrade to an issue
+    # (covered by the forced test below) — never crash the listing either way.
+    extra = struct.pack("<HHBi", 0x5455, 5, 0x01, -1)
+    path = tmp_path / "pre-epoch.zip"
+    info = zipfile.ZipInfo("t.txt", date_time=(1990, 1, 1, 0, 0, 0))
+    info.extra = extra
+    with zipfile.ZipFile(path, "w") as z:
+        z.writestr(info, b"data")
+    with open_archive(path) as ar:
+        member = ar.get("t.txt")
+        assert member is not None
+        expected = datetime.fromtimestamp(-1, tz=timezone.utc)
+        assert member.modified in (expected, None)  # None only where the OS rejects it
+
+
+def test_extended_timestamp_out_of_range_degrades_to_diagnostic(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Simulate Windows, where even tz-aware fromtimestamp routes through gmtime() and
+    # raises OSError for pre-1970 values: the member must list with modified=None and a
+    # MEMBER_TIMESTAMP_INVALID diagnostic, not crash with a raw OSError.
+    from archivey.diagnostics import DiagnosticCode
+    from archivey.internal.backends import zip_reader as zip_reader_module
+
+    class _WindowsLikeDatetime(datetime):
+        @classmethod
+        def fromtimestamp(cls, ts: float, tz: object = None) -> datetime:
+            if ts < 0:
+                raise OSError(22, "Invalid argument (simulated Windows gmtime)")
+            return datetime.fromtimestamp(ts, tz)  # type: ignore[arg-type]
+
+    monkeypatch.setattr(zip_reader_module, "datetime", _WindowsLikeDatetime)
+
+    extra = struct.pack("<HHBi", 0x5455, 5, 0x01, -(2**31))
+    path = tmp_path / "neg-ts.zip"
+    info = zipfile.ZipInfo("t.txt", date_time=(1990, 1, 1, 0, 0, 0))
+    info.extra = extra
+    with zipfile.ZipFile(path, "w") as z:
+        z.writestr(info, b"data")
+    with open_archive(path) as ar:
+        member = ar.get("t.txt")
+        assert member is not None
+        # DOS date survives; the bad extended field only loses its own override.
+        assert member.modified == datetime(1990, 1, 1, 0, 0, 0)
+        assert (
+            ar.diagnostics.counts.get(DiagnosticCode.MEMBER_TIMESTAMP_INVALID, 0) >= 1
+        )
+
+
+# ---------------------------------------------------------------------------
+# ZipInfo._raw_time must fail loud if stdlib drops it (deep W3)
+# ---------------------------------------------------------------------------
+
+
+def test_zipcrypto_check_byte_fails_loud_without_raw_time(tmp_path: Path) -> None:
+    # A silent 0 fallback would make every candidate fail the ZipCrypto 1-byte check
+    # and misreport correct passwords as wrong for data-descriptor members.
+    path = tmp_path / "plain.zip"
+    with zipfile.ZipFile(path, "w") as z:
+        z.writestr("a.txt", b"data")
+    with open_archive(path) as ar:
+        info = zipfile.ZipInfo("x")
+        info.flag_bits = 0x8  # data descriptor: check byte comes from _raw_time
+        assert not hasattr(info, "_raw_time")
+        with pytest.raises(RuntimeError, match="_raw_time"):
+            ar._zipcrypto_check_byte(info)  # type: ignore[attr-defined]
+        info._raw_time = 0xABCD
+        assert ar._zipcrypto_check_byte(info) == 0xAB  # type: ignore[attr-defined]


### PR DESCRIPTION
Focused second pass over the `review/` reports from #73, now **including the fixes** (maintainer approved implementing them). First commit is the three reports; second commit applies the fixes with regression tests.

## Fixed in this PR

**Concurrency (`reader_state.py`, `base_reader.py`, `archive_stream.py`):**
- **N1** — an exception escaping a streaming pass poisons the pass iterator: `scan_members()` now raises `ReadError` (chained to the original) instead of silently publishing the partial scan as the complete resolved member cache; `get_members_if_available()` stays `None`. Reproduced pre-fix, verified post-fix end-to-end.
- **N2** — snapshot publication order swapped so `_members_by_name_lists` is visible before the `_members_cache` sentinel the lock-free fast path keys on (load-bearing-order comment added; same order in `_finalize_pass_links`).
- **N3** — the internal-opens exemption is now **thread-scoped** (`_internal_open_threads` keyed by thread id): a foreign thread's `open()` during `extract_all()` on a non-CONCURRENT reader is rejected loudly again instead of being silently admitted onto unlocked shared handles.
- **N4** — both same-thread callback-re-entry deadlocks now raise `ArchiveyUsageError`: `begin_materialization` tracks the electing thread, and `mark_reader_closed` rejects `close()` from inside one of the closing thread's own worker calls (`OperationToken` records its acquiring thread).
- **N6** — dead `take_teardown_error` / write-only `_teardown_error` removed. **N7** — inaccurate publication comment fixed. **N5** — shutdown caveat + finalizer attach-ordering documented.

**Error boundary (S1):** `BaseArchiveReader` gains `_raise_translated` + `_translated_errors()` (an `__exit__`-based boundary, the out-of-stream counterpart of `ArchiveStream._fail`); the ten hand-rolled translate/stamp/raise sites in TAR/ISO/ZIP collapse onto it, and ZIP's `_reraise_member_error` delegates. Unrecognized exceptions still propagate raw; `EncryptionError` member-stamping stays skippable.

**Unknown unknowns:**
- **W2** — ZIP Extended Timestamp (0x5455) conversion guarded like its DOS/NTFS siblings (tz-aware `fromtimestamp` raises `OSError` on Windows for pre-1970 values — an attacker-controllable field crashed the listing); directory reader stat timestamps guarded (`_stat_datetime`).
- **W3** — `ZipInfo._raw_time` absence now fails loud (`RuntimeError` with a report-this message) instead of a silent `0` fallback that would misreport correct ZipCrypto passwords as wrong for data-descriptor members.
- **W1** — tarfile's silent end-of-archive on a corrupt non-first header documented (`docs/formats.md`, `docs/internal/known-issues.md`) and named in the EOF-marker diagnostic message.
- **W4** — `_iter_members` order-stability requirement stated in the contract. **W5** — extraction temp prefix named as a constant and documented as safe to delete.

## Tests

N1 (contract-level failing reader + end-to-end TAR repro), N3 (ReaderState unit test + foreign-thread-open-during-extract_all), N4 (both callback-re-entry paths raise instead of hanging; pytest-timeout backstops regressions), W2 (pre-epoch UT field, simulated-Windows monkeypatch, diagnostic emission), W3, directory guard — 11 new tests.

## Gates

All three dependency configs green (`[all]` 1364 passed, `[all-lowest]` 1363 passed, `[core-only]` 1160 passed + zero-dep import check); pyrefly and ty clean (warning count at baseline); ruff check + format clean.

## Deliberately deferred (with reasons, noted in the review docs)

- **S2/S3** structural refactors — they restructure exactly the code the N1/N2 point-fixes touch; better as their own change (S2 would subsume N1/N2 structurally). **S4** stays decision-sized.
- **W7/W8** (`os.pread` SharedSource strategy, `readinto` copy loop) — perf changes the report itself gates on benchmark work.
- `strict_archive_eof` default flip — a behavior change; documented instead.

## The reports (first commit)

- `review/deep-concurrency.md` — per-mechanism hold/violate verdicts with interleaving arguments; corrects the first review's lock-ordering claim; CPython-reliance inventory.
- `review/deep-simplification.md` — category-deleting changes; honest answer to the half-size question (no).
- `review/deep-unknown-unknowns.md` — stdlib leniency, platform divergence, private-API reliance sweep; corrects first-review U3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C3MzFD3nzPKKJwgju5bfnj