### PR TITLE
Propose: expose RAR `-ver` file-version members

### DIFF
--- a/openspec/changes/rar-file-version-members/.openspec.yaml
+++ b/openspec/changes/rar-file-version-members/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: library
+created: 2026-07-12

--- a/openspec/changes/rar-file-version-members/design.md
+++ b/openspec/changes/rar-file-version-members/design.md
@@ -1,0 +1,112 @@
+## Context
+
+Native RAR listing currently skips RAR3 `FILE_VERSION` and RAR5 extra `0x04`
+rows (same as `rarfile`). Those rows are real FILE payloads WinRAR keeps under
+`-ver`. `safe-extraction` already skips `is_current=False` on extract; 7z already
+uses that flag for last-entry-wins. Main `format-rar` does not yet normatively
+require omit or expose — behavior is implementation-only.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Expose RAR file-version history in the member list as first-class
+  `ArchiveMember`s.
+- Keep default extract safe/quiet via `is_current=False` (no new extract flag).
+- Make `open`/`read` of a history row return that revision’s bytes.
+- Align presented names with `unrar`/`WinRAR` (`path;n`) so tooling and mental
+  models match.
+
+**Non-Goals:**
+- Extract-all opt-in to write every revision to disk (callers use `open`/`read`).
+- Changing TAR duplicate `is_current` semantics in this change.
+- Native decompression of versioned members (still `unrar` when not direct-readable).
+- Surfacing version history through a separate API type or config gate.
+
+## Investigations
+
+### Format / `unrar` behavior (RAR 6.24 write + UNRAR 7.00)
+
+Built a three-revision `-ver` RAR5 archive (`file.txt` ← v1, v2, v3):
+
+| Probe | Result |
+| --- | --- |
+| `unrar lt` | Lists `file.txt;1`, `file.txt;2`, `file.txt` with `File version: N` on history |
+| Header name in extra | Path stays `file.txt`; version vint in FHEXTRA_VERSION; `unrar` appends `;n` when `n!=0` |
+| `unrar p -inul archive` (no member) | Prints **only** current (`v3`) |
+| `unrar p -inul -ver archive` | Prints **all** revisions in archive order (`v1`, `v2`, `v3`) |
+| `unrar p -inul archive 'file.txt;1'` | Prints `v1` (exact name; no `-ver` needed) |
+| `unrar p -inul archive file.txt` | Prints current `v3` |
+
+`cmddata.cpp`: `-ver` → `VersionControl=1`; `-verN` → `N+1`. `extract.cpp`: when
+`VersionControl==0`, versioned heads are skipped unless the requested name equals
+the versioned name (`EqualNames`).
+
+### Archivey solid demux implication
+
+Solid `_iter_with_data` uses bare `unrar p` (ALL pipe, no member). Without `-ver`,
+history payloads are absent from the pipe — demux would desync if history rows
+were treated as payload files. Named per-member `unrar p … path;n` works for
+random `open`/`read`.
+
+### Oracle
+
+`rarfile` still skips versioned entries (`pass  # skip old versions`). List
+equality vs rarfile MUST carve out `-ver` archives (or compare only current
+paths).
+
+## Decisions
+
+### 1. Expose history rows; mark non-current
+Include RAR3/RAR5 file-version FILE blocks in the member table with
+`is_current=False`. Live revision (no version extra / version 0) keeps the plain
+path and `is_current=True`.
+**Rejected:** Keep omitting (hides recoverable bytes). **Rejected:** Same plain
+path + `is_current=False` only (ambiguous for `get`/`unrar` naming).
+
+### 2. Presented name is `path;n` (WinRAR / `unrar` shape)
+Parser stores archive path + version; reader presents `f"{path};{n}"` when
+`n != 0`, and sets `extra["rar.file_version"] = n`. `raw_name` reflects the
+archive-stored path bytes (without forcing `;n` into raw header bytes).
+**Rejected:** Keep plain path and put version only in `extra` (breaks
+`unrar p` exact-name and user expectations from `unrar lt`).
+
+### 3. Data path: exact member name; `-ver` only for solid ALL demux
+- Random `open`/`read`: pass presented `path;n` into `unrar p … <member>` (no
+  `-ver`). Direct M0 nonsolid reads remain allowed when `_can_direct_read`.
+- Solid ALL-pipe demux: if the member list contains any versioned payload
+  FILE, spawn `unrar p -ver` so the pipe includes history bytes in order;
+  otherwise keep today’s bare `unrar p`.
+**Rejected:** Always pass `-ver` (changes ALL-pipe size map for archives
+without versions only cosmetically, but prefer minimal flag use).
+**Rejected:** Drop history from solid streams and only allow named open
+(inconsistent with “expose in iteration”).
+
+### 4. Default extract stays skip-via-`is_current`
+Rely on existing `safe-extraction` non-current skip. No new
+`include_file_versions=` extract knob in this change.
+**Rejected:** Config gate that hides history from `members()` (conflicts with
+“expose features as data”; extract already hides writes).
+
+### 5. Listing limits and parser ceilings count history rows
+Versioned FILE blocks consume `ListingLimits` / RAR parser member ceilings like
+any other member.
+**Rejected:** Exclude history from caps (would under-count hostile `-ver`
+bombs).
+
+### 6. Oracle / fixtures
+Add a small RAR5 `-ver` fixture via `scripts/gen_rar_fixtures.py`. Prefer RAR5;
+add RAR4/`FILE_VERSION` only if generation stays cheap. Document rarfile list
+mismatch on versioned archives in testing-contract.
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+| --- | --- |
+| **BREAKING** list length / names vs prior omit + rarfile | Document in proposal; carve oracle tests; names match `unrar lt` |
+| Solid demux forgets `-ver` | Gate ALL-pipe on “any versioned payload”; regression test |
+| Path that literally ends with `;n` | Rare; WinRAR already warns. Exact-name still works; document collision |
+| `get("file.txt")` ambiguity | Returns live member only (plain name); history is `file.txt;n` |
+
+## Open Questions
+
+None — `-ver` / exact-name behavior verified against UNRAR 7.00 for this design.

--- a/openspec/changes/rar-file-version-members/proposal.md
+++ b/openspec/changes/rar-file-version-members/proposal.md
@@ -1,0 +1,45 @@
+## Why
+
+WinRAR `-ver` archives store prior revisions of a path as real FILE payloads
+(RAR5 extra `0x04` / RAR3 `FILE_VERSION`). Archivey currently drops those rows
+(matching `rarfile`), which hides recoverable content. Philosophy prefers
+exposing format features as data; default extract already skips
+`is_current=False`, so history can be visible without changing safe defaults.
+
+## What Changes
+
+- **BREAKING (listing):** RAR file-version history rows appear in `members()` /
+  iteration instead of being omitted.
+- Present history as members with `is_current=False` and WinRAR/`unrar`-shaped
+  names (`path;n`); the live revision keeps the plain path and `is_current=True`.
+- `open` / `read` of a history member SHALL return that revision’s bytes via
+  `unrar p` (exact `path;n` member name; optional `-ver` only if needed for
+  bulk paths).
+- Default `extract` / `extract_all` SHALL skip history rows via the existing
+  non-current skip (no new extract flag in this change).
+- Fixture + tests for RAR5 `-ver` (and RAR3 if cheap); oracle comparisons that
+  assume rarfile’s omit behavior get explicit carve-outs.
+
+## Capabilities
+
+### New Capabilities
+
+<!-- none -->
+
+### Modified Capabilities
+
+- `format-rar`: expose file-version members; wire data reads to `unrar`
+- `archive-data-model`: clarify RAR version history vs 7z last-entry-wins
+  `is_current` (same flag, different provenance)
+- `testing-contract`: rarfile oracle exceptions for versioned members
+
+## Impact
+
+- Parser/reader: `rar_parser.py`, `rar_reader.py` / `rar_unrar.py`
+- Public surface: more `ArchiveMember` rows on `-ver` archives; extract
+  defaults unchanged for live paths
+- Specs: reverse today’s omit-in-code behavior into an expose+non-current
+  contract (main `format-rar` has no omit requirement yet; implementation
+  still skips)
+- Tests: new `-ver` fixtures under `tests/fixtures/rar/`; adjust any
+  list-equality vs rarfile

--- a/openspec/changes/rar-file-version-members/specs/archive-data-model/spec.md
+++ b/openspec/changes/rar-file-version-members/specs/archive-data-model/spec.md
@@ -1,0 +1,88 @@
+## MODIFIED Requirements
+
+### Requirement: ArchiveMember exposes the complete mutable member record
+
+The system SHALL define `ArchiveMember` as a mutable, unhashable dataclass that
+callers treat as read-only:
+
+```python
+@dataclass
+class ArchiveMember:
+    type: MemberType
+    name: str
+    raw_name: bytes | None
+    size: int | None
+    compressed_size: int | None
+    modified: datetime | None
+    accessed: datetime | None
+    created: datetime | None
+    mode: int | None
+    uid: int | None
+    gid: int | None
+    uname: str | None
+    gname: str | None
+    link_target: str | None
+    link_target_member: "ArchiveMember | None"
+    compression: tuple[CompressionMethod, ...] = ()
+    is_encrypted: bool = False
+    is_current: bool = True
+    is_sparse: bool = False
+    comment: str | None = None
+    create_system: "CreateSystem | None" = None
+    windows_attrs: int | None = None
+    hashes: Mapping[str, int | bytes] = field(default_factory=dict, compare=False)
+    diagnostics: tuple[Diagnostic, ...] = field(default=(), compare=False)
+    extra: dict[str, Any] = field(default_factory=dict, compare=False)
+
+    @property
+    def member_id(self) -> int: ...
+    @property
+    def archive_id(self) -> str: ...
+    @property
+    def is_file(self) -> bool: ...
+    @property
+    def is_dir(self) -> bool: ...
+    @property
+    def is_link(self) -> bool: ...
+    @property
+    def is_other(self) -> bool: ...
+    @property
+    def is_anti(self) -> bool: ...
+    @property
+    def is_junction(self) -> bool: ...
+
+    def modified_utc(self, tz_for_naive: tzinfo | None = None) -> datetime | None: ...
+    def replace(self, **kwargs: Any) -> "ArchiveMember": ...
+```
+
+`is_anti` SHALL be derived (`type == MemberType.ANTI`); there is no `is_anti` field.
+`is_current` SHALL mean “live for default extract / path identity”: 7z computes
+last-entry-wins (including anti supersession); RAR file-version history rows
+(`format-rar`) SHALL set `is_current=False` while the live revision stays
+`True`; other formats MAY default `True`. Unavailable values SHALL be `None`;
+`name` follows normalization while `raw_name` preserves stored bytes; timestamp
+timezone semantics are preserved; digest keys name their real algorithms; there
+is no `crc32` alias. Sizes, link targets, hashes, and diagnostics MAY be
+completed in place during streaming. `member_id` / `archive_id` preserve source
+identity, convenience properties are derived, and `replace()` creates an edited
+copy. `hashes`, `diagnostics`, and `extra` SHALL be excluded from equality.
+
+`ArchiveMember` SHALL remain unhashable and non-frozen. The `diagnostics` tuple
+itself is immutable, but the library MAY replace it in place for later
+member-specific events; previously returned members are live objects, not
+point-in-time snapshots.
+
+#### Scenario: member record matrix
+
+| Case | Expected |
+| --- | --- |
+| Format cannot provide a field | Field is `None`, not a default |
+| Streaming later learns `size` / `link_target` | Same yielded object is updated in place |
+| Caller needs a renamed member | Uses `member.replace(name=...)`; original unchanged |
+| `ArchiveMember` used as set item/dict key | Fails because the type is unhashable |
+| Naive and aware `modified` values pass through `modified_utc()` | Returned values are aware UTC; original `modified` fields unchanged |
+| ZIP CRC32 and RAR5 Blake2sp hashes | Stored under `"crc32"` int and `"blake2sp"` bytes keys respectively |
+| Extraction report holds a member later completed in place | Report's result tuple is immutable; member object reflects late field update |
+| `type == MemberType.ANTI` | `is_anti` true; `is_file` false |
+| Content superseded by later same-name / anti (7z) | Earlier member `is_current` false |
+| RAR `-ver` history row `path;n` | `is_current` false; live `path` remains true |

--- a/openspec/changes/rar-file-version-members/specs/format-rar/spec.md
+++ b/openspec/changes/rar-file-version-members/specs/format-rar/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: Expose RAR file-version history members
+
+The system SHALL include RAR file-version history FILE blocks in the member list
+instead of omitting them. RAR5 extra type `0x04` (and RAR3 `FILE_VERSION` when
+present) identifies a prior revision. History members SHALL use the WinRAR /
+`unrar` presented name `path;n` (version `n != 0`), set
+`extra["rar.file_version"] = n`, and set `is_current=False`. The live revision of
+the same archive path (no version extra, or version 0) SHALL keep the plain path
+name and `is_current=True`.
+
+`open` / `read` of a history `FILE` SHALL return that revision’s bytes. For
+`unrar`-backed reads the backend SHALL request the exact presented member name
+(`path;n`). Solid ALL-pipe demux SHALL pass `unrar`’s `-ver` switch when the
+member list contains any versioned payload FILE so the pipe includes history
+bytes in archive order; otherwise solid demux MAY omit `-ver`.
+
+Default `extract` / `extract_all` SHALL skip history rows through the existing
+`is_current=False` coordinator behavior (`safe-extraction`). History rows SHALL
+count toward listing / parser member ceilings like any other FILE.
+
+#### Scenario: file-version matrix
+
+| Case | Expected |
+| --- | --- |
+| RAR5 `-ver` archive with revisions 1..k then live path | Members include `path;1`…`path;k` (`is_current=False`) and `path` (`is_current=True`) |
+| `read("path;1")` / `open` that member | Bytes of revision 1 |
+| `read("path")` | Bytes of the live revision |
+| `extract_all` default | Writes live `path` only; history rows `SKIPPED` |
+| Solid archive that includes versioned payload FILEs | ALL-pipe demux uses `-ver`; stream order stays aligned |
+| Nonsolid named `unrar p` of `path;n` | Exact member name; `-ver` not required |
+| Hostile archive with many version rows | Rows count toward member caps |

--- a/openspec/changes/rar-file-version-members/specs/testing-contract/spec.md
+++ b/openspec/changes/rar-file-version-members/specs/testing-contract/spec.md
@@ -1,0 +1,37 @@
+## MODIFIED Requirements
+
+### Requirement: Cross-validate native readers against reference oracles
+
+The system SHALL validate native 7z and RAR readers against reference
+implementations used only as test oracles: `py7zr` and the `7z` CLI for 7z,
+`rarfile` and `unrar` for RAR. For representative corpora, native member metadata
+and decompressed bytes MUST match the oracle. Oracle libraries are dev-group
+dependencies only and SHALL NOT be required at runtime. Oracle-backed tests SHALL
+skip, not fail, when the oracle library or CLI is unavailable.
+
+The 7z corpus MUST cover core codecs supported without extras (LZMA1, LZMA2, simple
+BCJ filters, Delta, BZip2, Deflate, STORED), optional PPMd / Deflate64 under `[7z]`,
+and AES-encrypted archives under `[crypto]`. Unsupported codecs such as BCJ2 and
+unrecognized method IDs MUST raise the documented unsupported-codec error rather
+than returning bytes that diverge from the oracle.
+
+The RAR corpus MUST cover RAR4 and RAR5, solid and nonsolid, stored M0, symlinks,
+hardlinks/`FILE_COPY`, multi-volume sets, header-encrypted RAR5 (under `[rar]`/
+`[crypto]`), Blake2sp-only members, and at least one RAR5 `-ver` file-version
+archive. After the native RAR reader registers, RAR corpus entries MUST run (not
+skip solely for “reader not implemented”).
+
+`rarfile` omits file-version history rows. Dedicated `-ver` tests SHALL assert
+native listing/read/`unrar` behavior directly and MUST NOT require rarfile list
+equality for those history members. Non-versioned RAR corpus entries continue to
+cross-check metadata and bytes against rarfile/`unrar`.
+
+#### Scenario: native-reader oracle matrix
+
+| Case | Expected |
+| --- | --- |
+| 7z corpus entry read by native reader and `py7zr`/`7z` | Metadata and bytes match; skipped if oracle unavailable |
+| RAR corpus entry read by native reader and `rarfile`/`unrar` | Metadata and bytes match; skipped if oracle unavailable |
+| 7z entry uses BCJ2 or unknown method ID | Documented unsupported-codec error; no guessed output |
+| RAR solid+links / multi-volume / header-encrypted entry | Exercised once native RAR is registered; skip only if `unrar`/crypto/oracle absent |
+| RAR5 `-ver` history members | Native exposes `path;n` + live path; bytes match `unrar p` exact name / `-ver`; rarfile list equality not required for history rows |

--- a/openspec/changes/rar-file-version-members/tasks.md
+++ b/openspec/changes/rar-file-version-members/tasks.md
@@ -1,0 +1,22 @@
+## 1. Parser: retain file-version rows
+
+- [ ] 1.1 Stop dropping RAR5 `0x04` / RAR3 `FILE_VERSION` FILE blocks in `rar_parser`; record version vint on `RarMemberInfo`
+- [ ] 1.2 Keep split-merge / service-comment behavior unchanged for versioned and non-versioned rows
+
+## 2. Reader: present names, flags, and `unrar` wiring
+
+- [ ] 2.1 Map versioned rows to `ArchiveMember` with presented name `path;n`, `is_current=False`, `extra["rar.file_version"]=n`; live path stays plain + current
+- [ ] 2.2 Pass presented `path;n` into named `unrar p` for non-direct `open`/`read`
+- [ ] 2.3 Extend `open_unrar_p` (or caller) to pass `-ver` for solid ALL-pipe demux when any versioned payload FILE is present
+- [ ] 2.4 Ensure direct M0 nonsolid reads still work for versioned rows when `_can_direct_read`
+
+## 3. Fixtures and tests
+
+- [ ] 3.1 Add RAR5 `-ver` fixture generation in `scripts/gen_rar_fixtures.py` and commit binaries under `tests/fixtures/rar/`
+- [ ] 3.2 Tests: list shape (`path;n` + live), `read` bytes per revision, default `extract_all` skips history, solid demux with `-ver` stays aligned
+- [ ] 3.3 Carve rarfile list-equality / oracle paths so `-ver` history rows are not required to match rarfile’s omit behavior
+
+## 4. Verify
+
+- [ ] 4.1 Targeted pytest for the new fixture + solid/`unrar` cases (`requires_binary("unrar")` where needed)
+- [ ] 4.2 `openspec validate --strict rar-file-version-members`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

OpenSpec proposal to expose WinRAR `-ver` file-version history in the RAR reader (currently omitted like `rarfile`), while keeping default extract quiet via `is_current=False`.

### `unrar p` findings (locked in design)

| Invocation | Behavior |
| --- | --- |
| `unrar p archive` | Current revision only |
| `unrar p -ver archive` | All revisions in archive order |
| `unrar p archive 'file.txt;1'` | Exact history revision (no `-ver` needed) |

### Proposed contract

- List history as `path;n` with `is_current=False` + `extra["rar.file_version"]`
- Live path stays plain + `is_current=True`
- Named reads use exact `path;n`; solid ALL-pipe demux adds `-ver` when versioned payloads exist
- Default extract skips history via existing non-current coordinator behavior
- Carve rarfile list equality for `-ver` archives

Change: `openspec/changes/rar-file-version-members/` (proposal, design, specs, tasks). Validated with `openspec validate --strict`.

Ready for `/opsx:apply` after review.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c5ffa5b4-51aa-4418-af87-91b9c53613ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c5ffa5b4-51aa-4418-af87-91b9c53613ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

