### PR TITLE
Fix CI matrix to actually run Python 3.12/3.13/3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,8 @@ jobs:
       - name: Set up Python
         run: uv python install 3.12
       - name: Build docs (strict)
-        run: uv run --group docs mkdocs build --strict
+        # --python overrides repo `.python-version` (3.11) so docs actually run on 3.12.
+        run: uv run --python 3.12 --group docs mkdocs build --strict
 
   test:
     name: ${{ matrix.os }} / py${{ matrix.python-version }} / ${{ matrix.install }}
@@ -68,6 +69,10 @@ jobs:
     # Backstop for a hang outside a test (install/sync). A hung *test* fails much sooner via
     # pytest's per-test --timeout; this just bounds the whole job so it can't run for hours.
     timeout-minutes: 20
+    # Force every uv sync/run in this job onto the matrix interpreter. Without this,
+    # `.python-version` (3.11) wins and "py3.12/3.13/3.14" legs silently re-test 3.11.
+    env:
+      UV_PYTHON: ${{ matrix.python-version }}
     strategy:
       fail-fast: false
       matrix:
@@ -107,11 +112,11 @@ jobs:
       # the zero-dep core works and that no third-party runtime package is present.
       - name: Install core only (no extras, no dev group)
         if: matrix.install == 'core-only'
-        run: uv sync --no-dev
+        run: uv sync --python ${{ matrix.python-version }} --no-dev
 
       - name: Assert zero-dependency core
         if: matrix.install == 'core-only'
-        run: uv run --no-sync python tests/check_zero_dep_core.py
+        run: uv run --python ${{ matrix.python-version }} --no-sync python tests/check_zero_dep_core.py
 
       # Run the full suite against the zero-dep core too. pytest (+pytest-cov) is
       # layered in ephemerally with --with so the optional FORMAT libraries stay
@@ -119,12 +124,15 @@ jobs:
       # `requires` helper in tests/conftest.py), which is exactly what this leg proves.
       - name: Run tests (core-only)
         if: matrix.install == 'core-only'
-        run: uv run --no-sync --with pytest --with pytest-cov --with pytest-timeout pytest tests/ -q
+        run: >
+          uv run --python ${{ matrix.python-version }} --no-sync
+          --with pytest --with pytest-cov --with pytest-timeout
+          pytest tests/ -q
 
       # ---- [all]: full extras + dev group; run the whole suite.
       - name: Install all extras + dev group
         if: matrix.install == 'all'
-        run: uv sync --group dev --extra all
+        run: uv sync --python ${{ matrix.python-version }} --group dev --extra all
 
       # ---- [all-lowest]: same extras, but every declared dependency pinned to its minimum
       # allowed version (--resolution lowest-direct), so the suite runs against the floor of
@@ -132,17 +140,26 @@ jobs:
       # versions); the shared test step below uses --no-sync so this resolution stands.
       - name: Install all extras + dev group (minimum versions)
         if: matrix.install == 'all-lowest'
-        run: uv sync --group dev --extra all --resolution lowest-direct
+        run: >
+          uv sync --python ${{ matrix.python-version }}
+          --group dev --extra all --resolution lowest-direct
 
       - name: Install unrar (Linux only, for RAR data tests)
         if: (matrix.install == 'all' || matrix.install == 'all-lowest') && runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y unrar || true
 
+      - name: Assert synced venv Python matches matrix
+        # Catch regressions where `.python-version` silently overrides the matrix again.
+        run: >
+          uv run --python ${{ matrix.python-version }} --no-sync python -c
+          "import sys; exp=tuple(map(int, '${{ matrix.python-version }}'.split('.')));
+          got=sys.version_info[:2]; assert got==exp, (got, exp); print(sys.version)"
+
       - name: Run tests
         if: matrix.install == 'all' || matrix.install == 'all-lowest'
         # --no-sync so the all-lowest leg keeps its minimum-version resolution instead of
         # re-syncing back to the locked (current) versions.
-        run: uv run --no-sync pytest tests/ -q
+        run: uv run --python ${{ matrix.python-version }} --no-sync pytest tests/ -q
 
   # Free-threaded correctness for the declared MemberStreams.CONCURRENT seam (core backends).
   # Optional extras are not claimed covered here — skips do not count as free-threaded support.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,3 +47,7 @@ Non-obvious gotchas:
   Install with `uv sync --group fuzz --group dev --extra all`, then
   `uv run --no-sync python -m tests.atheris_fuzz --smoke`. Mutation /
   `ARCHIVEY_FUZZ` harnesses are unchanged. See `CONTRIBUTING.md` ("Coverage-guided fuzz").
+- **CI matrix Python versions**: repo `.python-version` pins local/default envs to 3.11.
+  The test matrix in `.github/workflows/ci.yml` must pass `--python <matrix>` (and set
+  `UV_PYTHON`) on every `uv sync` / `uv run`, or "py3.12/3.13/3.14" legs silently re-test
+  3.11. The free-threaded and atheris jobs already did this; the main `test` job must too.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,11 @@ These mirror CI's `[all]`, `[all-lowest]`, and `[core-only]` legs; all three mus
 green. (After the core-only leg, `uv sync --group dev --extra all` to restore your
 everyday environment.)
 
+CI also matrixes supported **Python versions** (3.11–3.14 on Linux; 3.11/3.14 on
+macOS/Windows). Repo `.python-version` pins the default local env to 3.11, so the
+workflow must pass `--python <matrix>` (and `UV_PYTHON`) on every `uv sync` /
+`uv run` in the test job — otherwise newer-version legs silently re-test 3.11.
+
 ## Tooling decisions
 
 - **Type-checking is Pyrefly + ty** — the library is kept clean on **both**. We do

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,7 +92,8 @@ dev = [
     # libarchive-c is a dev-only cross-validation oracle for optional corpus tests
     # (tests/test_libarchive_corpus.py); it is not a runtime backend.
     "libarchive-c>=5.0.0",
-    "backports.zstd>=1.0.0",
+    # Stdlib compression.zstd on 3.14+; backports only needed below that.
+    "backports.zstd>=1.0.0; python_version < '3.14'",
     "lz4>=4.4.5",
     "brotli>=1.1.0",
     # pycdlib (the [iso] extra) is in the dev group like the other optional format libs, so

--- a/src/archivey/internal/streams/streamtools/base.py
+++ b/src/archivey/internal/streams/streamtools/base.py
@@ -42,10 +42,10 @@ class ReadOnlyIOStream(io.RawIOBase, BinaryIO):
 
     @abc.abstractmethod
     def read(self, n: int = -1, /) -> bytes:
-        # @abstractmethod is an intent/static-check signal that subclasses must provide read().
-        # It does NOT prevent instantiation here: io.RawIOBase's C-level __new__ ignores
-        # __abstractmethods__ (a subclass without read() still constructs), so this body is the
-        # actual runtime guard — a forgotten read() fails loudly instead of looping via RawIOBase.
+        # @abstractmethod marks the subclass contract. On Python 3.12+ ABCMeta already
+        # rejects constructing a subclass that omits read(); on 3.11, io.RawIOBase's C
+        # __new__ still allows construction, so this body is the runtime guard — a
+        # forgotten read() fails loudly instead of looping via RawIOBase.
         raise NotImplementedError
 
     def readinto(self, b: "WriteableBuffer", /) -> int:

--- a/tests/test_archivey_config.py
+++ b/tests/test_archivey_config.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import dataclasses
 import io
 import logging
-from unittest import mock
 
 import pytest
 
@@ -69,11 +68,22 @@ def test_accelerator_modes_honored_via_config(
 
     import archivey.internal.backends.tar_reader as tar_reader_module
 
+    # open_codec_stream is stubbed so we can assert the config it received, but the
+    # stub must still yield a real uncompressed tar: tar_reader wraps it in
+    # BufferedReader, and on Python 3.14 (esp. macOS) a bare MagicMock's readinto()
+    # recurses through __index__ until pytest-timeout kills the test.
+    uncompressed = io.BytesIO()
+    with tarfile.open(fileobj=uncompressed, mode="w") as t:
+        info = tarfile.TarInfo("a.txt")
+        info.size = 1
+        t.addfile(info, io.BytesIO(b"x"))
+    tar_bytes = uncompressed.getvalue()
+
     captured: list[object] = []
 
     def _capture_open(codec, source, *, config, stamp=None, collector=None):
         captured.append(config)
-        return mock.MagicMock(__enter__=lambda s: s, __exit__=lambda *a: None)
+        return io.BytesIO(tar_bytes)
 
     monkeypatch.setattr(tar_reader_module, "open_codec_stream", _capture_open)
     cfg = ArchiveyConfig(

--- a/tests/test_stream_bases.py
+++ b/tests/test_stream_bases.py
@@ -35,12 +35,13 @@ def test_readonly_base_derives_readinto_readall_and_flags() -> None:
 
 
 def test_readonly_base_read_is_the_runtime_guard() -> None:
-    # read() is @abstractmethod (a static/intent signal) but io.RawIOBase's C __new__ does not
-    # enforce it, so the NotImplementedError body is the real guard if a subclass calls super().
+    # read() is @abstractmethod. On Python 3.12+ ABCMeta rejects construction of a
+    # subclass that omits it (TypeError). On 3.11, io.RawIOBase's C __new__ still lets
+    # the instance form, so the NotImplementedError body in read() is the runtime guard.
     class _ForgotRead(ReadOnlyIOStream):
         pass
 
-    with pytest.raises(NotImplementedError):
+    with pytest.raises((TypeError, NotImplementedError)):
         _ForgotRead().read()
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -18,6 +18,7 @@ source = { editable = "." }
     { name = "brotli" },
     { name = "cryptography" },
     { name = "inflate64" },
+    { name = "lz4" },
     { name = "pybcj" },
     { name = "pyppmd" },
 ]
@@ -92,7 +93,7 @@ zstd = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "backports-zstd" },
+    { name = "backports-zstd", marker = "python_full_version < '3.14'" },
     { name = "brotli" },
     { name = "coverage", extra = ["toml"] },
     { name = "cryptography" },
@@ -138,6 +139,7 @@ requires-dist = [
     { name = "cryptography", marker = "extra == 'crypto'", specifier = ">=45.0.0" },
     { name = "cryptography", marker = "extra == 'rar'", specifier = ">=45.0.0" },
     { name = "inflate64", marker = "extra == '7z'", specifier = ">=1.0.0" },
+    { name = "lz4", marker = "extra == '7z'", specifier = ">=4.4.5" },
     { name = "lz4", marker = "extra == 'lz4'", specifier = ">=4.4.5" },
     { name = "py7zr", marker = "extra == '7z-write'", specifier = ">=1.0.0" },
     { name = "pybcj", marker = "extra == '7z'", specifier = ">=1.0.6" },
@@ -151,7 +153,7 @@ provides-extras = ["7z", "rar", "crypto", "7z-write", "iso", "zstd", "lz4", "uni
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "backports-zstd", specifier = ">=1.0.0" },
+    { name = "backports-zstd", marker = "python_full_version < '3.14'", specifier = ">=1.0.0" },
     { name = "brotli", specifier = ">=1.1.0" },
     { name = "coverage", extras = ["toml"], specifier = ">=7.6.0" },
     { name = "cryptography", specifier = ">=45.0.0" },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

CI’s Python matrix was not actually running the declared interpreter. `setup-python` installed 3.12/3.13/3.14, but every `uv sync` / `uv run` followed `.python-version` (`3.11`), so “py3.14” jobs were often a different 3.11.x (and different liblzma) than the real 3.11 job.

That made failures look like “3.14-only” when they were environment skew. After the matrix started using the real interpreters, further breaks showed up and are fixed here too.

## Changes

- Pass `UV_PYTHON` and `--python ${{ matrix.python-version }}` on every `uv sync` / `uv run` in the test job
- Assert `sys.version_info[:2]` matches the matrix after sync
- Pin the docs job to `--python 3.12`
- Note the gotcha in `AGENTS.md` / `CONTRIBUTING.md`
- Accept `TypeError` (3.12+ ABCMeta) as well as `NotImplementedError` in `test_readonly_base_read_is_the_runtime_guard`
- Gate the unconditional `backports.zstd` entry in the `dev` dependency group with `python_version < '3.14'` (same as the `zstd`/`all` extras) so `uv sync --extra all` works on 3.14
- Replace the bare `MagicMock` open_codec_stream stub in `test_accelerator_modes_honored_via_config` with a `BytesIO` of real tar bytes (macOS py3.14 hung in `readinto` → `__index__` recursion)

## Test plan

- [x] Confirm CI matrix jobs report the expected Python version in logs
- [x] Local: `uv sync --python 3.14 --group dev --extra all` succeeds
- [x] Local: targeted stream-base + zstd tests pass on 3.12 and 3.14
- [x] Local: `test_accelerator_modes_honored_via_config` passes on 3.11 and 3.14
- [ ] CI green across ubuntu/macOS/windows for 3.11–3.14
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-76759766-a611-4b18-913b-0d00829dc589"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-76759766-a611-4b18-913b-0d00829dc589"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

