### PR TITLE
Propose listing-resource-limits (OpenSpec)

### DIFF
--- a/openspec/changes/listing-resource-limits/.openspec.yaml
+++ b/openspec/changes/listing-resource-limits/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: library
+created: 2026-07-12

--- a/openspec/changes/listing-resource-limits/design.md
+++ b/openspec/changes/listing-resource-limits/design.md
@@ -1,0 +1,128 @@
+## Context
+
+Threat-model O1: extraction has `ExtractionLimits` / `BombTracker`; listing does
+not. A crafted ZIP CD or 7z FilesInfo can force gigabytes of `ArchiveMember`
+allocations at `members()` / `scan_members()` before any extract guard runs.
+Review L1 partially fixed 7z by bounding `num_files` against header size
+(`CorruptionError`); the spine still needs configurable caps, and extract bomb
+failures still raise `ExtractionError` (wrong phase name for a shared safety
+story).
+
+Decisions below were locked with the maintainer in explore (2026-07).
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Configurable listing caps on `ArchiveyConfig` with safe defaults.
+- Uniform spine enforcement at member registration / materialization.
+- Keep format-local early bounds as defense-in-depth.
+- One `ResourceLimitError` for listing caps and extract bomb trips.
+- Honest metadata-byte accounting (retained strings/bytes, not compressed headers).
+
+**Non-Goals:**
+
+- Per-call `listing_limits=` on `members()` / `scan_members()`.
+- Bounding unbounded `read()` / `open()` stream sizes (follow-on).
+- `__slots__` on `ArchiveMember` (optional micro-opt, separate change).
+- OSS-Fuzz / Atheris (separate O5 work).
+- Casefold / Windows name portability (O2–O4).
+
+## Investigations
+
+### Member RAM vs metadata budget
+
+| Scale | ~`ArchiveMember` RAM (rich stand-in) | Retained name+raw (~80B paths) | TAR `N×512` headers |
+| --- | --- | --- | --- |
+| Linux sources (~90–100k) | ~100–110 MiB | ~15–20 MiB | ~46–51 MiB |
+| Chromium-scale (~400k) | ~450 MiB | ~60–80 MiB | ~205 MiB |
+| At `max_members=1M` | ~1.1 GiB | ~160 MiB | ~512 MiB |
+
+Defaults target “no false positive on Linux sources.” A 1 GiB host is already
+pressured by `max_members` object overhead long before the 64 MiB string budget;
+document lowering `max_members` on constrained hosts.
+
+### Compressed vs retained metadata
+
+Compressed 7z header size is a weak primary guard (small packed header → huge
+FilesInfo). TAR has no separate header blob. **Retained string/bytes lengths**
+are format-uniform and match the string-bomb half of O1; `max_members` covers
+object-count overhead.
+
+## Decisions
+
+### 1. Separate `ListingLimits` (do not reuse / rename `ExtractionLimits`)
+
+Listing and extraction need **distinct knobs**. Overloading `max_entries` breaks
+“list a huge archive, extract five selected members.” Rename-only to
+`SafetyLimits` does not fix the phase collision; a single flat object with both
+families of fields makes `extract(..., limits=)` awkward (must re-copy listing
+fields or invent partial override).
+
+**Rejected:** one shared `max_entries`; rename-only `SafetyLimits`; nested
+`SafetyLimits(listing=…, extraction=…)`.
+
+### 2. Defaults match on counts; metadata = 64 MiB retained strings
+
+- `ListingLimits.max_members = ExtractionLimits.max_entries = 1_048_576` so an
+  archive that lists under defaults can extract all members without a count
+  surprise.
+- `max_metadata_bytes = 64 * 2**20`.
+- `None` disables a guard; `ListingLimits.UNLIMITED` disables both.
+
+### 3. Metadata accounting
+
+As each member is registered, add UTF-8 lengths (`surrogateescape`) of `name`,
+`comment`, `link_target`, `uname`, `gname`; `len(raw_name)` when present; `str` /
+`bytes` values in `extra` (one-level nesting for PAX-like dicts). Also count
+`ArchiveInfo.comment` once when known. Exclude `_raw`, `hashes`, diagnostics,
+and Python object overhead.
+
+### 4. Enforcement points
+
+- **Spine:** check before/at `_register_member` when building a materialized /
+  resolved list (`members`, `scan_members`, extract paths that materialize).
+- **Format-local:** keep 7z `num_files > header_size → CorruptionError` (and
+  similar); that is “header is nonsense,” not “over config.”
+- **`stream_members` / forward iteration:** unguarded by design (O(1) escape).
+- Listing limits come only from the reader’s open `config`; no per-call override.
+
+### 5. `ResourceLimitError` for listing and extract bombs
+
+New `ResourceLimitError(ArchiveyError)` (sibling of `ExtractionError`, not a
+subclass — limit trips are not filter/path failures). Listing and all
+`ExtractionLimits` bomb trips (bytes, ratio, entries, archive-wide / live ratio)
+raise it. Message names the knob and limit. **BREAKING** for callers that
+caught only `ExtractionError` for bombs.
+
+**Rejected:** keep extract on `ExtractionError` and migrate later; reuse
+`ExtractionError` for listing.
+
+### 6. Config surface
+
+```python
+@dataclass(frozen=True)
+class ListingLimits:
+    max_members: int | None = 1_048_576
+    max_metadata_bytes: int | None = 64 * 2**20
+    UNLIMITED: ClassVar[ListingLimits]
+
+@dataclass(frozen=True)
+class ArchiveyConfig:
+    ...
+    extraction_limits: ExtractionLimits = ...
+    listing_limits: ListingLimits = ...
+```
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+| --- | --- |
+| Chromium-scale TAR false-positive on 64 MiB string budget | Unlikely under retained-string accounting; document raising the cap |
+| `stream_members` escape used to bypass caps | Documented; callers who need full materialization still hit caps |
+| BREAKING extract error type | Pre-1.0; changelog + update tests; `except ArchiveyError` still works |
+| Double-counting name + raw_name | Intentional (both retained); still well under Linux budget |
+
+## Open Questions
+
+None — decisions locked for proposal.

--- a/openspec/changes/listing-resource-limits/proposal.md
+++ b/openspec/changes/listing-resource-limits/proposal.md
@@ -1,0 +1,51 @@
+## Why
+
+Extraction already has bomb guards (`ExtractionLimits`), but listing does not:
+`members()` / `scan_members()` will materialize whatever the header claims — a
+metadata bomb of millions of entries or huge names/comments — before any
+extraction guard runs. That undercuts VISION's memory-safe hostile-input claim
+(threat-model O1). The 7z parser's header-size bound closed one format-local
+hole; the spine still needs uniform listing caps, and extract bomb failures
+should share one typed limit error with listing.
+
+## What Changes
+
+- Add frozen `ListingLimits` (`max_members`, `max_metadata_bytes`) on
+  `ArchiveyConfig.listing_limits`, applied for the reader lifetime from
+  `open_archive(config=…)`. No per-call listing override in v1.
+- Enforce listing caps when members are registered into a materialized /
+  resolved list (`members`, `scan_members`, extract prep that materializes).
+  Keep format-local early bounds (e.g. 7z header-size) as defense-in-depth.
+- **`stream_members` / forward iteration stay unguarded** (O(1) escape hatch).
+- Defaults: `max_members=1_048_576` (same as extract `max_entries`);
+  `max_metadata_bytes=64 MiB` (retained string/bytes accounting).
+- Add `ResourceLimitError(ArchiveyError)`.
+- **BREAKING:** extraction bomb trips (`max_extracted_bytes`, `max_ratio`,
+  `max_entries`) raise `ResourceLimitError` instead of `ExtractionError`.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `archive-reading`: `ListingLimits` schema; `ArchiveyConfig.listing_limits`;
+  materialization enforcement contract; metadata-byte accounting.
+- `safe-extraction`: bomb-guard failures raise `ResourceLimitError`.
+- `error-handling`: add `ResourceLimitError` to the public hierarchy.
+- `format-7z`: document parser-local count/header bounds as complementary to
+  spine listing limits (no silent reliance on extraction `max_entries`).
+
+## Impact
+
+- **Public API:** new `ListingLimits` / `ResourceLimitError` exports;
+  `ArchiveyConfig.listing_limits`; extract bomb `except ExtractionError`
+  callers must catch `ResourceLimitError` (or broader `ArchiveyError`).
+- **Modules:** `config.py`, `exceptions.py`, `base_reader` registration /
+  materialization, `extraction` / `BombTracker`, 7z parser bounds (already
+  partly landed), threat-model O1 status.
+- **Tests:** adversarial oversized member-count / metadata fixtures; extract
+  bomb error-type updates; `stream_members` remains uncapped.
+- **Deps/extras:** none.

--- a/openspec/changes/listing-resource-limits/specs/archive-reading/spec.md
+++ b/openspec/changes/listing-resource-limits/specs/archive-reading/spec.md
@@ -1,0 +1,124 @@
+## ADDED Requirements
+
+### Requirement: Listing resource limits
+
+The system SHALL define frozen `ListingLimits` and apply them from the reader's
+open `ArchiveyConfig.listing_limits` when registering members into a
+materialized or resolved member list (`members()`, `scan_members()`, and any
+path that materializes via `_get_members_registered` / equivalent). There is no
+per-call listing-limits override.
+
+```python
+@dataclass(frozen=True)
+class ListingLimits:
+    max_members: int | None = 1_048_576
+    max_metadata_bytes: int | None = 64 * 2**20  # 64 MiB
+    UNLIMITED: ClassVar["ListingLimits"]
+```
+
+`None` on a field disables that guard. `ListingLimits.UNLIMITED` disables both.
+Crossing either guard SHALL raise `ResourceLimitError` naming the knob and
+limit. Format-local parser bounds (e.g. 7z header-size checks) MAY still raise
+`CorruptionError` for nonsensical headers and are complementary, not a
+substitute.
+
+**Unguarded by design:** `stream_members()` / forward-only iteration MUST NOT
+enforce `ListingLimits` (O(1) escape hatch). Callers that need a full resolved
+list use `members()` / `scan_members()` and accept the caps.
+
+#### Scenario: listing-limits matrix
+
+| Case | Expected |
+| --- | --- |
+| Default config, archive with ≤1_048_576 members and metadata under 64 MiB | `members()` / `scan_members()` succeed |
+| Registered member count would exceed `max_members` | `ResourceLimitError` before/at that registration; no full cache published |
+| Cumulative retained metadata would exceed `max_metadata_bytes` | `ResourceLimitError` naming `max_metadata_bytes` |
+| `ListingLimits.UNLIMITED` | Count and metadata guards disabled |
+| `stream_members()` over an archive that would fail `members()` under defaults | Iteration proceeds without listing-limit errors |
+| `extract_all` path that materializes members first | Same listing caps as `members()` before extraction bomb guards |
+
+### Requirement: Listing metadata-byte accounting
+
+The system SHALL measure `max_metadata_bytes` as the sum of retained
+string/bytes field lengths accumulated as members are registered, plus
+archive-level `ArchiveInfo.comment` once when known:
+
+- `str` fields `name`, `comment`, `link_target`, `uname`, `gname`:
+  `len(s.encode("utf-8", "surrogateescape"))`
+- `raw_name`: `len(raw_name)` when not `None`
+- `extra`: lengths of `str` / `bytes` values; for a one-level `dict` value,
+  lengths of nested `str` / `bytes` values only
+- Exclude: `_raw`, `hashes`, diagnostics, Python object overhead
+
+#### Scenario: metadata accounting matrix
+
+| Case | Expected |
+| --- | --- |
+| Member with long `name` + `raw_name` | Both lengths count |
+| Huge `ArchiveInfo.comment` alone | Counts toward the budget once |
+| `extra` holds opaque non-str/bytes object | Not counted |
+| Undecodable surrogateescape name | Stable UTF-8-with-surrogateescape byte length |
+
+## MODIFIED Requirements
+
+### Requirement: Explicit configuration object
+
+The system SHALL define these complete frozen schemas:
+
+```python
+@dataclass(frozen=True)
+class ExtractionLimits:
+    max_extracted_bytes: int | None = 2 * 2**30
+    max_ratio: float | None = 1000.0
+    ratio_activation_threshold: int = 5 * 2**20
+    max_entries: int | None = 1_048_576
+    UNLIMITED: ClassVar["ExtractionLimits"]
+
+@dataclass(frozen=True)
+class ListingLimits:
+    max_members: int | None = 1_048_576
+    max_metadata_bytes: int | None = 64 * 2**20
+    UNLIMITED: ClassVar["ListingLimits"]
+
+@dataclass(frozen=True)
+class ArchiveyConfig:
+    use_rapidgzip: AcceleratorMode = AcceleratorMode.AUTO
+    use_indexed_bzip2: AcceleratorMode = AcceleratorMode.AUTO
+    strict_archive_eof: bool = False
+    extraction_limits: ExtractionLimits = ExtractionLimits()
+    listing_limits: ListingLimits = ListingLimits()
+    diagnostic_policy: DiagnosticPolicy = DiagnosticPolicy()
+    max_retained_diagnostic_references: int = 256
+    on_diagnostic: Callable[[Diagnostic], None] | None = None
+```
+
+`max_retained_diagnostic_references` SHALL be non-negative. Policy/default/override
+mappings and the dataclasses SHALL be defensively immutable. `config=None` →
+immutable library default. No mutable global/context-local diagnostic policy or
+callback.
+
+A reader carries its open config, including `listing_limits` for its lifetime.
+Later `extract_all(config=...)` MAY override policy/callback/strictness/
+accelerators/`extraction_limits` for new work, but SHALL NOT change the
+reader's effective `listing_limits` or
+`max_retained_diagnostic_references` (see `diagnostics`). Per-call `limits`
+still beat `config.extraction_limits`, then reader/library default. Other
+per-call operational args stay outside `ArchiveyConfig`.
+
+`strict_archive_eof=False` follows ordinary diagnostic policy for failed EOF check;
+`True` forces `TruncatedError` after ordered diagnostic rules in `error-handling`.
+
+`on_diagnostic` runs synchronously after count/retention/logging updates. Snapshot
+reads from a callback are allowed. Starting another operation on the same
+emitting reader/stream SHALL raise `UnsupportedOperationError`; other readers OK.
+Callbacks hold no Archivey collector/reader/stream/backend/registry lock
+(`diagnostics` / `reader-concurrency`).
+
+#### Scenario: config matrix
+
+| Case | Expected |
+| --- | --- |
+| `ArchiveyConfig()` | AUTO accelerators; EOF strictness false; documented extraction and listing defaults; COLLECT; budget 256; no callback |
+| Reader budget 10, then `extract_all(config=…budget=1000)` | New policy/callback may apply; diagnostics still under budget 10 |
+| `extract(..., extraction_limits=ExtractionLimits(max_ratio=100))` | 100:1 per-member ratio enforced (`safe-extraction`) |
+| Reader opened with `listing_limits=ListingLimits(max_members=10)` | Listing caps stay at 10 for the reader lifetime even if later `extract_all(config=...)` omits listing_limits |

--- a/openspec/changes/listing-resource-limits/specs/error-handling/spec.md
+++ b/openspec/changes/listing-resource-limits/specs/error-handling/spec.md
@@ -1,0 +1,58 @@
+## MODIFIED Requirements
+
+### Requirement: Single rooted archive exception hierarchy
+
+The system SHALL define every library-detected archive/environment failure under
+this exact `ArchiveyError` hierarchy:
+
+```text
+ArchiveyError(Exception)
+├── OpenError
+│   ├── FormatDetectionError
+│   ├── UnsupportedFormatError
+│   └── StreamNotSeekableError
+├── ReadError
+│   ├── CorruptionError
+│   ├── TruncatedError
+│   ├── EncryptionError
+│   └── LinkTargetNotFoundError
+├── WriteError
+├── ExtractionError
+│   └── FilterRejectionError
+│       ├── PathTraversalError
+│       ├── SymlinkEscapeError
+│       └── SpecialFileError
+├── ResourceLimitError
+├── UnsupportedFeatureError
+├── PackageNotInstalledError
+├── UnsupportedOperationError
+└── DiagnosticRaisedError
+```
+
+Subclass boundaries SHALL keep their existing meanings:
+`UnsupportedFeatureError` / `PackageNotInstalledError` may occur at open or read
+time, `StreamNotSeekableError` is an `OpenError`, and
+`UnsupportedOperationError` describes an archive/backend/access-mode operation
+that cannot be provided, not a caller-code bug. `DiagnosticRaisedError` is direct
+because advisory escalation can happen during detection, open, read, stream, or
+extraction. `ResourceLimitError` is direct because configurable resource caps can
+trip during listing materialization or extraction bomb guarding; it is not an
+`ExtractionError` subclass.
+
+| Error split | Meaning |
+| --- | --- |
+| `UnsupportedOperationError` | Valid API call against a reader/backend/mode that cannot provide the requested operation: random access on `streaming=True`, write through read-only RAR, operation on closed reader. |
+| `UnsupportedFeatureError` | Valid archive uses a recognized feature Archivey does not implement: unsupported ZIP method, AES ZIP entry, 7z BCJ2, unknown coder. |
+| `ResourceLimitError` | A configured listing or extraction resource limit was exceeded (`ListingLimits` / `ExtractionLimits` bomb guards). |
+
+#### Scenario: archive exception matrix
+
+| Case | Expected |
+| --- | --- |
+| Any open/read/extract/write failure detected by Archivey | Instance of `ArchiveyError`; `except ArchiveyError` catches it |
+| Diagnostic policy escalates | `DiagnosticRaisedError` is caught by `except ArchiveyError` |
+| Bad member CRC | `CorruptionError`, distinct from `EncryptionError` |
+| Missing codec/package/tool such as `pyppmd`, crypto backend, or `unrar` | `PackageNotInstalledError` names the missing component |
+| Recognized unsupported feature such as 7z BCJ2 | `UnsupportedFeatureError`; no incorrect output |
+| Listing `max_members` exceeded | `ResourceLimitError`, not `ExtractionError` |
+| Extraction `max_extracted_bytes` exceeded | `ResourceLimitError`, not `ExtractionError` |

--- a/openspec/changes/listing-resource-limits/specs/format-7z/spec.md
+++ b/openspec/changes/listing-resource-limits/specs/format-7z/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: Bound 7z header count fields before allocation
+
+The system SHALL bound count fields read from the 7z header (including
+`num_files` and other pre-allocated tables) against the already size-bounded,
+CRC-checked header buffer before allocating per-entry structures. A count that
+cannot fit in the remaining header semantics SHALL raise `CorruptionError`
+(hostile/nonsensical header), independent of `ListingLimits`.
+
+Spine `ListingLimits` (`archive-reading`) still apply when members are
+registered into a materialized list and raise `ResourceLimitError` when
+configured caps are exceeded. Parser bounds are defense-in-depth against
+allocation before Python `ArchiveMember` objects exist; they MUST NOT be
+implemented by reusing `ExtractionLimits.max_entries`.
+
+#### Scenario: 7z header bound matrix
+
+| Case | Expected |
+| --- | --- |
+| `num_files` greater than header buffer size | `CorruptionError` at parse; no giant pre-allocation |
+| Legitimate archive whose header is large enough for its file count | Parse succeeds; listing still subject to `ListingLimits` |
+| Archive within parser bounds but over `listing_limits.max_members` | Parse may succeed; `members()` / materialization raises `ResourceLimitError` |

--- a/openspec/changes/listing-resource-limits/specs/safe-extraction/spec.md
+++ b/openspec/changes/listing-resource-limits/specs/safe-extraction/spec.md
@@ -1,0 +1,167 @@
+## MODIFIED Requirements
+
+### Requirement: Enforce Cumulative Max-Extracted-Bytes Limit
+
+The system SHALL track total bytes written across a single `extract()` or
+`extract_all()` call and raise `ResourceLimitError` at the chunk boundary where
+the total exceeds `max_extracted_bytes`. The default is 2 GiB
+(2,147,483,648 bytes). Callers override it through `ExtractionLimits`; `None` via
+`ExtractionLimits.UNLIMITED` disables this guard.
+
+The limit SHALL be tracked by one `BombTracker` per extraction call. It is a
+global resource guard: when it trips, extraction halts and no later members are
+processed regardless of `OnError`.
+
+#### Scenario: cumulative byte limit matrix
+
+| Case | Expected |
+| --- | --- |
+| Running written-byte total crosses `max_extracted_bytes` | Immediate `ResourceLimitError`; extraction halts |
+| `ExtractionLimits(max_extracted_bytes=10 * 2**30)` | Enforced cumulative limit is 10 GiB |
+| `ExtractionLimits.UNLIMITED` | Cumulative byte guard is disabled |
+
+### Requirement: Enforce Per-ArchiveMember Max Decompression Ratio
+
+The system SHALL raise `ResourceLimitError` when a single member's output exceeds
+`max_ratio * member.compressed_size` after that member's output crosses
+`ratio_activation_threshold`. Defaults are `max_ratio=1000.0` and threshold
+5 MiB. The ratio is per-member output, not cumulative output, and is checked only
+when `member.compressed_size` is known and greater than zero. The original member
+is used so late-bound compressed-size metadata remains accurate.
+
+This guard SHALL be independent of cumulative bytes and archive-wide ratio
+guards. A ratio violation for one member is member-scoped and may be continued
+under `OnError.CONTINUE`; global guards remain always-stop.
+
+#### Scenario: per-member ratio matrix
+
+| Case | Expected |
+| --- | --- |
+| Member output exceeds ratio after threshold | `ResourceLimitError` while processing that member |
+| Tiny highly-compressible member stays below threshold | No ratio error; threshold prevents false positive |
+| `compressed_size is None` or `0` | Per-member ratio skipped; cumulative/global guards still apply |
+| `ExtractionLimits(max_ratio=100)` | Members over 100:1 trip this guard |
+
+### Requirement: Bomb Protection Scope Limited to Extraction Paths
+
+The system SHALL apply `ExtractionLimits` bomb guards only during
+`archivey.extract()` and `ArchiveReader.extract_all()`. `ArchiveReader.read()`
+and `ArchiveReader.open()` return decompressed data/streams without byte, ratio,
+or entry-count enforcement; callers are responsible for guarding direct reads.
+Listing materialization caps are separate (`ListingLimits` in `archive-reading`)
+and do not apply to `read()` / `open()` either.
+
+#### Scenario: bomb-scope matrix
+
+| Case | Expected |
+| --- | --- |
+| `reader.read(member)` on extreme-ratio data | Raw decompressed bytes returned or normal read error; no extraction bomb guard |
+| `reader.open(member)` | Stream delivers decompressed data without extraction limits |
+| `reader.members()` on a metadata bomb | `ListingLimits` / `ResourceLimitError` per `archive-reading`, not `ExtractionLimits` |
+
+### Requirement: Error Policy (OnError) for extraction failures
+
+`OnError.STOP` and `OnError.CONTINUE` SHALL govern per-member failures only.
+Under `CONTINUE`, a member-scoped `FilterRejectionError`, other member-scoped
+`ArchiveyError`, permitted read/write `OSError`, or per-member ratio violation
+records `REJECTED`/`FAILED`, removes partial output, emits the matching diagnostic
+under the active diagnostic policy, and proceeds.
+
+Diagnostic disposition SHALL still be authoritative: `RAISE` emits
+`DiagnosticRaisedError` and halts immediately even under `OnError.CONTINUE`;
+logging-handler and diagnostic-callback exceptions propagate unchanged. Under
+`STOP`, the genuine rejection/failure raises immediately and is not converted to
+an extraction advisory. Global resource guards (`ResourceLimitError` for
+cumulative bytes, archive-wide/live ratio, and max entries), `KeyboardInterrupt`,
+`MemoryError`, and unexpected programming exceptions are always-stop and are not
+swallowed.
+
+#### Scenario: OnError matrix
+
+| Case | Expected |
+| --- | --- |
+| Corrupt member under `CONTINUE` and default diagnostics | Partial output removed; `FAILED` result; `EXTRACTION_MEMBER_FAILED`; later members continue |
+| Extraction diagnostic resolves to `RAISE` under `CONTINUE` | `DiagnosticRaisedError` halts; no report returned |
+| `CorruptionError` under `STOP` | Original `CorruptionError` propagates; no continued-failure diagnostic |
+| Filesystem `OSError` while writing under `CONTINUE` | Partial output removed; `FAILED` result/diagnostic; extraction proceeds |
+| Cumulative bytes/live ratio/max entries exceed limit under `CONTINUE` | `ResourceLimitError` propagates and halts; no later member processed |
+| Default `STOP` member failure | Exception raises immediately; failing partial file removed; earlier outputs remain |
+| Mixed good/corrupt archive under `CONTINUE` | Extractable members are written; report includes `EXTRACTED` plus `FAILED`/`REJECTED`; no per-member exception escapes |
+
+### Requirement: Archive-wide decompression ratio for solid containers
+
+The system SHALL evaluate a static archive-wide ratio during extraction when a
+member's `compressed_size` is unknown/zero and the reader exposes a cheap
+`compressed_source_size`. The denominator is the archive source byte size: path
+`stat`, trusted integer `size`, `try_get_size()` from Archivey streams, or an
+O(1)-safe `SEEK_END`/restore probe for real files, `BytesIO`, and `mmap`.
+Anything that would decompress or scan payload to answer (for example foreign
+decompressor streams) yields `None`. For compressed containers this is compressed
+size; for uncompressed containers the resulting ratio is about 1:1 and harmless.
+
+The ratio SHALL be `cumulative_bytes_written / compressed_source_size`, checked
+in `BombTracker.count()` using the same `max_ratio` and cumulative
+`ratio_activation_threshold` as other ratio guards. If `compressed_source_size`
+is absent, the static archive-wide check is skipped. Per-member and archive-wide
+ratios are independent; either may trip first. A tripped archive-wide ratio
+SHALL raise `ResourceLimitError`.
+
+#### Scenario: static archive-wide ratio matrix
+
+| Case | Expected |
+| --- | --- |
+| Small `.tar.gz` file with known source size expands past `max_ratio` after threshold | `ResourceLimitError` during extraction |
+| Compressed tar from non-seekable pipe with unknown size | Static archive-wide ratio skipped; cumulative byte limit still applies |
+| Plain `.tar` | No meaningful compressed denominator; archive-wide ratio does not trip |
+| ZIP member has known `compressed_size` | Per-member ratio applies; archive-wide ratio does not replace it |
+| Nested archive opened from an Archivey member/codec stream with cheap size | Cheap source size may serve as archive-wide denominator |
+
+### Requirement: Enforce Maximum Entry Count
+
+The system SHALL count members actually written to disk during one extraction call
+and raise `ResourceLimitError` once the count exceeds `max_entries`. The default is
+`1_048_576`; callers override through `ExtractionLimits`, and `None` disables the
+guard. The counter protects against inode/per-directory/syscall bombs made of many
+tiny entries and is independent of byte and ratio limits.
+
+Only members that will create disk entries SHALL count: selector exclusions, user
+filter skips, and members dropped before writing do not increment the counter.
+Every written FILE, DIR, SYMLINK, and HARDLINK counts. This is a global resource
+guard and halts even under `OnError.CONTINUE`.
+
+#### Scenario: entry-count matrix
+
+| Case | Expected |
+| --- | --- |
+| More than `max_entries` members are written | `ResourceLimitError` once the count crosses the limit; extraction halts under any `OnError` |
+| `ExtractionLimits(max_entries=100)` | Error after the 100th written member when the 101st would be written |
+| Selector chooses one member from millions | Extraction can complete with `max_entries=1` because only selected written entries count |
+| Many tiny files stay below byte/ratio limits but exceed entry count | Entry-count guard still raises |
+
+### Requirement: Live archive-wide decompression ratio for unknown-size streams
+
+The system SHALL evaluate a live archive-wide ratio during extraction when no
+per-member `compressed_size` and no cheap static `compressed_source_size` is
+available, but the compressed backend can expose `compressed_bytes_consumed`.
+This covers compressed archives from non-seekable pipes and seekable opaque
+streams whose size is not cheaply knowable. Backends wrap the stream source in
+the counting reader exactly when the static denominator is absent.
+
+The ratio SHALL be `cumulative_bytes_written / compressed_bytes_consumed`, checked
+after cumulative output crosses `ratio_activation_threshold` using the same
+`max_ratio`. It is a cumulative global guard: if it trips, extraction halts even
+under `OnError.CONTINUE` with `ResourceLimitError`. The live path complements
+static checks and is not used when member compressed sizes or a cheap outer
+source size provide a denominator; whichever available guard trips first wins.
+Codec-layer seeks may re-read counted bytes, inflating the denominator and
+weakening the guard, but never causing a false positive.
+
+#### Scenario: live archive-wide ratio matrix
+
+| Case | Expected |
+| --- | --- |
+| Highly compressible `.tar.gz` from non-seekable pipe has no static denominator | Live ratio raises `ResourceLimitError` after threshold before absolute byte cap |
+| Live ratio exceeded under `OnError.CONTINUE` | `ResourceLimitError` propagates and extraction halts |
+| Plain uncompressed `.tar` from a pipe | Consumed and written bytes stay about 1:1; live ratio does not trip; byte limit still applies |
+| `.tar.gz` has cheap `compressed_source_size` | Static archive-wide ratio is used; live path is not engaged/double-counted |
+| Seekable opaque compressed stream has no cheap size/`size`/`try_get_size()`/O(1) end seek | Source is counted live; archive is not left with only the byte cap |

--- a/openspec/changes/listing-resource-limits/tasks.md
+++ b/openspec/changes/listing-resource-limits/tasks.md
@@ -1,0 +1,35 @@
+## 1. Public types and exports
+
+- [ ] 1.1 Add frozen `ListingLimits` (`max_members`, `max_metadata_bytes`, `UNLIMITED`) and `ArchiveyConfig.listing_limits` in `config.py`.
+- [ ] 1.2 Add `ResourceLimitError(ArchiveyError)` in the public exception hierarchy; export from `exceptions` / package `__init__` / `core`.
+- [ ] 1.3 Update `archive-reading` / `error-handling` public docs and threat-model O1 to point at the new contract.
+
+## 2. Spine listing enforcement
+
+- [ ] 2.1 Implement retained metadata-byte accounting helper (name/raw_name/comment/link_target/uname/gname/extra str|bytes + archive comment) per design.
+- [ ] 2.2 Enforce `ListingLimits` at member registration / materialization in `BaseArchiveReader`; fail with `ResourceLimitError` before publishing a full cache.
+- [ ] 2.3 Confirm `stream_members` / forward iteration never apply listing caps; confirm extract-prep materialization does.
+- [ ] 2.4 Ensure `extract_all(config=...)` cannot change the reader's effective `listing_limits`.
+
+## 3. Extraction bomb error type
+
+- [ ] 3.1 Raise `ResourceLimitError` from `BombTracker` / extraction paths for cumulative bytes, per-member ratio, archive-wide ratio, live ratio, and max entries.
+- [ ] 3.2 Update existing extraction bomb tests and any `except ExtractionError` assumptions for limit trips.
+
+## 4. Format-local bounds
+
+- [ ] 4.1 Keep/verify 7z `num_files` header-size bound raises `CorruptionError` (complementary to listing caps).
+- [ ] 4.2 Spot-check other formats for unbounded pre-alloc from header counts; add cheap local bounds only where needed (no extract-`max_entries` reuse).
+
+## 5. Tests
+
+- [ ] 5.1 Adversarial / synthetic fixtures: over `max_members`, over `max_metadata_bytes`, huge archive comment.
+- [ ] 5.2 Defaults: Linux-scale member counts under default caps succeed; `ListingLimits.UNLIMITED` disables guards.
+- [ ] 5.3 `stream_members` proceeds on an archive that would fail `members()` under tight listing caps.
+- [ ] 5.4 Matched defaults: `max_members == max_entries == 1_048_576`; listing then full extract without count surprise under defaults.
+
+## 6. Verify
+
+- [ ] 6.1 Targeted pytest for listing limits + updated extraction bomb error types; pyrefly + ty + ruff clean on touched files.
+- [ ] 6.2 `openspec validate --strict listing-resource-limits`
+- [ ] 6.3 Three-config smoke (`[all]`, `[all-lowest]`, `[core-only]`) for the affected tests before merge.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

OpenSpec proposal for **listing-time resource limits** (threat-model O1), locking the decisions from explore:

- Separate `ListingLimits` (`max_members=1_048_576`, `max_metadata_bytes=64 MiB`) on `ArchiveyConfig`
- Spine enforcement at materialization/registration; `stream_members` unguarded
- Format-local early bounds remain complementary (`CorruptionError`)
- New `ResourceLimitError` for listing **and** extraction bomb trips (**BREAKING**)

## Artifacts

- `openspec/changes/listing-resource-limits/` — proposal, design, delta specs (`archive-reading`, `safe-extraction`, `error-handling`, `format-7z`), tasks
- Validated: `openspec validate --strict listing-resource-limits`

## Next

Implementation via `/opsx:apply` / apply-change on this proposal. Specs-only in this PR.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c5ffa5b4-51aa-4418-af87-91b9c53613ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c5ffa5b4-51aa-4418-af87-91b9c53613ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

