### PR TITLE
Expand libarchive corpus to all formats + fix .tar.Z detection

### DIFF
--- a/src/archivey/internal/detection.py
+++ b/src/archivey/internal/detection.py
@@ -24,6 +24,7 @@ feed in later stages.
 
 from __future__ import annotations
 
+import io
 from dataclasses import dataclass, field, replace
 from enum import Enum
 from pathlib import Path
@@ -202,17 +203,37 @@ def _probe_inner_tar(
     if not is_codec_available(codec):
         return False
 
-    # The sequential backend is forced (streaming=True): the rapidgzip accelerator expects a
-    # complete/seekable source and rejects a bounded, non-seekable view, which would mis-defer
-    # a .tar.gz to bare .gz.
-    source = _BoundedPeekReader(peek_more, _INNER_TAR_MAX_PROBE_BYTES)
-    try:
-        with open_codec_stream(
-            codec, source, config=StreamConfig(streaming=True, seekable=False)
-        ) as stream:
-            head = stream.read(_INNER_TAR_PROBE_BYTES)
-    except (ArchiveyError, OSError, ValueError):
-        # Not decodable as this codec, or truncated before a full block -> not an inner tar.
+    def _read_tar_header(
+        source: BinaryIO, *, streaming: bool, seekable: bool
+    ) -> bytes | None:
+        try:
+            with open_codec_stream(
+                codec,
+                source,
+                config=StreamConfig(streaming=streaming, seekable=seekable),
+            ) as stream:
+                return stream.read(_INNER_TAR_PROBE_BYTES)
+        except (ArchiveyError, OSError, ValueError):
+            # Not decodable as this codec, or truncated before a full block.
+            return None
+
+    # Prefer a non-seekable bounded peek with streaming=True: the rapidgzip accelerator
+    # expects a complete/seekable source and would otherwise reject the probe view, which
+    # would mis-defer a .tar.gz to bare .gz.
+    head = _read_tar_header(
+        _BoundedPeekReader(peek_more, _INNER_TAR_MAX_PROBE_BYTES),
+        streaming=True,
+        seekable=False,
+    )
+    if head is None:
+        # unix-compress (LZW) requires a seekable source. Retry against a bounded
+        # BytesIO copy of the peeked prefix so .tar.Z still upgrades to TAR_Z.
+        head = _read_tar_header(
+            io.BytesIO(peek_more(_INNER_TAR_MAX_PROBE_BYTES)),
+            streaming=False,
+            seekable=True,
+        )
+    if head is None:
         return False
     return head[257:262] == b"ustar"
 

--- a/src/archivey/internal/detection.py
+++ b/src/archivey/internal/detection.py
@@ -24,7 +24,6 @@ feed in later stages.
 
 from __future__ import annotations
 
-import io
 from dataclasses import dataclass, field, replace
 from enum import Enum
 from pathlib import Path
@@ -45,6 +44,7 @@ from archivey.internal.logs import detection as logger
 from archivey.internal.registry import get_registry
 from archivey.internal.streams.peekable import DETECTION_LIMIT, PeekableStream
 from archivey.internal.streams.streamtools import (
+    ReadOnlyIOStream,
     is_seekable,
     read_exact,
     source_name,
@@ -141,23 +141,79 @@ def _match_extension(
     return None
 
 
+class _BoundedPeekReader(ReadOnlyIOStream):
+    """A bounded, non-consuming reader over a ``peek_more`` callable.
+
+    ``peek_more(n)`` returns the source's first ``n`` bytes without consuming them
+    (idempotent, growing supersets — see :func:`_peek_prefix`). Reads walk an
+    internal offset over successive peeks (caching the last buffer so growth stays
+    linear), letting a codec pull exactly as much compressed input as it needs and
+    never more than ``limit`` (one maximum compressor block).
+
+    Seekable within the bound so codecs that require seek (unix-compress) can still
+    probe; seeking never pulls bytes beyond ``limit``, and peeks still grow only on
+    demand when a read needs more of the prefix.
+    """
+
+    def __init__(self, peek_more: Callable[[int], bytes], limit: int) -> None:
+        super().__init__()
+        self._peek_more = peek_more
+        self._limit = limit
+        self._offset = 0
+        self._buf = b""
+
+    def readable(self) -> bool:
+        return True
+
+    def seekable(self) -> bool:
+        return True
+
+    def tell(self, /) -> int:
+        return self._offset
+
+    def seek(self, offset: int, whence: int = 0, /) -> int:
+        if whence == 0:  # SEEK_SET
+            new_pos = offset
+        elif whence == 1:  # SEEK_CUR
+            new_pos = self._offset + offset
+        elif whence == 2:  # SEEK_END — end of the bounded window, not the real source
+            new_pos = self._limit + offset
+        else:
+            raise ValueError(f"invalid whence: {whence!r}")
+        if new_pos < 0:
+            raise ValueError(f"negative seek position {new_pos}")
+        # Cap at the bound; reads past the peeked prefix already return b"".
+        self._offset = min(new_pos, self._limit)
+        return self._offset
+
+    def read(self, n: int = -1, /) -> bytes:
+        end = self._limit if n < 0 else min(self._offset + n, self._limit)
+        if end > len(self._buf):
+            self._buf = self._peek_more(end)  # a superset of the current buffer
+        chunk = self._buf[self._offset : end]
+        self._offset += len(chunk)
+        return chunk
+
+
 def _probe_inner_tar(
     stream_format: StreamFormat,
     peek_more: Callable[[int], bytes],
 ) -> bool:
     """Whether decompressing the source yields a TAR (``ustar`` at offset 257).
 
-    The codec layer decodes a bounded copy of the peeked prefix and the inner ``ustar``
-    magic confirms a tarball wrapped in the compressor. A stream-oriented codec
-    (gzip/xz/zstd/…) emits output incrementally and stops after a few KiB; a
-    block-transform codec (bzip2), which emits nothing until a whole block is read,
-    may pull up to one maximum block (``_INNER_TAR_MAX_PROBE_BYTES``).
+    The codec layer decodes the compressed source and the inner ``ustar`` magic confirms a
+    tarball wrapped in the compressor. The decoder reads from a bounded, non-consuming view of
+    the source (:class:`_BoundedPeekReader` over ``peek_more``), so it pulls exactly as much
+    compressed input as it needs to reach the TAR header region and no more: a stream-oriented
+    codec (gzip/xz/zstd/…) emits output incrementally and stops after a few KiB, while a
+    block-transform codec (bzip2), which emits nothing until a whole block is read, pulls up to
+    one maximum block (``_INNER_TAR_MAX_PROBE_BYTES``).
 
-    The probe source is a seekable ``BytesIO`` of that bounded prefix so codecs that
-    require seek (unix-compress / LZW) can still upgrade ``.tar.Z``. Accelerators are
-    forced ``OFF``: declaring ``seekable=True`` must not flip AUTO rapidgzip /
+    The peek reader is seekable within that bound so unix-compress (LZW) can probe.
+    Accelerators are forced ``OFF``: ``seekable=True`` must not flip AUTO rapidgzip /
     IndexedBzip2File on for a short detection peek (those paths reject incomplete
-    sources and can leak raw C++ exceptions on corrupt prefixes).
+    sources and can leak raw C++ exceptions on corrupt prefixes). Prefer that over
+    the older ``seekable=False`` workaround for keeping accelerators off the probe.
 
     Returns ``False`` (deferring the determination to open time) when the codec backend is
     absent, the source is not decodable as this codec, or the decoded output carries no TAR
@@ -178,9 +234,7 @@ def _probe_inner_tar(
     if not is_codec_available(codec):
         return False
 
-    # Seekable bounded prefix + accelerators OFF (see docstring). Prefer this over
-    # ``seekable=False`` as the way to keep rapidgzip off the probe path.
-    source = io.BytesIO(peek_more(_INNER_TAR_MAX_PROBE_BYTES))
+    source = _BoundedPeekReader(peek_more, _INNER_TAR_MAX_PROBE_BYTES)
     try:
         with open_codec_stream(
             codec,

--- a/src/archivey/internal/detection.py
+++ b/src/archivey/internal/detection.py
@@ -30,7 +30,7 @@ from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, BinaryIO, Callable
 
-from archivey.config import DEFAULT_ARCHIVEY_CONFIG
+from archivey.config import DEFAULT_ARCHIVEY_CONFIG, AcceleratorMode
 from archivey.diagnostics import (
     DiagnosticCode,
     DiagnosticSummary,
@@ -45,7 +45,6 @@ from archivey.internal.logs import detection as logger
 from archivey.internal.registry import get_registry
 from archivey.internal.streams.peekable import DETECTION_LIMIT, PeekableStream
 from archivey.internal.streams.streamtools import (
-    ReadOnlyIOStream,
     is_seekable,
     read_exact,
     source_name,
@@ -142,47 +141,23 @@ def _match_extension(
     return None
 
 
-class _BoundedPeekReader(ReadOnlyIOStream):
-    """A forward, non-consuming reader over a ``peek_more`` callable, capped at ``limit`` bytes.
-
-    ``peek_more(n)`` returns the source's first ``n`` bytes without consuming them (idempotent,
-    growing supersets — see :func:`_peek_prefix`). Reads walk an internal offset over
-    successive peeks (caching the last buffer so growth stays linear), letting a codec pull
-    exactly as much of the source as it needs to decode the probed region — and never more than
-    ``limit`` (one maximum compressor block). Read-only and non-seekable, so it behaves like the
-    streaming pipe the sequential backend expects and leaves the source untouched, working
-    uniformly whether that source is a path, a seekable stream, or a ``PeekableStream``.
-    """
-
-    def __init__(self, peek_more: Callable[[int], bytes], limit: int) -> None:
-        super().__init__()
-        self._peek_more = peek_more
-        self._limit = limit
-        self._offset = 0
-        self._buf = b""
-
-    def read(self, n: int = -1, /) -> bytes:
-        end = self._limit if n < 0 else min(self._offset + n, self._limit)
-        if end > len(self._buf):
-            self._buf = self._peek_more(end)  # a superset of the current buffer
-        chunk = self._buf[self._offset : end]
-        self._offset += len(chunk)
-        return chunk
-
-
 def _probe_inner_tar(
     stream_format: StreamFormat,
     peek_more: Callable[[int], bytes],
 ) -> bool:
     """Whether decompressing the source yields a TAR (``ustar`` at offset 257).
 
-    The codec layer decodes the compressed source and the inner ``ustar`` magic confirms a
-    tarball wrapped in the compressor. The decoder reads from a bounded, non-consuming view of
-    the source (:class:`_BoundedPeekReader` over ``peek_more``), so it pulls exactly as much
-    compressed input as it needs to reach the TAR header region and no more: a stream-oriented
-    codec (gzip/xz/zstd/…) emits output incrementally and stops after a few KiB, while a
-    block-transform codec (bzip2), which emits nothing until a whole block is read, pulls up to
-    one maximum block (``_INNER_TAR_MAX_PROBE_BYTES``).
+    The codec layer decodes a bounded copy of the peeked prefix and the inner ``ustar``
+    magic confirms a tarball wrapped in the compressor. A stream-oriented codec
+    (gzip/xz/zstd/…) emits output incrementally and stops after a few KiB; a
+    block-transform codec (bzip2), which emits nothing until a whole block is read,
+    may pull up to one maximum block (``_INNER_TAR_MAX_PROBE_BYTES``).
+
+    The probe source is a seekable ``BytesIO`` of that bounded prefix so codecs that
+    require seek (unix-compress / LZW) can still upgrade ``.tar.Z``. Accelerators are
+    forced ``OFF``: declaring ``seekable=True`` must not flip AUTO rapidgzip /
+    IndexedBzip2File on for a short detection peek (those paths reject incomplete
+    sources and can leak raw C++ exceptions on corrupt prefixes).
 
     Returns ``False`` (deferring the determination to open time) when the codec backend is
     absent, the source is not decodable as this codec, or the decoded output carries no TAR
@@ -203,37 +178,23 @@ def _probe_inner_tar(
     if not is_codec_available(codec):
         return False
 
-    def _read_tar_header(
-        source: BinaryIO, *, streaming: bool, seekable: bool
-    ) -> bytes | None:
-        try:
-            with open_codec_stream(
-                codec,
-                source,
-                config=StreamConfig(streaming=streaming, seekable=seekable),
-            ) as stream:
-                return stream.read(_INNER_TAR_PROBE_BYTES)
-        except (ArchiveyError, OSError, ValueError):
-            # Not decodable as this codec, or truncated before a full block.
-            return None
-
-    # Prefer a non-seekable bounded peek with streaming=True: the rapidgzip accelerator
-    # expects a complete/seekable source and would otherwise reject the probe view, which
-    # would mis-defer a .tar.gz to bare .gz.
-    head = _read_tar_header(
-        _BoundedPeekReader(peek_more, _INNER_TAR_MAX_PROBE_BYTES),
-        streaming=True,
-        seekable=False,
-    )
-    if head is None:
-        # unix-compress (LZW) requires a seekable source. Retry against a bounded
-        # BytesIO copy of the peeked prefix so .tar.Z still upgrades to TAR_Z.
-        head = _read_tar_header(
-            io.BytesIO(peek_more(_INNER_TAR_MAX_PROBE_BYTES)),
-            streaming=False,
-            seekable=True,
-        )
-    if head is None:
+    # Seekable bounded prefix + accelerators OFF (see docstring). Prefer this over
+    # ``seekable=False`` as the way to keep rapidgzip off the probe path.
+    source = io.BytesIO(peek_more(_INNER_TAR_MAX_PROBE_BYTES))
+    try:
+        with open_codec_stream(
+            codec,
+            source,
+            config=StreamConfig(
+                streaming=True,
+                seekable=True,
+                use_rapidgzip=AcceleratorMode.OFF,
+                use_indexed_bzip2=AcceleratorMode.OFF,
+            ),
+        ) as stream:
+            head = stream.read(_INNER_TAR_PROBE_BYTES)
+    except (ArchiveyError, OSError, ValueError):
+        # Not decodable as this codec, or truncated before a full block -> not an inner tar.
         return False
     return head[257:262] == b"ustar"
 

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -274,6 +274,29 @@ def test_inner_tar_over_xz_is_tar_xz() -> None:
     assert info.format == ArchiveFormat.TAR_XZ
 
 
+@requires("uncompresspy", "ncompress")
+def test_inner_tar_over_unix_compress_is_tar_z() -> None:
+    """unix-compress needs a seekable source; the inner-TAR probe must still upgrade .tar.Z."""
+    from archivey.types import ContainerFormat, StreamFormat
+    from tests.streams_util import make_unix_compress
+
+    data = make_unix_compress(_tar_bytes())
+    info = detect_format(io.BytesIO(data))
+    assert info.format == ArchiveFormat(ContainerFormat.TAR, StreamFormat.UNIX_COMPRESS)
+    assert info.confidence == DetectionConfidence.PROBABLE
+    assert info.detected_by == "content_probe"
+
+
+@requires("uncompresspy", "ncompress")
+def test_unix_compress_without_inner_tar_stays_bare_z() -> None:
+    from tests.streams_util import make_unix_compress
+
+    data = make_unix_compress(b"just some bytes, definitely not a tar header region")
+    info = detect_format(io.BytesIO(data))
+    assert info.format == ArchiveFormat.Z
+    assert info.detected_by == "magic"
+
+
 def _large_block_tar_bz2() -> bytes:
     """A ``.tar.bz2`` whose first bzip2 block is far larger than the detection prefix.
 

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -276,7 +276,7 @@ def test_inner_tar_over_xz_is_tar_xz() -> None:
 
 @requires("uncompresspy", "ncompress")
 def test_inner_tar_over_unix_compress_is_tar_z() -> None:
-    """unix-compress needs seek; the probe uses a seekable prefix with accelerators OFF."""
+    """unix-compress needs seek; the bounded peek reader is seekable within its limit."""
     from archivey.types import ContainerFormat, StreamFormat
     from tests.streams_util import make_unix_compress
 

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -276,7 +276,7 @@ def test_inner_tar_over_xz_is_tar_xz() -> None:
 
 @requires("uncompresspy", "ncompress")
 def test_inner_tar_over_unix_compress_is_tar_z() -> None:
-    """unix-compress needs a seekable source; the inner-TAR probe must still upgrade .tar.Z."""
+    """unix-compress needs seek; the probe uses a seekable prefix with accelerators OFF."""
     from archivey.types import ContainerFormat, StreamFormat
     from tests.streams_util import make_unix_compress
 

--- a/tests/test_libarchive_corpus.py
+++ b/tests/test_libarchive_corpus.py
@@ -11,13 +11,41 @@ Reference ``.uu`` blobs are decoded into ``ARCHIVEY_TEST_CACHE`` on first use.
 Skips archives libarchive cannot open, non-primary split volumes, libarchive
 fuzz/crash fixtures, and formats Archivey does not implement.
 
-7z triage (2026-07, vs libarchive ``libarchive/test``) — known 7z failures marked
+Triage (2026-07, vs libarchive ``libarchive/test``) — known failures marked
 ``xfail``:
 
+**7z**
 * **SPEC** ``*_bcj2_*`` — BCJ2 multi-packed-stream folders correctly raise
   ``UnsupportedFeatureError`` (format-7z rejects BCJ2).
 * **GAP** ``*_arm64`` (method ``0x0a``) — newer ARM64 BCJ filter not in our
   method table; correctly raises ``UnsupportedFeatureError`` today.
+
+**Compress / filter**
+* **GAP** legacy LZ4 frame variants (``test_compat_lz4_{2,3}``) — ``lz4`` frame
+  decoder rejects non-modern frame types.
+* **GAP** gzip trailing junk after a complete member (``test_compat_gzip_2``) —
+  stdlib ``gzip`` raises ``BadGzipFile``; libarchive tolerates trailing bytes.
+* **GAP** ``.tlz`` with raw LZMA Alone payloads — extension maps to TAR+lzip;
+  Archivey has no TAR+LZMA-Alone stream format.
+* **HARNESS** bare ``.lz`` that libarchive does not list as an archive
+  (``test_compat_lzip_3``).
+
+**ZIP**
+* **GAP** WinZip AES (method 99) / ZIPX PPMd/Zstd/XZ — stdlib ``zipfile`` does
+  not decode these; Archivey surfaces ``UnsupportedFeatureError``.
+* **GAP** ZIP members whose payload exceeds the declared size (libarchive
+  fixtures) — stdlib CRC/size checks reject them.
+* **GAP** assorted ZIP edge cases (extra padding, UTF-8 path presentation,
+  MSDOS directory typing).
+
+**TAR / sparse / nested**
+* **GAP** GNU sparse variants / PAX edge headers that stdlib ``tarfile`` rejects.
+* **NESTED** ``*.iso.Z`` / ``*.cpio.gz`` — outer compress around a non-TAR
+  container Archivey does not compose (skipped, not xfail).
+
+**RAR**
+* **GAP** some RAR5 extra-field / crypt-only headers; multi-volume sets need
+  sibling volumes (skipped like other split volumes).
 """
 
 from __future__ import annotations
@@ -33,7 +61,7 @@ from pathlib import Path
 import pytest
 
 from archivey import FormatDetectionError, MemberType, detect_format, open_archive
-from archivey.types import ContainerFormat
+from archivey.types import ArchiveFormat, ContainerFormat, StreamFormat
 from tests.conftest import ARCHIVEY_TEST_CACHE, requires
 
 _ENV = "ARCHIVEY_LIBARCHIVE_TEST_FILES"
@@ -43,6 +71,14 @@ _CACHE_SUBDIR = "libarchive-corpus"
 _PASSWORDS: dict[str, str] = {
     "test_read_format_7zip_encryption.7z": "12345678",
     "test_read_format_zip_zipx_encrypted.zipx": "test_password_zipx",
+    "test_read_format_zip_traditional_encryption_data.zip": "12345678",
+    "test_read_format_zip_encryption_data.zip": "12345678",
+    "test_read_format_zip_encryption_header.zip": "12345678",
+    "test_read_format_zip_encryption_partially.zip": "12345678",
+    "test_read_format_zip_winzip_aes128.zip": "password",
+    "test_read_format_zip_winzip_aes256.zip": "password",
+    "test_read_format_zip_winzip_aes256_large.zip": "password",
+    "test_read_format_zip_winzip_aes256_stored.zip": "password",
 }
 
 # Try these when an archive name hints at encryption but has no explicit mapping.
@@ -63,6 +99,28 @@ _SKIP_NAMES = frozenset(
         "test_splitted_rar_seek_support_ab",
         "test_splitted_rar_seek_support_ac",
         "test_splitted_rar_seek_support_aa",
+        # RAR5 multiarchive fixtures need sibling volumes beside part01.
+        "test_read_format_rar5_multiarchive.part01.rar",
+        "test_read_format_rar5_multiarchive_solid.part01.rar",
+        # Nested: outer unix-compress / gzip around ISO or cpio (no composed format).
+        "test_read_format_iso.iso.Z",
+        "test_read_format_iso_2.iso.Z",
+        "test_read_format_iso_3.iso.Z",
+        "test_read_format_iso_joliet.iso.Z",
+        "test_read_format_iso_joliet_by_nero.iso.Z",
+        "test_read_format_iso_joliet_long.iso.Z",
+        "test_read_format_iso_joliet_rockridge.iso.Z",
+        "test_read_format_iso_multi_extent.iso.Z",
+        "test_read_format_iso_rockridge.iso.Z",
+        "test_read_format_iso_rockridge_ce.iso.Z",
+        "test_read_format_iso_rockridge_ce_loop.iso.Z",
+        "test_read_format_iso_rockridge_new.iso.Z",
+        "test_read_format_iso_rockridge_rr_moved.iso.Z",
+        "test_read_format_iso_xorriso.iso.Z",
+        "test_read_format_iso_zisofs.iso.Z",
+        "test_write_disk_appledouble.cpio.gz",
+        # GNU sparse skip-entry OOMs/segfaults the process — skip rather than xfail.
+        "test_read_format_gtar_sparse_skip_entry.tar.Z",
     }
 )
 
@@ -71,8 +129,9 @@ _PART_RE = re.compile(
     re.IGNORECASE,
 )
 
-# Triaged 7z divergences. Values are (strict, reason).
-_XFAIL_7Z: dict[str, tuple[bool, str]] = {
+# Triaged divergences. Values are (strict, reason).
+_XFAIL: dict[str, tuple[bool, str]] = {
+    # --- 7z ---
     "test_read_format_7zip_bcj2_bzip2.7z": (
         True,
         "SPEC: BCJ2 multi-packed-stream folders are unsupported",
@@ -116,6 +175,150 @@ _XFAIL_7Z: dict[str, tuple[bool, str]] = {
     "test_read_format_7zip_lzma2_arm64.7z": (
         True,
         "GAP: ARM64 BCJ method 0x0a not in method table",
+    ),
+    # --- compress / filter ---
+    "test_compat_gzip_2.tgz": (
+        True,
+        "GAP: stdlib gzip rejects trailing junk after a complete member",
+    ),
+    "test_compat_lz4_2.tar.lz4": (
+        True,
+        "GAP: legacy LZ4 frame type not accepted by lz4.frame",
+    ),
+    "test_compat_lz4_3.tar.lz4": (
+        True,
+        "GAP: legacy LZ4 frame type not accepted by lz4.frame",
+    ),
+    "test_compat_lzma_1.tlz": (
+        True,
+        "GAP: .tlz extension maps to TAR+lzip; payload is raw LZMA Alone",
+    ),
+    "test_compat_lzma_2.tlz": (
+        True,
+        "GAP: .tlz extension maps to TAR+lzip; payload is raw LZMA Alone",
+    ),
+    "test_compat_lzma_3.tlz": (
+        True,
+        "GAP: .tlz extension maps to TAR+lzip; payload is raw LZMA Alone",
+    ),
+    "test_compat_lzip_3.lz": (
+        True,
+        "HARNESS: libarchive lists no members for this bare lzip fixture",
+    ),
+    # --- ZIP ---
+    "test_read_format_zip_ppmd8.zipx": (
+        True,
+        "GAP: ZIPX PPMd8 unsupported by stdlib zipfile",
+    ),
+    "test_read_format_zip_ppmd8_multi.zipx": (
+        True,
+        "GAP: ZIPX PPMd8 unsupported by stdlib zipfile",
+    ),
+    "test_read_format_zip_xz_multi.zipx": (
+        True,
+        "GAP: ZIPX XZ unsupported by stdlib zipfile",
+    ),
+    "test_read_format_zip_zstd.zipx": (
+        True,
+        "GAP: ZIPX Zstd unsupported by stdlib zipfile",
+    ),
+    "test_read_format_zip_zstd_multi.zipx": (
+        True,
+        "GAP: ZIPX Zstd unsupported by stdlib zipfile",
+    ),
+    "test_read_format_zip_winzip_aes128.zip": (
+        True,
+        "GAP: WinZip AES (method 99) unsupported by stdlib zipfile",
+    ),
+    "test_read_format_zip_winzip_aes256.zip": (
+        True,
+        "GAP: WinZip AES (method 99) unsupported by stdlib zipfile",
+    ),
+    "test_read_format_zip_winzip_aes256_large.zip": (
+        True,
+        "GAP: WinZip AES (method 99) unsupported by stdlib zipfile",
+    ),
+    "test_read_format_zip_winzip_aes256_stored.zip": (
+        True,
+        "GAP: WinZip AES (method 99) unsupported by stdlib zipfile",
+    ),
+    "test_read_data_into_fd_size_exceeds_declared_deflate.zip": (
+        True,
+        "GAP: stdlib zipfile rejects payload larger than declared size",
+    ),
+    "test_read_data_into_fd_size_exceeds_declared_stored.zip": (
+        True,
+        "GAP: stdlib zipfile rejects payload larger than declared size",
+    ),
+    "test_read_format_zip_size_exceeds_declared_deflate.zip": (
+        True,
+        "GAP: stdlib zipfile rejects payload larger than declared size",
+    ),
+    "test_read_format_zip_size_exceeds_declared_stored.zip": (
+        True,
+        "GAP: stdlib zipfile rejects payload larger than declared size",
+    ),
+    "test_read_format_zip.zip": (
+        True,
+        "GAP: libarchive ZIP fixture trips stdlib CRC check on file2",
+    ),
+    "test_read_format_zip_extra_padding.zip": (
+        True,
+        "GAP: ZIP with extra padding rejected by stdlib zipfile",
+    ),
+    "test_read_format_zip_7075_utf8_paths.zip": (
+        True,
+        "GAP: UTF-8 path presentation differs from libarchive",
+    ),
+    "test_read_format_zip_msdos.zip": (
+        True,
+        "GAP: MSDOS directory entry typed as FILE vs DIRECTORY",
+    ),
+    # --- TAR / sparse / PAX ---
+    "test_read_format_gtar_sparse_1_17_posix10_modified.tar": (
+        True,
+        "GAP: modified GNU sparse header not handled by stdlib tarfile",
+    ),
+    "test_read_format_tar_V_negative_size.tar": (
+        True,
+        "GAP: negative TAR size / invalid offset rejected by stdlib tarfile",
+    ),
+    "test_read_pax_empty_val_no_nl.tar": (
+        True,
+        "GAP: empty PAX value without newline rejected by stdlib tarfile",
+    ),
+    "test_read_format_tar_empty_with_gnulabel.tar": (
+        True,
+        "GAP: empty TAR with GNU label member-set differs from libarchive",
+    ),
+    "test_read_format_gtar_redundant_L.tar.Z": (
+        True,
+        "GAP: GNU long-name (L) handling differs from libarchive",
+    ),
+    "test_read_format_gtar_sparse_length.tar.Z": (
+        True,
+        "GAP: GNU sparse length / hole presentation differs from libarchive",
+    ),
+    "test_read_format_tar_empty_pax.tar.Z": (
+        True,
+        "GAP: empty PAX TAR over unix-compress rejected by stdlib tarfile",
+    ),
+    # --- RAR ---
+    "test_read_format_rar5_only_crypt_exfld.rar": (
+        True,
+        "GAP: RAR5 crypt-only extra field parsing",
+    ),
+    "test_read_format_rar5_unsupported_exfld.rar": (
+        True,
+        "GAP: RAR5 unsupported extra field parsing",
+    ),
+    "test_read_format_rar_unbound_staticdata.rar": (
+        True,
+        "GAP: RAR3 unbound static data / zero header size",
+    ),
+    "test_read_format_rar5_extra_field_version.rar": (
+        True,
+        "GAP: RAR5 version extra-field member naming",
     ),
 }
 
@@ -214,6 +417,15 @@ def _materialize_archive(uu_path: Path) -> Path | None:
         if dest.exists():
             dest.unlink(missing_ok=True)
         return None
+    # Nested outer-compress around ISO/cpio: detect as bare compressor, not a
+    # composed Archivey format. Skip rather than compare against libarchive's
+    # multi-filter open.
+    if info.format.container is ContainerFormat.RAW_STREAM and (
+        base.lower().endswith(".iso.z")
+        or base.lower().endswith(".cpio.gz")
+        or base.lower().endswith(".cpio.z")
+    ):
+        return None
     return dest
 
 
@@ -225,6 +437,16 @@ def _password_candidates(archive_name: str) -> tuple[str | None, ...]:
     if any(hint in lower for hint in _ENCRYPTION_NAME_HINTS):
         return (None, *_FALLBACK_PASSWORDS)
     return (None,)
+
+
+def _archivey_password(archive_name: str) -> str | tuple[str, ...] | None:
+    """Password argument for ``open_archive`` (omit bare ``None`` candidates)."""
+    cands = [p for p in _password_candidates(archive_name) if p is not None]
+    if not cands:
+        return None
+    if len(cands) == 1:
+        return cands[0]
+    return tuple(cands)
 
 
 def _normalize_name(name: str) -> str:
@@ -289,7 +511,7 @@ def _collect_libarchive_oracle(
 
 def _uu_param(path: Path) -> pytest.ParameterSet:
     name = path.name[:-3]
-    xfail = _XFAIL_7Z.get(name)
+    xfail = _XFAIL.get(name)
     if xfail is None:
         return pytest.param(path, id=name)
     strict, reason = xfail
@@ -336,8 +558,10 @@ def test_native_matches_libarchive_on_libarchive_corpus(
     except Exception as exc:  # noqa: BLE001 — oracle may reject unsupported fixtures
         pytest.skip(f"libarchive cannot open {archive.name}: {exc}")
 
-    password = _PASSWORDS.get(archive.name)
-    if password is not None and archive.name.endswith(".7z"):
+    password = _archivey_password(archive.name)
+    if password is not None and (
+        archive.name.endswith(".7z") or "aes" in archive.name.lower()
+    ):
         pytest.importorskip("cryptography")
 
     with open_archive(archive, password=password) as native:
@@ -380,3 +604,16 @@ def test_libarchive_corpus_discovered_archives() -> None:
         or "test_read_format_zip.zip" in names
         or any(name.endswith(".zip") for name in names)
     )
+
+
+def test_tar_z_detection_upgrades_via_inner_probe() -> None:
+    """Regression: unix-compress inner-TAR probe must upgrade ``*.tar.Z`` fixtures."""
+    if _ROOT is None:
+        pytest.skip(f"set {_ENV} to run")
+    uu = _ROOT / "test_compat_mac-1.tar.Z.uu"
+    if not uu.exists():
+        pytest.skip("libarchive fixture test_compat_mac-1.tar.Z.uu not present")
+    archive = _materialize_archive(uu)
+    assert archive is not None
+    info = detect_format(archive)
+    assert info.format == ArchiveFormat(ContainerFormat.TAR, StreamFormat.UNIX_COMPRESS)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Ran the opt-in libarchive corpus across **all** supported formats (not just 7z), fixed `.tar.Z` detection the right way, and triaged remaining gaps in the harness.

### Easy fix (library)

**Inner-TAR probe:** unix-compress needs a seekable source, so `.tar.Z` stayed bare `Z`. The probe now uses a seekable bounded `BytesIO` of the peeked prefix, and forces `use_rapidgzip` / `use_indexed_bzip2` to `AcceleratorMode.OFF` instead of the old `seekable=False` workaround (which was really about avoiding rapidgzip AUTO). That keeps accelerators off the detection path and stops raw `RuntimeError: bad_optional_access` leaks on corrupt gz/bz2 prefixes (Windows/macOS mutation CI).

### Harness

- ZIP passwords from libarchive’s own tests (`12345678` / `password`)
- Skip nested `*.iso.Z` / `*.cpio.gz` (no composed format)
- Skip RAR5 multiarchive `part01` and the GNU sparse skip-entry OOM fixture
- Expand `_XFAIL` beyond 7z for known GAP/SPEC divergences

### Corpus snapshot (forked triage)

| Status | Count |
| --- | --- |
| passed | ~145 |
| skipped | ~162 |
| xfailed | ~47 |

## Complicated / left as xfail or skip

- Gzip trailing junk; legacy LZ4 frames; `.tlz` as raw LZMA Alone
- WinZip AES / ZIPX PPMd·Zstd·XZ; ZIP size/CRC edge fixtures
- GNU sparse / long-name / empty PAX; nested ISO.Z
- RAR5 crypt/extra-field edges; 7z BCJ2 (SPEC) / ARM64 BCJ (GAP)

## Test plan

- [x] Detection + unix-compress `.tar.Z` upgrade
- [x] Mutation repros that failed on macOS/Windows (`basic-tar.bz2-bitflip`, `single-file-bz2-bitflip`, gz truncates)
- [x] Sample libarchive cases including `test_compat_mac-1.tar.Z`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-76759766-a611-4b18-913b-0d00829dc589"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-76759766-a611-4b18-913b-0d00829dc589"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

