### PR TITLE
Implement atheris-fuzz-harness (coverage-guided fuzz gate)

### DIFF
--- a/.github/workflows/atheris-fuzz.yml
+++ b/.github/workflows/atheris-fuzz.yml
@@ -1,0 +1,62 @@
+name: Atheris fuzz
+
+# Coverage-guided parser/entry-point fuzz (threat-model O5). Runs when main moves and
+# on manual dispatch — not on the default PR test matrix (see testing-contract).
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      budget_scale:
+        description: "Multiply default per-target budgets (e.g. 3 for a longer soak)"
+        required: false
+        default: "1"
+
+concurrency:
+  group: atheris-fuzz-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  fuzz:
+    name: Atheris (partitioned)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Set up Python
+        run: uv python install 3.12
+
+      # fuzz = atheris; dev = fixture builders (py7zr, …); all = ISO/codecs the targets need.
+      # Python 3.12: atheris publishes current wheels here (3.11 is capped at atheris 3.0.x).
+      - name: Sync (fuzz + dev + all extras)
+        run: uv sync --python 3.12 --group fuzz --group dev --extra all
+
+      - name: Run Atheris harness
+        env:
+          ARCHIVEY_FUZZ_ARTIFACT_DIR: artifacts/atheris
+          BUDGET_SCALE: ${{ github.event.inputs.budget_scale || '1' }}
+        run: |
+          scale="${BUDGET_SCALE:-1}"
+          export ARCHIVEY_FUZZ_BUDGET_SEVENZIP_HEADER=$((55 * scale))
+          export ARCHIVEY_FUZZ_BUDGET_SEVENZIP_OPEN=$((25 * scale))
+          export ARCHIVEY_FUZZ_BUDGET_DETECT_FORMAT=$((15 * scale))
+          export ARCHIVEY_FUZZ_BUDGET_ZIP_TAR=$((15 * scale))
+          export ARCHIVEY_FUZZ_BUDGET_ISO=$((10 * scale))
+          echo "Budgets: header=$ARCHIVEY_FUZZ_BUDGET_SEVENZIP_HEADER open=$ARCHIVEY_FUZZ_BUDGET_SEVENZIP_OPEN detect=$ARCHIVEY_FUZZ_BUDGET_DETECT_FORMAT zip_tar=$ARCHIVEY_FUZZ_BUDGET_ZIP_TAR iso=$ARCHIVEY_FUZZ_BUDGET_ISO"
+          uv run --python 3.12 --no-sync python -m tests.atheris_fuzz
+
+      - name: Upload crash artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: atheris-crashes
+          path: artifacts/atheris/
+          if-no-files-found: ignore
+          retention-days: 30

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,3 +43,7 @@ Non-obvious gotchas:
   `--no-dev` / lowest-resolution leg, restore the everyday env with
   `uv sync --group dev --extra all`.
 - Docs (optional): `uv run --group docs mkdocs build --strict`.
+- **Atheris fuzz** is a separate main-push / `workflow_dispatch` job (not the PR matrix).
+  Install with `uv sync --group fuzz --group dev --extra all`, then
+  `uv run --no-sync python -m tests.atheris_fuzz --smoke`. Mutation /
+  `ARCHIVEY_FUZZ` harnesses are unchanged. See `CONTRIBUTING.md` ("Coverage-guided fuzz").

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,6 +136,31 @@ everyday environment.)
   **fails**; then make it pass with the fix. The failing test is the proof the bug
   existed and that you fixed *that* bug.
 
+### Coverage-guided fuzz (Atheris)
+
+Atheris is **not** part of the everyday `pytest` / PR matrix. It lives in the PEP 735
+`fuzz` dependency group (`atheris`) and runs as a separate main-branch gate
+(`.github/workflows/atheris-fuzz.yml`: `push` to `main` + `workflow_dispatch`,
+partitioned ~120s). Mutation fuzz (`tests/test_mutation_fuzz.py`) and
+`ARCHIVEY_FUZZ=1` / `tests/fuzz_sevenzip_parser.py` stay as they are.
+
+Local smoke (Linux; needs corpus fixture builders). Prefer Python 3.12 for current
+Atheris wheels; on 3.11 ``uv`` resolves ``atheris`` 3.0.x::
+
+    uv sync --group fuzz --group dev --extra all
+    uv run --no-sync python -m tests.atheris_fuzz --smoke
+
+    # or explicitly:
+    uv sync --python 3.12 --group fuzz --group dev --extra all
+    uv run --python 3.12 --no-sync python -m tests.atheris_fuzz --smoke
+
+Deepen one target (budget seconds via env, e.g. `ARCHIVEY_FUZZ_BUDGET_SEVENZIP_HEADER=60`)::
+
+    uv run --no-sync python -m tests.atheris_fuzz --target sevenzip_header
+
+On a crash the harness writes the input under `artifacts/atheris/` and prints a one-line
+repro command.
+
 ## Working with the specs (please read)
 
 When you hit a **discrepancy** — specs disagreeing with the prose docs, the specs

--- a/docs/internal/threat-model.md
+++ b/docs/internal/threat-model.md
@@ -102,11 +102,11 @@ stream on NTFS. Not currently rejected.
 *Direction:* fold into the O3 policy work (reject `:` in names under `STRICT` on all
 platforms; it is never a portable filename character).
 
-### O5. Fuzzing — mutation harness landed; property + native-parser fuzzing still open
+### O5. Fuzzing — mutation + Hypothesis + Atheris gate landed; OSS-Fuzz / SECURITY.md later
 
-The safety claims rest on curated tests plus, now, a mutation harness. Remaining work,
-before the native 7z/RAR parsers (which parse untrusted binary headers in Python) ship and
-before any public "safe" claim:
+The safety claims rest on curated tests plus three complementary fuzz layers. Remaining
+work before any public "safe" claim is release packaging (OSS-Fuzz + disclosure docs),
+not the in-tree gate:
 
 1. **Landed:** the corpus **mutation harness** (`tests/test_mutation_fuzz.py`) — every
    corpus archive is deterministically mutated (truncations, bit flips, zeroed blocks,
@@ -115,20 +115,27 @@ before any public "safe" claim:
    exercises archivey's own **deterministic zero-dep parsing path** (accelerators forced
    off) and already found and fixed a batch of untranslated-exception bugs in the ZIP and
    ISO backends. `ARCHIVEY_FUZZ_MUTATIONS` deepens the sweep; green at 500 mutations/kind.
-2. **Still open:** property-based tests (Hypothesis) for the pure safety logic
-   (`normalize_member_name`, `check_universal`, `resolve_link_target_name`, volume
-   discovery, detection over arbitrary prefixes) — narrow, high-value, not yet written.
-3. **Native-reader entry gate:** coverage-guided fuzzing (Atheris) of the 7z/RAR header
-   parsers, seeded from the corpus + adversarial fixtures; nightly short runs in CI.
-4. **At public release:** OSS-Fuzz onboarding; `SECURITY.md` with a disclosure process.
+   Env-gated 7z parser mutation (`ARCHIVEY_FUZZ=1` / `tests/fuzz_sevenzip_parser.py`)
+   remains available for local deepening.
+2. **Landed:** property-based tests (Hypothesis) for the pure safety logic
+   (`tests/test_property_safety.py` — `normalize_member_name`, `check_universal`,
+   `resolve_link_target_name`, volume discovery, detection over arbitrary prefixes).
+3. **Landed:** coverage-guided **Atheris** harness (`tests/atheris_fuzz/`) over native 7z
+   header parse (CRC mutate-then-fixup), 7z open+members, `detect_format`, shallow
+   ZIP/TAR/ISO open+list, and a RAR scaffold that skips until the backend registers. CI
+   runs on **push to `main`** + **`workflow_dispatch`** (partitioned ~120s; not the PR
+   matrix; not always-on nightly). `atheris` lives in the PEP 735 `fuzz` dependency group
+   only — never a runtime extra. See `openspec/specs/testing-contract/spec.md`.
+4. **Still open (public release):** OSS-Fuzz onboarding; `SECURITY.md` with a disclosure
+   process. Accelerator hang sandbox (below) remains a separate follow-up.
 
 **Accelerator hang (found by the mutation harness).** The optional `[seekable]`
 accelerators (`rapidgzip`, and its bundled bzip2 decoder) are third-party C++ that can
 **busy-loop on crafted input** — a hang no Python-level translator can convert into an
 `ArchiveyError`, and one that SIGALRM/pytest-timeout cannot cleanly interrupt (the loop is
-in a C++ thread). So the mutation harness runs with accelerators **off**, and fuzzing that
-native code is deferred to a **resource-limited subprocess sandbox** (wall-clock + memory
-capped, killed on breach) alongside the Atheris work. Until then: the accelerators are an
+in a C++ thread). So the mutation and Atheris harnesses run with accelerators **off**, and
+fuzzing that native code is deferred to a **resource-limited subprocess sandbox**
+(wall-clock + memory capped, killed on breach). Until then: the accelerators are an
 opt-in performance path, not part of the defended parsing surface for untrusted input —
 callers processing untrusted archives under a hard latency budget should leave them off
 (`AcceleratorMode.OFF`) or enforce their own timeout. Worth surfacing in the eventual

--- a/openspec/changes/atheris-fuzz-harness/tasks.md
+++ b/openspec/changes/atheris-fuzz-harness/tasks.md
@@ -1,33 +1,33 @@
 ## 1. Packaging and docs
 
-- [ ] 1.1 Add PEP 735 `fuzz` dependency group with `atheris`; ensure absent from runtime extras / `[all]`.
-- [ ] 1.2 Update threat-model O5 (Atheris gate status; Hypothesis landed; SECURITY.md/OSS-Fuzz still later).
-- [ ] 1.3 Short CONTRIBUTING/AGENTS note: how to run fuzz locally and what the main-push job does.
+- [x] 1.1 Add PEP 735 `fuzz` dependency group with `atheris`; ensure absent from runtime extras / `[all]`.
+- [x] 1.2 Update threat-model O5 (Atheris gate status; Hypothesis landed; SECURITY.md/OSS-Fuzz still later).
+- [x] 1.3 Short CONTRIBUTING/AGENTS note: how to run fuzz locally and what the main-push job does.
 
 ## 2. Shared harness
 
-- [ ] 2.1 Implement shared Atheris runner: seed corpus from declarative/adversarial fixtures, accelerators off, per-slice timeouts, typed-error success contract.
-- [ ] 2.2 On failure: persist crashing input, upload CI artifact, print one-line repro command.
-- [ ] 2.3 Env overrides for per-target budgets (main defaults ≈ partitioned 120s).
-- [ ] 2.4 CRC/checksum fixup helpers: mutate-then-patch valid CRCs for gated layouts; configurable minority broken-CRC inputs; unit-test fixup against known-good headers.
+- [x] 2.1 Implement shared Atheris runner: seed corpus from declarative/adversarial fixtures, accelerators off, per-slice timeouts, typed-error success contract.
+- [x] 2.2 On failure: persist crashing input, upload CI artifact, print one-line repro command.
+- [x] 2.3 Env overrides for per-target budgets (main defaults ≈ partitioned 120s).
+- [x] 2.4 CRC/checksum fixup helpers: mutate-then-patch valid CRCs for gated layouts; configurable minority broken-CRC inputs; unit-test fixup against known-good headers.
 
 ## 3. Targets
 
-- [ ] 3.1 7z header-parse target (largest budget slice) **with next_header CRC fixup** by default.
-- [ ] 3.2 7z `open_archive` + members/materialize target (fixup where the path still CRC-gates listing).
-- [ ] 3.3 `detect_format` prefix target.
-- [ ] 3.4 ZIP + TAR open+members shallow targets; apply ZIP CRC fixup only where needed to reach wrapper logic behind checks.
-- [ ] 3.5 ISO open+members target with hard wall-clock kill.
-- [ ] 3.6 RAR scaffold target that skips until backend registered (plan CRC/header fixup when enabling).
+- [x] 3.1 7z header-parse target (largest budget slice) **with next_header CRC fixup** by default.
+- [x] 3.2 7z `open_archive` + members/materialize target (fixup where the path still CRC-gates listing).
+- [x] 3.3 `detect_format` prefix target.
+- [x] 3.4 ZIP + TAR open+members shallow targets; apply ZIP CRC fixup only where needed to reach wrapper logic behind checks.
+- [x] 3.5 ISO open+members target with hard wall-clock kill.
+- [x] 3.6 RAR scaffold target that skips until backend registered (plan CRC/header fixup when enabling).
 
 ## 4. CI workflow
 
-- [ ] 4.1 Add workflow: `push` to `main` + `workflow_dispatch`; Linux only; `uv sync --group fuzz` (+ needed extras for ISO/etc.).
-- [ ] 4.2 Do not attach Atheris to the default PR test matrix.
-- [ ] 4.3 Confirm mutation / `ARCHIVEY_FUZZ` harnesses still run as today.
+- [x] 4.1 Add workflow: `push` to `main` + `workflow_dispatch`; Linux only; `uv sync --group fuzz` (+ needed extras for ISO/etc.).
+- [x] 4.2 Do not attach Atheris to the default PR test matrix.
+- [x] 4.3 Confirm mutation / `ARCHIVEY_FUZZ` harnesses still run as today.
 
 ## 5. Verify
 
-- [ ] 5.1 Local smoke: each target runs briefly under Atheris without raw exceptions on seed corpus; 7z header target with fixup enters post-CRC parse on fixed-up seeds; broken-CRC minority still rejects.
-- [ ] 5.2 `openspec validate --strict atheris-fuzz-harness`
-- [ ] 5.3 Packaging audit / extras guard still green with `fuzz` group present.
+- [x] 5.1 Local smoke: each target runs briefly under Atheris without raw exceptions on seed corpus; 7z header target with fixup enters post-CRC parse on fixed-up seeds; broken-CRC minority still rejects.
+- [x] 5.2 `openspec validate --strict atheris-fuzz-harness`
+- [x] 5.3 Packaging audit / extras guard still green with `fuzz` group present.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,14 @@ docs = [
     "mkdocs-material>=9.6.0",
     "griffe-fieldz>=0.2.1",
 ]
+# Coverage-guided fuzz harness (Atheris / libFuzzer). CI-only: never a user-facing
+# runtime extra and never folded into `[all]` — see packaging-and-extras + threat-model O5.
+# Install with `uv sync --group fuzz` (plus `--group dev --extra all` for seed fixtures).
+fuzz = [
+    # 3.1+ drops cp311 wheels; keep 3.0.x on 3.11, allow latest on 3.12+.
+    "atheris>=3.0.0,<3.1; python_version < '3.12'",
+    "atheris>=3.0.0; python_version >= '3.12'",
+]
 
 [tool.hatch.version]
 path = "src/archivey/__init__.py"

--- a/src/archivey/internal/backends/sevenzip_parser.py
+++ b/src/archivey/internal/backends/sevenzip_parser.py
@@ -28,6 +28,11 @@ _SIGNATURE_HEADER_SIZE = 32
 _MAX_UINT64_ENCODING = 8
 _MAX_UTF16_CHARS = 65536
 _MAX_NUM_STREAMS = 65536
+# Hostile archives can claim a multi-EiB next-header offset/size. Cap before seek/read so we
+# never OverflowError on C ssize_t conversion or allocate a multi-GiB header buffer. Real 7z
+# headers are kilobytes; tens of MiB is already far past any legitimate archive.
+_MAX_NEXT_HEADER_SIZE = 64 << 20
+_MAX_SEEK_OFFSET = (1 << 63) - 1 - _SIGNATURE_HEADER_SIZE
 # 7z coder method IDs. Single source of truth: the reader imports these.
 _METHOD_COPY = b"\x00"
 _METHOD_LZMA = b"\x03\x01\x01"
@@ -204,9 +209,23 @@ def parse_sevenzip_archive(
     next_header_offset, next_header_size, next_header_crc = struct.unpack(
         "<QQI", start_header
     )
+    if next_header_offset > _MAX_SEEK_OFFSET:
+        raise CorruptionError(
+            f"7z next-header offset {next_header_offset} exceeds the seekable range"
+        )
+    if next_header_size > _MAX_NEXT_HEADER_SIZE:
+        raise CorruptionError(
+            f"7z next-header size {next_header_size} exceeds the "
+            f"{_MAX_NEXT_HEADER_SIZE}-byte parser limit"
+        )
 
     # Offsets in the header are relative to the end of the 32-byte signature header.
-    fp.seek(_SIGNATURE_HEADER_SIZE + next_header_offset)
+    try:
+        fp.seek(_SIGNATURE_HEADER_SIZE + next_header_offset)
+    except (OSError, OverflowError) as exc:
+        raise CorruptionError(
+            f"7z next-header seek failed at offset {next_header_offset}"
+        ) from exc
     header_data = _read_exact(fp, next_header_size, "7z next header")
     if _crc32(header_data) != next_header_crc:
         raise CorruptionError("7z next header CRC mismatch")

--- a/tests/atheris_fuzz/__init__.py
+++ b/tests/atheris_fuzz/__init__.py
@@ -1,0 +1,23 @@
+"""Coverage-guided Atheris fuzz harness (threat-model O5 / testing-contract).
+
+Not collected by the default pytest matrix. Run via::
+
+    uv sync --group fuzz --group dev --extra all
+    uv run --no-sync python -m tests.atheris_fuzz --smoke
+"""
+
+from __future__ import annotations
+
+__all__ = ["TARGET_NAMES", "DEFAULT_BUDGETS"]
+
+# Default main-push partition (~120s). Overridable via ARCHIVEY_FUZZ_BUDGET_<NAME>.
+DEFAULT_BUDGETS: dict[str, int] = {
+    "sevenzip_header": 55,
+    "sevenzip_open": 25,
+    "detect_format": 15,
+    "zip_tar": 15,
+    "iso": 10,
+    "rar": 0,  # scaffold; skipped until backend registers
+}
+
+TARGET_NAMES: tuple[str, ...] = tuple(DEFAULT_BUDGETS)

--- a/tests/atheris_fuzz/__main__.py
+++ b/tests/atheris_fuzz/__main__.py
@@ -1,0 +1,146 @@
+"""CLI entry: ``python -m tests.atheris_fuzz``.
+
+libFuzzer/Atheris allows ``Setup()`` only once per process, so multi-target runs
+spawn one child per target. Each child imports ``archivey`` under instrumentation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    from tests.atheris_fuzz import TARGET_NAMES
+
+    parser = argparse.ArgumentParser(
+        prog="python -m tests.atheris_fuzz",
+        description="Coverage-guided Atheris fuzz harness for archivey parsers/entry points.",
+    )
+    parser.add_argument(
+        "--target",
+        choices=TARGET_NAMES,
+        help="Run a single named target (default: all with positive budget).",
+    )
+    parser.add_argument(
+        "--smoke",
+        action="store_true",
+        help="1s budget per target — verifies seeds + instrumentation only.",
+    )
+    parser.add_argument(
+        "--repro",
+        type=Path,
+        help="Replay a single crashing input through the selected --target.",
+    )
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        help="Print targets and default budgets, then exit.",
+    )
+    parser.add_argument(
+        "--worker",
+        action="store_true",
+        help=argparse.SUPPRESS,  # internal: single-target worker process
+    )
+    return parser.parse_args(argv)
+
+
+def _load_targets_instrumented() -> dict:
+    import atheris
+
+    with atheris.instrument_imports(["archivey"]):
+        from tests.atheris_fuzz.targets import iter_target_specs, rar_available
+
+    return {
+        "specs": {s["name"]: s for s in iter_target_specs()},
+        "rar_available": rar_available,
+    }
+
+
+def _run_worker(args: argparse.Namespace) -> int:
+    from tests.atheris_fuzz.runner import run_repro, run_target
+
+    assert args.target is not None
+    loaded = _load_targets_instrumented()
+    spec = loaded["specs"][args.target]
+    skip_unless = spec.get("skip_unless")
+    if skip_unless is not None and not skip_unless():
+        print(f"[atheris] skipping {args.target}: backend not available", flush=True)
+        return 0
+
+    if args.repro is not None:
+        return run_repro(
+            name=args.target,
+            test_one_input=spec["fn"],
+            path=args.repro,
+            fixup=spec.get("fixup"),
+            per_input_timeout=spec.get("per_input_timeout"),
+        )
+
+    print(f"[atheris] running {args.target}…", flush=True)
+    return run_target(
+        name=args.target,
+        test_one_input=spec["fn"],
+        seeds=list(spec["seeds"]()),
+        fixup=spec.get("fixup"),
+        per_input_timeout=spec.get("per_input_timeout"),
+        smoke=args.smoke,
+    )
+
+
+def _spawn_target(name: str, *, smoke: bool, repro: Path | None) -> int:
+    cmd = [sys.executable, "-m", "tests.atheris_fuzz", "--worker", "--target", name]
+    if smoke:
+        cmd.append("--smoke")
+    if repro is not None:
+        cmd.extend(["--repro", str(repro)])
+    print(f"[atheris] spawn {' '.join(cmd)}", flush=True)
+    completed = subprocess.run(cmd, check=False, env=os.environ.copy())
+    return int(completed.returncode)
+
+
+def main(argv: list[str] | None = None) -> int:
+    from tests.atheris_fuzz import DEFAULT_BUDGETS, TARGET_NAMES
+
+    args = _parse_args(argv)
+
+    if args.list:
+        from tests.atheris_fuzz.targets import rar_available
+
+        for name in TARGET_NAMES:
+            skip = ""
+            if name == "rar" and not rar_available():
+                skip = " (skipped: RAR backend not registered)"
+            print(f"{name:20s} default={DEFAULT_BUDGETS[name]}s{skip}")
+        return 0
+
+    if args.worker:
+        if not args.target:
+            print("--worker requires --target", file=sys.stderr)
+            return 2
+        return _run_worker(args)
+
+    if args.repro is not None:
+        if not args.target:
+            print("--repro requires --target", file=sys.stderr)
+            return 2
+        return _spawn_target(args.target, smoke=False, repro=args.repro)
+
+    selected = [args.target] if args.target else list(TARGET_NAMES)
+    exit_code = 0
+    for name in selected:
+        # Always spawn: libFuzzer Setup() is once-per-process.
+        code = _spawn_target(name, smoke=args.smoke, repro=None)
+        if code != 0:
+            exit_code = code
+            print(f"[atheris] {name} FAILED (exit={code})", file=sys.stderr, flush=True)
+        else:
+            print(f"[atheris] {name} ok", flush=True)
+    return exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/atheris_fuzz/crc_fixup.py
+++ b/tests/atheris_fuzz/crc_fixup.py
@@ -1,0 +1,192 @@
+"""Mutate-then-fixup helpers for CRC-gated archive headers.
+
+libFuzzer CMP feedback does not reliably synthesize CRC32 over a mutated header body
+within short budgets. For targets whose interesting logic sits behind a header CRC we
+recompute and patch the CRC fields after mutation so coverage reaches post-check paths.
+A configurable minority of inputs keep deliberately broken CRCs so the reject path stays
+exercised.
+"""
+
+from __future__ import annotations
+
+import os
+import struct
+import zlib
+from collections.abc import Callable
+
+MAGIC_7Z = b"7z\xbc\xaf'\x1c"
+_SIGNATURE_HEADER_SIZE = 32
+
+# Fraction of inputs that keep a broken CRC (reject-path coverage). Override with
+# ARCHIVEY_FUZZ_BROKEN_CRC_RATE (0.0–1.0).
+_DEFAULT_BROKEN_CRC_RATE = 0.05
+
+
+def broken_crc_rate() -> float:
+    raw = os.environ.get("ARCHIVEY_FUZZ_BROKEN_CRC_RATE")
+    if raw is None:
+        return _DEFAULT_BROKEN_CRC_RATE
+    try:
+        rate = float(raw)
+    except ValueError:
+        return _DEFAULT_BROKEN_CRC_RATE
+    return min(1.0, max(0.0, rate))
+
+
+def _crc32(data: bytes) -> int:
+    return zlib.crc32(data) & 0xFFFFFFFF
+
+
+def should_break_crc(data: bytes) -> bool:
+    """Deterministic minority sampler from the input bytes (no extra RNG)."""
+    rate = broken_crc_rate()
+    if rate <= 0.0:
+        return False
+    if rate >= 1.0:
+        return True
+    # Stable bucket in [0, 1) from a cheap mix of the blob.
+    bucket = (_crc32(data) % 10_000) / 10_000.0
+    return bucket < rate
+
+
+def fixup_sevenzip_header_crcs(data: bytes, *, broken: bool | None = None) -> bytes:
+    """Recompute 7z signature + next-header CRCs (or leave them broken).
+
+    Layout (little-endian)::
+
+        magic[6] | ver[2] | start_header_crc[4] | next_offset[8] | next_size[8] | next_crc[4]
+        ... packed streams ...
+        next_header[next_size]
+
+    When ``broken`` is None, :func:`should_break_crc` decides. Broken mode flips the low
+    bit of the patched next-header CRC after a correct recompute so the reject path sees
+    a near-miss rather than an uninitialized field.
+    """
+    if len(data) < _SIGNATURE_HEADER_SIZE:
+        return data
+    if data[:6] != MAGIC_7Z:
+        return data
+
+    if broken is None:
+        broken = should_break_crc(data)
+
+    buf = bytearray(data)
+    next_header_offset, next_header_size, _old_crc = struct.unpack(
+        "<QQI", bytes(buf[12:32])
+    )
+    header_start = _SIGNATURE_HEADER_SIZE + next_header_offset
+    header_end = header_start + next_header_size
+    if (
+        next_header_size == 0
+        or header_end > len(buf)
+        or header_start < _SIGNATURE_HEADER_SIZE
+    ):
+        # Cannot locate a next-header body; still refresh the start-header CRC over the
+        # 20-byte start_header so signature-CRC reject stays distinct from next-header.
+        start_header = bytes(buf[12:32])
+        struct.pack_into("<I", buf, 8, _crc32(start_header))
+        return bytes(buf)
+
+    header_data = bytes(buf[header_start:header_end])
+    next_crc = _crc32(header_data)
+    if broken:
+        next_crc ^= 1
+    struct.pack_into("<I", buf, 28, next_crc)
+
+    start_header = bytes(buf[12:32])
+    start_crc = _crc32(start_header)
+    if broken:
+        # Keep start-header CRC valid so the failure is the next-header check (the gate
+        # that hides post-parse bugs). Broken start-header CRC is a different, thinner path.
+        pass
+    struct.pack_into("<I", buf, 8, start_crc)
+    return bytes(buf)
+
+
+def fixup_zip_local_and_cd_crc(data: bytes, *, broken: bool | None = None) -> bytes:
+    """Best-effort ZIP local-header + central-directory CRC32 patch for shallow open+list.
+
+    Stdlib ``zipfile`` lists from the central directory; member CRC mismatches mainly
+    surface on read. We still patch CD ``CRC-32`` (and matching local headers when the
+    relative offset is sane) so wrapper paths behind those fields can be reached. This is
+    intentionally conservative: malformed EOCD / spans return ``data`` unchanged.
+    """
+    if len(data) < 22:
+        return data
+
+    if broken is None:
+        broken = should_break_crc(data)
+
+    # Find the last EOCD signature (no zip64 locator walk for the shallow harness).
+    eocd_sig = b"PK\x05\x06"
+    idx = data.rfind(eocd_sig)
+    if idx < 0 or idx + 22 > len(data):
+        return data
+
+    cd_size = int.from_bytes(data[idx + 12 : idx + 16], "little")
+    cd_offset = int.from_bytes(data[idx + 16 : idx + 20], "little")
+    if cd_offset + cd_size > len(data) or cd_size == 0:
+        return data
+
+    buf = bytearray(data)
+    pos = cd_offset
+    end = cd_offset + cd_size
+    while pos + 46 <= end:
+        if buf[pos : pos + 4] != b"PK\x01\x02":
+            break
+        crc_off = pos + 16
+        comp_size = int.from_bytes(buf[pos + 20 : pos + 24], "little")
+        uncomp_size = int.from_bytes(buf[pos + 24 : pos + 28], "little")
+        name_len = int.from_bytes(buf[pos + 28 : pos + 30], "little")
+        extra_len = int.from_bytes(buf[pos + 30 : pos + 32], "little")
+        comment_len = int.from_bytes(buf[pos + 32 : pos + 34], "little")
+        local_off = int.from_bytes(buf[pos + 42 : pos + 46], "little")
+
+        # Prefer recomputing from the local compressed payload when the layout is sane;
+        # otherwise leave the stored CRC and only optionally break it.
+        new_crc: int | None = None
+        if (
+            local_off + 30 <= len(buf)
+            and buf[local_off : local_off + 4] == b"PK\x03\x04"
+        ):
+            ln = int.from_bytes(buf[local_off + 26 : local_off + 28], "little")
+            le = int.from_bytes(buf[local_off + 28 : local_off + 30], "little")
+            payload_start = local_off + 30 + ln + le
+            payload_end = payload_start + comp_size
+            if payload_end <= len(buf) and uncomp_size == 0 and comp_size == 0:
+                new_crc = 0
+            elif payload_end <= len(buf):
+                # Stored (method 0) payloads: CRC is over uncompressed == compressed bytes.
+                method = int.from_bytes(buf[local_off + 8 : local_off + 10], "little")
+                if method == 0:
+                    new_crc = _crc32(bytes(buf[payload_start:payload_end]))
+
+        if new_crc is not None:
+            if broken:
+                new_crc ^= 1
+            struct.pack_into("<I", buf, crc_off, new_crc)
+            # Mirror into the local header CRC field when present.
+            struct.pack_into("<I", buf, local_off + 14, new_crc)
+
+        pos += 46 + name_len + extra_len + comment_len
+
+    return bytes(buf)
+
+
+FixupFn = Callable[[bytes], bytes]
+
+
+def apply_fixup(
+    data: bytes,
+    fixup: FixupFn | None,
+    *,
+    broken: bool | None = None,
+) -> bytes:
+    """Apply ``fixup`` when provided; pass ``broken`` through when the helper accepts it."""
+    if fixup is None:
+        return data
+    # Prefer keyword form used by the helpers above.
+    try:
+        return fixup(data, broken=broken)  # type: ignore[call-arg]
+    except TypeError:
+        return fixup(data)

--- a/tests/atheris_fuzz/runner.py
+++ b/tests/atheris_fuzz/runner.py
@@ -1,0 +1,177 @@
+"""Shared Atheris runner: budgets, corpus, crash artifacts, typed-error contract."""
+
+from __future__ import annotations
+
+import os
+import signal
+import sys
+import traceback
+from collections.abc import Callable, Sequence
+from pathlib import Path
+from typing import Any
+
+from tests.atheris_fuzz import DEFAULT_BUDGETS
+from tests.atheris_fuzz.crc_fixup import FixupFn, apply_fixup
+from tests.atheris_fuzz.seeds import write_seed_corpus
+
+# Artifact root (CI uploads this directory on failure).
+_DEFAULT_ARTIFACT_DIR = Path(
+    os.environ.get("ARCHIVEY_FUZZ_ARTIFACT_DIR", "artifacts/atheris")
+)
+
+TargetFn = Callable[[bytes], None]
+
+
+def budget_seconds(target: str, default: int | None = None) -> int:
+    """Per-target wall budget. Env: ``ARCHIVEY_FUZZ_BUDGET_<TARGET_UPPER>``."""
+    env_key = f"ARCHIVEY_FUZZ_BUDGET_{target.upper()}"
+    raw = os.environ.get(env_key)
+    if raw is not None:
+        return max(0, int(raw))
+    if default is not None:
+        return default
+    return DEFAULT_BUDGETS.get(target, 10)
+
+
+def artifact_dir() -> Path:
+    return Path(
+        os.environ.get("ARCHIVEY_FUZZ_ARTIFACT_DIR", str(_DEFAULT_ARTIFACT_DIR))
+    )
+
+
+def repro_command(target: str, crash_path: Path) -> str:
+    return (
+        f"uv run --no-sync python -m tests.atheris_fuzz --target {target} "
+        f"--repro {crash_path}"
+    )
+
+
+def persist_crash(target: str, data: bytes, *, reason: str) -> Path:
+    out = artifact_dir() / target
+    out.mkdir(parents=True, exist_ok=True)
+    path = out / "crash-input.bin"
+    path.write_bytes(data)
+    meta = out / "crash-meta.txt"
+    meta.write_text(
+        f"reason={reason}\nrepro={repro_command(target, path)}\n", encoding="utf-8"
+    )
+    print(
+        f"[atheris] crash persisted: {path} ({reason})\n"
+        f"[atheris] repro: {repro_command(target, path)}",
+        file=sys.stderr,
+        flush=True,
+    )
+    return path
+
+
+def _install_slice_alarm(seconds: float) -> None:
+    """Hard wall-clock kill for a single TestOneInput (ISO hang class)."""
+
+    def _handler(signum: int, frame: Any) -> None:  # noqa: ARG001
+        raise TimeoutError(f"atheris input exceeded {seconds:.1f}s wall clock")
+
+    signal.signal(signal.SIGALRM, _handler)
+    # setitimer gives sub-second resolution; alarm() is integer-only.
+    signal.setitimer(signal.ITIMER_REAL, seconds)
+
+
+def _clear_slice_alarm() -> None:
+    signal.setitimer(signal.ITIMER_REAL, 0)
+
+
+def run_target(
+    *,
+    name: str,
+    test_one_input: TargetFn,
+    seeds: Sequence[bytes],
+    budget: int | None = None,
+    fixup: FixupFn | None = None,
+    per_input_timeout: float | None = None,
+    argv: list[str] | None = None,
+    smoke: bool = False,
+) -> int:
+    """Run one Atheris target. Returns process exit code (0 = success).
+
+    Success contract: budget expires with only typed ``ArchiveyError`` or clean returns
+    inside ``test_one_input`` (the target itself must swallow ``ArchiveyError``). Any other
+    exception, timeout, or abort fails the run and persists the crashing input.
+    """
+    import atheris
+
+    seconds = 1 if smoke else budget_seconds(name, budget)
+    if seconds <= 0 and not smoke:
+        print(f"[atheris] skipping {name}: budget={seconds}", flush=True)
+        return 0
+
+    corpus = artifact_dir() / "corpus" / name
+    write_seed_corpus(corpus, list(seeds))
+
+    # libFuzzer flags: time budget, artifact prefix, jobs=1 (deterministic-ish CI).
+    artifact_prefix = str(artifact_dir() / name) + "/"
+    Path(artifact_prefix).mkdir(parents=True, exist_ok=True)
+    lf_argv = [
+        sys.argv[0],
+        f"-max_total_time={max(1, seconds)}",
+        f"-artifact_prefix={artifact_prefix}",
+        "-print_final_stats=1",
+        str(corpus),
+    ]
+    if argv:
+        lf_argv.extend(argv)
+
+    @atheris.instrument_func
+    def _entry(data: bytes) -> None:
+        payload = apply_fixup(data, fixup)
+        if per_input_timeout is not None and per_input_timeout > 0:
+            _install_slice_alarm(per_input_timeout)
+        try:
+            test_one_input(payload)
+        except TimeoutError:
+            persist_crash(name, payload, reason="per-input-timeout")
+            raise
+        except Exception as exc:  # noqa: BLE001 — any non-ArchiveyError is a fuzz finding
+            # Targets must convert ArchiveyError to a soft return; anything else is a finding.
+            persist_crash(name, payload, reason=type(exc).__name__)
+            raise
+        finally:
+            if per_input_timeout is not None and per_input_timeout > 0:
+                _clear_slice_alarm()
+
+    try:
+        # instrument_imports covers first-load; instrument_all rewrites already-imported
+        # archivey modules so libFuzzer sees Python edge coverage (otherwise ft stays ~4).
+        atheris.instrument_all()
+        atheris.Setup(lf_argv, _entry)
+        atheris.Fuzz()
+    except SystemExit as exc:
+        return int(exc.code) if isinstance(exc.code, int) else 1
+    except Exception:  # noqa: BLE001 — libFuzzer/setup failures must fail the job
+        traceback.print_exc()
+        return 1
+    return 0
+
+
+def run_repro(
+    *,
+    name: str,
+    test_one_input: TargetFn,
+    path: Path,
+    fixup: FixupFn | None = None,
+    per_input_timeout: float | None = None,
+) -> int:
+    """Replay a single crashing input without libFuzzer."""
+    data = path.read_bytes()
+    payload = apply_fixup(data, fixup)
+    if per_input_timeout is not None and per_input_timeout > 0:
+        _install_slice_alarm(per_input_timeout)
+    try:
+        test_one_input(payload)
+    except Exception:  # noqa: BLE001 — repro must report any unexpected exception
+        traceback.print_exc()
+        persist_crash(name, payload, reason="repro-failure")
+        return 1
+    finally:
+        if per_input_timeout is not None and per_input_timeout > 0:
+            _clear_slice_alarm()
+    print(f"[atheris] repro of {path} completed without exception", flush=True)
+    return 0

--- a/tests/atheris_fuzz/seeds.py
+++ b/tests/atheris_fuzz/seeds.py
@@ -1,0 +1,127 @@
+"""Seed corpus for Atheris targets: declarative corpus + adversarial fixtures + tiny blobs."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+from tests.sample_archives import CORPUS, corpus_archive_path
+
+# Small corpus entry ids that build quickly and cover common layouts.
+_SEED_ENTRY_IDS = frozenset(
+    {"basic", "encoding", "large", "adversarial", "adversarial-tar"}
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_ADVERSARIAL_DIR = _REPO_ROOT / "tests" / "fixtures" / "adversarial"
+
+
+def _corpus_seeds(format_key: str, tmp: Path) -> list[bytes]:
+    out: list[bytes] = []
+    for entry in CORPUS:
+        if entry.id not in _SEED_ENTRY_IDS:
+            continue
+        if format_key not in entry.formats:
+            continue
+        if entry.requires_binaries:
+            # Encrypted / binary-gated fixtures are optional for the seed set.
+            continue
+        try:
+            path = corpus_archive_path(entry, format_key, tmp)
+        except (OSError, RuntimeError, ValueError, ImportError):
+            continue
+        if path.is_file():
+            out.append(path.read_bytes())
+    return out
+
+
+def _adversarial_seeds(*suffixes: str) -> list[bytes]:
+    if not _ADVERSARIAL_DIR.is_dir():
+        return []
+    out: list[bytes] = []
+    for path in sorted(_ADVERSARIAL_DIR.rglob("*")):
+        if not path.is_file():
+            continue
+        name = path.name.lower()
+        if suffixes and not any(name.endswith(s) for s in suffixes):
+            continue
+        try:
+            out.append(path.read_bytes())
+        except OSError:
+            continue
+    return out
+
+
+def sevenzip_seeds() -> list[bytes]:
+    from archivey.internal.backends.sevenzip_parser import MAGIC_7Z
+
+    tiny = [
+        b"",
+        MAGIC_7Z,
+        MAGIC_7Z + bytes(26),
+        b"not a 7z archive",
+        MAGIC_7Z + b"\x00\x04" + b"\xff" * 24,
+    ]
+    with tempfile.TemporaryDirectory(prefix="atheris-seed-7z-") as tmp:
+        return tiny + _corpus_seeds("7z", Path(tmp)) + _adversarial_seeds(".7z")
+
+
+def zip_seeds() -> list[bytes]:
+    tiny = [b"", b"PK\x03\x04", b"PK\x05\x06" + bytes(18), b"not a zip"]
+    with tempfile.TemporaryDirectory(prefix="atheris-seed-zip-") as tmp:
+        return tiny + _corpus_seeds("zip", Path(tmp)) + _adversarial_seeds(".zip")
+
+
+def tar_seeds() -> list[bytes]:
+    tiny = [b"", b"ustar\x00", b"not a tar"]
+    with tempfile.TemporaryDirectory(prefix="atheris-seed-tar-") as tmp:
+        return (
+            tiny
+            + _corpus_seeds("tar", Path(tmp))
+            + _corpus_seeds("tar.gz", Path(tmp))
+            + _adversarial_seeds(".tar", ".tar.gz", ".tgz")
+        )
+
+
+def iso_seeds() -> list[bytes]:
+    tiny = [b"", b"\x00" * 32768, b"not an iso"]
+    with tempfile.TemporaryDirectory(prefix="atheris-seed-iso-") as tmp:
+        return tiny + _corpus_seeds("iso", Path(tmp)) + _adversarial_seeds(".iso")
+
+
+def detect_format_seeds() -> list[bytes]:
+    """Mixed prefixes for ``detect_format`` — prefer short heads of real archives."""
+    seeds: list[bytes] = [b"", b"\x00" * 16, b"PK", b"7z", b"Rar!", b"ustar"]
+    for builder in (sevenzip_seeds, zip_seeds, tar_seeds, iso_seeds):
+        try:
+            for blob in builder():
+                seeds.append(blob[: min(len(blob), 512)])
+                if len(blob) > 512:
+                    seeds.append(blob[:4096])
+        except (OSError, RuntimeError, ValueError, ImportError):
+            continue
+    # Dedup while preserving order.
+    seen: set[bytes] = set()
+    out: list[bytes] = []
+    for s in seeds:
+        if s in seen:
+            continue
+        seen.add(s)
+        out.append(s)
+    return out
+
+
+def rar_seeds() -> list[bytes]:
+    # No native RAR backend yet; keep tiny magic-shaped seeds for when it registers.
+    return [b"", b"Rar!\x1a\x07\x00", b"Rar!\x1a\x07\x01\x00", b"not rar"]
+
+
+def write_seed_corpus(directory: Path, seeds: list[bytes]) -> int:
+    """Write seed files for libFuzzer ``-seed_inputs`` / corpus dir. Returns count."""
+    directory.mkdir(parents=True, exist_ok=True)
+    written = 0
+    for i, seed in enumerate(seeds):
+        path = directory / f"seed-{i:04d}"
+        path.write_bytes(seed)
+        written += 1
+    return written

--- a/tests/atheris_fuzz/targets.py
+++ b/tests/atheris_fuzz/targets.py
@@ -1,0 +1,212 @@
+"""Atheris target callables (typed ArchiveyError → soft return)."""
+
+from __future__ import annotations
+
+import io
+import os
+from collections.abc import Callable
+from typing import Any
+
+from archivey import (
+    AcceleratorMode,
+    ArchiveFormat,
+    ArchiveyConfig,
+    ArchiveyError,
+    detect_format,
+    format_availability,
+    open_archive,
+)
+from archivey.internal.backends.sevenzip_parser import (
+    SevenZipFolder,
+    parse_sevenzip_archive,
+)
+from archivey.internal.backends.sevenzip_reader import decode_folder_to_bytes
+from archivey.internal.registry import FormatSupport
+from archivey.internal.streams.crypto import SevenZipKeyCache
+from tests.atheris_fuzz.crc_fixup import (
+    fixup_sevenzip_header_crcs,
+    fixup_zip_local_and_cd_crc,
+)
+from tests.atheris_fuzz.seeds import (
+    detect_format_seeds,
+    iso_seeds,
+    rar_seeds,
+    sevenzip_seeds,
+    tar_seeds,
+    zip_seeds,
+)
+
+_FUZZ_CONFIG = ArchiveyConfig(
+    use_rapidgzip=AcceleratorMode.OFF, use_indexed_bzip2=AcceleratorMode.OFF
+)
+
+# Cap listing work so a pathological member table cannot burn the whole slice.
+_MAX_MEMBERS = 10_000
+
+
+def _decode_folder(
+    source: Any,
+    folder: SevenZipFolder,
+    compressed_size: int,
+    uncompressed_size: int,
+) -> bytes:
+    return decode_folder_to_bytes(
+        source,
+        folder,
+        compressed_size=compressed_size,
+        uncompressed_size=uncompressed_size,
+        password=None,
+        key_cache=SevenZipKeyCache(),
+    )
+
+
+def sevenzip_header_one(data: bytes) -> None:
+    try:
+        parse_sevenzip_archive(io.BytesIO(data), decode_folder=_decode_folder)
+    except ArchiveyError:
+        return
+
+
+def sevenzip_open_one(data: bytes) -> None:
+    try:
+        with open_archive(
+            io.BytesIO(data), format=ArchiveFormat.SEVEN_Z, config=_FUZZ_CONFIG
+        ) as arc:
+            for i, member in enumerate(arc):
+                if i >= _MAX_MEMBERS:
+                    break
+                _ = member.name
+    except ArchiveyError:
+        return
+
+
+def detect_format_one(data: bytes) -> None:
+    try:
+        detect_format(io.BytesIO(data))
+    except ArchiveyError:
+        return
+
+
+def zip_open_one(data: bytes) -> None:
+    try:
+        with open_archive(
+            io.BytesIO(data), format=ArchiveFormat.ZIP, config=_FUZZ_CONFIG
+        ) as arc:
+            for i, member in enumerate(arc):
+                if i >= _MAX_MEMBERS:
+                    break
+                _ = member.name
+    except ArchiveyError:
+        return
+
+
+def tar_open_one(data: bytes) -> None:
+    try:
+        with open_archive(
+            io.BytesIO(data), format=ArchiveFormat.TAR, config=_FUZZ_CONFIG
+        ) as arc:
+            for i, member in enumerate(arc):
+                if i >= _MAX_MEMBERS:
+                    break
+                _ = member.name
+    except ArchiveyError:
+        return
+
+
+def zip_tar_one(data: bytes) -> None:
+    """Shallow ZIP then TAR over the same bytes (wrapper/translation coverage)."""
+    fixed = fixup_zip_local_and_cd_crc(data)
+    zip_open_one(fixed)
+    tar_open_one(data)
+
+
+def iso_open_one(data: bytes) -> None:
+    try:
+        with open_archive(
+            io.BytesIO(data), format=ArchiveFormat.ISO, config=_FUZZ_CONFIG
+        ) as arc:
+            for i, member in enumerate(arc):
+                if i >= _MAX_MEMBERS:
+                    break
+                _ = member.name
+    except ArchiveyError:
+        return
+
+
+def rar_available() -> bool:
+    availability = format_availability(ArchiveFormat.RAR)
+    return availability.support is not FormatSupport.NONE
+
+
+def rar_open_one(data: bytes) -> None:
+    # When enabled: apply RAR header CRC fixup here (same mutate-then-fixup pattern as 7z).
+    try:
+        with open_archive(
+            io.BytesIO(data), format=ArchiveFormat.RAR, config=_FUZZ_CONFIG
+        ) as arc:
+            for i, member in enumerate(arc):
+                if i >= _MAX_MEMBERS:
+                    break
+                _ = member.name
+    except ArchiveyError:
+        return
+
+
+def iso_per_input_timeout() -> float:
+    raw = os.environ.get("ARCHIVEY_FUZZ_ISO_INPUT_TIMEOUT", "2.0")
+    try:
+        return max(0.1, float(raw))
+    except ValueError:
+        return 2.0
+
+
+TargetSpec = tuple[str, Callable[[bytes], None], Callable[[], list[bytes]], dict]
+
+
+def iter_target_specs() -> list[dict]:
+    """Descriptor dicts consumed by ``__main__`` / the CI runner."""
+    return [
+        {
+            "name": "sevenzip_header",
+            "fn": sevenzip_header_one,
+            "seeds": sevenzip_seeds,
+            "fixup": fixup_sevenzip_header_crcs,
+            "per_input_timeout": None,
+        },
+        {
+            "name": "sevenzip_open",
+            "fn": sevenzip_open_one,
+            "seeds": sevenzip_seeds,
+            "fixup": fixup_sevenzip_header_crcs,
+            "per_input_timeout": None,
+        },
+        {
+            "name": "detect_format",
+            "fn": detect_format_one,
+            "seeds": detect_format_seeds,
+            "fixup": None,
+            "per_input_timeout": None,
+        },
+        {
+            "name": "zip_tar",
+            "fn": zip_tar_one,
+            "seeds": lambda: zip_seeds() + tar_seeds(),
+            "fixup": None,  # ZIP fixup applied inside zip_tar_one for the ZIP half
+            "per_input_timeout": None,
+        },
+        {
+            "name": "iso",
+            "fn": iso_open_one,
+            "seeds": iso_seeds,
+            "fixup": None,
+            "per_input_timeout": iso_per_input_timeout(),
+        },
+        {
+            "name": "rar",
+            "fn": rar_open_one,
+            "seeds": rar_seeds,
+            "fixup": None,  # plan CRC/header fixup when enabling
+            "per_input_timeout": None,
+            "skip_unless": rar_available,
+        },
+    ]

--- a/tests/test_atheris_crc_fixup.py
+++ b/tests/test_atheris_crc_fixup.py
@@ -1,0 +1,134 @@
+"""Unit tests for Atheris CRC mutate-then-fixup helpers (no atheris import required)."""
+
+from __future__ import annotations
+
+import io
+import struct
+import zlib
+from pathlib import Path
+
+import pytest
+
+from archivey.exceptions import ArchiveyError, CorruptionError
+from archivey.internal.backends.sevenzip_parser import (
+    SevenZipFolder,
+    parse_sevenzip_archive,
+)
+from archivey.internal.backends.sevenzip_reader import decode_folder_to_bytes
+from archivey.internal.streams.crypto import SevenZipKeyCache
+from tests.atheris_fuzz.crc_fixup import (
+    fixup_sevenzip_header_crcs,
+    fixup_zip_local_and_cd_crc,
+)
+from tests.sample_archives import CORPUS, corpus_archive_path
+
+
+def _crc32(data: bytes) -> int:
+    return zlib.crc32(data) & 0xFFFFFFFF
+
+
+def _decode_folder(
+    source: object,
+    folder: SevenZipFolder,
+    compressed_size: int,
+    uncompressed_size: int,
+) -> bytes:
+    return decode_folder_to_bytes(
+        source,  # type: ignore[arg-type]
+        folder,
+        compressed_size=compressed_size,
+        uncompressed_size=uncompressed_size,
+        password=None,
+        key_cache=SevenZipKeyCache(),
+    )
+
+
+@pytest.fixture(scope="module")
+def basic_7z(tmp_path_factory: pytest.TempPathFactory) -> bytes:
+    pytest.importorskip("py7zr")
+    entry = next(e for e in CORPUS if e.id == "basic" and "7z" in e.formats)
+    path = corpus_archive_path(entry, "7z", tmp_path_factory.mktemp("crc-7z"))
+    return path.read_bytes()
+
+
+def _next_header_slice(data: bytes) -> tuple[int, int]:
+    off, size, _crc = struct.unpack("<QQI", data[12:32])
+    start = 32 + off
+    return start, start + size
+
+
+def test_fixup_sevenzip_restores_crcs_after_bitflip(basic_7z: bytes) -> None:
+    start, end = _next_header_slice(basic_7z)
+    assert end > start
+    data = bytearray(basic_7z)
+    # Flip a byte inside the next-header body (the CRC-gated region).
+    data[start] ^= 0x01
+    broken = bytes(data)
+
+    # Without fixup the next-header CRC must fail.
+    with pytest.raises(CorruptionError, match="next header CRC"):
+        parse_sevenzip_archive(io.BytesIO(broken), decode_folder=_decode_folder)
+
+    fixed = fixup_sevenzip_header_crcs(broken, broken=False)
+    # Signature + next-header CRCs must match recomputed values.
+    start_header = fixed[12:32]
+    assert int.from_bytes(fixed[8:12], "little") == _crc32(start_header)
+    off, size, nh_crc = struct.unpack("<QQI", start_header)
+    header = fixed[32 + off : 32 + off + size]
+    assert nh_crc == _crc32(header)
+
+    # Fixed-up blob must pass the CRC gate (may still raise typed errors for content).
+    try:
+        parse_sevenzip_archive(io.BytesIO(fixed), decode_folder=_decode_folder)
+    except CorruptionError as exc:
+        assert "next header CRC" not in str(exc)
+        assert "signature header CRC" not in str(exc)
+    except ArchiveyError:
+        pass
+
+
+def test_fixup_sevenzip_broken_mode_still_rejects(basic_7z: bytes) -> None:
+    start, _end = _next_header_slice(basic_7z)
+    flipped = bytearray(basic_7z)
+    flipped[start] ^= 0x02
+    fixed_broken = fixup_sevenzip_header_crcs(bytes(flipped), broken=True)
+    with pytest.raises(CorruptionError, match="next header CRC"):
+        parse_sevenzip_archive(io.BytesIO(fixed_broken), decode_folder=_decode_folder)
+
+
+def test_fixup_sevenzip_noop_on_non_magic() -> None:
+    blob = b"not a 7z archive" + b"\x00" * 64
+    assert fixup_sevenzip_header_crcs(blob, broken=False) == blob
+
+
+def test_fixup_sevenzip_known_good_header_unchanged(basic_7z: bytes) -> None:
+    # Re-patching a valid archive should yield byte-identical CRCs (body untouched).
+    fixed = fixup_sevenzip_header_crcs(basic_7z, broken=False)
+    assert fixed[12:] == basic_7z[12:]  # start_header + body identical
+    assert fixed[8:12] == basic_7z[8:12]
+
+
+def test_fixup_zip_stored_member_crc(tmp_path: Path) -> None:
+    import zipfile
+
+    path = tmp_path / "stored.zip"
+    with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_STORED) as zf:
+        zf.writestr("a.txt", b"hello zip crc")
+    data = path.read_bytes()
+
+    # Corrupt the central-directory CRC field, then fix it back.
+    eocd = data.rfind(b"PK\x05\x06")
+    cd_offset = int.from_bytes(data[eocd + 16 : eocd + 20], "little")
+    assert data[cd_offset : cd_offset + 4] == b"PK\x01\x02"
+    corrupted = bytearray(data)
+    corrupted[cd_offset + 16] ^= 0xFF
+    restored = fixup_zip_local_and_cd_crc(bytes(corrupted), broken=False)
+    assert (
+        restored[cd_offset + 16 : cd_offset + 20]
+        == data[cd_offset + 16 : cd_offset + 20]
+    )
+
+    broken = fixup_zip_local_and_cd_crc(data, broken=True)
+    assert (
+        broken[cd_offset + 16 : cd_offset + 20] != data[cd_offset + 16 : cd_offset + 20]
+    )

--- a/tests/test_extras_imported.py
+++ b/tests/test_extras_imported.py
@@ -119,5 +119,17 @@ def test_pyzstd_and_python_xz_are_not_in_any_extra() -> None:
         )
 
 
+def test_atheris_is_fuzz_group_not_runtime_extra() -> None:
+    """atheris is CI-only (PEP 735 ``fuzz`` group), never a user-facing extra / ``[all]``."""
+    with open(_PYPROJECT, "rb") as f:
+        data = tomllib.load(f)
+    leaves = _leaf_packages(data["project"]["optional-dependencies"])
+    assert "atheris" not in leaves
+    fuzz = data.get("dependency-groups", {}).get("fuzz", [])
+    assert any(_requirement_dist_name(req) == "atheris" for req in fuzz), (
+        "atheris must be declared in the PEP 735 fuzz dependency group"
+    )
+
+
 if __name__ == "__main__":  # pragma: no cover - convenience for manual runs
     sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/test_sevenzip_reader.py
+++ b/tests/test_sevenzip_reader.py
@@ -584,3 +584,54 @@ def test_files_info_count_is_bounded_against_header_size() -> None:
     buffer = io.BytesIO(b"\xff" + huge)  # a 9-byte "header" claiming 2**40 files
     with pytest.raises(CorruptionError, match="exceeds the .* header"):
         _read_files_info(buffer)
+
+
+def test_next_header_offset_overflow_is_typed_corruption() -> None:
+    """Huge nextHeaderOffset must not raise OverflowError on seek (Atheris finding)."""
+    import struct
+    import zlib
+
+    from archivey.exceptions import CorruptionError
+    from archivey.internal.backends.sevenzip_parser import (
+        MAGIC_7Z,
+        parse_sevenzip_archive,
+    )
+
+    # Valid signature CRC over a start_header that claims an absurd next-header offset.
+    next_offset = (1 << 64) - 1
+    next_size = 16
+    next_crc = 0
+    start_header = struct.pack("<QQI", next_offset, next_size, next_crc)
+    start_crc = zlib.crc32(start_header) & 0xFFFFFFFF
+    blob = MAGIC_7Z + bytes([0, 4]) + struct.pack("<I", start_crc) + start_header
+
+    def _boom(*_a: object, **_k: object) -> bytes:
+        raise AssertionError("decode_folder must not be reached")
+
+    with pytest.raises(CorruptionError, match="next-header offset"):
+        parse_sevenzip_archive(io.BytesIO(blob), decode_folder=_boom)  # type: ignore[arg-type]
+
+
+def test_next_header_size_cap_is_typed_corruption() -> None:
+    import struct
+    import zlib
+
+    from archivey.exceptions import CorruptionError
+    from archivey.internal.backends.sevenzip_parser import (
+        _MAX_NEXT_HEADER_SIZE,
+        MAGIC_7Z,
+        parse_sevenzip_archive,
+    )
+
+    next_offset = 0
+    next_size = _MAX_NEXT_HEADER_SIZE + 1
+    next_crc = 0
+    start_header = struct.pack("<QQI", next_offset, next_size, next_crc)
+    start_crc = zlib.crc32(start_header) & 0xFFFFFFFF
+    blob = MAGIC_7Z + bytes([0, 4]) + struct.pack("<I", start_crc) + start_header
+
+    def _boom(*_a: object, **_k: object) -> bytes:
+        raise AssertionError("decode_folder must not be reached")
+
+    with pytest.raises(CorruptionError, match="next-header size"):
+        parse_sevenzip_archive(io.BytesIO(blob), decode_folder=_boom)  # type: ignore[arg-type]

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,8 @@ revision = 3
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version >= '3.13'",
-    "python_full_version < '3.13'",
+    "python_full_version == '3.12.*'",
+    "python_full_version < '3.12'",
 ]
 
 [[package]]
@@ -119,6 +120,10 @@ docs = [
     { name = "mkdocs-material" },
     { name = "mkdocstrings", extra = ["python"] },
 ]
+fuzz = [
+    { name = "atheris", version = "3.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "atheris", version = "3.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -172,6 +177,38 @@ docs = [
     { name = "mkdocs-autorefs", specifier = ">=1.2.0" },
     { name = "mkdocs-material", specifier = ">=9.6.0" },
     { name = "mkdocstrings", extras = ["python"], specifier = ">=0.26.0" },
+]
+fuzz = [
+    { name = "atheris", marker = "python_full_version < '3.12'", specifier = ">=3.0.0,<3.1" },
+    { name = "atheris", marker = "python_full_version >= '3.12'", specifier = ">=3.0.0" },
+]
+
+[[package]]
+name = "atheris"
+version = "3.0.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.12'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f8/58/5965955898e16bee17c8379eae12194993bf641c4629016991248b862069/atheris-3.0.0.tar.gz", hash = "sha256:1f0929c7bc3040f3fe4102e557718734190cf2d7718bbb8e3ce6d3eb56ef5bb3", size = 373239, upload-time = "2025-11-24T23:54:02.15Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/15/cf109e2e8696a54c8c4bc3ef79a79bec32361eceb64eaa36690a682e83a9/atheris-3.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8a5c8a781467c187da40fd29139784193e2647058831f837f675d0bb8cbd8746", size = 34805555, upload-time = "2025-11-24T23:53:53.477Z" },
+    { url = "https://files.pythonhosted.org/packages/85/8c/e9960b996e70e5f6a523670431166b2b238de52fef094955515dcf854da1/atheris-3.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:510e502c57b6dc615fb174066407af620d4c7f73cf08a782c86e7761bf12c4eb", size = 34907016, upload-time = "2025-11-24T23:53:56.535Z" },
+    { url = "https://files.pythonhosted.org/packages/db/48/df670f75f458cc7c1752a01a394fd59c830b08172dd59cf29d73f31050f9/atheris-3.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a402cdca8a650d1371050b1f9552eb4cdc488d2db64950d603c4560318365eac", size = 34858525, upload-time = "2025-11-24T23:53:59.925Z" },
+]
+
+[[package]]
+name = "atheris"
+version = "3.1.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.13'",
+    "python_full_version == '3.12.*'",
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/88/fd6ad595dafa9c7ce56dbfcaff0c7244988dac3af86c771166c6516ccf6b/atheris-3.1.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ec5e11f21a4c197fe91f7aea2b2de88e623c73a21fc07b105ac6329a1588457b", size = 36875908, upload-time = "2026-06-17T00:04:01.104Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/18/e19718c384fd7d801d0da7485407daef9af6194b6d8c8818175bec5efec6/atheris-3.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f8a9f51ce8369026e8eb7b7174835e8c4c85a1a6db5d9add36c15100779d2a39", size = 36800563, upload-time = "2026-06-17T00:04:04.559Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/ff/ae7a5bfe99033e510bea4ed09934e636d93777317a48147369bc0dc2b71f/atheris-3.1.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:315a0b5c819852b1ffe1ca72efc389c7724881f2c33e4aacb8c6bcec49bd5011", size = 36772569, upload-time = "2026-06-17T00:04:07.702Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements OpenSpec change `atheris-fuzz-harness`: coverage-guided Atheris fuzzing for native parsers and entry points (threat-model O5).

- PEP 735 `fuzz` dependency group (`atheris`); absent from runtime extras / `[all]`
- Shared harness under `tests/atheris_fuzz/` with seed corpus, accelerators off, CRC mutate-then-fixup, crash artifacts + one-line repro
- Targets: 7z header (deep), 7z open+members, `detect_format`, ZIP+TAR shallow, ISO with per-input hard timeout, RAR scaffold (skips until registered)
- CI: `.github/workflows/atheris-fuzz.yml` on `push` to `main` + `workflow_dispatch` only (not the PR matrix)
- Bonus fix from first smoke run: bound hostile 7z `nextHeaderOffset` / `nextHeaderSize` so seek/read cannot raise raw `OverflowError`

## How to run

```bash
uv sync --group fuzz --group dev --extra all
uv run --no-sync python -m tests.atheris_fuzz --smoke
```

Mutation / `ARCHIVEY_FUZZ` harnesses are unchanged.

## Progress

**19/19** tasks complete. Ready to archive after merge (`/opsx:archive atheris-fuzz-harness`).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-302b2d61-4f70-4938-af1f-ba0e933342d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-302b2d61-4f70-4938-af1f-ba0e933342d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

