### PR TITLE
Enable Atheris RAR fuzz targets (+ OverflowError fix)

### DIFF
--- a/.github/workflows/atheris-fuzz.yml
+++ b/.github/workflows/atheris-fuzz.yml
@@ -44,14 +44,15 @@ jobs:
           BUDGET_SCALE: ${{ github.event.inputs.budget_scale || '1' }}
         run: |
           scale="${BUDGET_SCALE:-1}"
-          export ARCHIVEY_FUZZ_BUDGET_SEVENZIP_HEADER=$((55 * scale))
-          export ARCHIVEY_FUZZ_BUDGET_SEVENZIP_OPEN=$((25 * scale))
-          export ARCHIVEY_FUZZ_BUDGET_DETECT_FORMAT=$((15 * scale))
-          export ARCHIVEY_FUZZ_BUDGET_ZIP_TAR=$((15 * scale))
-          export ARCHIVEY_FUZZ_BUDGET_ISO=$((10 * scale))
-          echo "Budgets: header=$ARCHIVEY_FUZZ_BUDGET_SEVENZIP_HEADER open=$ARCHIVEY_FUZZ_BUDGET_SEVENZIP_OPEN detect=$ARCHIVEY_FUZZ_BUDGET_DETECT_FORMAT zip_tar=$ARCHIVEY_FUZZ_BUDGET_ZIP_TAR iso=$ARCHIVEY_FUZZ_BUDGET_ISO"
+          export ARCHIVEY_FUZZ_BUDGET_SEVENZIP_HEADER=$((45 * scale))
+          export ARCHIVEY_FUZZ_BUDGET_SEVENZIP_OPEN=$((20 * scale))
+          export ARCHIVEY_FUZZ_BUDGET_DETECT_FORMAT=$((12 * scale))
+          export ARCHIVEY_FUZZ_BUDGET_ZIP_TAR=$((12 * scale))
+          export ARCHIVEY_FUZZ_BUDGET_ISO=$((8 * scale))
+          export ARCHIVEY_FUZZ_BUDGET_RAR_HEADER=$((30 * scale))
+          export ARCHIVEY_FUZZ_BUDGET_RAR=$((15 * scale))
+          echo "Budgets: header=$ARCHIVEY_FUZZ_BUDGET_SEVENZIP_HEADER open=$ARCHIVEY_FUZZ_BUDGET_SEVENZIP_OPEN detect=$ARCHIVEY_FUZZ_BUDGET_DETECT_FORMAT zip_tar=$ARCHIVEY_FUZZ_BUDGET_ZIP_TAR iso=$ARCHIVEY_FUZZ_BUDGET_ISO rar_header=$ARCHIVEY_FUZZ_BUDGET_RAR_HEADER rar=$ARCHIVEY_FUZZ_BUDGET_RAR"
           uv run --python 3.12 --no-sync python -m tests.atheris_fuzz
-
       - name: Upload crash artifacts
         if: failure()
         uses: actions/upload-artifact@v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -141,8 +141,9 @@ everyday environment.)
 Atheris is **not** part of the everyday `pytest` / PR matrix. It lives in the PEP 735
 `fuzz` dependency group (`atheris`) and runs as a separate main-branch gate
 (`.github/workflows/atheris-fuzz.yml`: `push` to `main` + `workflow_dispatch`,
-partitioned ~120s). Mutation fuzz (`tests/test_mutation_fuzz.py`) and
-`ARCHIVEY_FUZZ=1` / `tests/fuzz_sevenzip_parser.py` stay as they are.
+partitioned ~150s across 7z, RAR, detect_format, ZIP/TAR, and ISO). Mutation fuzz
+(`tests/test_mutation_fuzz.py`) and `ARCHIVEY_FUZZ=1` / `tests/fuzz_sevenzip_parser.py`
+/ `tests/fuzz_rar_parser.py` stay as they are.
 
 Local smoke (Linux; needs corpus fixture builders). Prefer Python 3.12 for current
 Atheris wheels; on 3.11 ``uv`` resolves ``atheris`` 3.0.x::
@@ -154,10 +155,11 @@ Atheris wheels; on 3.11 ``uv`` resolves ``atheris`` 3.0.x::
     uv sync --python 3.12 --group fuzz --group dev --extra all
     uv run --python 3.12 --no-sync python -m tests.atheris_fuzz --smoke
 
-Deepen one target (budget seconds via env, e.g. `ARCHIVEY_FUZZ_BUDGET_SEVENZIP_HEADER=60`)::
+Deepen one target (budget seconds via env, e.g. `ARCHIVEY_FUZZ_BUDGET_SEVENZIP_HEADER=60`
+or `ARCHIVEY_FUZZ_BUDGET_RAR_HEADER=60`)::
 
     uv run --no-sync python -m tests.atheris_fuzz --target sevenzip_header
-
+    uv run --no-sync python -m tests.atheris_fuzz --target rar_header
 On a crash the harness writes the input under `artifacts/atheris/` and prints a one-line
 repro command.
 

--- a/docs/internal/threat-model.md
+++ b/docs/internal/threat-model.md
@@ -121,11 +121,11 @@ not the in-tree gate:
    (`tests/test_property_safety.py` — `normalize_member_name`, `check_universal`,
    `resolve_link_target_name`, volume discovery, detection over arbitrary prefixes).
 3. **Landed:** coverage-guided **Atheris** harness (`tests/atheris_fuzz/`) over native 7z
-   header parse (CRC mutate-then-fixup), 7z open+members, `detect_format`, shallow
-   ZIP/TAR/ISO open+list, and a RAR scaffold that skips until the backend registers. CI
-   runs on **push to `main`** + **`workflow_dispatch`** (partitioned ~120s; not the PR
-   matrix; not always-on nightly). `atheris` lives in the PEP 735 `fuzz` dependency group
-   only — never a runtime extra. See `openspec/specs/testing-contract/spec.md`.
+   and RAR header parse (CRC mutate-then-fixup), 7z/RAR open+members, `detect_format`,
+   and shallow ZIP/TAR/ISO open+list. CI runs on **push to `main`** + **`workflow_dispatch`**
+   (partitioned ~150s; not the PR matrix; not always-on nightly). `atheris` lives in the
+   PEP 735 `fuzz` dependency group only — never a runtime extra. See
+   `openspec/specs/testing-contract/spec.md`.
 4. **Still open (public release):** OSS-Fuzz onboarding; `SECURITY.md` with a disclosure
    process. Accelerator hang sandbox (below) remains a separate follow-up.
 

--- a/openspec/specs/testing-contract/spec.md
+++ b/openspec/specs/testing-contract/spec.md
@@ -267,7 +267,7 @@ minority of inputs (or a small dedicated budget) SHALL retain broken CRCs so
 the reject path stays exercised.
 
 The default main-branch run SHALL partition a wall-clock budget of approximately
-120 seconds across these targets (exact seconds MAY be env-overridable):
+150 seconds across these targets (exact seconds MAY be env-overridable):
 
 | Target | Role |
 | --- | --- |
@@ -276,7 +276,8 @@ The default main-branch run SHALL partition a wall-clock budget of approximately
 | `detect_format` over arbitrary/prefix seeds | Magic/peek-replay entry point |
 | ZIP and TAR `open_archive` + member list | Shallow wrapper/translation coverage |
 | ISO `open_archive` + member list | Shallow; MUST use a hard wall-clock kill timeout |
-| RAR metadata parse (+ open/list when registered) | Scaffold now; skip cleanly until the backend is available |
+| Native RAR header parse | Deep coverage of the pure-Python RAR3/RAR5 metadata parser (CRC mutate-then-fixup) |
+| RAR `open_archive` + member list | Reader/spine path after parse; skip cleanly if the backend is unavailable |
 
 Full member **extract** is out of scope for this harness (covered by the
 mutation harness). Stream/codec-only targets MAY be added later without removing
@@ -296,12 +297,12 @@ installed only via the CI `fuzz` dependency group (`packaging-and-extras`).
 
 | Case | Expected |
 | --- | --- |
-| Push to `main` | Fuzz workflow runs partitioned ~120s budget; green if no crash/hang/raw exception |
+| Push to `main` | Fuzz workflow runs partitioned ~150s budget; green if no crash/hang/raw exception |
 | `workflow_dispatch` with longer env budget | Same targets; extended exploration |
 | Pull request (default matrix) | Atheris job not required |
-| RAR backend absent | RAR target skipped; other targets still run |
+| RAR backend absent | RAR targets skipped; other targets still run |
 | Fuzzer finds a crashing input | Job fails; repro bytes uploaded; re-run command printed |
-| 7z header target with fixup enabled | Most iterations present a matching header CRC and enter post-CRC parse |
+| 7z / RAR header target with fixup enabled | Most iterations present a matching header CRC and enter post-CRC parse |
 | Broken-CRC sample / minority path | Typed CRC/corruption failure; reject path still hit |
 | Mutation harness / `ARCHIVEY_FUZZ` | Still available and unchanged in role |
 

--- a/src/archivey/internal/backends/rar_parser.py
+++ b/src/archivey/internal/backends/rar_parser.py
@@ -44,6 +44,8 @@ SFX_MAX = 2 * 1024 * 1024
 _RAR_MAX_PASSWORD = 127
 _RAR_MAX_KDF_SHIFT = 24
 _RAR5_MAX_HEADER = 2 * 1024 * 1024
+# BytesIO/file seek offsets must fit in a C ssize_t; hostile RAR5 vints can exceed that.
+_MAX_SEEK = (1 << 63) - 1
 
 # RAR3 block types
 _RAR3_MARK = 0x72
@@ -387,10 +389,33 @@ def _crc32(data: bytes | memoryview) -> int:
 
 
 def _require_exact(stream: BinaryIO, n: int, what: str) -> bytes:
-    data = read_exact(stream, n)
+    if n < 0 or n > _MAX_SEEK:
+        raise CorruptionError(f"Invalid {what} length: {n}")
+    try:
+        data = read_exact(stream, n)
+    except OverflowError as exc:
+        raise CorruptionError(f"Invalid {what} length: {n}") from exc
     if len(data) != n:
         raise CorruptionError(f"Unexpected EOF while reading {what}")
     return data
+
+
+def _seek_after_packed(source: BinaryIO, data_offset: int, add_size: int) -> None:
+    """Skip past a packed-data region, translating hostile sizes to CorruptionError."""
+    if data_offset < 0 or add_size < 0:
+        raise CorruptionError(
+            f"Invalid RAR packed-data span: offset={data_offset}, size={add_size}"
+        )
+    if add_size > _MAX_SEEK - data_offset:
+        raise CorruptionError(
+            f"RAR packed size {add_size} at offset {data_offset} exceeds the seekable range"
+        )
+    try:
+        source.seek(data_offset + add_size)
+    except (OverflowError, OSError) as exc:
+        raise CorruptionError(
+            f"RAR packed-data seek failed at offset {data_offset}+{add_size}"
+        ) from exc
 
 
 def _load_vint(buf: bytes | bytearray | memoryview, pos: int) -> tuple[int, int]:
@@ -774,7 +799,7 @@ def _parse_rar3(
             add_size = 0
 
         if block_type == _RAR3_MARK:
-            source.seek(data_offset + add_size)
+            _seek_after_packed(source, data_offset, add_size)
             continue
 
         if block_type == _RAR3_MAIN:
@@ -799,7 +824,7 @@ def _parse_rar3(
                 raise CorruptionError(
                     f"RAR3 MAIN header CRC mismatch: expected {header_crc:#x}, got {calc:#x}"
                 )
-            source.seek(data_offset + add_size)
+            _seek_after_packed(source, data_offset, add_size)
             continue
 
         if block_type == _RAR3_ENDARC:
@@ -862,11 +887,11 @@ def _parse_rar3(
                 else:
                     comment = cmt
 
-            source.seek(data_offset + add_size)
+            _seek_after_packed(source, data_offset, add_size)
             continue
 
         # Unknown / skippable block
-        source.seek(data_offset + add_size)
+        _seek_after_packed(source, data_offset, add_size)
 
     return RarArchive(
         version=4,
@@ -1133,7 +1158,7 @@ def _parse_rar5(
                 )
             is_solid = bool(main_flags & _RAR5_MAIN_SOLID)
             is_volume = bool(main_flags & _RAR5_MAIN_ISVOL)
-            source.seek(data_offset + add_size)
+            _seek_after_packed(source, data_offset, add_size)
             continue
 
         if block_type == _RAR5_ENCRYPTION:
@@ -1162,7 +1187,7 @@ def _parse_rar5(
                 raise EncryptionError(
                     "RAR archive has encrypted headers but no password was provided"
                 )
-            source.seek(data_offset + add_size)
+            _seek_after_packed(source, data_offset, add_size)
             continue
 
         if block_type == _RAR5_ENDARC:
@@ -1204,11 +1229,11 @@ def _parse_rar5(
                 source.seek(data_offset)
                 raw = _require_exact(source, member.file_size, "RAR5 comment")
                 comment = raw.split(b"\0", 1)[0].decode("utf8", "replace")
-            source.seek(data_offset + add_size)
+            _seek_after_packed(source, data_offset, add_size)
             continue
 
         # Unknown block — skip data area.
-        source.seek(data_offset + add_size)
+        _seek_after_packed(source, data_offset, add_size)
 
     return RarArchive(
         version=5,

--- a/src/archivey/internal/backends/rar_parser.py
+++ b/src/archivey/internal/backends/rar_parser.py
@@ -484,14 +484,18 @@ def _parse_dos_time(stamp: int) -> datetime:
 
 def _load_unixtime(
     buf: bytes | bytearray | memoryview, pos: int
-) -> tuple[datetime, int]:
+) -> tuple[datetime | None, int]:
     secs, pos = _load_le32(buf, pos)
-    return datetime.fromtimestamp(secs, timezone.utc), pos
+    try:
+        return datetime.fromtimestamp(secs, timezone.utc), pos
+    except (ValueError, OverflowError, OSError):
+        # Hostile / out-of-range timestamps must not abort listing.
+        return None, pos
 
 
 def _load_windowstime(
     buf: bytes | bytearray | memoryview, pos: int
-) -> tuple[datetime, int]:
+) -> tuple[datetime | None, int]:
     # Windows FILETIME: 100ns since 1601-01-01.
     lo, pos = _load_le32(buf, pos)
     hi, pos = _load_le32(buf, pos)
@@ -499,10 +503,13 @@ def _load_windowstime(
     # unix epoch (1970) in 100ns units from windows epoch (1601)
     unix_ticks = ticks - 116444736000000000
     secs, rem = divmod(unix_ticks, 10_000_000)
-    dt = datetime.fromtimestamp(secs, timezone.utc)
-    if rem:
-        dt = dt.replace(microsecond=rem // 10)
-    return dt, pos
+    try:
+        dt = datetime.fromtimestamp(secs, timezone.utc)
+        if rem:
+            dt = dt.replace(microsecond=min(rem // 10, 999999))
+        return dt, pos
+    except (ValueError, OverflowError, OSError):
+        return None, pos
 
 
 def _normalize_password_utf8(password: str | bytes) -> bytes:
@@ -1472,7 +1479,10 @@ def _parse_rar5_xtime(
     if tflags & _RAR5_XTIME_UNIXTIME_NS:
         if tflags & _RAR5_XTIME_HAS_MTIME and mtime is not None:
             nsec, pos = _load_le32(xdata, pos)
-            mtime = mtime.replace(microsecond=min(nsec // 1000, 999999))
+            try:
+                mtime = mtime.replace(microsecond=min(nsec // 1000, 999999))
+            except ValueError:
+                pass
         if tflags & _RAR5_XTIME_HAS_CTIME:
             _, pos = _load_le32(xdata, pos)
         if tflags & _RAR5_XTIME_HAS_ATIME:

--- a/src/archivey/internal/backends/rar_reader.py
+++ b/src/archivey/internal/backends/rar_reader.py
@@ -387,10 +387,13 @@ class RarReader(BaseArchiveReader):
         mode: int | None = None
         windows_attrs: int | None = None
         if info.mode is not None:
+            # RAR5 stores mode as a vint; mask before S_IMODE so hostile values cannot
+            # raise OverflowError from the C helper.
+            raw_mode = info.mode & 0xFFFFFFFF
             if info.host_os == 3:  # Unix
-                mode = stat.S_IMODE(info.mode)
+                mode = stat.S_IMODE(raw_mode)
             elif info.host_os == 2:  # Win32
-                windows_attrs = info.mode
+                windows_attrs = raw_mode
 
         member = ArchiveMember(
             type=member_type,

--- a/src/archivey/internal/backends/rar_reader.py
+++ b/src/archivey/internal/backends/rar_reader.py
@@ -387,13 +387,14 @@ class RarReader(BaseArchiveReader):
         mode: int | None = None
         windows_attrs: int | None = None
         if info.mode is not None:
-            # RAR5 stores mode as a vint; mask before S_IMODE so hostile values cannot
-            # raise OverflowError from the C helper.
-            raw_mode = info.mode & 0xFFFFFFFF
+            # RAR5 stores attr as a vint (hostile values can exceed C unsigned long).
+            # Unix: ArchiveMember.mode is the low 12 permission bits (S_IMODE);
+            # mask before the C helper so OverflowError cannot abort listing.
+            # Win32: FILE_ATTRIBUTE_* is a 32-bit field.
             if info.host_os == 3:  # Unix
-                mode = stat.S_IMODE(raw_mode)
+                mode = stat.S_IMODE(info.mode & 0o7777)
             elif info.host_os == 2:  # Win32
-                windows_attrs = raw_mode
+                windows_attrs = info.mode & 0xFFFFFFFF
 
         member = ArchiveMember(
             type=member_type,

--- a/tests/atheris_fuzz/__init__.py
+++ b/tests/atheris_fuzz/__init__.py
@@ -10,14 +10,15 @@ from __future__ import annotations
 
 __all__ = ["TARGET_NAMES", "DEFAULT_BUDGETS"]
 
-# Default main-push partition (~120s). Overridable via ARCHIVEY_FUZZ_BUDGET_<NAME>.
+# Default main-push partition (~150s). Overridable via ARCHIVEY_FUZZ_BUDGET_<NAME>.
 DEFAULT_BUDGETS: dict[str, int] = {
-    "sevenzip_header": 55,
-    "sevenzip_open": 25,
-    "detect_format": 15,
-    "zip_tar": 15,
-    "iso": 10,
-    "rar": 0,  # scaffold; skipped until backend registers
+    "sevenzip_header": 45,
+    "sevenzip_open": 20,
+    "detect_format": 12,
+    "zip_tar": 12,
+    "iso": 8,
+    "rar_header": 30,
+    "rar": 15,  # open+list once native RAR is registered
 }
 
 TARGET_NAMES: tuple[str, ...] = tuple(DEFAULT_BUDGETS)

--- a/tests/atheris_fuzz/__main__.py
+++ b/tests/atheris_fuzz/__main__.py
@@ -112,7 +112,7 @@ def main(argv: list[str] | None = None) -> int:
 
         for name in TARGET_NAMES:
             skip = ""
-            if name == "rar" and not rar_available():
+            if name.startswith("rar") and not rar_available():
                 skip = " (skipped: RAR backend not registered)"
             print(f"{name:20s} default={DEFAULT_BUDGETS[name]}s{skip}")
         return 0

--- a/tests/atheris_fuzz/crc_fixup.py
+++ b/tests/atheris_fuzz/crc_fixup.py
@@ -173,6 +173,256 @@ def fixup_zip_local_and_cd_crc(data: bytes, *, broken: bool | None = None) -> by
     return bytes(buf)
 
 
+# ---------------------------------------------------------------------------
+# RAR3 / RAR5 header CRC fixup
+# ---------------------------------------------------------------------------
+
+_RAR3_ID = b"Rar!\x1a\x07\x00"
+_RAR5_ID = b"Rar!\x1a\x07\x01\x00"
+_RAR_SFX_NEEDLE = b"Rar!\x1a\x07"
+_RAR_SFX_MAX = 2 * 1024 * 1024
+
+_RAR3_MARK = 0x72
+_RAR3_MAIN = 0x73
+_RAR3_FILE = 0x74
+_RAR3_SUB = 0x7A
+_RAR3_ENDARC = 0x7B
+_RAR3_LONG_BLOCK = 0x8000
+_RAR3_MAIN_ENCRYPTVER = 0x0200
+_RAR3_MAIN_PASSWORD = 0x0080
+_RAR3_FILE_LARGE = 0x0100
+_RAR3_FILE_SALT = 0x0400
+_RAR3_FILE_EXTTIME = 0x1000
+
+_RAR5_ENDARC = 5
+_RAR5_ENCRYPTION = 4
+_RAR5_FLAG_EXTRA = 0x01
+_RAR5_FLAG_DATA = 0x02
+_RAR5_MAX_HEADER = 2 * 1024 * 1024
+
+_S_RAR3_BLK = struct.Struct("<HBHH")  # crc16, type, flags, header_size
+_S_RAR3_FILE = struct.Struct("<LLBLLBBHL")
+
+
+def _find_rar_magic(data: bytes) -> tuple[int, bool] | None:
+    """Return ``(offset, is_rar5)`` for the first RAR magic within the SFX scan limit."""
+    limit = min(len(data), _RAR_SFX_MAX + len(_RAR5_ID))
+    if data.startswith(_RAR5_ID):
+        return 0, True
+    if data.startswith(_RAR3_ID):
+        return 0, False
+    pos = 0
+    while pos < limit:
+        idx = data.find(_RAR_SFX_NEEDLE, pos, limit)
+        if idx < 0:
+            return None
+        if data[idx : idx + len(_RAR5_ID)] == _RAR5_ID:
+            return idx, True
+        if data[idx : idx + len(_RAR3_ID)] == _RAR3_ID:
+            return idx, False
+        pos = idx + len(_RAR_SFX_NEEDLE)
+    return None
+
+
+def _load_vint_at(buf: bytes | bytearray, pos: int) -> tuple[int, int] | None:
+    limit = min(pos + 11, len(buf))
+    res = ofs = 0
+    while pos < limit:
+        b = buf[pos]
+        res += (b & 0x7F) << ofs
+        pos += 1
+        ofs += 7
+        if b < 0x80:
+            return res, pos
+    return None
+
+
+def _rar3_ext_time_end(hdata: bytes, pos: int) -> int | None:
+    """Advance past a RAR3 extended-time field; ``None`` if truncated."""
+    if pos + 2 > len(hdata):
+        return None
+    flags = struct.unpack_from("<H", hdata, pos)[0]
+    pos += 2
+    for shift in (12, 8, 4, 0):
+        flag = (flags >> shift) & 0xF
+        if not (flag & 8):
+            continue
+        # First field may reuse DOS mtime (basetime present) and only store rem;
+        # later fields include a DOS stamp when basetime is absent. Mirror parser:
+        # mtime slot has basetime; others do not.
+        has_basetime = shift == 12
+        if not has_basetime:
+            if pos + 4 > len(hdata):
+                return None
+            pos += 4
+        cnt = flag & 3
+        if pos + cnt > len(hdata):
+            return None
+        pos += cnt
+    return pos
+
+
+def _rar3_file_crc_pos(hdata: bytes, flags: int, *, is_service: bool) -> int | None:
+    """Mirror ``rar_parser._parse_rar3_file_header`` CRC coverage end, or ``None``."""
+    pos = _S_RAR3_BLK.size
+    if flags & _RAR3_LONG_BLOCK:
+        if pos + 4 > len(hdata):
+            return None
+        pos += 4
+    # FILE re-reads pack_size as first field when LONG_BLOCK was set.
+    file_pos = pos - 4 if (flags & _RAR3_LONG_BLOCK) else pos
+    if file_pos + _S_RAR3_FILE.size > len(hdata):
+        return None
+    fld = _S_RAR3_FILE.unpack_from(hdata, file_pos)
+    pos = file_pos + _S_RAR3_FILE.size
+    name_size = fld[7]
+    if flags & _RAR3_FILE_LARGE:
+        if pos + 8 > len(hdata):
+            return None
+        pos += 8
+    if pos + name_size > len(hdata):
+        return None
+    pos += name_size
+    if flags & _RAR3_FILE_SALT:
+        if pos + 8 > len(hdata):
+            return None
+        pos += 8
+    if flags & _RAR3_FILE_EXTTIME:
+        end = _rar3_ext_time_end(hdata, pos)
+        if end is None:
+            return None
+        pos = end
+    header_size = _S_RAR3_BLK.unpack_from(hdata, 0)[3]
+    return header_size if is_service else pos
+
+
+def _fixup_rar3_headers(buf: bytearray, start: int, *, broken: bool) -> None:
+    pos = start + len(_RAR3_ID)
+    # Cap walks so a hostile chain cannot hang the fixup itself.
+    for _ in range(10_000):
+        if pos + _S_RAR3_BLK.size > len(buf):
+            return
+        _header_crc, block_type, flags, header_size = _S_RAR3_BLK.unpack_from(buf, pos)
+        if header_size < _S_RAR3_BLK.size or pos + header_size > len(buf):
+            return
+        hdata = memoryview(buf)[pos : pos + header_size]
+        add_size = 0
+        field_pos = _S_RAR3_BLK.size
+        if flags & _RAR3_LONG_BLOCK:
+            if field_pos + 4 > header_size:
+                return
+            add_size = struct.unpack_from("<I", hdata, field_pos)[0]
+            field_pos += 4
+
+        crc_pos: int | None
+        if block_type == _RAR3_MAIN:
+            field_pos += 6
+            if flags & _RAR3_MAIN_ENCRYPTVER:
+                field_pos += 1
+            crc_pos = field_pos
+        elif block_type == _RAR3_ENDARC:
+            crc_pos = header_size
+        elif block_type in (_RAR3_FILE, _RAR3_SUB):
+            crc_pos = _rar3_file_crc_pos(
+                bytes(hdata), flags, is_service=(block_type == _RAR3_SUB)
+            )
+        elif block_type == _RAR3_MARK:
+            crc_pos = None  # leave MARK CRC alone
+        else:
+            # Unknown skippable: CRC usually covers [2:header_size].
+            crc_pos = header_size
+
+        if crc_pos is not None and 2 <= crc_pos <= header_size:
+            new_crc = _crc32(bytes(hdata[2:crc_pos])) & 0xFFFF
+            if broken:
+                new_crc ^= 1
+            struct.pack_into("<H", buf, pos, new_crc)
+
+        next_pos = pos + header_size + add_size
+        if next_pos <= pos:
+            return
+        pos = next_pos
+        if block_type == _RAR3_ENDARC:
+            return
+        # Encrypted headers: ciphertext follows; stop rather than mis-patch.
+        if block_type == _RAR3_MAIN and (flags & _RAR3_MAIN_PASSWORD):
+            return
+
+
+def _fixup_rar5_headers(buf: bytearray, start: int, *, broken: bool) -> None:
+    pos = start + len(_RAR5_ID)
+    for _ in range(10_000):
+        if pos + 5 > len(buf):
+            return
+        vint = _load_vint_at(buf, pos + 4)
+        if vint is None:
+            return
+        hdrlen, after_vint = vint
+        if hdrlen > _RAR5_MAX_HEADER:
+            return
+        header_size = (after_vint - pos) + hdrlen
+        if header_size < 5 or pos + header_size > len(buf):
+            return
+
+        new_crc = _crc32(bytes(buf[pos + 4 : pos + header_size]))
+        if broken:
+            new_crc ^= 1
+        struct.pack_into("<I", buf, pos, new_crc)
+
+        # Decode type/flags/add_size to skip packed data and stop at end/encryption.
+        cursor = after_vint
+        block_type_v = _load_vint_at(buf, cursor)
+        if block_type_v is None:
+            return
+        block_type, cursor = block_type_v
+        flags_v = _load_vint_at(buf, cursor)
+        if flags_v is None:
+            return
+        block_flags, cursor = flags_v
+        if block_flags & _RAR5_FLAG_EXTRA:
+            extra_v = _load_vint_at(buf, cursor)
+            if extra_v is None:
+                return
+            _extra, cursor = extra_v
+        add_size = 0
+        if block_flags & _RAR5_FLAG_DATA:
+            add_v = _load_vint_at(buf, cursor)
+            if add_v is None:
+                return
+            add_size, cursor = add_v
+
+        next_pos = pos + header_size + add_size
+        if next_pos <= pos:
+            return
+        pos = next_pos
+        if block_type in (_RAR5_ENDARC, _RAR5_ENCRYPTION):
+            return
+
+
+def fixup_rar_header_crcs(data: bytes, *, broken: bool | None = None) -> bytes:
+    """Recompute RAR3/RAR5 block header CRCs (or leave them broken).
+
+    RAR5: CRC32 over the header bytes after the CRC field (exact).
+    RAR3: CRC16 over ``hdata[2:crc_pos]`` using the same ``crc_pos`` rules as
+    ``rar_parser`` (MAIN fields / FILE field walk / full ENDARC). Encrypted-header
+    archives stop before the ciphertext so we do not invent plaintext CRCs.
+    """
+    located = _find_rar_magic(data)
+    if located is None:
+        return data
+
+    if broken is None:
+        broken = should_break_crc(data)
+
+    start, is_rar5 = located
+    buf = bytearray(data)
+    if is_rar5:
+        _fixup_rar5_headers(buf, start, broken=broken)
+    else:
+        _fixup_rar3_headers(buf, start, broken=broken)
+    return bytes(buf)
+
+
 FixupFn = Callable[[bytes], bytes]
 
 

--- a/tests/atheris_fuzz/seeds.py
+++ b/tests/atheris_fuzz/seeds.py
@@ -89,10 +89,39 @@ def iso_seeds() -> list[bytes]:
         return tiny + _corpus_seeds("iso", Path(tmp)) + _adversarial_seeds(".iso")
 
 
+def rar_seeds() -> list[bytes]:
+    """Tiny magics + on-disk RAR fixtures (RAR3/RAR5, solid, links, volumes, …)."""
+    from archivey.internal.backends.rar_parser import RAR5_ID, RAR_ID
+
+    tiny = [
+        b"",
+        RAR_ID,
+        RAR5_ID,
+        b"not rar",
+        RAR_ID + b"\x00" * 32,
+        RAR5_ID + b"\xff" * 64,
+        # SFX-shaped: garbage prefix then magic (parser scans up to SFX_MAX).
+        b"MZ" + b"\x00" * 64 + RAR5_ID + b"\x00" * 16,
+    ]
+    fixture_dir = _REPO_ROOT / "tests" / "fixtures" / "rar"
+    fixtures: list[bytes] = []
+    if fixture_dir.is_dir():
+        for path in sorted(fixture_dir.glob("*.rar")):
+            # Skip volume continuation alone — needs part1 as first volume.
+            if path.name.endswith(".part2.rar") or ".part2." in path.name:
+                continue
+            # Header-encrypted archives need a password; still useful as reject-path seeds.
+            try:
+                fixtures.append(path.read_bytes())
+            except OSError:
+                continue
+    return tiny + fixtures + _adversarial_seeds(".rar")
+
+
 def detect_format_seeds() -> list[bytes]:
     """Mixed prefixes for ``detect_format`` — prefer short heads of real archives."""
     seeds: list[bytes] = [b"", b"\x00" * 16, b"PK", b"7z", b"Rar!", b"ustar"]
-    for builder in (sevenzip_seeds, zip_seeds, tar_seeds, iso_seeds):
+    for builder in (sevenzip_seeds, zip_seeds, tar_seeds, iso_seeds, rar_seeds):
         try:
             for blob in builder():
                 seeds.append(blob[: min(len(blob), 512)])
@@ -109,11 +138,6 @@ def detect_format_seeds() -> list[bytes]:
         seen.add(s)
         out.append(s)
     return out
-
-
-def rar_seeds() -> list[bytes]:
-    # No native RAR backend yet; keep tiny magic-shaped seeds for when it registers.
-    return [b"", b"Rar!\x1a\x07\x00", b"Rar!\x1a\x07\x01\x00", b"not rar"]
 
 
 def write_seed_corpus(directory: Path, seeds: list[bytes]) -> int:

--- a/tests/atheris_fuzz/targets.py
+++ b/tests/atheris_fuzz/targets.py
@@ -16,6 +16,7 @@ from archivey import (
     format_availability,
     open_archive,
 )
+from archivey.internal.backends.rar_parser import parse_rar_archive
 from archivey.internal.backends.sevenzip_parser import (
     SevenZipFolder,
     parse_sevenzip_archive,
@@ -24,6 +25,7 @@ from archivey.internal.backends.sevenzip_reader import decode_folder_to_bytes
 from archivey.internal.registry import FormatSupport
 from archivey.internal.streams.crypto import SevenZipKeyCache
 from tests.atheris_fuzz.crc_fixup import (
+    fixup_rar_header_crcs,
     fixup_sevenzip_header_crcs,
     fixup_zip_local_and_cd_crc,
 )
@@ -138,8 +140,14 @@ def rar_available() -> bool:
     return availability.support is not FormatSupport.NONE
 
 
+def rar_header_one(data: bytes) -> None:
+    try:
+        parse_rar_archive(io.BytesIO(data))
+    except ArchiveyError:
+        return
+
+
 def rar_open_one(data: bytes) -> None:
-    # When enabled: apply RAR header CRC fixup here (same mutate-then-fixup pattern as 7z).
     try:
         with open_archive(
             io.BytesIO(data), format=ArchiveFormat.RAR, config=_FUZZ_CONFIG
@@ -202,10 +210,18 @@ def iter_target_specs() -> list[dict]:
             "per_input_timeout": iso_per_input_timeout(),
         },
         {
+            "name": "rar_header",
+            "fn": rar_header_one,
+            "seeds": rar_seeds,
+            "fixup": fixup_rar_header_crcs,
+            "per_input_timeout": None,
+            "skip_unless": rar_available,
+        },
+        {
             "name": "rar",
             "fn": rar_open_one,
             "seeds": rar_seeds,
-            "fixup": None,  # plan CRC/header fixup when enabling
+            "fixup": fixup_rar_header_crcs,
             "per_input_timeout": None,
             "skip_unless": rar_available,
         },

--- a/tests/test_atheris_crc_fixup.py
+++ b/tests/test_atheris_crc_fixup.py
@@ -132,3 +132,90 @@ def test_fixup_zip_stored_member_crc(tmp_path: Path) -> None:
     assert (
         broken[cd_offset + 16 : cd_offset + 20] != data[cd_offset + 16 : cd_offset + 20]
     )
+
+
+@pytest.fixture(scope="module")
+def basic_rar5() -> bytes:
+    return (
+        Path(__file__).parent / "fixtures" / "rar" / "basic_nonsolid__.rar"
+    ).read_bytes()
+
+
+@pytest.fixture(scope="module")
+def basic_rar4() -> bytes:
+    return (
+        Path(__file__).parent / "fixtures" / "rar" / "basic_nonsolid__rar4.rar"
+    ).read_bytes()
+
+
+@pytest.fixture(scope="module")
+def comment_rar4() -> bytes:
+    return (
+        Path(__file__).parent / "fixtures" / "rar" / "rar15-comment.rar"
+    ).read_bytes()
+
+
+def test_fixup_rar5_restores_crcs_after_bitflip(basic_rar5: bytes) -> None:
+    from archivey.internal.backends.rar_parser import parse_rar_archive
+    from tests.atheris_fuzz.crc_fixup import fixup_rar_header_crcs
+
+    flipped = bytearray(basic_rar5)
+    flipped[24] ^= 0x01
+    broken = bytes(flipped)
+    with pytest.raises(CorruptionError, match="RAR5 header CRC"):
+        parse_rar_archive(io.BytesIO(broken))
+
+    fixed = fixup_rar_header_crcs(broken, broken=False)
+    arc = parse_rar_archive(io.BytesIO(fixed))
+    assert arc.version == 5
+    assert len(arc.members) >= 1
+
+
+def test_fixup_rar5_broken_mode_still_rejects(basic_rar5: bytes) -> None:
+    from archivey.internal.backends.rar_parser import parse_rar_archive
+    from tests.atheris_fuzz.crc_fixup import fixup_rar_header_crcs
+
+    fixed_broken = fixup_rar_header_crcs(basic_rar5, broken=True)
+    with pytest.raises(CorruptionError, match="RAR5 header CRC"):
+        parse_rar_archive(io.BytesIO(fixed_broken))
+
+
+def test_fixup_rar3_restores_crcs_after_bitflip(basic_rar4: bytes) -> None:
+    from archivey.internal.backends.rar_parser import parse_rar_archive
+    from tests.atheris_fuzz.crc_fixup import fixup_rar_header_crcs
+
+    # Corrupt the MAIN block CRC16 (first two bytes after the 7-byte RAR3 magic).
+    flipped = bytearray(basic_rar4)
+    flipped[7] ^= 0xFF
+    broken = bytes(flipped)
+    with pytest.raises(CorruptionError, match="RAR3 .*CRC"):
+        parse_rar_archive(io.BytesIO(broken))
+
+    fixed = fixup_rar_header_crcs(broken, broken=False)
+    arc = parse_rar_archive(io.BytesIO(fixed))
+    assert arc.version == 4
+    assert len(arc.members) >= 1
+
+
+def test_fixup_rar3_comment_archive_crc_pos(comment_rar4: bytes) -> None:
+    """Comment subblocks: CRC must not cover the full header_size."""
+    from archivey.internal.backends.rar_parser import parse_rar_archive
+    from tests.atheris_fuzz.crc_fixup import fixup_rar_header_crcs
+
+    assert fixup_rar_header_crcs(comment_rar4, broken=False) == comment_rar4
+    flipped = bytearray(comment_rar4)
+    flipped[30] ^= 0x01
+    fixed = fixup_rar_header_crcs(bytes(flipped), broken=False)
+    try:
+        parse_rar_archive(io.BytesIO(fixed))
+    except CorruptionError as exc:
+        assert "CRC" not in str(exc)
+    except ArchiveyError:
+        pass
+
+
+def test_fixup_rar_noop_on_non_magic() -> None:
+    from tests.atheris_fuzz.crc_fixup import fixup_rar_header_crcs
+
+    blob = b"not a rar archive" + b"\x00" * 64
+    assert fixup_rar_header_crcs(blob, broken=False) == blob

--- a/tests/test_rar_reader.py
+++ b/tests/test_rar_reader.py
@@ -311,6 +311,46 @@ def test_rar5_out_of_range_windowstime_is_tolerated() -> None:
     assert pos == 8
 
 
+def test_rar_reader_masks_hostile_unix_mode() -> None:
+    """Atheris: huge RAR5 mode vint must not OverflowError in ``stat.S_IMODE``."""
+    from archivey.internal.backends.rar_parser import RarMemberInfo
+    from archivey.internal.backends.rar_reader import RarReader
+
+    info = RarMemberInfo(
+        filename="a.txt",
+        orig_filename=b"a.txt",
+        file_size=0,
+        compress_size=0,
+        compress_type=0x30,
+        crc32=None,
+        blake2sp_hash=None,
+        mtime=None,
+        mode=(1 << 80) | 0o100644,
+        host_os=3,
+        flags=0,
+        file_redir=None,
+        file_encryption=None,
+        header_offset=0,
+        header_size=0,
+        data_offset=0,
+        extract_version=50,
+        file_solid=False,
+        is_directory=False,
+        is_symlink=False,
+        is_hardlink_or_copy=False,
+        is_encrypted=False,
+        volume_index=0,
+        split_before=False,
+        split_after=False,
+    )
+    # Build a reader without opening a real archive — call the mapper directly.
+    reader = object.__new__(RarReader)
+    reader._diagnostics_collector = None
+    reader._archive_name = "<test>"
+    member = RarReader._to_member(reader, info)
+    assert member.mode == 0o0644
+
+
 def test_non_rarlab_unrar_rejected(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/test_rar_reader.py
+++ b/tests/test_rar_reader.py
@@ -17,7 +17,7 @@ from archivey.exceptions import (
     TruncatedError,
 )
 from archivey.internal.backends import rar_unrar
-from archivey.internal.backends.rar_parser import RAR_ID, parse_rar_archive
+from archivey.internal.backends.rar_parser import RAR5_ID, RAR_ID, parse_rar_archive
 from archivey.types import MemberType
 from tests.conftest import requires, requires_binary
 
@@ -271,6 +271,33 @@ def test_extract_version_20_payload_accepted() -> None:
     assert member.extract_version == 20
     assert member.file_size == 2
     assert member.compress_size == 2
+
+
+def test_rar5_hostile_packed_size_is_corruption() -> None:
+    """Atheris: huge RAR5 vint add_size must not raise raw OverflowError on seek."""
+    import zlib
+
+    def vint(n: int) -> bytes:
+        out = bytearray()
+        while True:
+            b = n & 0x7F
+            n >>= 7
+            if n:
+                out.append(b | 0x80)
+            else:
+                out.append(b)
+                return bytes(out)
+
+    def block(body: bytes) -> bytes:
+        header_wo_crc = vint(len(body)) + body
+        crc = zlib.crc32(header_wo_crc) & 0xFFFFFFFF
+        return struct.pack("<I", crc) + header_wo_crc
+
+    main = block(vint(1) + vint(0) + vint(0))  # MAIN, no flags, main_flags=0
+    hostile = block(vint(99) + vint(0x02) + vint(1 << 70))  # unknown + DATA + huge
+    blob = RAR5_ID + main + hostile
+    with pytest.raises(CorruptionError, match="seekable range|packed size"):
+        parse_rar_archive(io.BytesIO(blob))
 
 
 def test_non_rarlab_unrar_rejected(

--- a/tests/test_rar_reader.py
+++ b/tests/test_rar_reader.py
@@ -357,6 +357,7 @@ def test_rar_reader_masks_hostile_unix_mode() -> None:
     assert member_win.mode is None
     assert member_win.windows_attrs == 0x20
 
+
 def test_non_rarlab_unrar_rejected(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/test_rar_reader.py
+++ b/tests/test_rar_reader.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 import io
 import struct
 import zlib
@@ -350,6 +351,11 @@ def test_rar_reader_masks_hostile_unix_mode() -> None:
     member = RarReader._to_member(reader, info)
     assert member.mode == 0o0644
 
+    # Win32 attrs are masked to 32 bits (FILE_ATTRIBUTE_* width).
+    info_win = dataclasses.replace(info, host_os=2, mode=(1 << 40) | 0x20)
+    member_win = RarReader._to_member(reader, info_win)
+    assert member_win.mode is None
+    assert member_win.windows_attrs == 0x20
 
 def test_non_rarlab_unrar_rejected(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path

--- a/tests/test_rar_reader.py
+++ b/tests/test_rar_reader.py
@@ -300,6 +300,17 @@ def test_rar5_hostile_packed_size_is_corruption() -> None:
         parse_rar_archive(io.BytesIO(blob))
 
 
+def test_rar5_out_of_range_windowstime_is_tolerated() -> None:
+    """Atheris: hostile FILETIME must not raise raw ValueError from fromtimestamp."""
+    from archivey.internal.backends.rar_parser import _load_windowstime
+
+    # FILETIME ticks far beyond datetime's year range.
+    buf = struct.pack("<II", 0xFFFFFFFF, 0x7FFFFFFF)
+    dt, pos = _load_windowstime(buf, 0)
+    assert dt is None
+    assert pos == 8
+
+
 def test_non_rarlab_unrar_rejected(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Enable the Atheris RAR scaffold now that the native RAR reader is on `main`, and fix three fuzz finds from the first soaks.

### Harness
- **`rar_header`** — `parse_rar_archive` with RAR3/RAR5 CRC mutate-then-fixup
- **`rar`** — `open_archive` + member list with the same fixup
- Seeds from `tests/fixtures/rar/` (+ tiny magics / SFX-shaped prefix)
- CI budgets: `rar_header=30s`, `rar=15s` (partition ~150s); docs/spec/CONTRIBUTING updated

### Fuzz finds fixed
1. **OverflowError** on `seek` — hostile RAR5 vint `add_size` → `_seek_after_packed` → `CorruptionError`
2. **ValueError** — out-of-range Windows FILETIME / unix timestamps → `mtime=None`
3. **OverflowError** in `stat.S_IMODE` — huge RAR5 mode vint → mask to 32 bits before `S_IMODE`

### Local soak (post-fix)
- `rar_header`: ~120s / ~1M execs — green
- `rar` open+list: ~90s / ~270k execs — green

## Test plan
- [x] CRC fixup unit tests (RAR3/RAR5/comment)
- [x] Regression tests for all three finds
- [x] Extended local Atheris soaks on both RAR targets
- [ ] CI Atheris job after merge to main
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-302b2d61-4f70-4938-af1f-ba0e933342d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-302b2d61-4f70-4938-af1f-ba0e933342d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

