### PR TITLE
Propose: vendor unix-compress LZW into core (drop uncompresspy)

### DIFF
--- a/IDEAS.md
+++ b/IDEAS.md
@@ -50,13 +50,6 @@
   wheels won't install but CLI tools are on PATH. Forward-only; needs availability
   detection and careful subprocess/error handling. Low-priority backend tier.
 
-- **Non-seekable unix-compress (`.Z`)** — the `uncompresspy` backend currently requires a
-  **seekable** source (it decodes via random access), so archivey reports
-  `StreamNotSeekableError` for a `.Z` pipe/socket. The library's decode path looks
-  straightforward to make forward-only; low-priority task to either fork the relevant bit
-  into archivey or send a fix upstream so `.Z` works on non-seekable streams like the other
-  single-file compressors.
-
 - **UU / Base64 transport encodings as single-file wrappers** — classic `uuencode`
   (`.uu` / `.uue`, including `begin-base64`) shows up in old mail/Usenet drops and some
   vendor corpora; libarchive treats it as a filter and stores many of its own test

--- a/docs/formats.md
+++ b/docs/formats.md
@@ -17,7 +17,7 @@ most often surprise callers. Authoritative detail lives in `openspec/specs/forma
 | ISO | no | `[iso]` (`pycdlib`) | indexed | direct | Seekable source required |
 | `.zst` / `.tar.zst` | 3.14+ core; else `[zstd]` | `[zstd]` → `backports.zstd` | — | rewind seek unless indexed later | |
 | `.lz4` / `.tar.lz4` | no | `[lz4]` | — | rewind seek | |
-| `.Z` / `.tar.Z` | no | `[unix-compress]` | — | special | Truncation undetectable |
+| `.Z` / `.tar.Z` | yes | — | — | CLEAR seek points when seekable | Truncation undetectable |
 
 Recommended installs: `archivey[recommended]` or `archivey[recommended-lite]` (no
 `rapidgzip`). Full codec rationale: [library analysis](internal/library-analysis.md).
@@ -87,8 +87,9 @@ Recommended installs: `archivey[recommended]` or `archivey[recommended-lite]` (n
 
 - One synthetic member (name from the source path, or `data` for anonymous streams).
 - `.gz` may expose `extra["gzip.original_filename"]` when the header carries `FNAME`.
-- `.Z` (unix-compress) needs `[unix-compress]`; truncation cannot be detected (format
-  carries no length/checksum).
+- `.Z` (unix-compress) is core (native LZW); truncation cannot be detected (format
+  carries no length/checksum). Forward decode works on non-seekable sources; CLEAR
+  boundaries provide seek points when seekability is declared.
 - `archivey.open_stream(...)` matches the archive rule: non-seekable unless
   `seekable=True`.
 

--- a/docs/formats.md
+++ b/docs/formats.md
@@ -17,7 +17,7 @@ most often surprise callers. Authoritative detail lives in `openspec/specs/forma
 | ISO | no | `[iso]` (`pycdlib`) | indexed | direct | Seekable source required |
 | `.zst` / `.tar.zst` | 3.14+ core; else `[zstd]` | `[zstd]` → `backports.zstd` | — | rewind seek unless indexed later | |
 | `.lz4` / `.tar.lz4` | no | `[lz4]` | — | rewind seek | |
-| `.Z` / `.tar.Z` | yes | — | — | CLEAR seek points when seekable | Truncation undetectable |
+| `.Z` / `.tar.Z` | yes | — | — | CLEAR seek points when seekable | Best-effort truncation (nonzero leftover bits) |
 
 Recommended installs: `archivey[recommended]` or `archivey[recommended-lite]` (no
 `rapidgzip`). Full codec rationale: [library analysis](internal/library-analysis.md).
@@ -87,9 +87,10 @@ Recommended installs: `archivey[recommended]` or `archivey[recommended-lite]` (n
 
 - One synthetic member (name from the source path, or `data` for anonymous streams).
 - `.gz` may expose `extra["gzip.original_filename"]` when the header carries `FNAME`.
-- `.Z` (unix-compress) is core (native LZW); truncation cannot be detected (format
-  carries no length/checksum). Forward decode works on non-seekable sources; CLEAR
-  boundaries provide seek points when seekability is declared.
+- `.Z` (unix-compress) is core (native LZW). Truncation is best-effort: nonzero leftover
+  bits after the last complete code raise `TruncatedError` on the next `read()` after
+  delivering available bytes; zero-leftover cuts remain silent. Forward decode works on
+  non-seekable sources; CLEAR boundaries provide seek points when seekability is declared.
 - `archivey.open_stream(...)` matches the archive rule: non-seekable unless
   `seekable=True`.
 

--- a/docs/internal/library-analysis.md
+++ b/docs/internal/library-analysis.md
@@ -55,7 +55,7 @@ Two recurring notes:
 | zstd | **stdlib `compression.zstd` (3.14+) / `backports.zstd` (<3.14)** | `[zstd]` on <3.14; core on 3.14+ | no (rewind) | yes (frame checksum) | **yes** |
 | lz4 | `lz4` | `[lz4]` | no (rewind) | yes | yes |
 | brotli | `brotli` | `[7z]` | no (rewind) | yes | partial² |
-| unix-compress (`.Z`) | native `unix_compress.py` (LZW) | core | **yes** (CLEAR seek points) | yes | no³ |
+| unix-compress (`.Z`) | native `unix_compress.py` (LZW) | core | **yes** (CLEAR seek points) | yes | best-effort³ |
 | Deflate64 | `inflate64` | `[7z]` | no | yes | yes |
 | PPMd (var.H) | `pyppmd` | `[7z]` | no | yes | yes |
 
@@ -65,8 +65,9 @@ and `seekable-decompressor-streams`).
 ² brotli has no length/CRC trailer, so a truncated stream is detected only when the
 decompressor never reports "finished" at EOF (surfaced as `TruncatedError`), not by a stored
 size.
-³ the `.Z` format carries no length or checksum, so truncation is undetectable — a cut stream
-just yields fewer bytes.
+³ `.Z` has no length/checksum; finished compressors zero-pad after the last complete code, so
+nonzero leftover bits at EOF are a best-effort `TruncatedError` (raised on the next empty
+`read()` after delivering bytes). Cuts that leave only zero leftover bits stay silent.
 
 ---
 
@@ -299,8 +300,10 @@ CPython.
 LZW (`.Z`) decode via Archivey's native `LzwState` / `UnixCompressDecompressorStream`
 (adapted from uncompresspy under BSD-3-Clause attribution). Forward decode works on
 non-seekable sources; on a seekable source with seekability declared, CLEAR boundaries
-become `SeekPoint`s. The format has no length/checksum, so truncation is undetectable.
-`ncompress` remains a *compressor* only (test-fixture generator in the `dev` group).
+become `SeekPoint`s. Reserved header flags (`0x60`) raise `UnsupportedFeatureError`.
+Truncation is best-effort via nonzero leftover bits after the last complete code
+(`TruncatedError` on the next empty `read()`). `ncompress` remains a *compressor* only
+(test-fixture generator in the `dev` group).
 
 ### Deflate64 — `inflate64`
 

--- a/docs/internal/library-analysis.md
+++ b/docs/internal/library-analysis.md
@@ -55,7 +55,7 @@ Two recurring notes:
 | zstd | **stdlib `compression.zstd` (3.14+) / `backports.zstd` (<3.14)** | `[zstd]` on <3.14; core on 3.14+ | no (rewind) | yes (frame checksum) | **yes** |
 | lz4 | `lz4` | `[lz4]` | no (rewind) | yes | yes |
 | brotli | `brotli` | `[7z]` | no (rewind) | yes | partial² |
-| unix-compress (`.Z`) | `uncompresspy` | `[unix-compress]` | yes (random-access decoder) | yes | no³ |
+| unix-compress (`.Z`) | native `unix_compress.py` (LZW) | core | **yes** (CLEAR seek points) | yes | no³ |
 | Deflate64 | `inflate64` | `[7z]` | no | yes | yes |
 | PPMd (var.H) | `pyppmd` | `[7z]` | no | yes | yes |
 
@@ -294,13 +294,13 @@ caught only by "never finished at EOF". Pulled by the `[7z]` bundle (7z can use 
 for standalone `.br`. The `brotlicffi` fork is an alternative for PyPy but adds nothing on
 CPython.
 
-### unix-compress (`.Z`) — `uncompresspy`
+### unix-compress (`.Z`) — native LZW
 
-LZW (`.Z`) decode via `uncompresspy`. It decodes via random access, so it currently **requires a
-seekable source** (a `.Z` pipe reports `StreamNotSeekableError`); making it forward-only is an
-idea in `IDEAS.md`. The format has no length/checksum, so truncation is undetectable. Chosen
-because it is the maintained pure-Python `.Z` *decoder*; `ncompress` is a *compressor* only (used
-as a test-fixture generator in the `dev` group, not a runtime decoder).
+LZW (`.Z`) decode via Archivey's native `LzwState` / `UnixCompressDecompressorStream`
+(adapted from uncompresspy under BSD-3-Clause attribution). Forward decode works on
+non-seekable sources; on a seekable source with seekability declared, CLEAR boundaries
+become `SeekPoint`s. The format has no length/checksum, so truncation is undetectable.
+`ncompress` remains a *compressor* only (test-fixture generator in the `dev` group).
 
 ### Deflate64 — `inflate64`
 
@@ -319,8 +319,8 @@ missing-dependency gating are already wired.)
 
 These live in the `dev` dependency group, never an extra (`packaging-and-extras`): `py7zr` and
 `rarfile` (decode **oracles** to cross-check the native 7z reader and RAR metadata parser),
-`ncompress` (an LZW **compressor** to generate `.Z` fixtures, since `uncompresspy` only
-decodes). The active suite uses `backports.zstd` (or stdlib `compression.zstd` on 3.14+) for
+`ncompress` (an LZW **compressor** to generate `.Z` fixtures for the native unix-compress
+decoder). The active suite uses `backports.zstd` (or stdlib `compression.zstd` on 3.14+) for
 zstd fixture generation.
 
 A guard test (`tests/test_extras_imported.py`) asserts that every package pinned in a

--- a/openspec/changes/vendor-unix-compress-lzw/.openspec.yaml
+++ b/openspec/changes/vendor-unix-compress-lzw/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: library
+created: 2026-07-13

--- a/openspec/changes/vendor-unix-compress-lzw/design.md
+++ b/openspec/changes/vendor-unix-compress-lzw/design.md
@@ -59,7 +59,7 @@ After the 3-byte header, resume origin is `SeekPoint(0, 3)`. `_make_decompressor
 
 ### Truncation / finished semantics
 
-`DecompressorStream._read_decompressed_chunk` raises `TruncatedError` unless `_is_decompressor_finished()` is true at source EOF. `.Z` has no end marker; today’s codec intentionally never raises truncation. The unix-compress stream MUST treat input EOF as finished (optional soft warning for a partial trailing code, matching uncompresspy’s `warn_truncation`, but not a typed truncation error).
+`DecompressorStream._read_decompressed_chunk` raises `TruncatedError` unless `_is_decompressor_finished()` is true at source EOF. `.Z` has no end marker; today’s codec intentionally never raises truncation. The unix-compress stream MUST treat input EOF as finished. A partial trailing code is accepted silently (not `TruncatedError`, and not a soft `warnings.warn` — see decision 5).
 
 ### Packaging / zero-dep
 
@@ -102,7 +102,7 @@ compressed chunk
 - Owns dictionary, bit buffer, code-width growth, KwKwK, and CLEAR realignment via a bounded in-memory buffer (never `seek`s a file).
 - Counts *logically consumed* compressed bytes (including CLEAR discard) so units’ `comp_size` are accurate even when the outer read chunk overshot.
 - Knows nothing about `SeekPoint`, absolute offsets, or files.
-- On first feed, parse the 3-byte header (or accept pre-parsed params); corruption → raise typed/`ValueError` for the codec translator.
+- On first feed, parse the 3-byte header (or accept pre-parsed params); format errors raise `CorruptionError` directly (same pattern as native xz/lzip — no stdlib `ValueError` for the codec translator).
 
 **`UnixCompressDecompressorStream`:**
 
@@ -142,9 +142,11 @@ Drop the extra from `pyproject.toml`, `[recommended-lite]` composition, and miss
 
 Keep `ncompress` in the `dev` group only.
 
-### 5. Error translation
+### 5. Error taxonomy (no soft warnings)
 
-Invalid magic / invalid codes / bad header → `CorruptionError`. No `StreamNotSeekableError` from the codec for `.Z` pipes. No `PackageNotInstalledError` for unix-compress. Partial final code at EOF → optional warning only; not `TruncatedError`.
+Invalid magic / invalid codes / bad header → raise `CorruptionError` from the LZW kernel (not stdlib `ValueError` + codec `translate`). Constructor misuse (`max_width`/`block_mode` only one set) is an `assert` — unreachable from public paths. No `StreamNotSeekableError` from the codec for `.Z` pipes. No `PackageNotInstalledError` for unix-compress.
+
+Partial final code at EOF and reserved header bits (0x60) are **silent**: `.Z` has no trailer to confirm truncation, and Archivey’s diagnostic taxonomy has no fitting code for “unknown compress flags” / “partial trailing LZW code.” Emitting `warnings.warn` would bypass the collector; inventing a new `DiagnosticCode` is a cross-cutting diagnostics change deferred until a caller needs those advisories. Not `TruncatedError`.
 
 ### 6. Docs / IDEAS cleanup in the same change
 

--- a/openspec/changes/vendor-unix-compress-lzw/design.md
+++ b/openspec/changes/vendor-unix-compress-lzw/design.md
@@ -16,7 +16,7 @@ License: archivey is MIT; uncompresspy 0.4.1 is BSD-3-Clause (Copyright 2025 Tia
 - Seekable source without declared seekability → forward-only (no seek-point table), matching other codecs.
 - Non-seekable source → `seekable()` false; `seek` unsupported.
 - Move `.Z` into zero-dep core; remove `[unix-compress]` / `uncompresspy`.
-- Preserve behavioral parity with today’s decoder on the existing corpus / `ncompress` fixtures (corruption → `CorruptionError`; truncation still undetectable).
+- Preserve behavioral parity with today’s decoder on the existing corpus / `ncompress` fixtures (corruption → `CorruptionError`; reserved header flags → `UnsupportedFeatureError`; best-effort nonzero-leftover truncation → `TruncatedError` after delivering bytes).
 
 **Non-Goals:**
 
@@ -24,7 +24,7 @@ License: archivey is MIT; uncompresspy 0.4.1 is BSD-3-Clause (Copyright 2025 Tia
 - Upstreaming the streaming fix to uncompresspy as the primary path.
 - Rewriting the algorithm from `ncompress` or another reference (kept as a rejected alternative).
 - Changing detection magic (`1F 9D`) or TAR+`.Z` composition rules.
-- Emitting `TruncatedError` for cut `.Z` streams (format has no length/checksum).
+- Guaranteeing detection of every truncated `.Z` (cuts that leave only zero leftover bits remain silent).
 
 ## Investigations
 
@@ -59,7 +59,7 @@ After the 3-byte header, resume origin is `SeekPoint(0, 3)`. `_make_decompressor
 
 ### Truncation / finished semantics
 
-`DecompressorStream._read_decompressed_chunk` raises `TruncatedError` unless `_is_decompressor_finished()` is true at source EOF. `.Z` has no end marker; today’s codec intentionally never raises truncation. The unix-compress stream MUST treat input EOF as finished. A partial trailing code is accepted silently (not `TruncatedError`, and not a soft `warnings.warn` — see decision 5).
+`DecompressorStream._read_decompressed_chunk` raises `TruncatedError` unless `_is_decompressor_finished()` is true at source EOF. `.Z` has no end marker, so the unix-compress stream MUST still mark finished at input EOF (otherwise every valid file would raise). Best-effort truncation: after flush, if leftover bits after the last complete code are nonzero, deliver decoded bytes then raise `TruncatedError` on the next empty `read()` (see decision 5).
 
 ### Packaging / zero-dep
 
@@ -142,11 +142,11 @@ Drop the extra from `pyproject.toml`, `[recommended-lite]` composition, and miss
 
 Keep `ncompress` in the `dev` group only.
 
-### 5. Error taxonomy (no soft warnings)
+### 5. Error taxonomy
 
-Invalid magic / invalid codes / bad header → raise `CorruptionError` from the LZW kernel (not stdlib `ValueError` + codec `translate`). Constructor misuse (`max_width`/`block_mode` only one set) is an `assert` — unreachable from public paths. No `StreamNotSeekableError` from the codec for `.Z` pipes. No `PackageNotInstalledError` for unix-compress.
+Invalid magic / invalid codes / bad header width → raise `CorruptionError` from the LZW kernel (not stdlib `ValueError` + codec `translate`). Unknown reserved header flag bits (`0x60`) → `UnsupportedFeatureError` at header parse. Constructor misuse (`max_width`/`block_mode` only one set) is an `assert` — unreachable from public paths. No `StreamNotSeekableError` from the codec for `.Z` pipes. No `PackageNotInstalledError` for unix-compress.
 
-Partial final code at EOF and reserved header bits (0x60) are **silent**: `.Z` has no trailer to confirm truncation, and Archivey’s diagnostic taxonomy has no fitting code for “unknown compress flags” / “partial trailing LZW code.” Emitting `warnings.warn` would bypass the collector; inventing a new `DiagnosticCode` is a cross-cutting diagnostics change deferred until a caller needs those advisories. Not `TruncatedError`.
+Truncation is best-effort only (no length/checksum trailer). Finished compressors zero-pad after the last complete LZW code; at source EOF, if leftover bits are nonzero, deliver all decoded bytes then raise `TruncatedError` on the next empty `read()`. Zero leftover bits (including cuts exactly on a code boundary) end successfully — undetectable. Do not invent soft `warnings.warn` / new `DiagnosticCode`s for this.
 
 ### 6. Docs / IDEAS cleanup in the same change
 
@@ -158,7 +158,7 @@ Update `docs/internal/library-analysis.md`, remove the IDEAS “non-seekable uni
 | --- | --- |
 | Behavioral drift vs uncompresspy on edge CLEAR/alignment cases | Keep existing corpus + `ncompress` roundtrips; add explicit CLEAR-heavy / multi-block seek tests |
 | Incorrect compressed_offset on SeekPoints when feeding large chunks | Unit-test CLEAR seek resumes byte-identical to forward decode from that offset; compare against full re-decode |
-| `DecompressorStream` EOF → `TruncatedError` | Override finished/flush semantics for `.Z` as above; regression test truncated fixture yields short data without error |
+| `DecompressorStream` EOF → `TruncatedError` | Mark finished at EOF; arm best-effort nonzero-leftover `TruncatedError` for the next empty read; regression: valid files never raise; truncated-with-nonzero-leftover raises after delivering bytes |
 | License attribution missed | File-level BSD-3 header + third-party notice in package metadata/docs |
 | Slightly larger core wheel | ~200–300 lines pure Python; acceptable vs an extra dependency |
 

--- a/openspec/changes/vendor-unix-compress-lzw/design.md
+++ b/openspec/changes/vendor-unix-compress-lzw/design.md
@@ -10,7 +10,7 @@ License: archivey is MIT; uncompresspy 0.4.1 is BSD-3-Clause (Copyright 2025 Tia
 
 **Goals:**
 
-- Vendor/adapt the LZW decode kernel into a `DecompressorStream` subclass.
+- Vendor/adapt the LZW decode kernel as a push state machine behind `SegmentedDecompressorStream` (same split as xz/lzip).
 - Forward decode works on non-seekable sources (CLEAR overshoot handled in a bounded buffer).
 - Seekable source + declared seekability → CLEAR positions become `SeekPoint`s; random access resumes from the nearest CLEAR (or start) with an empty dictionary.
 - Seekable source without declared seekability → forward-only (no seek-point table), matching other codecs.
@@ -40,19 +40,20 @@ License: archivey is MIT; uncompresspy 0.4.1 is BSD-3-Clause (Copyright 2025 Tia
 
 Unix-compress packs codes into blocks of `code_width` bytes. After CLEAR, the bitstream realigns to the next block boundary. uncompresspy reads a whole block-sized chunk, then on CLEAR repositions with a relative `seek`. Overshoot is at most one code-width block — bounded — so an in-memory unread/discard replaces the seek.
 
+### How existing stream bases split responsibility
+
+| Pattern | Used by | Shape | Mid-decode events |
+| --- | --- | --- | --- |
+| Simple `DecompressorStream` | zlib, brotli, ppmd | `_decompress_chunk(chunk) → bytes` | None; rewind from origin |
+| `SegmentedDecompressorStream` | xz, lzip | `state.feed(chunk) → (bytes, [(decomp, comp), …])` | Stream turns units into `SeekPoint`s via cursors |
+
+CLEAR is a mid-decode event with relative segment sizes — same shape as xz/lzip member/stream completions, not zlib.
+
 ### SeekPoint fit
 
-At CLEAR the dictionary resets to the 256 literals (+ placeholder in block mode). That is exactly a resume state with no dictionary payload to serialize:
+At CLEAR the dictionary resets to the 256 literals (+ placeholder in block mode). That is a resume state with no dictionary payload to serialize. Absolute offsets live on the stream’s `_comp_cursor` / `_decomp_cursor`; the state machine only reports relative `(decomp_size, comp_size)` for each CLEAR-ended segment.
 
-```
-SeekPoint(
-  decompressed_offset=<bytes emitted so far>,
-  compressed_offset=<absolute source pos after CLEAR realignment>,
-  state=None,  # or header params only; dict always empty at CLEAR
-)
-```
-
-Stream start is already `SeekPoint(0, 3)` after the 3-byte header (uncompresspy’s first checkpoint). `_create_decompressor(point)` rebuilds a fresh LZW state with the header’s `max_width` / `block_mode` already parsed.
+After the 3-byte header, resume origin is `SeekPoint(0, 3)`. `_make_decompressor(point)` rebuilds a fresh `LzwState` with header params (`max_width`, `block_mode`) already known on the stream.
 
 `DecompressorStream.seekable()` already delegates to `_inner.seekable()`, and `add_seek_points` no-ops when `seekable=False` on construction — the dual contract falls out of the existing base.
 
@@ -72,13 +73,56 @@ Port header + decode loop + KwKwK special case into an internal module (e.g. `st
 
 **Rejected:** keep `uncompresspy` and only upstream a streaming patch (does not fix ownership/stability). **Rejected:** rewrite from `ncompress` (Unlicense) — more behavioral risk vs the decoder we already test against.
 
-### 2. `UnixCompressDecompressorStream(DecompressorStream[LzwState])`
+### 2. Split `LzwState` + `UnixCompressDecompressorStream(SegmentedDecompressorStream)`
 
-Same pattern as Brotli/PPMd wrappers: codec `open()` constructs the stream with `seekable=config.seekable`. LZW state is push-oriented (`feed` compressed bytes → decompressed bytes), owning a small input bit/byte buffer so CLEAR realignment never calls `seek` on the source.
+Do **not** dump the algorithm into the stream subclass, and do **not** use the zlib-only `_decompress_chunk → bytes` shape (CLEAR has nowhere to surface). Follow xz/lzip:
 
-Track absolute compressed cursor as bytes are consumed so CLEAR can `add_seek_points([SeekPoint(decomp_pos, comp_pos)])` when `_index_enabled`.
+```
+compressed chunk
+       │
+       ▼
+┌──────────────────┐
+│ LzwState         │  pure state machine (testable without I/O)
+│ feed / flush     │  header, dict, bitbuf, KwKwK, CLEAR unread
+│ is_finished      │
+└────────┬─────────┘
+         │ (out_bytes, [(decomp_n, comp_n), …])  one unit per CLEAR
+         ▼
+┌──────────────────────────────┐
+│ UnixCompressDecompressorStream│  SegmentedDecompressorStream
+│ _comp/_decomp_cursor         │
+│ _on_completed_segments       │──▶ add_seek_points after advancing
+│ header params for resume     │
+└──────────────────────────────┘
+```
 
-**Rejected:** wrap `LZWFile` with a `BufferedReader` that fakes seek via full buffering (violates “no silent unbounded buffer of non-seekable” / ADR 0010).
+**`LzwState`** (lives in e.g. `streams/unix_compress.py`):
+
+- Implements the `_SegmentDecompressor` protocol: `feed` / `flush` → `(bytes, list[tuple[int, int]])`, `is_finished`.
+- Owns dictionary, bit buffer, code-width growth, KwKwK, and CLEAR realignment via a bounded in-memory buffer (never `seek`s a file).
+- Counts *logically consumed* compressed bytes (including CLEAR discard) so units’ `comp_size` are accurate even when the outer read chunk overshot.
+- Knows nothing about `SeekPoint`, absolute offsets, or files.
+- On first feed, parse the 3-byte header (or accept pre-parsed params); corruption → raise typed/`ValueError` for the codec translator.
+
+**`UnixCompressDecompressorStream`:**
+
+- `codec.open()` constructs it with `seekable=config.seekable`.
+- Stores `max_width` / `block_mode` after header parse so `_make_decompressor(point)` can rebuild an empty-dict `LzwState` at any CLEAR/`SeekPoint(0, 3)`.
+- `_on_completed_segments`: for each unit, **advance cursors first**, then register the resume point (empty dict *after* CLEAR) — inverse of lzip’s “point then advance,” which marks segment *start* of the member that just finished:
+
+  ```python
+  for decomp_size, comp_size in units:
+      self._comp_cursor += comp_size
+      self._decomp_cursor += decomp_size
+      self.add_seek_points(
+          [SeekPoint(self._decomp_cursor, self._comp_cursor)]
+      )
+  ```
+
+- No `_build_index` override: `.Z` has no trailer; progressive CLEAR points only; `SEEK_END` uses the base class scan-to-EOF when size is unknown.
+- `_is_decompressor_finished()` is true at source EOF (see truncation decision).
+
+**Rejected:** zlib-style `_decompress_chunk → bytes` plus ad-hoc `state.take_clears()` (reinvents segmented poorly). **Rejected:** monolithic stream subclass with inline LZW (harder to unit-test; blurs state vs I/O). **Rejected:** wrap `LZWFile` with a buffer that fakes seek (violates ADR 0010).
 
 ### 3. Seek contract mirrors xz/lzip, not stdlib gzip
 
@@ -118,4 +162,4 @@ Update `docs/internal/library-analysis.md`, remove the IDEAS “non-seekable uni
 
 ## Open Questions
 
-None blocking — seek dual-contract and CLEAR→SeekPoint approach confirmed for this proposal.
+None blocking — seek dual-contract, CLEAR→SeekPoint, and `LzwState` / `SegmentedDecompressorStream` module split confirmed.

--- a/openspec/changes/vendor-unix-compress-lzw/design.md
+++ b/openspec/changes/vendor-unix-compress-lzw/design.md
@@ -1,0 +1,121 @@
+## Context
+
+Unix-compress (`.Z`, LZW) is wired today as `UnixCompressCodec` → `uncompresspy.LZWFile` (`src/archivey/internal/streams/codecs.py`). That library is a ~600-line pure-Python `RawIOBase` with its own open/read/seek/checkpoint plumbing. Archivey already owns the equivalent via `DecompressorStream` + `SeekPoint` (`decompressor_stream.py`); xz/lzip already register format-native seek points the same way.
+
+`uncompresspy` requires a seekable source because CLEAR-code bit realignment does `file.seek(...)` during forward decode, not only for random access. Specs currently encode that as “`.Z` always needs seek.” `IDEAS.md` already flags non-seekable `.Z` as a follow-up. `seekable-decompressor-streams` already anticipates “unix-compress indexed seeks” by excluding them from `STREAM_REWIND_REDECOMPRESSES`.
+
+License: archivey is MIT; uncompresspy 0.4.1 is BSD-3-Clause (Copyright 2025 Tiago Gomes). Compatible with attribution.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Vendor/adapt the LZW decode kernel into a `DecompressorStream` subclass.
+- Forward decode works on non-seekable sources (CLEAR overshoot handled in a bounded buffer).
+- Seekable source + declared seekability → CLEAR positions become `SeekPoint`s; random access resumes from the nearest CLEAR (or start) with an empty dictionary.
+- Seekable source without declared seekability → forward-only (no seek-point table), matching other codecs.
+- Non-seekable source → `seekable()` false; `seek` unsupported.
+- Move `.Z` into zero-dep core; remove `[unix-compress]` / `uncompresspy`.
+- Preserve behavioral parity with today’s decoder on the existing corpus / `ncompress` fixtures (corruption → `CorruptionError`; truncation still undetectable).
+
+**Non-Goals:**
+
+- Compression / writing `.Z` (still out of scope; fixtures stay on `ncompress`).
+- Upstreaming the streaming fix to uncompresspy as the primary path.
+- Rewriting the algorithm from `ncompress` or another reference (kept as a rejected alternative).
+- Changing detection magic (`1F 9D`) or TAR+`.Z` composition rules.
+- Emitting `TruncatedError` for cut `.Z` streams (format has no length/checksum).
+
+## Investigations
+
+### What uncompresspy actually does
+
+| Piece | Lines (approx.) | Archivey equivalent |
+| --- | --- | --- |
+| Path/file open, `RawIOBase`, `open()`, `extract()` | ~250 | `DecompressorStream` / `ReadOnlyIOStream` / codec layer |
+| Checkpoint list + `seek`/`tell` | ~80 | `SeekPoint` + `DecompressorStream.seek` |
+| Header + LZW loop + CLEAR realignment | ~200–250 | **Port this** |
+
+### Why CLEAR needs “seek” today
+
+Unix-compress packs codes into blocks of `code_width` bytes. After CLEAR, the bitstream realigns to the next block boundary. uncompresspy reads a whole block-sized chunk, then on CLEAR repositions with a relative `seek`. Overshoot is at most one code-width block — bounded — so an in-memory unread/discard replaces the seek.
+
+### SeekPoint fit
+
+At CLEAR the dictionary resets to the 256 literals (+ placeholder in block mode). That is exactly a resume state with no dictionary payload to serialize:
+
+```
+SeekPoint(
+  decompressed_offset=<bytes emitted so far>,
+  compressed_offset=<absolute source pos after CLEAR realignment>,
+  state=None,  # or header params only; dict always empty at CLEAR
+)
+```
+
+Stream start is already `SeekPoint(0, 3)` after the 3-byte header (uncompresspy’s first checkpoint). `_create_decompressor(point)` rebuilds a fresh LZW state with the header’s `max_width` / `block_mode` already parsed.
+
+`DecompressorStream.seekable()` already delegates to `_inner.seekable()`, and `add_seek_points` no-ops when `seekable=False` on construction — the dual contract falls out of the existing base.
+
+### Truncation / finished semantics
+
+`DecompressorStream._read_decompressed_chunk` raises `TruncatedError` unless `_is_decompressor_finished()` is true at source EOF. `.Z` has no end marker; today’s codec intentionally never raises truncation. The unix-compress stream MUST treat input EOF as finished (optional soft warning for a partial trailing code, matching uncompresspy’s `warn_truncation`, but not a typed truncation error).
+
+### Packaging / zero-dep
+
+`.Z` becomes another pure-Python core codec alongside native xz/lzip. Core-only CI (`check_zero_dep_core.py`) must still pass: no `uncompresspy` import. `ncompress` remains dev-only for fixture generation.
+
+## Decisions
+
+### 1. Adapt uncompresspy’s LZW kernel; do not keep the package
+
+Port header + decode loop + KwKwK special case into an internal module (e.g. `streams/unix_compress.py` or `streams/lzw.py`) under a BSD-3-Clause file header / `NOTICE` entry naming Tiago Gomes / uncompresspy. Project license stays MIT.
+
+**Rejected:** keep `uncompresspy` and only upstream a streaming patch (does not fix ownership/stability). **Rejected:** rewrite from `ncompress` (Unlicense) — more behavioral risk vs the decoder we already test against.
+
+### 2. `UnixCompressDecompressorStream(DecompressorStream[LzwState])`
+
+Same pattern as Brotli/PPMd wrappers: codec `open()` constructs the stream with `seekable=config.seekable`. LZW state is push-oriented (`feed` compressed bytes → decompressed bytes), owning a small input bit/byte buffer so CLEAR realignment never calls `seek` on the source.
+
+Track absolute compressed cursor as bytes are consumed so CLEAR can `add_seek_points([SeekPoint(decomp_pos, comp_pos)])` when `_index_enabled`.
+
+**Rejected:** wrap `LZWFile` with a `BufferedReader` that fakes seek via full buffering (violates “no silent unbounded buffer of non-seekable” / ADR 0010).
+
+### 3. Seek contract mirrors xz/lzip, not stdlib gzip
+
+| Source | Declared `seekable` | Behavior |
+| --- | --- | --- |
+| Non-seekable | any | Forward-only; `seekable()` false |
+| Seekable | false | Forward-only; no CLEAR table retained |
+| Seekable | true | CLEAR → `SeekPoint`; random access from nearest CLEAR/start |
+
+`UnixCompressCodec.rewind_warning` stays `None` (indexed path; already excluded from rewind diagnostics). No accelerator extra.
+
+**Rejected:** always O(n) rewind from offset 0 with a `RewindWarning` (throws away free CLEAR index).
+
+### 4. Core packaging; remove `[unix-compress]`
+
+Drop the extra from `pyproject.toml`, `[recommended-lite]` composition, and missing-backend tests. Pre-1.0 **BREAKING** for anyone who depended on the extra name alone; capability moves to bare install. Do not leave an empty deprecated extra unless a later release needs a migration shim.
+
+Keep `ncompress` in the `dev` group only.
+
+### 5. Error translation
+
+Invalid magic / invalid codes / bad header → `CorruptionError`. No `StreamNotSeekableError` from the codec for `.Z` pipes. No `PackageNotInstalledError` for unix-compress. Partial final code at EOF → optional warning only; not `TruncatedError`.
+
+### 6. Docs / IDEAS cleanup in the same change
+
+Update `docs/internal/library-analysis.md`, remove the IDEAS “non-seekable unix-compress” bullet (done by this change), adjust purpose prose in affected specs.
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+| --- | --- |
+| Behavioral drift vs uncompresspy on edge CLEAR/alignment cases | Keep existing corpus + `ncompress` roundtrips; add explicit CLEAR-heavy / multi-block seek tests |
+| Incorrect compressed_offset on SeekPoints when feeding large chunks | Unit-test CLEAR seek resumes byte-identical to forward decode from that offset; compare against full re-decode |
+| `DecompressorStream` EOF → `TruncatedError` | Override finished/flush semantics for `.Z` as above; regression test truncated fixture yields short data without error |
+| License attribution missed | File-level BSD-3 header + third-party notice in package metadata/docs |
+| Slightly larger core wheel | ~200–300 lines pure Python; acceptable vs an extra dependency |
+
+## Open Questions
+
+None blocking — seek dual-contract and CLEAR→SeekPoint approach confirmed for this proposal.

--- a/openspec/changes/vendor-unix-compress-lzw/proposal.md
+++ b/openspec/changes/vendor-unix-compress-lzw/proposal.md
@@ -1,0 +1,33 @@
+## Why
+
+Unix-compress (`.Z`) currently depends on `uncompresspy`, a small Beta pure-Python package that reinvents stream plumbing Archivey already owns, requires a seekable source (even for forward decode, because CLEAR realignment seeks), and offers weak long-term support guarantees. Vendoring the LZW kernel into Archivey's `DecompressorStream` layer removes the dependency, unlocks non-seekable sources, and gives seekable sources CLEAR-based seek points like other indexed codecs.
+
+## What Changes
+
+- Replace the `uncompresspy` backend with an internal LZW decoder adapted from it (BSD-3-Clause attribution retained).
+- Wire unix-compress through `DecompressorStream`: forward decode never seeks the source; CLEAR overshoot is resolved in a bounded in-memory buffer.
+- On a seekable source with seekability declared, register a `SeekPoint` at each CLEAR (and at stream start) so backward/random seeks resume from the nearest reset — no `STREAM_REWIND_REDECOMPRESSES`.
+- Match other codecs' seek contract: non-seekable source → non-seekable decompression; seekable source → seekable decompression when seekability is requested.
+- Move `.Z` / `.tar.Z` into the zero-dependency core.
+- **BREAKING** (pre-1.0): remove the `[unix-compress]` extra and the `PackageNotInstalledError` path for `uncompresspy`. Callers who only installed that extra get the capability from bare `archivey`.
+- Drop `uncompresspy` from runtime extras and the `dev` group; keep `ncompress` as the test-only fixture compressor.
+- Retire the IDEAS.md "non-seekable unix-compress" item; update packaging / library-analysis docs.
+
+## Capabilities
+
+### New Capabilities
+
+### Modified Capabilities
+
+- `compressed-streams`: unix-compress default backend becomes the native LZW stream; availability moves to core.
+- `packaging-and-extras`: drop `[unix-compress]`; core install lists `.Z` / `.tar.Z`.
+- `format-single-file-compressors`: `.Z` no longer requires a seekable source; streaming/non-seekable behavior matches other single-file codecs.
+- `seekable-decompressor-streams`: specify CLEAR→`SeekPoint` indexing for unix-compress (already excluded from rewind diagnostics).
+
+## Impact
+
+- Code: new LZW state + `UnixCompressDecompressorStream` under `src/archivey/internal/streams/`; `UnixCompressCodec` in `codecs.py` stops importing `uncompresspy`.
+- Packaging: `pyproject.toml` extras / dependency groups; `tests/check_zero_dep_core.py` and extras-import guards.
+- Specs/docs: capabilities above; `docs/internal/library-analysis.md`; `IDEAS.md`; purpose prose in format/packaging specs.
+- Tests: remove `@requires("uncompresspy")` / missing-backend cases; add non-seekable forward decode, seekable CLEAR seek-point seeks, corruption translation; keep `ncompress` for fixtures.
+- License: retain Tiago Gomes / uncompresspy BSD-3-Clause notice on the vendored kernel (project stays MIT).

--- a/openspec/changes/vendor-unix-compress-lzw/specs/compressed-streams/spec.md
+++ b/openspec/changes/vendor-unix-compress-lzw/specs/compressed-streams/spec.md
@@ -1,0 +1,33 @@
+## MODIFIED Requirements
+
+### Requirement: Each supported codec has a default backend
+
+The system SHALL decompress supported codecs through these default backends:
+
+| Codec | Default backend | Availability |
+| --- | --- | --- |
+| gzip | stdlib `gzip` | core |
+| bzip2 | stdlib `bz2` | core |
+| xz | native xz stream over stdlib `lzma` | core |
+| LZMA1 / LZMA2 raw | stdlib `lzma` `FORMAT_RAW` | core |
+| Delta, BCJ x86/ARM/ARMT/PPC/SPARC/IA64 | `lzma` raw filters | core |
+| raw Deflate | stdlib `zlib` (`-15`) | core |
+| Copy/STORED | pass-through | core |
+| zstd | stdlib `compression.zstd` (3.14+) / `backports.zstd` (<3.14) | optional `[zstd]` before 3.14; core on 3.14+ |
+| lz4 | `lz4` | optional `[lz4]` |
+| Brotli | `brotli` | optional `[7z]` |
+| unix-compress `.Z` | native LZW `DecompressorStream` | core |
+| PPMd var.H | `pyppmd` | optional `[7z]` |
+| Deflate64 | `inflate64` | optional `[7z]` |
+| AES-256 decrypt stage | wrapped crypto backend | optional `[crypto]` |
+
+#### Scenario: backend matrix
+
+| Case | Expected |
+| --- | --- |
+| Default gzip stream | stdlib `gzip` |
+| Default zstd on Python 3.14+ | stdlib `compression.zstd` |
+| Default zstd on Python 3.11-3.13 with `backports.zstd` | `backports.zstd` using the same API |
+| 7z folder LZMA2 raw stream | `lzma` in `FORMAT_RAW` mode |
+| Default unix-compress `.Z` stream | native LZW stream; no `uncompresspy` import |
+| Core-only install opens `.Z` | Succeeds without optional extras |

--- a/openspec/changes/vendor-unix-compress-lzw/specs/format-single-file-compressors/spec.md
+++ b/openspec/changes/vendor-unix-compress-lzw/specs/format-single-file-compressors/spec.md
@@ -1,0 +1,31 @@
+## MODIFIED Requirements
+
+### Requirement: Report single-file compressor properties
+
+The backend SHALL expose these properties for every single-file compressor:
+
+| Property | Value |
+| --- | --- |
+| Listing cost | `INDEXED`; exactly one member |
+| Access cost | `DIRECT`; no inter-member dependency exists |
+| Supports write | Yes |
+| Requires seek | Random access (`streaming=False`) requires seek; forward-only `streaming=True` accepts non-seekable sources for every supported single-file codec including `.Z` |
+
+Random access over a non-seekable source SHALL fail fast at open with
+`StreamNotSeekableError`; the backend MUST NOT buffer an unbounded source to
+simulate repeatable reads. Under `streaming=True`, every supported single-file
+codec including unix-compress `.Z` SHALL stream from non-seekable sources.
+
+Member-stream seekability is a stream-level property from index- or
+accelerator-backed decoders (for example xz indexes, CLEAR seek points for
+unix-compress, `indexed_bzip2`, `rapidgzip`, seekable zstd), not an archive-level
+`CostReceipt` field.
+
+#### Scenario: property matrix
+
+| Case | Expected |
+| --- | --- |
+| Open any supported single-file compressor | `listing_cost=INDEXED`; `access_cost=DIRECT` |
+| Non-seekable source with `streaming=False` | `StreamNotSeekableError` |
+| Non-seekable source with `streaming=True` (including `.Z`) | Opens and `stream_members()` yields data |
+| Seekable `.Z` with declared member-stream seekability | Member stream is seekable via CLEAR seek points |

--- a/openspec/changes/vendor-unix-compress-lzw/specs/format-single-file-compressors/spec.md
+++ b/openspec/changes/vendor-unix-compress-lzw/specs/format-single-file-compressors/spec.md
@@ -29,3 +29,16 @@ unix-compress, `indexed_bzip2`, `rapidgzip`, seekable zstd), not an archive-leve
 | Non-seekable source with `streaming=False` | `StreamNotSeekableError` |
 | Non-seekable source with `streaming=True` (including `.Z`) | Opens and `stream_members()` yields data |
 | Seekable `.Z` with declared member-stream seekability | Member stream is seekable via CLEAR seek points |
+
+### Requirement: Report member size with codec caveats
+
+The system SHALL populate `member.size` according to codec metadata and
+format-specific reliability limits. For unix-compress `.Z`, size SHALL remain
+`None` until full decompression (no size trailer), and truncation SHALL be
+detected best-effort via nonzero leftover bits after the last complete LZW code.
+
+#### Scenario: size matrix
+
+| Case | Expected |
+| --- | --- |
+| Truncated `.Z` with nonzero leftover bits | Available bytes delivered; next `read()` raises `TruncatedError` |

--- a/openspec/changes/vendor-unix-compress-lzw/specs/packaging-and-extras/spec.md
+++ b/openspec/changes/vendor-unix-compress-lzw/specs/packaging-and-extras/spec.md
@@ -1,0 +1,89 @@
+## MODIFIED Requirements
+
+### Requirement: Zero-dependency core
+
+The system SHALL install with no third-party runtime dependencies when no extras are
+requested. Bare `pip install archivey` MUST fully support every native or
+stdlib-backed reader: ZIP, TAR including `tar.gz` / `tar.bz2` / `tar.xz` / `tar.Z`,
+single-file GZ / BZ2 / XZ / Z (unix-compress), directories, and 7z reading for common
+codecs (LZMA/LZMA2/BCJ/Delta/Deflate/BZip2/STORED) with CRC32 verification.
+
+The system SHALL parse RAR metadata/listing natively in core with CRC32
+verification. Reading RAR member data additionally requires the external `unrar`
+system binary at runtime; no pip extra supplies that binary. RAR members that carry
+only Blake2sp hashes still read without `[rar]`, but the Blake2sp integrity check is
+skipped with a diagnostic/warning.
+
+The build SHALL use `hatchling` and the distribution name `archivey`.
+
+#### Scenario: core install matrix
+
+| Case | Expected |
+| --- | --- |
+| `pip install archivey` with no extras | No third-party runtime packages installed |
+| Core read of ZIP/TAR/GZ/BZ2/XZ/Z/directory/common-codec 7z | Fully functional |
+| Core read of `.tar.Z` / bare `.Z` | Native LZW decode; no `uncompresspy` |
+| Core RAR listing | Native metadata/listing works |
+| Core RAR data read with no `unrar` on `PATH` | Clear error says the external `unrar` tool is required |
+| Core-only 7z write | Unavailable until `[7z-write]`; 7z reading still works |
+
+### Requirement: Optional extras enable specific capabilities
+
+The system SHALL gate each optional capability behind a named extra that pulls the
+third-party dependency required for that capability. 7z and RAR reading are native
+for the common case, so extras cover less-common 7z codecs, encryption, 7z writing,
+ISO, extra compression formats, seeking accelerators, and the CLI.
+
+| Extra | Pulls in | Enables |
+| --- | --- | --- |
+| *(none)* | stdlib only + native parsers | ZIP, TAR + stdlib compressed TAR variants including `.tar.Z`, GZ, BZ2, XZ, Z (unix-compress), directory, 7z read for common codecs (including LZMA2+BCJ), RAR metadata/listing; RAR data still needs RARLAB `unrar` |
+| `[7z]` | `pyppmd`, `inflate64`, `backports.zstd` on Python <3.14, `brotli`, `lz4`, `cryptography`, `pybcj` | All 7z reading features: PPMd, Deflate64, Zstd, Brotli, LZ4, AES, LZMA1+BCJ |
+| `[rar]` | `cryptography`, Blake2sp backend | Header-encrypted RAR5 and Blake2sp checksum verification; RAR data still needs RARLAB `unrar` |
+| `[crypto]` | `cryptography` | AES/crypto backend subset used by `[7z]` / `[rar]` |
+| `[7z-write]` | `py7zr` | 7z writing only; reading remains native |
+| `[iso]` | `pycdlib` | ISO 9660 (`.iso`) |
+| `[zstd]` | `backports.zstd` on Python <3.14 | Standalone Zstandard (`.zst`, `.tar.zst`); Python 3.14+ uses stdlib `compression.zstd` |
+| `[lz4]` | `lz4` | Standalone LZ4 (`.lz4`, `.tar.lz4`) and 7z LZ4 folders |
+| `[cli]` | `tqdm` | `archivey` command-line interface progress output |
+| `[seekable]` | `rapidgzip` | Faster gzip/bzip2 decompression and random access into gz/bz2 streams via rapidgzip / bundled `IndexedBzip2File` |
+| `[recommended-lite]` | `[7z]` + `[rar]` + `[7z-write]` + `[iso]` + `[zstd]` + `[lz4]` + `[cli]` | Every broadly wheeled format/codec dependency; excludes build-finicky C++ seek libs |
+| `[recommended]` | `[recommended-lite]` + `[seekable]` | Recommended install: every primary backend plus gz/bz2 seeking and speed |
+| `[all]` | `[recommended]` plus every alternative/secondary backend, currently none | Everything; currently resolves exactly to `[recommended]` |
+
+The system SHALL make `[recommended]` the sensible all-useful install and
+`[recommended-lite]` the fallback when `rapidgzip` cannot build. `[recommended-lite]`
+MUST retain every format and codec except gz/bz2 seeking and the speed boost from
+`[seekable]`.
+
+The system SHALL keep `[all]` as a future-proof superset for redundant alternative
+backends. At present `[all]` MUST resolve to exactly `[recommended]`; the former
+`python-xz` and `pyzstd` alternatives are not pinned because the compression-library
+analysis dropped them.
+
+The system SHALL treat `[7z]` and `[rar]` as format bundles for complete read support
+that requires Python packages. Missing optional libraries MUST degrade by one rule:
+raise `PackageNotInstalledError` or `UnsupportedFeatureError` only when bytes cannot
+be produced, and skip any integrity check that cannot be computed with an integrity
+diagnostic/warning instead of failing the read.
+
+The system SHALL keep `py7zr` and `rarfile` as dev-only test oracles except for
+`py7zr` under `[7z-write]`. BCJ2-filtered 7z members MUST remain unsupported by every
+extra. Installing any individual extra MUST make that capability available without
+requiring unrelated extras. `[all]` MUST be equivalent to installing every runtime
+extra. No user-facing extra SHALL pull an alternate RAR decompressor library or tool
+wrapper.
+
+Development tools, oracle libraries, and fixture generators such as `ncompress`
+SHALL live in the PEP 735 `dev` dependency group, not in user-facing runtime extras.
+The system SHALL NOT list `uncompresspy` in any user-facing extra or the `dev` group.
+
+#### Scenario: extras matrix
+
+| Case | Expected |
+| --- | --- |
+| Install `[7z]` | PPMd / Deflate64 / Zstd / Brotli / LZ4 / AES / LZMA1+BCJ 7z reading work |
+| Install `[rar]` without `unrar` on `PATH` | Header-encrypted listing works; data read still errors on missing `unrar` |
+| Install `[recommended-lite]` | All format/codec deps except rapidgzip; unix-compress needs no extra |
+| Install `[recommended]` | Same as lite plus gz/bz2 seeking via rapidgzip |
+| Install `[all]` | Resolves to `[recommended]` while no alternate backends exist |
+| Bare install | `.Z` / `.tar.Z` readable; no `[unix-compress]` extra exists |

--- a/openspec/changes/vendor-unix-compress-lzw/specs/seekable-decompressor-streams/spec.md
+++ b/openspec/changes/vendor-unix-compress-lzw/specs/seekable-decompressor-streams/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: Unix-compress uses CLEAR seek points
+
+When seekability is declared and the compressed source is seekable, the system
+SHALL register `SeekPoint`s at stream start (after the 3-byte `.Z` header) and at
+each LZW CLEAR realignment. A seek SHALL resume from the nearest preceding
+seek point with an empty dictionary and MUST NOT emit
+`STREAM_REWIND_REDECOMPRESSES`.
+
+Forward decode SHALL NOT call `seek` on the compressed source: CLEAR bit-block
+realignment MUST use a bounded in-memory buffer. When seekability is not
+declared, the system SHALL NOT retain a CLEAR seek-point table. When the source
+is not seekable, the decompressor stream SHALL report `seekable() is False` and
+`seek` SHALL raise `io.UnsupportedOperation`.
+
+Unix-compress has no length or checksum trailer: source EOF SHALL end the stream
+successfully even if a partial trailing code remains; the system MUST NOT raise
+`TruncatedError` solely because the bitstream ended mid-code.
+
+#### Scenario: unix-compress seek matrix
+
+| Case | Expected |
+| --- | --- |
+| Seekable `.Z`, `seekable=True`, seek backward across a CLEAR | Resumes from CLEAR/`SeekPoint`; no rewind diagnostic |
+| Seekable `.Z`, `seekable=False` | Forward-only; no CLEAR table retained |
+| Non-seekable `.Z` pipe, forward read | Decompresses; `seekable()` false |
+| Truncated `.Z` (cut bitstream) | Yields fewer bytes; no `TruncatedError` |
+| Corrupt LZW codes | `CorruptionError` |

--- a/openspec/changes/vendor-unix-compress-lzw/specs/seekable-decompressor-streams/spec.md
+++ b/openspec/changes/vendor-unix-compress-lzw/specs/seekable-decompressor-streams/spec.md
@@ -14,9 +14,15 @@ declared, the system SHALL NOT retain a CLEAR seek-point table. When the source
 is not seekable, the decompressor stream SHALL report `seekable() is False` and
 `seek` SHALL raise `io.UnsupportedOperation`.
 
-Unix-compress has no length or checksum trailer: source EOF SHALL end the stream
-successfully even if a partial trailing code remains; the system MUST NOT raise
-`TruncatedError` solely because the bitstream ended mid-code.
+Unix-compress has no length or checksum trailer. At source EOF, after all
+decoded bytes have been delivered, the system SHALL best-effort detect
+truncation: if any leftover bits remain after the last complete LZW code and
+those bits are nonzero (finished compressors zero-pad), the next `read()` SHALL
+raise `TruncatedError`. Zero leftover bits (including a cut exactly on a code
+boundary) SHALL end successfully — such truncation remains undetectable.
+
+Unknown reserved header flag bits (`0x60` in the third header byte) SHALL raise
+`UnsupportedFeatureError` when the header is parsed.
 
 #### Scenario: unix-compress seek matrix
 
@@ -25,5 +31,7 @@ successfully even if a partial trailing code remains; the system MUST NOT raise
 | Seekable `.Z`, `seekable=True`, seek backward across a CLEAR | Resumes from CLEAR/`SeekPoint`; no rewind diagnostic |
 | Seekable `.Z`, `seekable=False` | Forward-only; no CLEAR table retained |
 | Non-seekable `.Z` pipe, forward read | Decompresses; `seekable()` false |
-| Truncated `.Z` (cut bitstream) | Yields fewer bytes; no `TruncatedError` |
+| Truncated `.Z` with nonzero leftover bits | Yields available bytes; next `read()` raises `TruncatedError` |
+| Truncated `.Z` with only zero leftover bits | Yields fewer bytes; no `TruncatedError` (undetectable) |
+| Header flag byte has reserved bits `0x60` set | `UnsupportedFeatureError` |
 | Corrupt LZW codes | `CorruptionError` |

--- a/openspec/changes/vendor-unix-compress-lzw/tasks.md
+++ b/openspec/changes/vendor-unix-compress-lzw/tasks.md
@@ -1,9 +1,9 @@
 ## 1. LZW kernel + stream
 
 - [x] 1.1 Add `LzwState` (`feed`/`flush`/`is_finished`, CLEAR in-memory realignment, relative segment units) adapted from uncompresspy with BSD-3-Clause attribution
-- [x] 1.2 Implement `UnixCompressDecompressorStream(SegmentedDecompressorStream)`: cursors, CLEAR units → `SeekPoint` after advance, EOF-finished (no `TruncatedError`), no trailer `_build_index`
+- [x] 1.2 Implement `UnixCompressDecompressorStream(SegmentedDecompressorStream)`: cursors, CLEAR units → `SeekPoint` after advance, EOF-finished, best-effort `TruncatedError` on next empty read when leftover bits are nonzero; no trailer `_build_index`
 - [x] 1.3 Point `UnixCompressCodec.open` at the native stream (`seekable=config.seekable`); drop `uncompresspy` import, requirement, and seekable-only error translation
-- [x] 1.4 Align errors/advisories with Archivey: LZW raises `CorruptionError` (not stdlib `ValueError`); drop soft `warnings.warn` (no suitable `DiagnosticCode` yet for reserved header bits / partial trailing codes)
+- [x] 1.4 Align errors with Archivey: `CorruptionError` for bad magic/codes; `UnsupportedFeatureError` for reserved header flags (`0x60`); best-effort nonzero-leftover → deferred `TruncatedError`
 
 ## 2. Packaging + docs
 
@@ -14,7 +14,7 @@
 ## 3. Tests
 
 - [x] 3.1 Rewrite unix-compress tests: drop `@requires("uncompresspy")` and the missing-backend case; keep `ncompress` for fixture generation
-- [x] 3.2 Cover non-seekable forward decode, seekable CLEAR seek-point seeks (no rewind diagnostic), corruption → `CorruptionError`, truncated short read without `TruncatedError`
+- [x] 3.2 Cover non-seekable forward decode, seekable CLEAR seek-point seeks (no rewind diagnostic), corruption → `CorruptionError`, reserved flags → `UnsupportedFeatureError`, truncated-with-nonzero-leftover → deferred `TruncatedError`
 - [x] 3.3 Confirm core-only / extras-import guards: `.Z` works without third-party packages; `uncompresspy` is not a leaf extra
 
 ## 4. Verify

--- a/openspec/changes/vendor-unix-compress-lzw/tasks.md
+++ b/openspec/changes/vendor-unix-compress-lzw/tasks.md
@@ -1,20 +1,20 @@
 ## 1. LZW kernel + stream
 
-- [ ] 1.1 Add `LzwState` (`feed`/`flush`/`is_finished`, CLEAR in-memory realignment, relative segment units) adapted from uncompresspy with BSD-3-Clause attribution
-- [ ] 1.2 Implement `UnixCompressDecompressorStream(SegmentedDecompressorStream)`: cursors, CLEAR units → `SeekPoint` after advance, EOF-finished (no `TruncatedError`), no trailer `_build_index`
-- [ ] 1.3 Point `UnixCompressCodec.open` at the native stream (`seekable=config.seekable`); drop `uncompresspy` import, requirement, and seekable-only error translation
+- [x] 1.1 Add `LzwState` (`feed`/`flush`/`is_finished`, CLEAR in-memory realignment, relative segment units) adapted from uncompresspy with BSD-3-Clause attribution
+- [x] 1.2 Implement `UnixCompressDecompressorStream(SegmentedDecompressorStream)`: cursors, CLEAR units → `SeekPoint` after advance, EOF-finished (no `TruncatedError`), no trailer `_build_index`
+- [x] 1.3 Point `UnixCompressCodec.open` at the native stream (`seekable=config.seekable`); drop `uncompresspy` import, requirement, and seekable-only error translation
 
 ## 2. Packaging + docs
 
-- [ ] 2.1 Remove `[unix-compress]` / `uncompresspy` from `pyproject.toml` extras, recommended-lite, and the `dev` group; keep `ncompress` for fixtures
-- [ ] 2.2 Update `docs/internal/library-analysis.md`, purpose prose that still names `uncompresspy`, and remove the IDEAS.md non-seekable `.Z` bullet
-- [ ] 2.3 Sync main specs from this change’s deltas (`compressed-streams`, `packaging-and-extras`, `format-single-file-compressors`, `seekable-decompressor-streams`) when applying
+- [x] 2.1 Remove `[unix-compress]` / `uncompresspy` from `pyproject.toml` extras, recommended-lite, and the `dev` group; keep `ncompress` for fixtures
+- [x] 2.2 Update `docs/internal/library-analysis.md`, purpose prose that still names `uncompresspy`, and remove the IDEAS.md non-seekable `.Z` bullet
+- [x] 2.3 Sync main specs from this change’s deltas (`compressed-streams`, `packaging-and-extras`, `format-single-file-compressors`, `seekable-decompressor-streams`) when applying
 
 ## 3. Tests
 
-- [ ] 3.1 Rewrite unix-compress tests: drop `@requires("uncompresspy")` and the missing-backend case; keep `ncompress` for fixture generation
-- [ ] 3.2 Cover non-seekable forward decode, seekable CLEAR seek-point seeks (no rewind diagnostic), corruption → `CorruptionError`, truncated short read without `TruncatedError`
-- [ ] 3.3 Confirm core-only / extras-import guards: `.Z` works without third-party packages; `uncompresspy` is not a leaf extra
+- [x] 3.1 Rewrite unix-compress tests: drop `@requires("uncompresspy")` and the missing-backend case; keep `ncompress` for fixture generation
+- [x] 3.2 Cover non-seekable forward decode, seekable CLEAR seek-point seeks (no rewind diagnostic), corruption → `CorruptionError`, truncated short read without `TruncatedError`
+- [x] 3.3 Confirm core-only / extras-import guards: `.Z` works without third-party packages; `uncompresspy` is not a leaf extra
 
 ## 4. Verify
 

--- a/openspec/changes/vendor-unix-compress-lzw/tasks.md
+++ b/openspec/changes/vendor-unix-compress-lzw/tasks.md
@@ -1,0 +1,22 @@
+## 1. LZW kernel + stream
+
+- [ ] 1.1 Add internal LZW module (header + decode + CLEAR in-memory realignment) adapted from uncompresspy with BSD-3-Clause attribution
+- [ ] 1.2 Implement `UnixCompressDecompressorStream(DecompressorStream)`: push feed, EOF-finished (no `TruncatedError`), CLEAR → `add_seek_points` when index enabled
+- [ ] 1.3 Point `UnixCompressCodec.open` at the native stream (`seekable=config.seekable`); drop `uncompresspy` import, requirement, and seekable-only error translation
+
+## 2. Packaging + docs
+
+- [ ] 2.1 Remove `[unix-compress]` / `uncompresspy` from `pyproject.toml` extras, recommended-lite, and the `dev` group; keep `ncompress` for fixtures
+- [ ] 2.2 Update `docs/internal/library-analysis.md`, purpose prose that still names `uncompresspy`, and remove the IDEAS.md non-seekable `.Z` bullet
+- [ ] 2.3 Sync main specs from this change’s deltas (`compressed-streams`, `packaging-and-extras`, `format-single-file-compressors`, `seekable-decompressor-streams`) when applying
+
+## 3. Tests
+
+- [ ] 3.1 Rewrite unix-compress tests: drop `@requires("uncompresspy")` and the missing-backend case; keep `ncompress` for fixture generation
+- [ ] 3.2 Cover non-seekable forward decode, seekable CLEAR seek-point seeks (no rewind diagnostic), corruption → `CorruptionError`, truncated short read without `TruncatedError`
+- [ ] 3.3 Confirm core-only / extras-import guards: `.Z` works without third-party packages; `uncompresspy` is not a leaf extra
+
+## 4. Verify
+
+- [ ] 4.1 Targeted pytest for unix-compress / codecs / single-file / seek behavior
+- [ ] 4.2 `openspec validate --strict vendor-unix-compress-lzw`

--- a/openspec/changes/vendor-unix-compress-lzw/tasks.md
+++ b/openspec/changes/vendor-unix-compress-lzw/tasks.md
@@ -3,6 +3,7 @@
 - [x] 1.1 Add `LzwState` (`feed`/`flush`/`is_finished`, CLEAR in-memory realignment, relative segment units) adapted from uncompresspy with BSD-3-Clause attribution
 - [x] 1.2 Implement `UnixCompressDecompressorStream(SegmentedDecompressorStream)`: cursors, CLEAR units → `SeekPoint` after advance, EOF-finished (no `TruncatedError`), no trailer `_build_index`
 - [x] 1.3 Point `UnixCompressCodec.open` at the native stream (`seekable=config.seekable`); drop `uncompresspy` import, requirement, and seekable-only error translation
+- [x] 1.4 Align errors/advisories with Archivey: LZW raises `CorruptionError` (not stdlib `ValueError`); drop soft `warnings.warn` (no suitable `DiagnosticCode` yet for reserved header bits / partial trailing codes)
 
 ## 2. Packaging + docs
 

--- a/openspec/changes/vendor-unix-compress-lzw/tasks.md
+++ b/openspec/changes/vendor-unix-compress-lzw/tasks.md
@@ -1,7 +1,7 @@
 ## 1. LZW kernel + stream
 
-- [ ] 1.1 Add internal LZW module (header + decode + CLEAR in-memory realignment) adapted from uncompresspy with BSD-3-Clause attribution
-- [ ] 1.2 Implement `UnixCompressDecompressorStream(DecompressorStream)`: push feed, EOF-finished (no `TruncatedError`), CLEAR → `add_seek_points` when index enabled
+- [ ] 1.1 Add `LzwState` (`feed`/`flush`/`is_finished`, CLEAR in-memory realignment, relative segment units) adapted from uncompresspy with BSD-3-Clause attribution
+- [ ] 1.2 Implement `UnixCompressDecompressorStream(SegmentedDecompressorStream)`: cursors, CLEAR units → `SeekPoint` after advance, EOF-finished (no `TruncatedError`), no trailer `_build_index`
 - [ ] 1.3 Point `UnixCompressCodec.open` at the native stream (`seekable=config.seekable`); drop `uncompresspy` import, requirement, and seekable-only error translation
 
 ## 2. Packaging + docs

--- a/openspec/changes/vendor-unix-compress-lzw/tasks.md
+++ b/openspec/changes/vendor-unix-compress-lzw/tasks.md
@@ -18,5 +18,5 @@
 
 ## 4. Verify
 
-- [ ] 4.1 Targeted pytest for unix-compress / codecs / single-file / seek behavior
-- [ ] 4.2 `openspec validate --strict vendor-unix-compress-lzw`
+- [x] 4.1 Targeted pytest for unix-compress / codecs / single-file / seek behavior
+- [x] 4.2 `openspec validate --strict vendor-unix-compress-lzw`

--- a/openspec/specs/compressed-streams/spec.md
+++ b/openspec/specs/compressed-streams/spec.md
@@ -88,7 +88,7 @@ The system SHALL decompress supported codecs through these default backends:
 | zstd | stdlib `compression.zstd` (3.14+) / `backports.zstd` (<3.14) | optional `[zstd]` before 3.14; core on 3.14+ |
 | lz4 | `lz4` | optional `[lz4]` |
 | Brotli | `brotli` | optional `[7z]` |
-| unix-compress `.Z` | `uncompresspy` | optional `[unix-compress]` |
+| unix-compress `.Z` | native LZW `DecompressorStream` | core |
 | PPMd var.H | `pyppmd` | optional `[7z]` |
 | Deflate64 | `inflate64` | optional `[7z]` |
 | AES-256 decrypt stage | wrapped crypto backend | optional `[crypto]` |
@@ -106,6 +106,8 @@ raw LZMA1/LZMA2 remain container-only.
 | Default zstd on Python 3.11-3.13 with `backports.zstd` | `backports.zstd` using the same API |
 | Standalone `.lzma` / Alone stream | `lzma` in `FORMAT_ALONE` mode |
 | 7z folder LZMA2 raw stream | `lzma` in `FORMAT_RAW` mode |
+| Default unix-compress `.Z` stream | native LZW stream; no `uncompresspy` import |
+| Core-only install opens `.Z` | Succeeds without optional extras |
 
 ### Requirement: AES decryption is one wrapped pipeline stage
 

--- a/openspec/specs/format-single-file-compressors/spec.md
+++ b/openspec/specs/format-single-file-compressors/spec.md
@@ -94,7 +94,7 @@ format-specific reliability limits:
 | Codec | `member.size` behavior |
 | --- | --- |
 | GZ | Always `None`; stored ISIZE is modulo 2^32 and may be wrong |
-| BZ2, ZLIB, BR, Z | `None` until full decompression; `.Z` also has no truncation signal |
+| BZ2, ZLIB, BR, Z | `None` until full decompression; `.Z` has no size trailer (best-effort truncation via nonzero leftover bits) |
 | XZ, ZST | Header size when encoder wrote it; otherwise `None` |
 | LZ4 | Frame content-size field when present; otherwise `None` |
 | LZIP | Available from the trailer through the seekable lzip backend |
@@ -113,7 +113,7 @@ updated to that byte count.
 | `.lz` opened through seekable lzip backend | Size is available from the trailer |
 | Alone stream with known header size | `member.size` equals that size |
 | Alone stream with unknown-size marker | Size is `None` until EOF may update it |
-| Truncated `.Z` | Decoder may yield fewer bytes with no truncation error |
+| Truncated `.Z` with nonzero leftover bits | Available bytes delivered; next `read()` raises `TruncatedError` |
 
 ### Requirement: Surface gzip stored metadata without trusting it as the name
 

--- a/openspec/specs/format-single-file-compressors/spec.md
+++ b/openspec/specs/format-single-file-compressors/spec.md
@@ -10,8 +10,8 @@ name is inferred from the source filename.
 This capability is the standalone-stream side of `compressed-streams`. Raw
 Deflate and raw LZMA1/LZMA2 are not standalone formats because they lack
 self-framing; they appear only inside containers such as ZIP or 7z. Unix-compress
-(`.Z`, LZW) is supported through `uncompresspy` via `[unix-compress]`, requires a
-seekable source, and cannot signal truncation because the format has no length or
+(`.Z`, LZW) is decoded natively in core, streams from non-seekable sources under
+`streaming=True`, and cannot signal truncation because the format has no length or
 checksum trailer.
 
 ## Related specs
@@ -22,7 +22,7 @@ checksum trailer.
 | `access-mode-and-cost` | Listing/access cost and non-seekable legality |
 | `compressed-streams` | Codec descriptors, decoder availability, metadata hooks |
 | `format-detection` | Bare stream detection and combined TAR-compressor detection |
-| `packaging-and-extras` | Optional codec extras such as `[unix-compress]`, Brotli, LZ4, Zstd |
+| `packaging-and-extras` | Optional codec extras such as Brotli, LZ4, Zstd |
 
 ## Requirements
 
@@ -65,17 +65,17 @@ The backend SHALL expose these properties for every single-file compressor:
 | Listing cost | `INDEXED`; exactly one member |
 | Access cost | `DIRECT`; no inter-member dependency exists |
 | Supports write | Yes |
-| Requires seek | Random access (`streaming=False`) requires seek; forward-only `streaming=True` accepts non-seekable sources except `.Z` |
+| Requires seek | Random access (`streaming=False`) requires seek; forward-only `streaming=True` accepts non-seekable sources for every supported single-file codec including `.Z` |
 
 Random access over a non-seekable source SHALL fail fast at open with
 `StreamNotSeekableError`; the backend MUST NOT buffer an unbounded source to
-simulate repeatable reads. Under `streaming=True`, non-`.Z` codecs SHALL stream
-from non-seekable sources. Unix-compress `.Z` SHALL require seek in both modes
-because its decoder does.
+simulate repeatable reads. Under `streaming=True`, every supported single-file
+codec including unix-compress `.Z` SHALL stream from non-seekable sources.
 
-Member-stream seekability is a stream-level property from accelerator-backed
-decoders (for example xz indexes, `indexed_bzip2`, `rapidgzip`, seekable zstd),
-not an archive-level `CostReceipt` field.
+Member-stream seekability is a stream-level property from index- or
+accelerator-backed decoders (for example xz indexes, CLEAR seek points for
+unix-compress, `indexed_bzip2`, `rapidgzip`, seekable zstd), not an archive-level
+`CostReceipt` field.
 
 #### Scenario: property matrix
 
@@ -83,8 +83,8 @@ not an archive-level `CostReceipt` field.
 | --- | --- |
 | Open any supported single-file compressor | `listing_cost=INDEXED`; `access_cost=DIRECT` |
 | Non-seekable source with `streaming=False` | `StreamNotSeekableError` |
-| Non-`.Z` non-seekable source with `streaming=True` | Opens and `stream_members()` yields data |
-| `.Z` non-seekable source in either mode | `StreamNotSeekableError` |
+| Non-seekable source with `streaming=True` (including `.Z`) | Opens and `stream_members()` yields data |
+| Seekable `.Z` with declared member-stream seekability | Member stream is seekable via CLEAR seek points |
 
 ### Requirement: Report member size with codec caveats
 

--- a/openspec/specs/packaging-and-extras/spec.md
+++ b/openspec/specs/packaging-and-extras/spec.md
@@ -26,9 +26,9 @@ format specs.
 
 The system SHALL install with no third-party runtime dependencies when no extras are
 requested. Bare `pip install archivey` MUST fully support every native or
-stdlib-backed reader: ZIP, TAR including `tar.gz` / `tar.bz2` / `tar.xz`, single-file
-GZ / BZ2 / XZ, directories, and 7z reading for common codecs
-(LZMA/LZMA2/BCJ/Delta/Deflate/BZip2/STORED) with CRC32 verification.
+stdlib-backed reader: ZIP, TAR including `tar.gz` / `tar.bz2` / `tar.xz` / `tar.Z`,
+single-file GZ / BZ2 / XZ / Z (unix-compress), directories, and 7z reading for common
+codecs (LZMA/LZMA2/BCJ/Delta/Deflate/BZip2/STORED) with CRC32 verification.
 
 The system SHALL parse RAR metadata/listing natively in core with CRC32
 verification. Reading RAR member data additionally requires the external `unrar`
@@ -43,7 +43,8 @@ The build SHALL use `hatchling` and the distribution name `archivey`.
 | Case | Expected |
 | --- | --- |
 | `pip install archivey` with no extras | No third-party runtime packages installed |
-| Core read of ZIP/TAR/GZ/BZ2/XZ/directory/common-codec 7z | Fully functional |
+| Core read of ZIP/TAR/GZ/BZ2/XZ/Z/directory/common-codec 7z | Fully functional |
+| Core read of `.tar.Z` / bare `.Z` | Native LZW decode; no `uncompresspy` |
 | Core RAR listing | Native metadata/listing works |
 | Core RAR data read with no `unrar` on `PATH` | Clear error says the external `unrar` tool is required |
 | Core-only 7z write | Unavailable until `[7z-write]`; 7z reading still works |
@@ -57,7 +58,7 @@ ISO, extra compression formats, seeking accelerators, and the CLI.
 
 | Extra | Pulls in | Enables |
 | --- | --- | --- |
-| *(none)* | stdlib only + native parsers | ZIP, TAR + stdlib compressed TAR variants, GZ, BZ2, XZ, directory, 7z read for common codecs (including LZMA2+BCJ), RAR metadata/listing; RAR data still needs RARLAB `unrar` |
+| *(none)* | stdlib only + native parsers | ZIP, TAR + stdlib compressed TAR variants including `.tar.Z`, GZ, BZ2, XZ, Z (unix-compress), directory, 7z read for common codecs (including LZMA2+BCJ), RAR metadata/listing; RAR data still needs RARLAB `unrar` |
 | `[7z]` | `pyppmd`, `inflate64`, `backports.zstd` on Python <3.14, `brotli`, `lz4`, `cryptography`, `pybcj` | All 7z reading features: PPMd, Deflate64, Zstd, Brotli, LZ4, AES, LZMA1+BCJ |
 | `[rar]` | `cryptography`, Blake2sp backend | Header-encrypted RAR5 and Blake2sp checksum verification; RAR data still needs RARLAB `unrar` |
 | `[crypto]` | `cryptography` | AES/crypto backend subset used by `[7z]` / `[rar]` |
@@ -65,10 +66,9 @@ ISO, extra compression formats, seeking accelerators, and the CLI.
 | `[iso]` | `pycdlib` | ISO 9660 (`.iso`) |
 | `[zstd]` | `backports.zstd` on Python <3.14 | Standalone Zstandard (`.zst`, `.tar.zst`); Python 3.14+ uses stdlib `compression.zstd` |
 | `[lz4]` | `lz4` | Standalone LZ4 (`.lz4`, `.tar.lz4`) and 7z LZ4 folders |
-| `[unix-compress]` | `uncompresspy` | Unix-compress (`.Z`, `.tar.Z`) LZW decompression |
 | `[cli]` | `tqdm` | `archivey` command-line interface progress output |
 | `[seekable]` | `rapidgzip` | Faster gzip/bzip2 decompression and random access into gz/bz2 streams via rapidgzip / bundled `IndexedBzip2File` |
-| `[recommended-lite]` | `[7z]` + `[rar]` + `[7z-write]` + `[iso]` + `[zstd]` + `[lz4]` + `[unix-compress]` + `[cli]` | Every broadly wheeled format/codec dependency; excludes build-finicky C++ seek libs |
+| `[recommended-lite]` | `[7z]` + `[rar]` + `[7z-write]` + `[iso]` + `[zstd]` + `[lz4]` + `[cli]` | Every broadly wheeled format/codec dependency; excludes build-finicky C++ seek libs |
 | `[recommended]` | `[recommended-lite]` + `[seekable]` | Recommended install: every primary backend plus gz/bz2 seeking and speed |
 | `[all]` | `[recommended]` plus every alternative/secondary backend, currently none | Everything; currently resolves exactly to `[recommended]` |
 
@@ -97,6 +97,7 @@ wrapper.
 
 Development tools, oracle libraries, and fixture generators such as `ncompress`
 SHALL live in the PEP 735 `dev` dependency group, not in user-facing runtime extras.
+The system SHALL NOT list `uncompresspy` in any user-facing extra or the `dev` group.
 
 #### Scenario: extras matrix
 
@@ -104,10 +105,11 @@ SHALL live in the PEP 735 `dev` dependency group, not in user-facing runtime ext
 | --- | --- |
 | `pip install archivey[iso]` | Installs `pycdlib`; `.iso` works; unrelated optional deps are not pulled in |
 | `pip install archivey[recommended]` | Every optional format/codec and CLI capability plus `[seekable]`; no redundant xz/zstd alternative backend |
-| `pip install archivey[recommended-lite]` after `[recommended]` cannot build `rapidgzip` | Every format/codec still works; only gz/bz2 seeking and speed boost are absent |
+| `pip install archivey[recommended-lite]` after `[recommended]` cannot build `rapidgzip` | Every format/codec still works; only gz/bz2 seeking and speed boost are absent; unix-compress needs no extra |
 | `pip install archivey[all]` | Installs `[recommended]` plus current alternatives; currently exactly `[recommended]` |
 | `pip install archivey[7z]` | Installs `pybcj` (import name `bcj`) and `lz4` so LZMA1+BCJ and LZ4 7z members decode |
 | `pip install archivey[lz4]` | Standalone `.lz4` / `.tar.lz4` and 7z LZ4 folders work without requiring unrelated extras |
+| Bare install | `.Z` / `.tar.Z` readable; no `[unix-compress]` extra exists |
 | RAR5 data with only Blake2sp hashes and no `[rar]` | Bytes are returned unverified with a warning; no hard failure solely for skipped Blake2sp |
 | 7z member uses BCJ2 | Unsupported-codec error; no extra enables it |
 | RAR data without RARLAB `unrar` | `PackageNotInstalledError`; no alternate-tool extra exists |

--- a/openspec/specs/seekable-decompressor-streams/spec.md
+++ b/openspec/specs/seekable-decompressor-streams/spec.md
@@ -174,9 +174,15 @@ declared, the system SHALL NOT retain a CLEAR seek-point table. When the source
 is not seekable, the decompressor stream SHALL report `seekable() is False` and
 `seek` SHALL raise `io.UnsupportedOperation`.
 
-Unix-compress has no length or checksum trailer: source EOF SHALL end the stream
-successfully even if a partial trailing code remains; the system MUST NOT raise
-`TruncatedError` solely because the bitstream ended mid-code.
+Unix-compress has no length or checksum trailer. At source EOF, after all
+decoded bytes have been delivered, the system SHALL best-effort detect
+truncation: if any leftover bits remain after the last complete LZW code and
+those bits are nonzero (finished compressors zero-pad), the next `read()` SHALL
+raise `TruncatedError`. Zero leftover bits (including a cut exactly on a code
+boundary) SHALL end successfully — such truncation remains undetectable.
+
+Unknown reserved header flag bits (`0x60` in the third header byte) SHALL raise
+`UnsupportedFeatureError` when the header is parsed.
 
 #### Scenario: unix-compress seek matrix
 
@@ -185,5 +191,7 @@ successfully even if a partial trailing code remains; the system MUST NOT raise
 | Seekable `.Z`, `seekable=True`, seek backward across a CLEAR | Resumes from CLEAR/`SeekPoint`; no rewind diagnostic |
 | Seekable `.Z`, `seekable=False` | Forward-only; no CLEAR table retained |
 | Non-seekable `.Z` pipe, forward read | Decompresses; `seekable()` false |
-| Truncated `.Z` (cut bitstream) | Yields fewer bytes; no `TruncatedError` |
+| Truncated `.Z` with nonzero leftover bits | Yields available bytes; next `read()` raises `TruncatedError` |
+| Truncated `.Z` with only zero leftover bits | Yields fewer bytes; no `TruncatedError` (undetectable) |
+| Header flag byte has reserved bits `0x60` set | `UnsupportedFeatureError` |
 | Corrupt LZW codes | `CorruptionError` |

--- a/openspec/specs/seekable-decompressor-streams/spec.md
+++ b/openspec/specs/seekable-decompressor-streams/spec.md
@@ -159,3 +159,31 @@ operation summaries. Unsafe corruption SHALL remain a typed
 | Recoverable XZ index scan failure | `SEEK_INDEX_DEGRADED` collected/logged; stream falls back sequentially |
 | Same issue resolves to `RAISE` | `DiagnosticRaisedError`; no fallback |
 | Corruption prevents correct sequential decoding | `CorruptionError` / `TruncatedError`, not diagnostic fallback |
+
+### Requirement: Unix-compress uses CLEAR seek points
+
+When seekability is declared and the compressed source is seekable, the system
+SHALL register `SeekPoint`s at stream start (after the 3-byte `.Z` header) and at
+each LZW CLEAR realignment. A seek SHALL resume from the nearest preceding
+seek point with an empty dictionary and MUST NOT emit
+`STREAM_REWIND_REDECOMPRESSES`.
+
+Forward decode SHALL NOT call `seek` on the compressed source: CLEAR bit-block
+realignment MUST use a bounded in-memory buffer. When seekability is not
+declared, the system SHALL NOT retain a CLEAR seek-point table. When the source
+is not seekable, the decompressor stream SHALL report `seekable() is False` and
+`seek` SHALL raise `io.UnsupportedOperation`.
+
+Unix-compress has no length or checksum trailer: source EOF SHALL end the stream
+successfully even if a partial trailing code remains; the system MUST NOT raise
+`TruncatedError` solely because the bitstream ended mid-code.
+
+#### Scenario: unix-compress seek matrix
+
+| Case | Expected |
+| --- | --- |
+| Seekable `.Z`, `seekable=True`, seek backward across a CLEAR | Resumes from CLEAR/`SeekPoint`; no rewind diagnostic |
+| Seekable `.Z`, `seekable=False` | Forward-only; no CLEAR table retained |
+| Non-seekable `.Z` pipe, forward read | Decompresses; `seekable()` false |
+| Truncated `.Z` (cut bitstream) | Yields fewer bytes; no `TruncatedError` |
+| Corrupt LZW codes | `CorruptionError` |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,9 +46,6 @@ zstd = [
 lz4 = [
     "lz4>=4.4.5",
 ]
-unix-compress = [
-    "uncompresspy>=0.4.0",
-]
 cli = [
     "tqdm>=4.67.0",
 ]
@@ -60,7 +57,7 @@ seekable = [
     "rapidgzip>=0.16.0",
 ]
 recommended-lite = [
-    "archivey[7z,rar,7z-write,iso,zstd,lz4,unix-compress,cli]",
+    "archivey[7z,rar,7z-write,iso,zstd,lz4,cli]",
 ]
 recommended = [
     "archivey[recommended-lite,seekable]",
@@ -101,9 +98,8 @@ dev = [
     # PyCdlibIO annotation. The core-only CI leg installs with --no-dev, so it stays absent
     # there and the zero-dep core / graceful-degradation paths are still exercised.
     "pycdlib>=1.16.0",
-    # uncompresspy is the runtime decoder for unix-compress (.Z); ncompress is a test-only
-    # LZW *compressor* (uncompresspy only decompresses) used to generate .Z fixtures.
-    "uncompresspy>=0.4.0",
+    # ncompress is a test-only LZW *compressor* used to generate .Z fixtures for the
+    # native unix-compress decoder (core; decode-only).
     "ncompress>=1.0.0",
     "cryptography>=45.0.0",
     # Exercise real third-party stream objects in tests/test_stream_inputs.py: urllib3 is

--- a/src/archivey/internal/backends/single_file_reader.py
+++ b/src/archivey/internal/backends/single_file_reader.py
@@ -341,8 +341,7 @@ class SingleFileBackend(ReadBackend):
         if c.single_file_format is not None
     )
     # A compressed stream decodes front-to-back, so streaming=True works on a
-    # non-seekable source (except unix-compress, whose codec itself needs seek and
-    # rejects it at open). Random access always needs a seekable source.
+    # non-seekable source. Random access always needs a seekable source.
     SUPPORTS_STREAMING_NON_SEEKABLE = True
 
     def open_read(

--- a/src/archivey/internal/detection.py
+++ b/src/archivey/internal/detection.py
@@ -150,9 +150,10 @@ class _BoundedPeekReader(ReadOnlyIOStream):
     linear), letting a codec pull exactly as much compressed input as it needs and
     never more than ``limit`` (one maximum compressor block).
 
-    Seekable within the bound so codecs that require seek (unix-compress) can still
-    probe; seeking never pulls bytes beyond ``limit``, and peeks still grow only on
-    demand when a read needs more of the prefix.
+    Seekable within the bound so codecs that use seek during a probe (or need a
+    repositionable view of the peeked prefix) can still run; seeking never pulls
+    bytes beyond ``limit``, and peeks still grow only on demand when a read needs
+    more of the prefix.
     """
 
     def __init__(self, peek_more: Callable[[int], bytes], limit: int) -> None:
@@ -209,7 +210,8 @@ def _probe_inner_tar(
     block-transform codec (bzip2), which emits nothing until a whole block is read, pulls up to
     one maximum block (``_INNER_TAR_MAX_PROBE_BYTES``).
 
-    The peek reader is seekable within that bound so unix-compress (LZW) can probe.
+    The peek reader is seekable within that bound so codecs can reposition inside
+    the peeked prefix during a probe.
     Accelerators are forced ``OFF``: ``seekable=True`` must not flip AUTO rapidgzip /
     IndexedBzip2File on for a short detection peek (those paths reject incomplete
     sources and can leak raw C++ exceptions on corrupt prefixes). Prefer that over

--- a/src/archivey/internal/streams/codecs.py
+++ b/src/archivey/internal/streams/codecs.py
@@ -56,6 +56,7 @@ from archivey.internal.streams.streamtools import (
     ensure_bufferedio,
     fix_stream_start_position,
 )
+from archivey.internal.streams.unix_compress import UnixCompressDecompressorStream
 from archivey.internal.streams.xz import XzDecompressorStream
 from archivey.types import (
     ArchiveFormat,
@@ -95,7 +96,6 @@ def _optional_zstd() -> ModuleType | None:
 _zstd = _optional_zstd()
 _lz4_frame = _optional("lz4.frame")
 _brotli = _optional("brotli")
-_uncompresspy = _optional("uncompresspy")
 _pyppmd = _optional("pyppmd")
 _inflate64 = _optional("inflate64")
 _rapidgzip = _optional("rapidgzip")
@@ -1002,36 +1002,18 @@ class UnixCompressCodec(StreamCodec):
     codec = Codec.UNIX_COMPRESS
     stream_format = StreamFormat.UNIX_COMPRESS
     magic = (MagicSignature(0, b"\x1f\x9d", ArchiveFormat.Z),)
-    requirement = MissingComponent(
-        "uncompresspy", "pip install archivey[unix-compress]", ("unix_compress",)
-    )
-
-    def _backend_present(self) -> bool:
-        return _uncompresspy is not None
 
     def open(
         self, source: CodecSource, params: CodecParams, config: StreamConfig
     ) -> BinaryIO:
-        if _uncompresspy is None:
-            raise PackageNotInstalledError(
-                "The 'uncompresspy' package is required for unix-compress (.Z) streams "
-                "(install the 'unix-compress' extra)."
-            )
-        # uncompresspy.LZWFile accepts a path or a (seekable) file object and is itself a
-        # RawIOBase, so ensure_binaryio passes it through unchanged.
-        src = os.fspath(source) if isinstance(source, (str, os.PathLike)) else source
-        return ensure_binaryio(_uncompresspy.LZWFile(src))
+        # Native LZW over DecompressorStream: forward decode works on non-seekable
+        # sources; CLEAR boundaries become SeekPoints when config.seekable is true.
+        return UnixCompressDecompressorStream(source, seekable=config.seekable)
 
     def translate(self, exc: Exception) -> ArchiveyError | None:
-        # uncompresspy raises ValueError both for a non-seekable input (it needs random
-        # access to decode) and for a corrupt LZW bitstream. The .Z format carries no length
-        # or checksum trailer, so truncation is undetectable — a cut stream just yields fewer
-        # bytes with no error (there is intentionally no TruncatedError path here).
+        # The .Z format carries no length or checksum trailer, so truncation is
+        # undetectable — a cut stream just yields fewer bytes with no TruncatedError.
         if isinstance(exc, ValueError):
-            if "seekable" in str(exc):
-                return StreamNotSeekableError(
-                    "uncompresspy does not support non-seekable streams"
-                )
             return CorruptionError(f"Error reading unix-compress (.Z) stream: {exc!r}")
         return None
 

--- a/src/archivey/internal/streams/codecs.py
+++ b/src/archivey/internal/streams/codecs.py
@@ -1011,10 +1011,8 @@ class UnixCompressCodec(StreamCodec):
         return UnixCompressDecompressorStream(source, seekable=config.seekable)
 
     def translate(self, exc: Exception) -> ArchiveyError | None:
-        # The .Z format carries no length or checksum trailer, so truncation is
-        # undetectable — a cut stream just yields fewer bytes with no TruncatedError.
-        if isinstance(exc, ValueError):
-            return CorruptionError(f"Error reading unix-compress (.Z) stream: {exc!r}")
+        # Native LZW raises CorruptionError directly (like xz/lzip). `.Z` has no
+        # length/checksum trailer, so truncation is never a TruncatedError.
         return None
 
 

--- a/src/archivey/internal/streams/codecs.py
+++ b/src/archivey/internal/streams/codecs.py
@@ -1011,8 +1011,8 @@ class UnixCompressCodec(StreamCodec):
         return UnixCompressDecompressorStream(source, seekable=config.seekable)
 
     def translate(self, exc: Exception) -> ArchiveyError | None:
-        # Native LZW raises CorruptionError directly (like xz/lzip). `.Z` has no
-        # length/checksum trailer, so truncation is never a TruncatedError.
+        # Native LZW raises CorruptionError / UnsupportedFeatureError / TruncatedError
+        # directly (like xz/lzip). No third-party exception remapping.
         return None
 
 

--- a/src/archivey/internal/streams/unix_compress.py
+++ b/src/archivey/internal/streams/unix_compress.py
@@ -10,9 +10,9 @@ and forward decode never requires a seekable source.
 from __future__ import annotations
 
 import os
-import warnings
 from typing import BinaryIO
 
+from archivey.exceptions import CorruptionError
 from archivey.internal.diagnostics_collector import DiagnosticCollector
 from archivey.internal.streams.decompressor_stream import (
     SeekPoint,
@@ -26,32 +26,29 @@ _MAGIC_BYTE0 = 0x1F
 _MAGIC_BYTE1 = 0x9D
 _BLOCK_MODE_FLAG = 0x80
 _CODE_WIDTH_FLAG = 0x1F
-_UNKNOWN_FLAGS = 0x60
 _HEADER_SIZE = 3
 
 
 def _parse_header(header: bytes) -> tuple[int, bool]:
     """Validate the 3-byte ``.Z`` header → ``(max_width, block_mode)``."""
     if len(header) < _HEADER_SIZE:
-        raise ValueError("File too short, missing header.")
+        raise CorruptionError("unix-compress (.Z) stream is too short (missing header)")
     if header[0] != _MAGIC_BYTE0 or header[1] != _MAGIC_BYTE1:
-        raise ValueError(
-            f"Invalid file header: Magic bytes do not match (expected {_MAGIC_BYTE0:02x} "
-            f"{_MAGIC_BYTE1:02x}, got {header[0]:02x} {header[1]:02x})."
+        raise CorruptionError(
+            f"unix-compress (.Z) magic mismatch (expected {_MAGIC_BYTE0:02x} "
+            f"{_MAGIC_BYTE1:02x}, got {header[0]:02x} {header[1]:02x})"
         )
     flag_byte = header[2]
     max_width = flag_byte & _CODE_WIDTH_FLAG
     if max_width < _INITIAL_CODE_WIDTH:
-        raise ValueError(
-            f"Invalid file header: Max code width less than the minimum of "
-            f"{_INITIAL_CODE_WIDTH}."
+        raise CorruptionError(
+            f"unix-compress (.Z) max code width {max_width} is below the minimum "
+            f"of {_INITIAL_CODE_WIDTH}"
         )
-    if flag_byte & _UNKNOWN_FLAGS:
-        warnings.warn(
-            "File header contains unknown flags, decompression may be incorrect.",
-            RuntimeWarning,
-            stacklevel=2,
-        )
+    # Classic compress header bits 0x60 are reserved. Real compressors leave them
+    # clear; if set we still decode — a broken bitstream surfaces as CorruptionError
+    # from invalid codes. Soft advisories would need a new DiagnosticCode (none fits
+    # today); do not emit stdlib warnings.warn.
     block_mode = bool(flag_byte & _BLOCK_MODE_FLAG)
     return max_width, block_mode
 
@@ -62,6 +59,10 @@ class LzwState:
     Each CLEAR ends a segment unit ``(decompressed_size, compressed_size)`` measured
     from the previous CLEAR (or from just after the header). Absolute offsets and
     :class:`SeekPoint` registration belong to the stream wrapper.
+
+    Format errors raise :class:`CorruptionError` directly (same pattern as native
+    xz/lzip). ``.Z`` has no length/checksum trailer, so EOF always finishes — a
+    partial trailing code is accepted silently rather than as :class:`TruncatedError`.
     """
 
     def __init__(
@@ -69,9 +70,7 @@ class LzwState:
         *,
         max_width: int | None = None,
         block_mode: bool | None = None,
-        warn_truncation: bool = True,
     ) -> None:
-        self._warn_truncation = warn_truncation
         self._buf = bytearray()
         self._finished = False
         self._header_params: tuple[int, bool] | None = None
@@ -80,8 +79,7 @@ class LzwState:
         self._seg_decomp = 0
         self._pending_skip = 0
         if not self._need_header:
-            if max_width is None or block_mode is None:
-                raise ValueError("max_width and block_mode are required together")
+            assert max_width is not None and block_mode is not None
             self._init_dictionary(max_width, block_mode)
             self._header_params = (max_width, block_mode)
 
@@ -98,17 +96,9 @@ class LzwState:
 
     def flush(self) -> tuple[bytes, list[tuple[int, int]]]:
         out, units = self._process(eof=True)
-        if (
-            self._warn_truncation
-            and self._header_params is not None
-            and self._bits_in_buffer >= 8
-        ):
-            warnings.warn(
-                "Bitstream ended in a partial code, file may be truncated.",
-                RuntimeWarning,
-                stacklevel=2,
-            )
-        # Release dictionary growth; .Z has no end marker so EOF always finishes.
+        # Partial trailing bits (bits_in_buffer >= 8) can mean a cut bitstream, but
+        # `.Z` has no trailer to confirm that — accept EOF as finished (no TruncatedError,
+        # no warning). Matches the format-single-file-compressors truncation contract.
         if self._header_params is not None:
             del self._dictionary[self._starting_code :]
         self._finished = True
@@ -141,7 +131,9 @@ class LzwState:
         if self._need_header:
             if len(self._buf) < _HEADER_SIZE:
                 if eof and self._buf:
-                    raise ValueError("File too short, missing header.")
+                    raise CorruptionError(
+                        "unix-compress (.Z) stream is too short (missing header)"
+                    )
                 return b"", []
             header = bytes(self._buf[:_HEADER_SIZE])
             del self._buf[:_HEADER_SIZE]
@@ -238,14 +230,16 @@ class LzwState:
                 except IndexError:
                     if code == next_code:
                         if prev_entry is None:
-                            raise ValueError(
-                                f"Invalid code {code} encountered in bitstream. "
-                                "Expected a literal character."
+                            # First code after CLEAR/start must be a literal; KwKwK
+                            # needs a previous entry. Corrupt or non-block-mode abuse.
+                            raise CorruptionError(
+                                f"unix-compress (.Z) invalid code {code} "
+                                "(expected a literal)"
                             ) from None
                         entry = prev_entry + prev_entry[:1]
                     else:
-                        raise ValueError(
-                            f"Invalid code {code} encountered in bitstream."
+                        raise CorruptionError(
+                            f"unix-compress (.Z) invalid code {code} in bitstream"
                         ) from None
 
                 output.extend(entry)

--- a/src/archivey/internal/streams/unix_compress.py
+++ b/src/archivey/internal/streams/unix_compress.py
@@ -1,0 +1,343 @@
+"""Unix-compress (``.Z``) LZW decode via :class:`DecompressorStream`.
+
+The LZW kernel is adapted from `uncompresspy` (https://github.com/kYwzor/uncompresspy),
+Copyright (c) 2025 Tiago Gomes, used under the BSD 3-Clause License (see the notice at
+the bottom of this file). Archivey wraps it in :class:`SegmentedDecompressorStream` so
+CLEAR boundaries become :class:`~archivey.internal.streams.decompressor_stream.SeekPoint`s
+and forward decode never requires a seekable source.
+"""
+
+from __future__ import annotations
+
+import os
+import warnings
+from typing import BinaryIO
+
+from archivey.internal.diagnostics_collector import DiagnosticCollector
+from archivey.internal.streams.decompressor_stream import (
+    SeekPoint,
+    SegmentedDecompressorStream,
+)
+
+_INITIAL_CODE_WIDTH = 9
+_INITIAL_MASK = 2**_INITIAL_CODE_WIDTH - 1
+_CLEAR_CODE = 256
+_MAGIC_BYTE0 = 0x1F
+_MAGIC_BYTE1 = 0x9D
+_BLOCK_MODE_FLAG = 0x80
+_CODE_WIDTH_FLAG = 0x1F
+_UNKNOWN_FLAGS = 0x60
+_HEADER_SIZE = 3
+
+
+def _parse_header(header: bytes) -> tuple[int, bool]:
+    """Validate the 3-byte ``.Z`` header → ``(max_width, block_mode)``."""
+    if len(header) < _HEADER_SIZE:
+        raise ValueError("File too short, missing header.")
+    if header[0] != _MAGIC_BYTE0 or header[1] != _MAGIC_BYTE1:
+        raise ValueError(
+            f"Invalid file header: Magic bytes do not match (expected {_MAGIC_BYTE0:02x} "
+            f"{_MAGIC_BYTE1:02x}, got {header[0]:02x} {header[1]:02x})."
+        )
+    flag_byte = header[2]
+    max_width = flag_byte & _CODE_WIDTH_FLAG
+    if max_width < _INITIAL_CODE_WIDTH:
+        raise ValueError(
+            f"Invalid file header: Max code width less than the minimum of "
+            f"{_INITIAL_CODE_WIDTH}."
+        )
+    if flag_byte & _UNKNOWN_FLAGS:
+        warnings.warn(
+            "File header contains unknown flags, decompression may be incorrect.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+    block_mode = bool(flag_byte & _BLOCK_MODE_FLAG)
+    return max_width, block_mode
+
+
+class LzwState:
+    """Push LZW decoder: ``feed`` / ``flush`` → ``(bytes, segment_units)``.
+
+    Each CLEAR ends a segment unit ``(decompressed_size, compressed_size)`` measured
+    from the previous CLEAR (or from just after the header). Absolute offsets and
+    :class:`SeekPoint` registration belong to the stream wrapper.
+    """
+
+    def __init__(
+        self,
+        *,
+        max_width: int | None = None,
+        block_mode: bool | None = None,
+        warn_truncation: bool = True,
+    ) -> None:
+        self._warn_truncation = warn_truncation
+        self._buf = bytearray()
+        self._finished = False
+        self._header_params: tuple[int, bool] | None = None
+        self._need_header = max_width is None
+        self._seg_comp = 0
+        self._seg_decomp = 0
+        if not self._need_header:
+            if max_width is None or block_mode is None:
+                raise ValueError("max_width and block_mode are required together")
+            self._init_dictionary(max_width, block_mode)
+            self._header_params = (max_width, block_mode)
+
+    @property
+    def header_params(self) -> tuple[int, bool] | None:
+        """``(max_width, block_mode)`` once the header is known, else ``None``."""
+        return self._header_params
+
+    def feed(self, data: bytes) -> tuple[bytes, list[tuple[int, int]]]:
+        if self._finished:
+            return b"", []
+        self._buf.extend(data)
+        return self._process(eof=False)
+
+    def flush(self) -> tuple[bytes, list[tuple[int, int]]]:
+        out, units = self._process(eof=True)
+        if (
+            self._warn_truncation
+            and self._header_params is not None
+            and self._bits_in_buffer >= 8
+        ):
+            warnings.warn(
+                "Bitstream ended in a partial code, file may be truncated.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+        # Release dictionary growth; .Z has no end marker so EOF always finishes.
+        if self._header_params is not None:
+            del self._dictionary[self._starting_code :]
+        self._finished = True
+        return out, units
+
+    def is_finished(self) -> bool:
+        return self._finished
+
+    def _init_dictionary(self, max_width: int, block_mode: bool) -> None:
+        self._max_width = max_width
+        self._block_mode = block_mode
+        self._dictionary: list[bytes] = [i.to_bytes() for i in range(256)]
+        if block_mode:
+            self._dictionary.append(b"")
+        self._starting_code = len(self._dictionary)
+        self._next_code = self._starting_code
+        self._bit_buffer = 0
+        self._bits_in_buffer = 0
+        self._prev_entry: bytes | None = None
+        self._code_width = _INITIAL_CODE_WIDTH
+        self._current_mask = _INITIAL_MASK
+
+    def _process(self, *, eof: bool) -> tuple[bytes, list[tuple[int, int]]]:
+        output = bytearray()
+        units: list[tuple[int, int]] = []
+
+        if self._need_header:
+            if len(self._buf) < _HEADER_SIZE:
+                if eof and self._buf:
+                    raise ValueError("File too short, missing header.")
+                return b"", []
+            header = bytes(self._buf[:_HEADER_SIZE])
+            del self._buf[:_HEADER_SIZE]
+            max_width, block_mode = _parse_header(header)
+            self._init_dictionary(max_width, block_mode)
+            self._header_params = (max_width, block_mode)
+            self._need_header = False
+
+        # Local aliases — hot path (same trick as uncompresspy, ~2x).
+        bit_buffer = self._bit_buffer
+        bits_in_buffer = self._bits_in_buffer
+        code_width = self._code_width
+        current_mask = self._current_mask
+        next_code = self._next_code
+        prev_entry = self._prev_entry
+        dictionary = self._dictionary
+        max_width = self._max_width
+        block_mode = self._block_mode
+        starting_code = self._starting_code
+        seg_comp = self._seg_comp
+        seg_decomp = self._seg_decomp
+
+        while True:
+            block_size = code_width * (1 << (code_width - 4))
+            if not self._buf:
+                break
+            if len(self._buf) < block_size and not eof:
+                break
+
+            cur_chunk = bytes(self._buf[:block_size])
+            del self._buf[: len(cur_chunk)]
+            cleared = False
+
+            for i, cur_byte in enumerate(cur_chunk):
+                bit_buffer += cur_byte << bits_in_buffer
+                bits_in_buffer += 8
+
+                if bits_in_buffer < code_width:
+                    continue
+
+                code = bit_buffer & current_mask
+                bit_buffer >>= code_width
+                bits_in_buffer -= code_width
+
+                if code == _CLEAR_CODE and block_mode:
+                    # Realign to the next code_width-byte boundary within this chunk,
+                    # then unread the remainder (in-memory stand-in for file.seek).
+                    if advanced := i % code_width:
+                        i += code_width - advanced
+                    # Bytes 0..i-1 of cur_chunk are consumed; put i.. back.
+                    self._buf[0:0] = cur_chunk[i:]
+                    seg_comp += i
+                    units.append((seg_decomp, seg_comp))
+                    seg_comp = 0
+                    seg_decomp = 0
+                    # Mirror uncompresspy reset (dict / width / bitbuf).
+                    del dictionary[starting_code:]
+                    next_code = starting_code
+                    code_width = _INITIAL_CODE_WIDTH
+                    current_mask = _INITIAL_MASK
+                    bit_buffer = 0
+                    bits_in_buffer = 0
+                    prev_entry = None
+                    cleared = True
+                    break
+
+                try:
+                    entry = dictionary[code]
+                except IndexError:
+                    if code == next_code:
+                        if prev_entry is None:
+                            raise ValueError(
+                                f"Invalid code {code} encountered in bitstream. "
+                                "Expected a literal character."
+                            ) from None
+                        entry = prev_entry + prev_entry[:1]
+                    else:
+                        raise ValueError(
+                            f"Invalid code {code} encountered in bitstream."
+                        ) from None
+
+                output.extend(entry)
+                seg_decomp += len(entry)
+
+                if next_code <= current_mask and prev_entry is not None:
+                    dictionary.append(prev_entry + entry[:1])
+                    next_code += 1
+
+                prev_entry = entry
+            else:
+                # Full/partial chunk consumed without CLEAR — count all bytes.
+                seg_comp += len(cur_chunk)
+                if code_width < max_width and len(cur_chunk) == block_size:
+                    code_width += 1
+                    current_mask = (1 << code_width) - 1
+                    bit_buffer = 0
+                    bits_in_buffer = 0
+
+            if cleared:
+                continue
+            if len(cur_chunk) < block_size:
+                # Short final chunk at EOF — stop (matches uncompresspy's short read).
+                break
+
+        self._bit_buffer = bit_buffer
+        self._bits_in_buffer = bits_in_buffer
+        self._code_width = code_width
+        self._current_mask = current_mask
+        self._next_code = next_code
+        self._prev_entry = prev_entry
+        self._seg_comp = seg_comp
+        self._seg_decomp = seg_decomp
+        return bytes(output), units
+
+
+class UnixCompressDecompressorStream(SegmentedDecompressorStream[LzwState]):
+    """Seekable unix-compress stream: CLEAR → :class:`SeekPoint` when indexing is on."""
+
+    def __init__(
+        self,
+        path: str | os.PathLike[str] | BinaryIO,
+        *,
+        collector: DiagnosticCollector | None = None,
+        seekable: bool = True,
+    ) -> None:
+        self._max_width: int | None = None
+        self._block_mode: bool | None = None
+        self._header_committed = False
+        super().__init__(
+            path, collector=collector, codec_name="unix_compress", seekable=seekable
+        )
+
+    def _make_decompressor(self, point: SeekPoint) -> LzwState:
+        if self._max_width is not None and self._block_mode is not None:
+            return LzwState(max_width=self._max_width, block_mode=self._block_mode)
+        # Origin open only: header still in the stream at compressed_offset 0.
+        return LzwState()
+
+    def _decompress_chunk(self, chunk: bytes) -> bytes:
+        data, units = self._decompressor.feed(chunk)
+        self._commit_header_if_needed()
+        self._on_completed_segments(units)
+        return data
+
+    def _flush_decompressor(self) -> bytes:
+        data, units = self._decompressor.flush()
+        self._commit_header_if_needed()
+        self._on_completed_segments(units)
+        return data
+
+    def _commit_header_if_needed(self) -> None:
+        if self._header_committed:
+            return
+        params = self._decompressor.header_params
+        if params is None:
+            return
+        self._max_width, self._block_mode = params
+        self._comp_cursor = _HEADER_SIZE
+        self._decomp_cursor = 0
+        if self._seek_points and self._seek_points[0].compressed_offset == 0:
+            self._seek_points[0] = SeekPoint(0, _HEADER_SIZE)
+        self._header_committed = True
+
+    def _on_completed_segments(self, units: list[tuple[int, int]]) -> None:
+        for decomp_size, comp_size in units:
+            self._comp_cursor += comp_size
+            self._decomp_cursor += decomp_size
+            self.add_seek_points(
+                [SeekPoint(self._decomp_cursor, self._comp_cursor)]
+            )
+
+
+# ---------------------------------------------------------------------------
+# BSD 3-Clause License notice for the adapted LZW kernel (from uncompresspy)
+# ---------------------------------------------------------------------------
+#
+# Copyright (c) 2025, Tiago Gomes
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+#    list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived from
+#    this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/src/archivey/internal/streams/unix_compress.py
+++ b/src/archivey/internal/streams/unix_compress.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import os
 from typing import BinaryIO
 
-from archivey.exceptions import CorruptionError
+from archivey.exceptions import CorruptionError, TruncatedError, UnsupportedFeatureError
 from archivey.internal.diagnostics_collector import DiagnosticCollector
 from archivey.internal.streams.decompressor_stream import (
     SeekPoint,
@@ -26,6 +26,7 @@ _MAGIC_BYTE0 = 0x1F
 _MAGIC_BYTE1 = 0x9D
 _BLOCK_MODE_FLAG = 0x80
 _CODE_WIDTH_FLAG = 0x1F
+_RESERVED_FLAGS = 0x60
 _HEADER_SIZE = 3
 
 
@@ -39,16 +40,18 @@ def _parse_header(header: bytes) -> tuple[int, bool]:
             f"{_MAGIC_BYTE1:02x}, got {header[0]:02x} {header[1]:02x})"
         )
     flag_byte = header[2]
+    reserved = flag_byte & _RESERVED_FLAGS
+    if reserved:
+        raise UnsupportedFeatureError(
+            f"unix-compress (.Z) header has unknown reserved flags "
+            f"(0x{reserved:02x} in flag byte 0x{flag_byte:02x})"
+        )
     max_width = flag_byte & _CODE_WIDTH_FLAG
     if max_width < _INITIAL_CODE_WIDTH:
         raise CorruptionError(
             f"unix-compress (.Z) max code width {max_width} is below the minimum "
             f"of {_INITIAL_CODE_WIDTH}"
         )
-    # Classic compress header bits 0x60 are reserved. Real compressors leave them
-    # clear; if set we still decode — a broken bitstream surfaces as CorruptionError
-    # from invalid codes. Soft advisories would need a new DiagnosticCode (none fits
-    # today); do not emit stdlib warnings.warn.
     block_mode = bool(flag_byte & _BLOCK_MODE_FLAG)
     return max_width, block_mode
 
@@ -61,8 +64,9 @@ class LzwState:
     :class:`SeekPoint` registration belong to the stream wrapper.
 
     Format errors raise :class:`CorruptionError` directly (same pattern as native
-    xz/lzip). ``.Z`` has no length/checksum trailer, so EOF always finishes — a
-    partial trailing code is accepted silently rather than as :class:`TruncatedError`.
+    xz/lzip). Unknown reserved header flags raise :class:`UnsupportedFeatureError`.
+    At EOF, nonzero leftover bits after the last complete code are a best-effort
+    truncation signal (:attr:`truncated`); zero padding is normal for finished streams.
     """
 
     def __init__(
@@ -73,6 +77,7 @@ class LzwState:
     ) -> None:
         self._buf = bytearray()
         self._finished = False
+        self._truncated = False
         self._header_params: tuple[int, bool] | None = None
         self._need_header = max_width is None
         self._seg_comp = 0
@@ -88,6 +93,11 @@ class LzwState:
         """``(max_width, block_mode)`` once the header is known, else ``None``."""
         return self._header_params
 
+    @property
+    def truncated(self) -> bool:
+        """True after ``flush`` when leftover bits after the last code were nonzero."""
+        return self._truncated
+
     def feed(self, data: bytes) -> tuple[bytes, list[tuple[int, int]]]:
         if self._finished:
             return b"", []
@@ -96,9 +106,13 @@ class LzwState:
 
     def flush(self) -> tuple[bytes, list[tuple[int, int]]]:
         out, units = self._process(eof=True)
-        # Partial trailing bits (bits_in_buffer >= 8) can mean a cut bitstream, but
-        # `.Z` has no trailer to confirm that — accept EOF as finished (no TruncatedError,
-        # no warning). Matches the format-single-file-compressors truncation contract.
+        # Finished compressors zero-pad the last incomplete code slot. Nonzero leftover
+        # bits are a best-effort truncation / corrupt-padding signal (exact mid-code
+        # cuts that leave only zero bits remain undetectable — no length trailer).
+        if self._header_params is not None and self._bits_in_buffer > 0:
+            leftover = self._bit_buffer & ((1 << self._bits_in_buffer) - 1)
+            if leftover:
+                self._truncated = True
         if self._header_params is not None:
             del self._dictionary[self._starting_code :]
         self._finished = True
@@ -294,6 +308,7 @@ class UnixCompressDecompressorStream(SegmentedDecompressorStream[LzwState]):
         self._max_width: int | None = None
         self._block_mode: bool | None = None
         self._header_committed = False
+        self._pending_truncated: TruncatedError | None = None
         super().__init__(
             path, collector=collector, codec_name="unix_compress", seekable=seekable
         )
@@ -314,6 +329,26 @@ class UnixCompressDecompressorStream(SegmentedDecompressorStream[LzwState]):
         data, units = self._decompressor.flush()
         self._commit_header_if_needed()
         self._on_completed_segments(units)
+        # Deliver all decoded bytes first; raise TruncatedError on the next empty read.
+        if self._decompressor.truncated:
+            self._pending_truncated = TruncatedError(
+                "unix-compress (.Z) stream is truncated (nonzero leftover bits after "
+                "the last complete LZW code)"
+            )
+        return data
+
+    def _reset_to_seek_point(self, point: SeekPoint) -> None:
+        self._pending_truncated = None
+        super()._reset_to_seek_point(point)
+
+    def read(self, n: int = -1, /) -> bytes:
+        if n == 0:
+            return b""
+        data = super().read(n)
+        if not data and self._pending_truncated is not None:
+            err = self._pending_truncated
+            self._pending_truncated = None
+            raise err
         return data
 
     def _commit_header_if_needed(self) -> None:

--- a/src/archivey/internal/streams/unix_compress.py
+++ b/src/archivey/internal/streams/unix_compress.py
@@ -78,6 +78,7 @@ class LzwState:
         self._need_header = max_width is None
         self._seg_comp = 0
         self._seg_decomp = 0
+        self._pending_skip = 0
         if not self._need_header:
             if max_width is None or block_mode is None:
                 raise ValueError("max_width and block_mode are required together")
@@ -129,6 +130,9 @@ class LzwState:
         self._prev_entry: bytes | None = None
         self._code_width = _INITIAL_CODE_WIDTH
         self._current_mask = _INITIAL_MASK
+        self._bytes_in_era = 0
+        self._codes_in_era = 0
+        self._pending_skip = 0
 
     def _process(self, *, eof: bool) -> tuple[bytes, list[tuple[int, int]]]:
         output = bytearray()
@@ -146,6 +150,13 @@ class LzwState:
             self._header_params = (max_width, block_mode)
             self._need_header = False
 
+        if self._pending_skip:
+            skip = min(self._pending_skip, len(self._buf))
+            del self._buf[:skip]
+            self._pending_skip -= skip
+            if self._pending_skip:
+                return b"", []
+
         # Local aliases — hot path (same trick as uncompresspy, ~2x).
         bit_buffer = self._bit_buffer
         bits_in_buffer = self._bits_in_buffer
@@ -159,41 +170,49 @@ class LzwState:
         starting_code = self._starting_code
         seg_comp = self._seg_comp
         seg_decomp = self._seg_decomp
+        # Bytes/codes since the last CLEAR or code-width bump (era start). uncompresspy
+        # reads one era-block of size code_width * 2**(code_width-4) at a time; we process
+        # push chunks byte-by-byte but keep the same alignment and width-bump rules.
+        bytes_in_era = self._bytes_in_era
+        codes_in_era = self._codes_in_era
+        codes_per_era = 1 << (code_width - 1)
 
-        while True:
-            block_size = code_width * (1 << (code_width - 4))
-            if not self._buf:
-                break
-            if len(self._buf) < block_size and not eof:
-                break
+        buf_i = 0
+        while buf_i < len(self._buf):
+            cur_byte = self._buf[buf_i]
+            buf_i += 1
+            bytes_in_era += 1
+            bit_buffer += cur_byte << bits_in_buffer
+            bits_in_buffer += 8
+            seg_comp += 1
 
-            cur_chunk = bytes(self._buf[:block_size])
-            del self._buf[: len(cur_chunk)]
             cleared = False
-
-            for i, cur_byte in enumerate(cur_chunk):
-                bit_buffer += cur_byte << bits_in_buffer
-                bits_in_buffer += 8
-
-                if bits_in_buffer < code_width:
-                    continue
-
+            while bits_in_buffer >= code_width:
                 code = bit_buffer & current_mask
                 bit_buffer >>= code_width
                 bits_in_buffer -= code_width
+                codes_in_era += 1
 
                 if code == _CLEAR_CODE and block_mode:
-                    # Realign to the next code_width-byte boundary within this chunk,
+                    # Realign to the next code_width-byte boundary within this era,
                     # then unread the remainder (in-memory stand-in for file.seek).
+                    # bytes_in_era is the 1-based count of bytes consumed in the era;
+                    # uncompresspy's `i` is 0-based within the current read chunk, which
+                    # always starts at an era boundary — so i == bytes_in_era - 1.
+                    i = bytes_in_era - 1
                     if advanced := i % code_width:
                         i += code_width - advanced
-                    # Bytes 0..i-1 of cur_chunk are consumed; put i.. back.
-                    self._buf[0:0] = cur_chunk[i:]
-                    seg_comp += i
+                    era_start = buf_i - bytes_in_era
+                    target = era_start + i
+                    # Padding forward, or re-read the CLEAR-completing byte when it
+                    # already sits on a code_width boundary (matches uncompresspy).
+                    if target > buf_i:
+                        seg_comp += target - buf_i
+                    elif target < buf_i:
+                        seg_comp -= buf_i - target
                     units.append((seg_decomp, seg_comp))
                     seg_comp = 0
                     seg_decomp = 0
-                    # Mirror uncompresspy reset (dict / width / bitbuf).
                     del dictionary[starting_code:]
                     next_code = starting_code
                     code_width = _INITIAL_CODE_WIDTH
@@ -201,6 +220,16 @@ class LzwState:
                     bit_buffer = 0
                     bits_in_buffer = 0
                     prev_entry = None
+                    bytes_in_era = 0
+                    codes_in_era = 0
+                    codes_per_era = 1 << (code_width - 1)
+                    if target > len(self._buf):
+                        # CLEAR realignment extends past this feed — skip the rest
+                        # of the padding at the start of the next feed.
+                        self._pending_skip = target - len(self._buf)
+                        buf_i = len(self._buf)
+                    else:
+                        buf_i = target
                     cleared = True
                     break
 
@@ -227,20 +256,23 @@ class LzwState:
                     next_code += 1
 
                 prev_entry = entry
-            else:
-                # Full/partial chunk consumed without CLEAR — count all bytes.
-                seg_comp += len(cur_chunk)
-                if code_width < max_width and len(cur_chunk) == block_size:
+
+                if codes_in_era >= codes_per_era and code_width < max_width:
                     code_width += 1
                     current_mask = (1 << code_width) - 1
                     bit_buffer = 0
                     bits_in_buffer = 0
+                    bytes_in_era = 0
+                    codes_in_era = 0
+                    codes_per_era = 1 << (code_width - 1)
+                    # Remainder bits from the current byte are discarded (matches
+                    # uncompresspy clearing the bit buffer at a width bump).
+                    break
 
             if cleared:
                 continue
-            if len(cur_chunk) < block_size:
-                # Short final chunk at EOF — stop (matches uncompresspy's short read).
-                break
+
+        del self._buf[:buf_i]
 
         self._bit_buffer = bit_buffer
         self._bits_in_buffer = bits_in_buffer
@@ -250,6 +282,8 @@ class LzwState:
         self._prev_entry = prev_entry
         self._seg_comp = seg_comp
         self._seg_decomp = seg_decomp
+        self._bytes_in_era = bytes_in_era
+        self._codes_in_era = codes_in_era
         return bytes(output), units
 
 
@@ -305,9 +339,7 @@ class UnixCompressDecompressorStream(SegmentedDecompressorStream[LzwState]):
         for decomp_size, comp_size in units:
             self._comp_cursor += comp_size
             self._decomp_cursor += decomp_size
-            self.add_seek_points(
-                [SeekPoint(self._decomp_cursor, self._comp_cursor)]
-            )
+            self.add_seek_points([SeekPoint(self._decomp_cursor, self._comp_cursor)])
 
 
 # ---------------------------------------------------------------------------

--- a/tests/check_zero_dep_core.py
+++ b/tests/check_zero_dep_core.py
@@ -59,3 +59,17 @@ with tempfile.TemporaryDirectory() as d:
             sys.exit(f"FAIL: directory backend read wrong data: {data!r}")
 
 print("directory backend round-trip OK")
+
+# 3. Native unix-compress (.Z) is core — no third-party decoder.
+# Precomputed ncompress fixture for b"hi" (avoids needing ncompress in core-only).
+_Z_HI = bytes.fromhex("1f9d9068d200")
+with tempfile.TemporaryDirectory() as d:
+    zpath = os.path.join(d, "hi.Z")
+    with open(zpath, "wb") as f:
+        f.write(_Z_HI)
+    with open_archive(zpath) as ar:
+        data = ar.read(ar.members()[0])
+        if data != b"hi":
+            sys.exit(f"FAIL: unix-compress core decode wrong data: {data!r}")
+
+print("unix-compress (.Z) core decode OK")

--- a/tests/streams_util.py
+++ b/tests/streams_util.py
@@ -134,10 +134,9 @@ def make_multiblock_xz(data: bytes, block_size: int) -> bytes:
 def make_unix_compress(data: bytes) -> bytes:
     """LZW-compress ``data`` into a standard unix-compress (`.Z`) stream.
 
-    The runtime decoder (``uncompresspy``) only decompresses, so fixtures are produced
-    with ``ncompress`` (a separate LZW *compressor*) — giving a genuine cross-
-    implementation roundtrip. Imported lazily so this module still imports in the
-    core-only test leg, where ncompress is absent (callers guard with ``requires``).
+    Fixtures are produced with ``ncompress`` (an LZW *compressor*); Archivey decodes
+    natively. Imported lazily so this module still imports in the core-only test leg,
+    where ncompress is absent (callers guard with ``requires``).
     """
     import ncompress
 

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -7,7 +7,6 @@ import gzip
 import hashlib
 import importlib.util
 import io
-import warnings
 import zlib
 
 import pytest
@@ -314,9 +313,7 @@ def test_unix_compress_truncated_yields_short_read_without_truncated_error() -> 
     compressed = make_unix_compress(CONTENT)
     truncated = compressed[: len(compressed) // 2]
     with open_codec_stream(Codec.UNIX_COMPRESS, io.BytesIO(truncated)) as stream:
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", RuntimeWarning)
-            data = stream.read()
+        data = stream.read()
     assert len(data) < len(CONTENT)
 
 

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -7,15 +7,16 @@ import gzip
 import hashlib
 import importlib.util
 import io
+import warnings
 import zlib
 
 import pytest
 
+from archivey.diagnostics import DiagnosticCode
 from archivey.exceptions import (
     ArchiveyError,
     CorruptionError,
     PackageNotInstalledError,
-    StreamNotSeekableError,
     TruncatedError,
 )
 from archivey.internal.config import (
@@ -87,9 +88,9 @@ def test_brotli_backend_roundtrip() -> None:
         assert stream.read() == CONTENT
 
 
-@requires("uncompresspy", "ncompress")
+@requires("ncompress")
 def test_unix_compress_backend_roundtrip() -> None:
-    """A unix-compress (.Z) stream decompresses via the uncompresspy backend."""
+    """A unix-compress (.Z) stream decompresses via the native LZW backend."""
     compressed = make_unix_compress(CONTENT)
     with open_codec_stream(Codec.UNIX_COMPRESS, io.BytesIO(compressed)) as stream:
         assert stream.read() == CONTENT
@@ -143,15 +144,6 @@ def test_ppmd_without_pyppmd_raises() -> None:
 def test_brotli_without_brotli_raises() -> None:
     with pytest.raises(PackageNotInstalledError, match="brotli"):
         open_codec_stream(Codec.BROTLI, io.BytesIO(b""))
-
-
-@pytest.mark.skipif(
-    importlib.util.find_spec("uncompresspy") is not None,
-    reason="uncompresspy is installed; the missing-backend path cannot be exercised",
-)
-def test_unix_compress_without_uncompresspy_raises() -> None:
-    with pytest.raises(PackageNotInstalledError, match="uncompresspy"):
-        open_codec_stream(Codec.UNIX_COMPRESS, io.BytesIO(b""))
 
 
 def test_aes_without_crypto_raises(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -297,7 +289,7 @@ def test_truncated_zstd_translates_to_truncated() -> None:
             stream.read()
 
 
-@requires("uncompresspy", "ncompress")
+@requires("ncompress")
 def test_corrupt_unix_compress_translates_to_corruption() -> None:
     corrupt = bytearray(make_unix_compress(CONTENT))
     corrupt[10] ^= 0xFF  # break the LZW bitstream
@@ -306,13 +298,55 @@ def test_corrupt_unix_compress_translates_to_corruption() -> None:
             stream.read()
 
 
-@requires("uncompresspy", "ncompress")
-def test_unix_compress_non_seekable_source_translates() -> None:
-    """uncompresspy needs random access; a non-seekable source is reported, not leaked."""
+@requires("ncompress")
+def test_unix_compress_non_seekable_source_streams() -> None:
+    """Native LZW forward-decodes a non-seekable source; the stream is not seekable."""
     compressed = make_unix_compress(CONTENT)
-    # The seekable requirement is enforced at open time (eager), so the open call raises.
-    with pytest.raises(StreamNotSeekableError):
-        open_codec_stream(Codec.UNIX_COMPRESS, NonSeekableBytesIO(compressed))
+    with open_codec_stream(
+        Codec.UNIX_COMPRESS, NonSeekableBytesIO(compressed)
+    ) as stream:
+        assert not stream.seekable()
+        assert stream.read() == CONTENT
+
+
+@requires("ncompress")
+def test_unix_compress_truncated_yields_short_read_without_truncated_error() -> None:
+    compressed = make_unix_compress(CONTENT)
+    truncated = compressed[: len(compressed) // 2]
+    with open_codec_stream(Codec.UNIX_COMPRESS, io.BytesIO(truncated)) as stream:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", RuntimeWarning)
+            data = stream.read()
+    assert len(data) < len(CONTENT)
+
+
+@requires("ncompress")
+def test_unix_compress_clear_seek_points() -> None:
+    """CLEAR boundaries become SeekPoints; random access resumes without rewind diagnostics."""
+    # Distinct words force dictionary growth until classic compress emits CLEAR.
+    payload = b"".join(i.to_bytes(4, "big") for i in range(50_000))
+    compressed = make_unix_compress(payload)
+    config = StreamConfig(seekable=True)
+    with open_codec_stream(
+        Codec.UNIX_COMPRESS, io.BytesIO(compressed), config=config
+    ) as stream:
+        assert stream.seekable()
+        # Drive a full pass so CLEAR points accumulate, then seek via ArchiveStream.
+        assert stream.read() == payload
+        stream.seek(0)
+        assert stream.read(16) == payload[:16]
+        mid = len(payload) // 2
+        stream.seek(mid)
+        assert stream.read(8) == payload[mid : mid + 8]
+        stream.seek(100)
+        assert stream.read(4) == payload[100:104]
+        # Indexed CLEAR seeks must not emit the O(n) rewind diagnostic.
+        assert (
+            stream.diagnostics.counts.get(
+                DiagnosticCode.STREAM_REWIND_REDECOMPRESSES, 0
+            )
+            == 0
+        )
 
 
 def test_translated_error_is_stamped() -> None:

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -17,6 +17,7 @@ from archivey.exceptions import (
     CorruptionError,
     PackageNotInstalledError,
     TruncatedError,
+    UnsupportedFeatureError,
 )
 from archivey.internal.config import (
     AcceleratorMode,
@@ -309,12 +310,33 @@ def test_unix_compress_non_seekable_source_streams() -> None:
 
 
 @requires("ncompress")
-def test_unix_compress_truncated_yields_short_read_without_truncated_error() -> None:
+def test_unix_compress_truncated_raises_on_next_read() -> None:
     compressed = make_unix_compress(CONTENT)
     truncated = compressed[: len(compressed) // 2]
     with open_codec_stream(Codec.UNIX_COMPRESS, io.BytesIO(truncated)) as stream:
         data = stream.read()
-    assert len(data) < len(CONTENT)
+        assert len(data) < len(CONTENT)
+        with pytest.raises(TruncatedError, match="leftover bits"):
+            stream.read()
+
+
+@requires("ncompress")
+def test_unix_compress_reserved_header_flags_unsupported() -> None:
+    compressed = bytearray(make_unix_compress(CONTENT))
+    compressed[2] |= 0x60  # classic compress reserved flag bits
+    with open_codec_stream(Codec.UNIX_COMPRESS, io.BytesIO(bytes(compressed))) as stream:
+        with pytest.raises(UnsupportedFeatureError, match="reserved flags"):
+            stream.read()
+
+
+@requires("ncompress")
+def test_unix_compress_valid_stream_has_zero_leftover_padding() -> None:
+    """Finished compressors zero-pad; a full read must not arm TruncatedError."""
+    compressed = make_unix_compress(CONTENT)
+    with open_codec_stream(Codec.UNIX_COMPRESS, io.BytesIO(compressed)) as stream:
+        assert stream.read() == CONTENT
+        assert stream.read() == b""
+        assert stream.read() == b""
 
 
 @requires("ncompress")

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -324,7 +324,9 @@ def test_unix_compress_truncated_raises_on_next_read() -> None:
 def test_unix_compress_reserved_header_flags_unsupported() -> None:
     compressed = bytearray(make_unix_compress(CONTENT))
     compressed[2] |= 0x60  # classic compress reserved flag bits
-    with open_codec_stream(Codec.UNIX_COMPRESS, io.BytesIO(bytes(compressed))) as stream:
+    with open_codec_stream(
+        Codec.UNIX_COMPRESS, io.BytesIO(bytes(compressed))
+    ) as stream:
         with pytest.raises(UnsupportedFeatureError, match="reserved flags"):
             stream.read()
 

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -298,9 +298,9 @@ def test_inner_tar_over_xz_is_tar_xz() -> None:
     assert info.format == ArchiveFormat.TAR_XZ
 
 
-@requires("uncompresspy", "ncompress")
+@requires("ncompress")
 def test_inner_tar_over_unix_compress_is_tar_z() -> None:
-    """unix-compress needs seek; the bounded peek reader is seekable within its limit."""
+    """Bounded peek reader is seekable within its limit for inner-TAR upgrade."""
     from archivey.types import ContainerFormat, StreamFormat
     from tests.streams_util import make_unix_compress
 
@@ -311,7 +311,7 @@ def test_inner_tar_over_unix_compress_is_tar_z() -> None:
     assert info.detected_by == "content_probe"
 
 
-@requires("uncompresspy", "ncompress")
+@requires("ncompress")
 def test_unix_compress_without_inner_tar_stays_bare_z() -> None:
     from tests.streams_util import make_unix_compress
 

--- a/tests/test_single_file.py
+++ b/tests/test_single_file.py
@@ -1,7 +1,7 @@
 """Single-file compressor backend tests — Stage 2.
 
 Covers name inference, the one-member shape, the gzip stored-name surface, per-format
-size rules, DIRECT/INDEXED cost, the unix-compress non-seekable rule, and the
+size rules, DIRECT/INDEXED cost, non-seekable streaming (including `.Z`), and the
 password-rejection rule. ZST/LZ4 standalone are first-class here; only their
 seekable-decompressor refinements remain for Phase 8.
 """
@@ -304,8 +304,8 @@ def test_non_seekable_gzip_requires_streaming_mode() -> None:
 
 
 def test_non_seekable_gzip_streams_fine() -> None:
-    # Single-file formats (except .Z) stream from a non-seekable source under
-    # streaming=True (the mode a non-seekable source requires).
+    # Single-file formats stream from a non-seekable source under streaming=True
+    # (the mode a non-seekable source requires).
     data = gzip.compress(b"streamed payload")
     with open_archive(NonSeekableBytesIO(data), streaming=True) as ar:
         # Read while the generator is live: exhaustion closes the current stream.
@@ -321,14 +321,26 @@ def test_non_seekable_gzip_streams_fine() -> None:
             assert stream.read() == b"streamed payload"
 
 
-@requires("uncompresspy", "ncompress")
-def test_unix_compress_non_seekable_raises() -> None:
+@requires("ncompress")
+def test_unix_compress_non_seekable_requires_streaming_mode() -> None:
+    """Random access still needs a seekable source — same rule as gzip."""
     data = make_unix_compress(b"lzw payload")
     with pytest.raises(StreamNotSeekableError):
         open_archive(NonSeekableBytesIO(data), format=ArchiveFormat.Z)
 
 
-@requires("uncompresspy", "ncompress")
+@requires("ncompress")
+def test_unix_compress_non_seekable_streams_fine() -> None:
+    data = make_unix_compress(b"lzw payload")
+    with open_archive(
+        NonSeekableBytesIO(data), format=ArchiveFormat.Z, streaming=True
+    ) as ar:
+        for _member, stream in ar.stream_members():
+            assert stream is not None
+            assert stream.read() == b"lzw payload"
+
+
+@requires("ncompress")
 def test_unix_compress_seekable_reads(tmp_path: Path) -> None:
     path = tmp_path / "data.Z"
     path.write_bytes(make_unix_compress(b"lzw payload"))


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Vendors a native unix-compress (`.Z`) LZW decoder into Archivey’s stream layer, dropping the `uncompresspy` dependency and the `[unix-compress]` extra. `.Z` / `.tar.Z` become zero-dep core; CLEAR codes become `SeekPoint`s on seekable sources; non-seekable sources stream without seeking.

OpenSpec change: `vendor-unix-compress-lzw`.

### Error taxonomy

- Format errors raise `CorruptionError` directly (same pattern as xz/lzip)
- Reserved header flags (`0x60`) raise `UnsupportedFeatureError` at header parse
- Best-effort truncation: finished compressors zero-pad after the last complete LZW code; nonzero leftover bits arm `TruncatedError`, raised on the **next empty `read()`** after all decoded bytes are delivered (zero-leftover cuts remain undetectable)

## Test plan

- [x] `pytest tests/test_codecs.py -k unix_compress`
- [x] `pytest tests/test_single_file.py -k unix_compress`
- [x] ruff / pyrefly / ty on touched modules
- [x] `openspec validate --strict vendor-unix-compress-lzw`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b1594759-bb64-4936-87ee-9dab3cc00461"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b1594759-bb64-4936-87ee-9dab3cc00461"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

