### PR TITLE
Add UU/Base64 transport encodings to IDEAS backlog

### DIFF
--- a/IDEAS.md
+++ b/IDEAS.md
@@ -57,6 +57,20 @@
   into archivey or send a fix upstream so `.Z` works on non-seekable streams like the other
   single-file compressors.
 
+- **UU / Base64 transport encodings as single-file wrappers** — classic `uuencode`
+  (`.uu` / `.uue`, including `begin-base64`) shows up in old mail/Usenet drops and some
+  vendor corpora; libarchive treats it as a filter and stores many of its own test
+  fixtures uu-encoded (authoring hygiene, not end-user demand). Fits the existing
+  one-member `SingleFileBackend` shape: peel one wrapper, yield opaque payload bytes
+  (same pattern as `.iso.xz` — no general filter stacking). Decoder is trivial pure
+  Python / zero-dep; the non-trivial bits are weak line-oriented detection (`begin `),
+  trusting the embedded name/mode like gzip `FNAME`, and ratio-guard assumptions that
+  expect compression to *shrink*. Scope as bare single-file only — not transparent
+  `uu → gz → tar`. Same “legacy wrapper / open anything in old backups” niche as `.Z`;
+  lower priority than anything on the native 7z/RAR / CLI path. Sibling encodings
+  (xxencode, BinHex, yEnc) only if a real corpus itch appears. Promote when a backup
+  corpus actually wants `detect_format` / `open_archive` to Just Work on `.uu`.
+
 ## API & ergonomics
 
 - **`SANITIZE` extraction policy: name rewriting** — the post-v1 opt-in `SANITIZE`


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Parks classic uuencode (`.uu` / `.uue`, including `begin-base64`) as a speculative single-file wrapper idea in `IDEAS.md`.

**Why:** fits the “open anything in old backups” niche next to `.Z`; libarchive’s `.uu` fixtures are storage hygiene, not demand signal. Scope deliberately narrow — peel one layer via `SingleFileBackend`, no transparent filter stacking.

**Non-goals in this note:** xxencode / BinHex / yEnc unless a real corpus appears; any Phase roadmap promotion.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d2c7cf0d-d386-4ef4-aafc-b0e53c68d9c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d2c7cf0d-d386-4ef4-aafc-b0e53c68d9c9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

