### PR TITLE
Propose atheris-fuzz-harness (OpenSpec)

### DIFF
--- a/openspec/changes/atheris-fuzz-harness/.openspec.yaml
+++ b/openspec/changes/atheris-fuzz-harness/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: library
+created: 2026-07-12

--- a/openspec/changes/atheris-fuzz-harness/design.md
+++ b/openspec/changes/atheris-fuzz-harness/design.md
@@ -15,7 +15,8 @@ ZIP/TAR/ISO; defer `SECURITY.md` / OSS-Fuzz / accelerator sandbox.
 
 **Goals:**
 
-- Shared Atheris infra with seeds, budgets, crash artifacts, repro commands.
+- Shared Atheris infra with seeds, budgets, crash artifacts, repro commands,
+  and CRC fixup for checksum-gated parsers.
 - Partitioned main-push job that deep-stresses 7z headers and also exercises
   detection + leaf open/list paths.
 - RAR target scaffold that skips cleanly until the backend registers.
@@ -53,6 +54,19 @@ Explore preferred a `[fuzz]` extra. `packaging-and-extras` requires user-facing
 extras to map to `src/` runtime imports and parks test-only deps in PEP 735
 groups. **Atheris is never imported from `src/`**, so a runtime extra would
 violate that contract (and risk leaking into `[all]`).
+
+### CRC barriers vs coverage guidance
+
+Archive headers often gate parsing on CRC/checksum equality (7z
+`next_header_crc`, ZIP CD/local CRCs, …). Random mutation almost always fails
+the check, so the fuzzer spends its budget on the reject edge and rarely
+reaches post-CRC logic — the same blind spot that let review L1
+(`num_files` OOM behind a valid CRC) slip past the mutation harness.
+
+libFuzzer CMP/value-profile feedback can help with small magic constants but
+does **not** reliably synthesize a correct CRC32 over a mutated header body
+within short (or even overnight) budgets. Coverage alone does not teach “write
+`crc32(body)` into offset *k*.”
 
 ## Decisions
 
@@ -110,6 +124,21 @@ Hypothesis remains the property layer (`testing-contract` already specs it).
 
 Disclosure docs are release packaging, not required to land the harness.
 
+### 8. CRC/checksum fixup for CRC-gated targets
+
+For targets whose interesting logic sits behind a header CRC (7z header parse
+first; ZIP/RAR where applicable), the harness SHALL **mutate then fix up**:
+recompute the relevant CRC(s) and patch them into the blob before calling the
+parser. Default inputs therefore exercise post-CRC paths. A configurable
+minority of iterations (or a tiny dedicated slice) MUST feed **broken-CRC**
+blobs so the reject path remains covered.
+
+Implementation preference: Python-side fixup in the test one-liner / wrapper
+(simple with Atheris). Custom libFuzzer mutators are optional later.
+
+**Rejected:** relying on unaided Atheris/CMP feedback to discover valid CRCs;
+stripping CRC checks only in fuzz builds (diverges from production).
+
 ## Risks / Trade-offs
 
 | Risk | Mitigation |
@@ -119,6 +148,8 @@ Disclosure docs are release packaging, not required to land the harness.
 | Atheris / libFuzzer platform friction | Linux `ubuntu-latest` only for the fuzz workflow |
 | Budget starvation of 7z headers | Fixed partition; headers get the largest slice |
 | Packaging confusion (`[fuzz]` vs group) | Spec + CONTRIBUTING one-liner |
+| CRC gate hides post-check bugs (L1 class) | Mutate-then-fixup + sampled broken-CRC inputs |
+| Fixup bugs mask real CRC handling | Keep broken-CRC samples; fixup only known field layouts |
 
 ## Open Questions
 

--- a/openspec/changes/atheris-fuzz-harness/design.md
+++ b/openspec/changes/atheris-fuzz-harness/design.md
@@ -1,0 +1,125 @@
+## Context
+
+Threat-model O5 / PLAN Phase 6 entry gate: mutation harness + Hypothesis landed;
+coverage-guided Atheris for native parsers did not. Existing
+`tests/fuzz_sevenzip_parser.py` is env-gated mutation, not Atheris.
+`docs/internal/threat-model.md` still lists Hypothesis as open (stale) and
+couples Atheris with OSS-Fuzz/`SECURITY.md` at release — this change splits them.
+
+Maintainer decisions (explore 2026-07): bursty activity → fuzz on **push to
+`main`** + **`workflow_dispatch`**, not always-on nightly; partitioned ~120s
+budget; headers **and** open+members; include `detect_format` and shallow
+ZIP/TAR/ISO; defer `SECURITY.md` / OSS-Fuzz / accelerator sandbox.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Shared Atheris infra with seeds, budgets, crash artifacts, repro commands.
+- Partitioned main-push job that deep-stresses 7z headers and also exercises
+  detection + leaf open/list paths.
+- RAR target scaffold that skips cleanly until the backend registers.
+- Spec/threat-model updates so the gate is normative, not tribal knowledge.
+
+**Non-Goals:**
+
+- OSS-Fuzz onboarding.
+- `SECURITY.md` / disclosure process (follow-up).
+- Accelerator hang sandbox (document accelerators-off only).
+- Full extract inside Atheris (mutation harness already covers extract).
+- Stream/codec-only targets (follow-on).
+- Making Atheris a PR-matrix requirement.
+
+## Investigations
+
+### Why not only 7z/RAR
+
+Mutation fuzz already sweeps open/list/read/extract across formats. Atheris ROI
+is highest on dense pure-Python parsers archivey owns (7z today, RAR next) and
+on tricky entry points (`detect_format`). ZIP/TAR mostly parse via stdlib; still
+worth a **shallow** open+members slice for wrapper/error-translation bugs. ISO
+needs a **hard timeout** (known pycdlib hang class).
+
+### CI discovery vs flake
+
+Atheris going red means crash/hang/timeout/OOM — not a soft assertion flake.
+Short budgets make **finding** non-reproducible across identical commits (lucky
+path exploration). Mitigation: upload crashing input + print one-line repro;
+treat red-without-diff as “keep the artifact,” not “ignore.”
+
+### Packaging: `[fuzz]` extra vs dependency group
+
+Explore preferred a `[fuzz]` extra. `packaging-and-extras` requires user-facing
+extras to map to `src/` runtime imports and parks test-only deps in PEP 735
+groups. **Atheris is never imported from `src/`**, so a runtime extra would
+violate that contract (and risk leaking into `[all]`).
+
+## Decisions
+
+### 1. Trigger: push to `main` + `workflow_dispatch`
+
+Bursty/dormant workflow: run when main moves; manual deepen anytime. Rejected
+always-on nightly (waste + stale failures) and “nightly if dirty” as the *only*
+gate (separates fault from notice). Optional dirty-nightly soak can land later.
+
+### 2. Dependency: PEP 735 `fuzz` group (not a runtime extra)
+
+```toml
+[dependency-groups]
+fuzz = ["atheris>=…"]
+```
+
+CI: `uv sync --group fuzz` (plus whatever core/`[all]` the targets need).
+**Rejected:** user-facing `[fuzz]` extra without a packaging allowlist. If a
+pip-discoverable extra is wanted later, add an explicit “tooling extras,
+excluded from `[all]`” packaging rule first.
+
+### 3. Partitioned ~120s main-push budget (defaults)
+
+| Slice | Seconds | Target |
+| --- | --- | --- |
+| 7z headers | 55 | `parse_sevenzip_archive` (or equivalent) |
+| 7z open+members | 25 | `open_archive` + list/materialize |
+| detect_format | 15 | peekable prefix → `detect_format` |
+| ZIP+TAR open+members | 15 | shallow |
+| ISO open+members | 10 | shallow + hard wall timeout |
+
+`workflow_dispatch` / env overrides MAY lengthen slices. Extract is out of the
+Atheris job. Accelerators forced **off**.
+
+### 4. Target set and RAR scaffold
+
+Implement shared runner; register targets above; RAR metadata (+ open when
+available) registered but **skipped** until the backend is importable/registered.
+Streams/codecs deferred.
+
+### 5. Success / failure contract
+
+Success: budget expires with only typed `ArchiveyError` or clean returns — no
+raw exceptions, no hang past slice timeout, no process abort. Failure: non-zero
+exit; upload repro bytes/artifact; print local re-run command. Job is required
+on `main` for visibility (red X on the merge commit).
+
+### 6. Relationship to existing harnesses
+
+Keep `tests/test_mutation_fuzz.py` and `tests/fuzz_sevenzip_parser.py` (mutation /
+`ARCHIVEY_FUZZ`). Atheris is additive coverage guidance, not a replacement.
+Hypothesis remains the property layer (`testing-contract` already specs it).
+
+### 7. Defer SECURITY.md
+
+Disclosure docs are release packaging, not required to land the harness.
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+| --- | --- |
+| Non-reproducible discovery on short budgets | Crash artifacts + repro command; dispatch longer runs |
+| ISO/accelerator hangs kill the job | Accelerators off; ISO slice hard-killed |
+| Atheris / libFuzzer platform friction | Linux `ubuntu-latest` only for the fuzz workflow |
+| Budget starvation of 7z headers | Fixed partition; headers get the largest slice |
+| Packaging confusion (`[fuzz]` vs group) | Spec + CONTRIBUTING one-liner |
+
+## Open Questions
+
+None for this proposal.

--- a/openspec/changes/atheris-fuzz-harness/proposal.md
+++ b/openspec/changes/atheris-fuzz-harness/proposal.md
@@ -13,6 +13,11 @@ fuzz should fire when `main` moves.
   crash artifact upload, one-line repro) behind a CI-only `fuzz` dependency
   group (not a runtime extra — packaging forbids test-only packages in
   user-facing extras).
+- **CRC/checksum fixup** after mutation for CRC-gated targets (especially 7z
+  headers): recompute and patch valid CRCs so coverage guidance reaches
+  post-check parser paths; keep a minority of deliberately broken-CRC inputs
+  so the reject path stays covered. Do not rely on libFuzzer CMP feedback to
+  solve CRC32.
 - Main-push workflow (~120s partitioned) + `workflow_dispatch` (longer budgets
   via env). No always-on nightly.
 - Targets: 7z header parse (deep); 7z open+members; `detect_format` prefixes;
@@ -32,7 +37,7 @@ None.
 ### Modified Capabilities
 
 - `testing-contract`: coverage-guided Atheris entry gate; target matrix;
-  CI trigger/budget contract; relationship to mutation/Hypothesis harnesses.
+  CRC fixup contract; CI trigger/budget; relationship to mutation/Hypothesis.
 - `packaging-and-extras`: document the CI-only `fuzz` dependency group
   (atheris); confirm it is absent from `[all]` / `[recommended*]` / runtime
   extras.

--- a/openspec/changes/atheris-fuzz-harness/proposal.md
+++ b/openspec/changes/atheris-fuzz-harness/proposal.md
@@ -1,0 +1,48 @@
+## Why
+
+Native 7z (and soon RAR) parsers accept hostile headers in pure Python — the
+surface VISION bets on for memory-safe parsing. Mutation fuzz and Hypothesis
+cover deterministic “never raw exception” paths, but miss crafted-header bugs
+that need coverage guidance (review L1 / threat-model O5). The project is
+bursty and often dormant, so plain nightly CI wastes runs and buries failures;
+fuzz should fire when `main` moves.
+
+## What Changes
+
+- Add shared Atheris harness infrastructure (seed corpus, partitioned budgets,
+  crash artifact upload, one-line repro) behind a CI-only `fuzz` dependency
+  group (not a runtime extra — packaging forbids test-only packages in
+  user-facing extras).
+- Main-push workflow (~120s partitioned) + `workflow_dispatch` (longer budgets
+  via env). No always-on nightly.
+- Targets: 7z header parse (deep); 7z open+members; `detect_format` prefixes;
+  ZIP/TAR/(ISO) open+members (shallower); RAR scaffold (skip until registered).
+  Accelerators off; extract out of scope for this harness.
+- Extend `testing-contract` with the coverage-guided native/entry-point fuzz
+  gate; update threat-model O5 status. Mutation/`ARCHIVEY_FUZZ` harnesses stay.
+- Out of scope: OSS-Fuzz, accelerator subprocess sandbox, `SECURITY.md`
+  (separate follow-up).
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `testing-contract`: coverage-guided Atheris entry gate; target matrix;
+  CI trigger/budget contract; relationship to mutation/Hypothesis harnesses.
+- `packaging-and-extras`: document the CI-only `fuzz` dependency group
+  (atheris); confirm it is absent from `[all]` / `[recommended*]` / runtime
+  extras.
+
+## Impact
+
+- **CI:** new workflow (or job) on `push` to `main` + `workflow_dispatch`;
+  failure uploads repro inputs; does not enlarge the PR test matrix.
+- **Deps:** `atheris` only via `dependency-groups.fuzz` / fuzz job install.
+- **Tests:** new harness modules under `tests/`; existing mutation env gates
+  unchanged.
+- **Public API / runtime:** none.
+- **Docs:** threat-model O5; brief CONTRIBUTING/AGENTS note on how to run.

--- a/openspec/changes/atheris-fuzz-harness/specs/packaging-and-extras/spec.md
+++ b/openspec/changes/atheris-fuzz-harness/specs/packaging-and-extras/spec.md
@@ -1,0 +1,43 @@
+## ADDED Requirements
+
+### Requirement: CI-only fuzz dependency group
+
+The system SHALL provide a PEP 735 dependency group named `fuzz` that installs
+`atheris` (and any harness-only helpers it needs) for coverage-guided fuzz CI.
+The `fuzz` group is **not** a user-facing runtime extra: it MUST NOT appear in
+`[all]`, `[recommended]`, `[recommended-lite]`, or any format/codec/CLI extra,
+and MUST NOT be required to import or use `archivey` at runtime.
+
+#### Scenario: fuzz packaging matrix
+
+| Case | Expected |
+| --- | --- |
+| `pip install archivey` / `archivey[all]` | `atheris` not installed |
+| Fuzz CI job | Installs via `uv sync --group fuzz` (plus target runtime needs) |
+| Runtime import of `archivey` without fuzz group | No `atheris` dependency |
+
+## MODIFIED Requirements
+
+### Requirement: Optional extras map only to libraries the code uses
+
+User-facing extras SHALL list only libraries imported by `src/` at runtime for that
+capability. A package used only by tests, decode oracles, fixture generation, or
+fuzz harnesses MUST live in a PEP 735 dependency group (`dev`, `fuzz`, …) and be
+absent from every user-facing extra.
+
+The per-codec library choice and rationale SHALL be recorded in
+`docs/internal/library-analysis.md`. A guard test or check script SHALL prevent dead or
+test-only dependencies from returning to user-facing extras. A dependency pinned
+ahead of its implementation phase, such as `[cli]` or `[7z-write]`, is permitted only
+through an explicit documented allowlist in that guard.
+
+#### Scenario: dependency-audit matrix
+
+| Case | Expected |
+| --- | --- |
+| User-facing extra audited against `src/` imports | Every pinned package is reachable from runtime code or explicitly allowlisted |
+| Library imported only by tests (`rarfile`, oracle `py7zr`, `ncompress`, fixture-only `pyzstd`) | Declared in `dev`; absent from runtime extras |
+| `atheris` | Declared in `fuzz` group; absent from runtime extras and `[all]` |
+| `pip install archivey[zstd]` on Python 3.11-3.13 | Installs `backports.zstd`; does not pull `zstandard` |
+| `pip install archivey[zstd]` on Python 3.14+ | No third-party zstd package required; stdlib `compression.zstd` provides the backend |
+| Extra lists a library no `src/` module imports and not allowlisted | Packaging audit fails |

--- a/openspec/changes/atheris-fuzz-harness/specs/testing-contract/spec.md
+++ b/openspec/changes/atheris-fuzz-harness/specs/testing-contract/spec.md
@@ -9,6 +9,14 @@ success as: within each time budget, only typed `ArchiveyError` subclasses or
 clean returns — never an uncaught non-`ArchiveyError` exception, process abort,
 or hang past the slice timeout.
 
+For CRC/checksum-gated targets (native 7z header parse at minimum; other
+formats when their interesting paths sit behind a header CRC), the harness
+SHALL apply a **mutate-then-fixup** step that recomputes and patches valid
+CRC fields before invoking the parser, so coverage guidance reaches post-CRC
+logic. It MUST NOT rely on unaided libFuzzer CMP feedback to solve CRC32. A
+minority of inputs (or a small dedicated budget) SHALL retain broken CRCs so
+the reject path stays exercised.
+
 The default main-branch run SHALL partition a wall-clock budget of approximately
 120 seconds across these targets (exact seconds MAY be env-overridable):
 
@@ -44,4 +52,6 @@ installed only via the CI `fuzz` dependency group (`packaging-and-extras`).
 | Pull request (default matrix) | Atheris job not required |
 | RAR backend absent | RAR target skipped; other targets still run |
 | Fuzzer finds a crashing input | Job fails; repro bytes uploaded; re-run command printed |
+| 7z header target with fixup enabled | Most iterations present a matching header CRC and enter post-CRC parse |
+| Broken-CRC sample / minority path | Typed CRC/corruption failure; reject path still hit |
 | Mutation harness / `ARCHIVEY_FUZZ` | Still available and unchanged in role |

--- a/openspec/changes/atheris-fuzz-harness/specs/testing-contract/spec.md
+++ b/openspec/changes/atheris-fuzz-harness/specs/testing-contract/spec.md
@@ -1,0 +1,47 @@
+## ADDED Requirements
+
+### Requirement: Coverage-guided fuzz gate for parsers and entry points
+
+The test suite SHALL provide an Atheris (libFuzzer) coverage-guided fuzz harness
+over archivey-owned hostile-input entry points. The harness MUST seed from the
+declarative corpus and adversarial fixtures, force accelerators off, and treat
+success as: within each time budget, only typed `ArchiveyError` subclasses or
+clean returns — never an uncaught non-`ArchiveyError` exception, process abort,
+or hang past the slice timeout.
+
+The default main-branch run SHALL partition a wall-clock budget of approximately
+120 seconds across these targets (exact seconds MAY be env-overridable):
+
+| Target | Role |
+| --- | --- |
+| Native 7z header parse | Deep coverage of the pure-Python header parser |
+| 7z `open_archive` + member list/materialize | Reader/spine path after parse |
+| `detect_format` over arbitrary/prefix seeds | Magic/peek-replay entry point |
+| ZIP and TAR `open_archive` + member list | Shallow wrapper/translation coverage |
+| ISO `open_archive` + member list | Shallow; MUST use a hard wall-clock kill timeout |
+| RAR metadata parse (+ open/list when registered) | Scaffold now; skip cleanly until the backend is available |
+
+Full member **extract** is out of scope for this harness (covered by the
+mutation harness). Stream/codec-only targets MAY be added later without removing
+the above.
+
+CI SHALL run the harness on every push to `main` and via `workflow_dispatch`
+(longer budgets allowed). It MUST NOT be part of the default pull-request test
+matrix. On failure the job SHALL upload reproducing inputs as artifacts and
+print a one-line local re-run command. Always-on nightly schedules are not
+required.
+
+The existing corpus mutation harness and Hypothesis property tests remain
+mandatory complementary layers; Atheris does not replace them. `atheris` is
+installed only via the CI `fuzz` dependency group (`packaging-and-extras`).
+
+#### Scenario: atheris gate matrix
+
+| Case | Expected |
+| --- | --- |
+| Push to `main` | Fuzz workflow runs partitioned ~120s budget; green if no crash/hang/raw exception |
+| `workflow_dispatch` with longer env budget | Same targets; extended exploration |
+| Pull request (default matrix) | Atheris job not required |
+| RAR backend absent | RAR target skipped; other targets still run |
+| Fuzzer finds a crashing input | Job fails; repro bytes uploaded; re-run command printed |
+| Mutation harness / `ARCHIVEY_FUZZ` | Still available and unchanged in role |

--- a/openspec/changes/atheris-fuzz-harness/tasks.md
+++ b/openspec/changes/atheris-fuzz-harness/tasks.md
@@ -9,15 +9,16 @@
 - [ ] 2.1 Implement shared Atheris runner: seed corpus from declarative/adversarial fixtures, accelerators off, per-slice timeouts, typed-error success contract.
 - [ ] 2.2 On failure: persist crashing input, upload CI artifact, print one-line repro command.
 - [ ] 2.3 Env overrides for per-target budgets (main defaults ≈ partitioned 120s).
+- [ ] 2.4 CRC/checksum fixup helpers: mutate-then-patch valid CRCs for gated layouts; configurable minority broken-CRC inputs; unit-test fixup against known-good headers.
 
 ## 3. Targets
 
-- [ ] 3.1 7z header-parse target (largest budget slice).
-- [ ] 3.2 7z `open_archive` + members/materialize target.
+- [ ] 3.1 7z header-parse target (largest budget slice) **with next_header CRC fixup** by default.
+- [ ] 3.2 7z `open_archive` + members/materialize target (fixup where the path still CRC-gates listing).
 - [ ] 3.3 `detect_format` prefix target.
-- [ ] 3.4 ZIP + TAR open+members shallow targets.
+- [ ] 3.4 ZIP + TAR open+members shallow targets; apply ZIP CRC fixup only where needed to reach wrapper logic behind checks.
 - [ ] 3.5 ISO open+members target with hard wall-clock kill.
-- [ ] 3.6 RAR scaffold target that skips until backend registered.
+- [ ] 3.6 RAR scaffold target that skips until backend registered (plan CRC/header fixup when enabling).
 
 ## 4. CI workflow
 
@@ -27,6 +28,6 @@
 
 ## 5. Verify
 
-- [ ] 5.1 Local smoke: each target runs briefly under Atheris without raw exceptions on seed corpus.
+- [ ] 5.1 Local smoke: each target runs briefly under Atheris without raw exceptions on seed corpus; 7z header target with fixup enters post-CRC parse on fixed-up seeds; broken-CRC minority still rejects.
 - [ ] 5.2 `openspec validate --strict atheris-fuzz-harness`
 - [ ] 5.3 Packaging audit / extras guard still green with `fuzz` group present.

--- a/openspec/changes/atheris-fuzz-harness/tasks.md
+++ b/openspec/changes/atheris-fuzz-harness/tasks.md
@@ -1,0 +1,32 @@
+## 1. Packaging and docs
+
+- [ ] 1.1 Add PEP 735 `fuzz` dependency group with `atheris`; ensure absent from runtime extras / `[all]`.
+- [ ] 1.2 Update threat-model O5 (Atheris gate status; Hypothesis landed; SECURITY.md/OSS-Fuzz still later).
+- [ ] 1.3 Short CONTRIBUTING/AGENTS note: how to run fuzz locally and what the main-push job does.
+
+## 2. Shared harness
+
+- [ ] 2.1 Implement shared Atheris runner: seed corpus from declarative/adversarial fixtures, accelerators off, per-slice timeouts, typed-error success contract.
+- [ ] 2.2 On failure: persist crashing input, upload CI artifact, print one-line repro command.
+- [ ] 2.3 Env overrides for per-target budgets (main defaults ≈ partitioned 120s).
+
+## 3. Targets
+
+- [ ] 3.1 7z header-parse target (largest budget slice).
+- [ ] 3.2 7z `open_archive` + members/materialize target.
+- [ ] 3.3 `detect_format` prefix target.
+- [ ] 3.4 ZIP + TAR open+members shallow targets.
+- [ ] 3.5 ISO open+members target with hard wall-clock kill.
+- [ ] 3.6 RAR scaffold target that skips until backend registered.
+
+## 4. CI workflow
+
+- [ ] 4.1 Add workflow: `push` to `main` + `workflow_dispatch`; Linux only; `uv sync --group fuzz` (+ needed extras for ISO/etc.).
+- [ ] 4.2 Do not attach Atheris to the default PR test matrix.
+- [ ] 4.3 Confirm mutation / `ARCHIVEY_FUZZ` harnesses still run as today.
+
+## 5. Verify
+
+- [ ] 5.1 Local smoke: each target runs briefly under Atheris without raw exceptions on seed corpus.
+- [ ] 5.2 `openspec validate --strict atheris-fuzz-harness`
+- [ ] 5.3 Packaging audit / extras guard still green with `fuzz` group present.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

OpenSpec proposal for the **Atheris coverage-guided fuzz gate** (threat-model O5), with decisions from explore:

- Trigger: **push to `main` + `workflow_dispatch`** (no always-on nightly — better for bursty/dormant work)
- ~120s partitioned: 7z headers (deep), 7z open+members, `detect_format`, ZIP/TAR/ISO shallow; RAR scaffold
- Accelerators off; extract left to the mutation harness
- **`atheris` via PEP 735 `fuzz` dependency group** (not a runtime `[fuzz]` extra — packaging forbids test-only deps in user extras)
- **CRC fixup:** mutate-then-patch valid header CRCs so post-check parser paths get coverage; minority broken-CRC inputs keep the reject path warm (do not rely on CMP feedback to solve CRC32)
- Out of scope: OSS-Fuzz, accelerator sandbox, `SECURITY.md` (separate follow-up)

## Artifacts

`openspec/changes/atheris-fuzz-harness/` — proposal, design, deltas (`testing-contract`, `packaging-and-extras`), tasks.

Validated: `openspec validate --strict atheris-fuzz-harness`

## Note vs explore Q3

Explore preferred a `[fuzz]` extra; design switches to a dependency group to stay honest with `packaging-and-extras`. Happy to revisit if you want an explicit “tooling extras excluded from `[all]`” packaging rule instead.

## Next

`/opsx:apply` when ready to implement. Specs-only in this PR.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c5ffa5b4-51aa-4418-af87-91b9c53613ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c5ffa5b4-51aa-4418-af87-91b9c53613ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

