### PR TITLE
Propose: spike IndexedDecompressStream composition refactor

### DIFF
--- a/openspec/changes/spike-indexed-decompress-stream/.openspec.yaml
+++ b/openspec/changes/spike-indexed-decompress-stream/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: library
+created: 2026-07-13

--- a/openspec/changes/spike-indexed-decompress-stream/design.md
+++ b/openspec/changes/spike-indexed-decompress-stream/design.md
@@ -147,31 +147,38 @@ class Decoder(Protocol):
 ```
 
 Zlib/brotli/ppmd/deflate64/bcj → adapters, `hints=[]`, `pending_error` always
-`None`. Lzip/xz/.Z → existing state machines; format meaning lives in the
-SeekTable policy, not in stream-subclass cursor folklore.
+`None`. Lzip/xz/.Z → existing state machines; before/after / enrichment semantics
+live in the index-wiring layer (Open Question B), not in stream-subclass cursor
+folklore.
 
 **Rejected:** absolute offsets from Decoders (couples them to cursors/I/O).
 **Rejected:** keep separate `_decompress_chunk → bytes` vs `feed → (bytes, units)`.
 **Rejected:** duck-typing `truncated` / ad-hoc attributes — use the Protocol property.
 
-### 3. SeekTable owns index paths (shape of xz enrichment still open — see B)
+### 3. Seek / index discovery wiring (open — see B)
 
-| Format | Progressive `record` | `build_full` |
+Two viable framings for where format knowledge lives vs where points are stored —
+**Model 1 (per-format SeekTable)** vs **Model 2 (generic store; format pushes)**.
+Not locked; maintainer lean is Model 1 (cleaner), still open. See Open Question B.
+
+Whichever model wins, the *behaviors* to cover are:
+
+| Format | Progressive (during decode) | One-shot (`build_full` / end index) |
 | --- | --- | --- |
-| zlib family | no-op | no-op (rewind from 0) |
+| zlib family | none | none (rewind from 0) |
 | lzip | member starts (`before`) | backwards trailer scan |
-| xz | stream starts + **block enrichment** (how: Open Question B) | backwards footer/index scan |
-| unix-compress | CLEAR resumes (`after`) | no-op (`SEEK_END` → base scan-to-EOF) |
+| xz | stream starts + **block enrichment from footer** | backwards footer/index scan |
+| unix-compress | CLEAR resumes (`after`) | none (`SEEK_END` → base scan-to-EOF) |
 | BGZF (future) | — | forward member walk via BC/MZ |
 
-Demand-driven: undeclared seekability → `NullSeekTable` (no points, no scans).
+Demand-driven: undeclared seekability → no points / no scans.
 
 ### 4. `recreate(point)` is the resume strategy
 
 XZ’s `_XzState` vs `_XzBlockChain` becomes a choice inside `Decoder.recreate`, not
 a union on the stream. No `_create_decompressor` / `_make_decompressor` dual API.
-(XZ recreate may need the table’s subsequent block points — factory closure or
-`recreate(point, table)`; settled with Open Question B.)
+(XZ recreate may need subsequent block points from the store — factory closure or
+passing the table; settled with Open Question B.)
 
 ### 5. Deferred `.Z` TruncatedError via formal `pending_error` (locked)
 
@@ -180,8 +187,8 @@ a union on the stream. No `_create_decompressor` / `_make_decompressor` dual API
 nonzero; other Decoders leave it `None`. `DecompressorStream.read` raises and
 clears it on the next empty read after delivering bytes. Header params for
 CLEAR recreate live on the Decoder / unix-compress factory; origin
-`SeekPoint(0, 3)` adjustment is SeekTable’s job — no format stream subclass
-overriding `read` / chunk / flush / reset.
+`SeekPoint(0, 3)` adjustment lives with index wiring (Open Question B) — no
+format stream subclass overriding `read` / chunk / flush / reset.
 
 ### 6. Keep the name `DecompressorStream` (locked)
 
@@ -193,7 +200,7 @@ allowed if it earns its keep; not required for this change.
 
 Zlib-family Decoder adapters stay in `decompress.py`; xz/lzip/.Z keep parsers in
 their modules and lose stream-subclass tails. Construction sites in `codecs.py`
-become thin factories wiring `(Decoder, SeekTable)` into `DecompressorStream`.
+become thin factories wiring Decoder + index policy into `DecompressorStream`.
 
 **Rejected:** rename to `IndexedDecompressStream` (leaks structure; churn for
 little clarity).
@@ -219,25 +226,93 @@ parallel — wait on or re-target this composition model.
 
 | Risk | Mitigation |
 | --- | --- |
-| Over-abstract SeekTable into a plugin framework | Cap at ~4–5 concrete policies; no registry of registries |
-| XZ progressive enrichment fights clean `record` | Open Question B; spike before migration; keep seek tests green |
+| Over-abstract index discovery into a plugin maze | Cap at a few concrete policies; Open Question B must pick Model 1 or 2 first |
+| XZ progressive enrichment / end-index wiring | Open Question B; spike before migration; keep seek tests green |
 | Subtle SEEK_END / size / buffer regressions | Existing `test_seekable_streams` + unix-compress seek matrix are the gate |
 | Accidental rename pressure | Decision 6: keep `DecompressorStream` |
 
 ## Open Questions
 
-### B. Where does XZ block enrichment live?
+### B. Per-format SeekTable vs generic store (format pushes)
 
-Today, when a multi-stream XZ file finishes a stream during a forward read, the
-stream subclass seeks the compressed file, reads that stream’s footer/index, and
-registers block-level `SeekPoint`s (with `state=block bounds`) — then restores
-the file position. That is “progressive enrichment.” On a later seek into a
-block, `recreate` builds `_XzBlockChain` from those points.
+Two jobs got conflated earlier: **(1) store** seek points, and **(2) discover**
+extra points by reading format structures (lzip trailers, xz footers). Today
+those already split in spirit: a generic `_seek_points` list on the stream, plus
+format scanners (`_read_index_backwards`, `_read_xz_index_backwards`) wired by
+the stream subclass’s `_build_index`. Lzip only uses the **one-shot** end-index
+path (`SEEK_END` / past frontier → `_ensure_index_built` → scan). XZ also does
+**progressive** discovery (as each stream finishes during forward read, scan that
+stream’s footer for block points).
 
-**Still open:** who owns that enrichment after the refactor — a fat SeekTable, a
-thin table plus a stream hook, or a separate Enricher? Options and trade-offs are
-being explored in the change discussion; lock one here before §2.
+**Still open:** which composition model owns format knowledge after the refactor.
 
-**Also must handle:** while replaying via `_XzBlockChain`, completed units only
-advance cursors (no new points). `recreate` needs subsequent block points from
-the table.
+#### Model 1 — Per-format SeekTable (format knowledge in the table)
+
+The stream talks only to a `SeekTable` protocol. Each format supplies a subclass
+that knows how to parse its end index / progressive enrichment. The table may
+read `inner` inside `build_full` (and, for xz, during progressive `record`).
+
+```python
+class SeekTable(Protocol):
+    def record(self, hints: list[ResumeHint]) -> None: ...
+    def build_full(self, inner: BinaryIO) -> int | None: ...  # may I/O
+    def best_at(self, pos: int) -> SeekPoint: ...
+
+class LzipSeekTable:
+    def build_full(self, inner):
+        bounds = _read_index_backwards(inner, ...)
+        self._points.extend(...)
+        return total_size
+
+class XzSeekTable:
+    def record(self, hints):  # stream boundaries + may enrich from footer
+        ...
+    def build_full(self, inner):
+        ...
+```
+
+- **Pros:** one object per format; stream loop identical for all codecs; matches
+  “SeekTable policy” language; end-index + progressive live in one place for xz.
+- **Cons:** table is not a pure in-memory store — format I/O and diagnostics live
+  here too.
+
+**Maintainer lean:** Model 1 feels cleaner — not settled.
+
+#### Model 2 — Generic store; format pushes
+
+`SeekTable` is only a point list (`add` / `best_at`). Format modules own scanners
+(as today) and **push** points in. The stream (or a tiny wiring helper) calls the
+format loader when an index is needed; xz progressive push is also format code
+calling `table.add(block_points)`.
+
+```python
+class SeekTable:  # no format, no file I/O
+    def add(self, points: list[SeekPoint]) -> None: ...
+    def best_at(self, pos: int) -> SeekPoint: ...
+
+def load_lzip_index(inner) -> tuple[list[SeekPoint], int]:
+    bounds = _read_index_backwards(inner, ...)
+    return points, total_size
+
+# stream / wiring:
+points, size = load_lzip_index(self._inner)
+table.add(points)
+```
+
+- **Pros:** closest to today’s split; table never touches the file; scanners stay
+  next to parsers; “store vs discover” is obvious.
+- **Cons:** stream (or another helper) must know *when* to call which loader;
+  xz progressive enrichment needs an explicit push hook somewhere outside the
+  table — slightly more moving parts at the call site.
+
+#### What either model must still handle
+
+- XZ block-chain **replay**: completed units advance cursors but do not add points.
+- XZ `recreate`: needs subsequent block points from the store.
+- Recoverable scan failure → `SEEK_INDEX_DEGRADED` + sequential fallback (today’s
+  `_build_index_backwards` behavior).
+
+**Finalize when:** pick Model 1 or 2, spike xz progressive + lzip one-shot under
+that shape, keep `tests/test_seekable_streams.py` green, then move the choice
+into Decisions and delete this section.
+

--- a/openspec/changes/spike-indexed-decompress-stream/design.md
+++ b/openspec/changes/spike-indexed-decompress-stream/design.md
@@ -32,9 +32,9 @@ Provenance: explore session that mapped the hierarchy and proposed composition
 **Goals:**
 
 - Lock the target architecture (composition over inheritance) and every open thread
-  that would block a safe refactor.
-- Run small spikes where a thread is empirically uncertain (esp. XZ progressive
-  enrichment) and record the decision in this file before mechanical migration.
+  that would block a safe refactor. **A/C/D/E locked; B (XZ enrichment placement)
+  still open.**
+- Spike Open Question B and record the decision here before mechanical migration.
 - After decisions: behavior-preserving refactor; delete `SegmentedDecompressorStream`
   and per-format stream subclasses; keep format parsers/state machines.
 - Leave a clear plug shape for BGZF / future native zstd frame index.

--- a/openspec/changes/spike-indexed-decompress-stream/design.md
+++ b/openspec/changes/spike-indexed-decompress-stream/design.md
@@ -1,0 +1,251 @@
+## Context
+
+Today’s native indexed decompressors live under `internal/streams/`:
+
+```
+ReadOnlyIOStream
+      │
+DecompressorStream          ← buffer, pos, seek, SeekPoint table, EOF/size
+      │            │
+thin adapters      SegmentedDecompressorStream
+(zlib/brotli/…)         │         │         │
+                     lzip       xz        .Z
+                                   │
+                             SeekPoint.state → _XzBlockChain
+```
+
+Parallel world in `codecs.py`: `_AcceleratorStream` / stdlib gzip·bz2 / truncation
+backstop — same *job* (bytes out of a compressed source), different hierarchy.
+
+Caller contracts live in `seekable-decompressor-streams` (demand-driven indexes,
+native xz/lzip indexes, CLEAR seek points, rewind diagnostics, seek-index
+degradation). This change must preserve those; the problem is accidental hierarchy
+cost, not missing behavior.
+
+Provenance: explore session that mapped the hierarchy and proposed composition
+(one stream + Decoder + SeekTable). Related in-flight: `seekable-gzip-and-block-writing`
+(plans another `DecompressorStream` subclass for BGZF); `vendor-unix-compress-lzw`
+(already split `LzwState` + stream — the pattern to generalize).
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Lock the target architecture (composition over inheritance) and every open thread
+  that would block a safe refactor.
+- Run small spikes where a thread is empirically uncertain (esp. XZ progressive
+  enrichment) and record the decision in this file before mechanical migration.
+- After decisions: behavior-preserving refactor; delete `SegmentedDecompressorStream`
+  and per-format stream subclasses; keep format parsers/state machines.
+- Leave a clear plug shape for BGZF / future native zstd frame index.
+
+**Non-Goals:**
+
+- Changing public seek/truncation/diagnostic contracts (unless a spike *forces* a
+  tiny clarification — default is zero caller-visible change).
+- Folding rapidgzip / `_AcceleratorStream` into Decoder.
+- Rewriting XZ/lzip/LZW parsers.
+- Implementing BGZF or seekable-gzip writing in this change (coordinate only).
+- “Half the size of `xz.py`” — most of that file is essential format complexity.
+
+## Investigations
+
+### Hierarchy tax vs essential complexity
+
+| Piece | ~LOC | Nature |
+| --- | --- | --- |
+| `DecompressorStream` seek/buffer/index | ~250 | Essential — keep **once** |
+| `SegmentedDecompressorStream` | ~90 | Thin adapter; disappears if every Decoder returns hints |
+| 5× classes in `decompress.py` | ~187 | Boilerplate for 4 abstract methods |
+| lzip/xz/.Z *stream subclass tails* | ~40–100 each | Glue that should not need inheritance |
+| Format parsers + state machines | bulk of xz/lzip/unix_compress | Essential — leave |
+
+### Three index-building paths (today)
+
+1. **Progressive** — `add_seek_points` during `feed` / completed segments.
+2. **One-shot** — `_build_index` on `SEEK_END` / seek past known frontier.
+3. **XZ-only mid-read** — `_update_index` seeks `_inner`, scans that stream’s footer,
+   restores position.
+
+### Seek-point semantics disagree
+
+| Format | On completed unit |
+| --- | --- |
+| lzip / xz member-start | **point first**, then advance cursors |
+| unix-compress CLEAR | **advance first**, then point (resume *after* CLEAR) |
+
+Both correct for their formats; the segmented base does not encode which. Folklore.
+
+### XZ dual decoder
+
+`SeekPoint.state: Any` is either `None` → `_XzState` or `_XzBlockBounds` →
+`_XzBlockChain`. The stream type param is a union because resume strategy was
+stuffed into the decoder type instead of `recreate(point)`.
+
+### `.Z` leaks through the base
+
+`UnixCompressDecompressorStream` overrides `read`, `_decompress_chunk`,
+`_flush_decompressor`, `_reset_to_seek_point` for deferred `TruncatedError` and
+header commit — the “sealed” segmented API is not sealed.
+
+### Target shape (agreed direction)
+
+```
+┌─────────────────────────────────────────┐
+│       IndexedDecompressStream           │  buffer, pos, eof, size, seek/read
+│         HAS Decoder + SeekTable         │
+└───────────────┬─────────────┬───────────┘
+                ▼             ▼
+         Decoder protocol   SeekTable
+         feed/flush/        points / record(hint)
+         finished/recreate  build_full / best_at
+```
+
+Every Decoder returns the same `DecodeOut(data, hints=…)`. Simple codecs always
+emit empty hints → `SegmentedDecompressorStream` deletes itself.
+
+## Decisions
+
+### 1. Composition, not a smarter subclass tree
+
+Replace `DecompressorStream` / `SegmentedDecompressorStream` / per-format stream
+subclasses with **one** `IndexedDecompressStream` that owns I/O + seek/buffer/EOF
+once, plus injected `Decoder` + `SeekTable`.
+
+**Rejected:** keep inheritance and only tidy naming. **Rejected:** merge
+accelerators into Decoder (foreign `BinaryIO`; lifecycle/`weakref.finalize` stays
+at birth site).
+
+### 2. Unify decoder shapes via ResumeHint
+
+```python
+@dataclass
+class DecodeOut:
+    data: bytes
+    hints: list[ResumeHint] = field(default_factory=list)
+
+@dataclass
+class ResumeHint:
+    # See Open Question A — absolute vs relative; default lean below.
+    decompressed: int
+    compressed: int
+    state: Any = None  # XZ block bounds today; rare
+
+class Decoder(Protocol):
+    def recreate(self, point: SeekPoint) -> Decoder: ...
+    def feed(self, chunk: bytes) -> DecodeOut: ...
+    def flush(self) -> DecodeOut: ...
+    @property
+    def finished(self) -> bool: ...
+```
+
+Zlib/brotli/ppmd/deflate64/bcj → adapters, `hints=[]`.  
+Lzip/xz/.Z → state machines already mostly exist; emit hints with **format meaning
+baked in** (no more point-then-advance vs advance-then-point in stream subclasses).
+
+**Rejected:** keep separate `_decompress_chunk → bytes` vs `feed → (bytes, units)`
+forever. **Rejected:** zlib-style plus ad-hoc `take_clears()` (reinvents segmented).
+
+### 3. SeekTable owns all three index paths
+
+| Format | `record(hint)` | `build_full(inner, last)` |
+| --- | --- | --- |
+| zlib family | no-op | no-op (rewind from 0) |
+| lzip | member starts | backwards trailer scan |
+| xz | stream starts **+ progressive block enrichment** | backwards footer/index scan |
+| unix-compress | CLEAR resumes | no-op (`SEEK_END` → base scan-to-EOF) |
+| BGZF (future) | — | walk BC/MZ members |
+
+XZ progressive enrichment moves from `_on_completed_segments` into
+**XZ’s `SeekTable.record`** (may seek/restore `_inner`). Same behavior, one home.
+
+Demand-driven: undeclared seekability → `NullSeekTable` (no points, no scans).
+
+### 4. `recreate(point)` is the resume strategy
+
+XZ’s `_XzState` vs `_XzBlockChain` becomes a choice inside `Decoder.recreate`, not
+a union on the stream. No `_create_decompressor` / `_make_decompressor` dual API.
+
+### 5. Deferred `.Z` TruncatedError is one stream hook, not four overrides
+
+Decoder `flush` may set `pending_error`; `IndexedDecompressStream.read` raises it
+on the next empty read after delivering bytes. Matches today’s contract; removes
+the need to override chunk/flush/reset/read in the format stream class.
+
+### 6. Spike-gated implementation
+
+Do **not** start the mechanical migration until Open Questions A–D below are
+closed (or explicitly deferred with a written fallback). Tasks §1 are the spike;
+§2+ are the refactor.
+
+### 7. Coordinate BGZF / seekable-gzip
+
+`seekable-gzip-and-block-writing` MUST NOT land another `DecompressorStream`
+subclass leaf in parallel. Either this change lands first and BGZF is a
+Decoder+SeekTable policy, or BGZF waits / re-targets.
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+| --- | --- |
+| Over-abstract SeekTable into a plugin framework | Cap at ~4–5 concrete policies; no registry of registries |
+| XZ progressive enrichment fights clean `record` | Spike task: port `_update_index` behind SeekTable; keep existing seek tests green |
+| Subtle SEEK_END / size / buffer regressions | Existing `test_seekable_streams` + unix-compress seek matrix are the gate; no “improve” seeks in the same PR |
+| Naming churn (`IndexedDecompressStream` vs keep `DecompressorStream`) | Prefer rename that matches composition; keep a thin alias only if imports elsewhere hurt |
+| Specs stay empty while validate wants a delta | Add a **shared seek-surface** clarifying requirement (parity across native indexed codecs) — no caller behavior change |
+
+## Open Questions
+
+These are the **loose threads that must be finalized before implementation**.
+Each should leave this section when closed (move the answer into Decisions).
+
+### A. Absolute vs relative ResumeHints
+
+- **Options:** (1) Decoders emit **relative** `(decomp_delta, comp_delta)` and the
+  stream’s single cursor helper converts to absolute SeekPoints; (2) Decoders emit
+  **absolute** offsets (know cursors or receive them).
+- **Lean:** (1) — keeps state machines I/O-agnostic (current xz/lzip/.Z already
+  return relative units). Format-specific “before vs after” becomes which absolute
+  the SeekTable records, not which way the Decoder orders cursor math.
+- **Finalize when:** write the cursor helper + one lzip and one `.Z` SeekTable in a
+  spike branch; confirm seek tests agree.
+
+### B. XZ progressive enrichment under SeekTable.record
+
+- **Question:** Can `_update_index` (seek inner → `_read_xz_index_backwards` for the
+  just-finished stream → restore → add block SeekPoints with `state=bounds`) live
+  entirely in `XzSeekTable.record` without the stream knowing about footers?
+- **Lean:** Yes — `record` receives the completed-stream hint + access to `inner`
+  and the live SeekPoint list; stream only calls `table.record` / `decoder.feed`.
+- **Finalize when:** spike that deletes `_on_completed_segments` branching on
+  `isinstance(_XzState)` and keeps `test_seekable_streams` / size-via-index tests green.
+
+### C. Pending-error / header-commit hooks on Decoder
+
+- **Question:** Is `pending_error` on Decoder enough for `.Z`, or does the stream
+  need a tiny `after_flush` / `on_empty_read` callback protocol?
+- **Lean:** `pending_error` property set by `flush`, cleared by stream after raise;
+  header params for recreate live on the Decoder or a small side object owned by
+  the unix-compress factory — not on the stream subclass.
+- **Finalize when:** spike recreating deferred TruncatedError without overriding
+  `read` on a format-specific stream class.
+
+### D. Naming and module layout
+
+- **Question:** Keep filename `decompressor_stream.py` and rename the class to
+  `IndexedDecompressStream`, or rename module too? Where do `Decoder` adapters live
+  (`decompress.py` vs per-codec modules)?
+- **Lean:** Class rename to `IndexedDecompressStream` (or keep `DecompressorStream`
+  as the one stream class name to limit churn — pick one in spike); module can stay
+  until a follow-up. Adapters stay beside codecs that need them; zlib-family thin
+  adapters can remain in one `decompress.py` as functions/classes implementing
+  Decoder only.
+- **Finalize when:** grepping import sites (`codecs.py`, tests, single_file_reader)
+  and choosing the lower-churn name in Decisions.
+
+### E. (Optional defer) Native zstd frame index
+
+Out of scope for this change’s implementation, but the SeekTable plug shape should
+not paint us into a corner. Confirm the design doesn’t assume “backwards trailer
+only” — progressive CLEAR-like points and one-shot member walks (BGZF) must both fit.
+No spike required beyond a written note in Decisions once A–D close.

--- a/openspec/changes/spike-indexed-decompress-stream/design.md
+++ b/openspec/changes/spike-indexed-decompress-stream/design.md
@@ -116,20 +116,25 @@ once, plus injected `Decoder` + `SeekTable`.
 accelerators into Decoder (foreign `BinaryIO`; lifecycle/`weakref.finalize` stays
 at birth site).
 
-### 2. Unify decoder shapes via ResumeHint
+### 2. Unify decoder shapes via relative ResumeHints (locked)
+
+Decoders emit **relative** `(decomp_delta, comp_delta)` units. A SeekTable policy
+turns them into absolute `SeekPoint`s (`before` = lzip/xz stream boundary;
+`after` = unix-compress CLEAR). Enrichment (xz blocks, BGZF member walks) may
+also inject absolute points from index/trailer scans — those do not come from
+relative units.
 
 ```python
 @dataclass
 class DecodeOut:
     data: bytes
-    hints: list[ResumeHint] = field(default_factory=list)
+    hints: list[ResumeHint] = field(default_factory=list)  # relative sizes
 
 @dataclass
 class ResumeHint:
-    # See Open Question A — absolute vs relative; default lean below.
-    decompressed: int
+    decompressed: int  # delta since previous hint / origin
     compressed: int
-    state: Any = None  # XZ block bounds today; rare
+    state: Any = None  # rare; xz block bounds today
 
 class Decoder(Protocol):
     def recreate(self, point: SeekPoint) -> Decoder: ...
@@ -137,27 +142,27 @@ class Decoder(Protocol):
     def flush(self) -> DecodeOut: ...
     @property
     def finished(self) -> bool: ...
+    @property
+    def pending_error(self) -> BaseException | None: ...
 ```
 
-Zlib/brotli/ppmd/deflate64/bcj → adapters, `hints=[]`.  
-Lzip/xz/.Z → state machines already mostly exist; emit hints with **format meaning
-baked in** (no more point-then-advance vs advance-then-point in stream subclasses).
+Zlib/brotli/ppmd/deflate64/bcj → adapters, `hints=[]`, `pending_error` always
+`None`. Lzip/xz/.Z → existing state machines; format meaning lives in the
+SeekTable policy, not in stream-subclass cursor folklore.
 
-**Rejected:** keep separate `_decompress_chunk → bytes` vs `feed → (bytes, units)`
-forever. **Rejected:** zlib-style plus ad-hoc `take_clears()` (reinvents segmented).
+**Rejected:** absolute offsets from Decoders (couples them to cursors/I/O).
+**Rejected:** keep separate `_decompress_chunk → bytes` vs `feed → (bytes, units)`.
+**Rejected:** duck-typing `truncated` / ad-hoc attributes — use the Protocol property.
 
-### 3. SeekTable owns all three index paths
+### 3. SeekTable owns index paths (shape of xz enrichment still open — see B)
 
-| Format | `record(hint)` | `build_full(inner, last)` |
+| Format | Progressive `record` | `build_full` |
 | --- | --- | --- |
 | zlib family | no-op | no-op (rewind from 0) |
-| lzip | member starts | backwards trailer scan |
-| xz | stream starts **+ progressive block enrichment** | backwards footer/index scan |
-| unix-compress | CLEAR resumes | no-op (`SEEK_END` → base scan-to-EOF) |
-| BGZF (future) | — | walk BC/MZ members |
-
-XZ progressive enrichment moves from `_on_completed_segments` into
-**XZ’s `SeekTable.record`** (may seek/restore `_inner`). Same behavior, one home.
+| lzip | member starts (`before`) | backwards trailer scan |
+| xz | stream starts + **block enrichment** (how: Open Question B) | backwards footer/index scan |
+| unix-compress | CLEAR resumes (`after`) | no-op (`SEEK_END` → base scan-to-EOF) |
+| BGZF (future) | — | forward member walk via BC/MZ |
 
 Demand-driven: undeclared seekability → `NullSeekTable` (no points, no scans).
 
@@ -165,87 +170,74 @@ Demand-driven: undeclared seekability → `NullSeekTable` (no points, no scans).
 
 XZ’s `_XzState` vs `_XzBlockChain` becomes a choice inside `Decoder.recreate`, not
 a union on the stream. No `_create_decompressor` / `_make_decompressor` dual API.
+(XZ recreate may need the table’s subsequent block points — factory closure or
+`recreate(point, table)`; settled with Open Question B.)
 
-### 5. Deferred `.Z` TruncatedError is one stream hook, not four overrides
+### 5. Deferred `.Z` TruncatedError via formal `pending_error` (locked)
 
-Decoder `flush` may set `pending_error`; `IndexedDecompressStream.read` raises it
-on the next empty read after delivering bytes. Matches today’s contract; removes
-the need to override chunk/flush/reset/read in the format stream class.
+`Decoder.pending_error` is a real Protocol property (not duck-typed). After
+`flush`, unix-compress sets it to `TruncatedError` when leftover bits are
+nonzero; other Decoders leave it `None`. `DecompressorStream.read` raises and
+clears it on the next empty read after delivering bytes. Header params for
+CLEAR recreate live on the Decoder / unix-compress factory; origin
+`SeekPoint(0, 3)` adjustment is SeekTable’s job — no format stream subclass
+overriding `read` / chunk / flush / reset.
 
-### 6. Spike-gated implementation
+### 6. Keep the name `DecompressorStream` (locked)
 
-Do **not** start the mechanical migration until Open Questions A–D below are
-closed (or explicitly deferred with a written fallback). Tasks §1 are the spike;
-§2+ are the refactor.
+The one composed stream class stays **`DecompressorStream`** — it is already the
+external vocabulary (specs, docs, `isinstance` / mental model) and should not
+expose “Indexed…” implementation detail in the type name. Module
+`decompressor_stream.py` stays. A later interface/implementation split is
+allowed if it earns its keep; not required for this change.
 
-### 7. Coordinate BGZF / seekable-gzip
+Zlib-family Decoder adapters stay in `decompress.py`; xz/lzip/.Z keep parsers in
+their modules and lose stream-subclass tails. Construction sites in `codecs.py`
+become thin factories wiring `(Decoder, SeekTable)` into `DecompressorStream`.
 
-`seekable-gzip-and-block-writing` MUST NOT land another `DecompressorStream`
-subclass leaf in parallel. Either this change lands first and BGZF is a
-Decoder+SeekTable policy, or BGZF waits / re-targets.
+**Rejected:** rename to `IndexedDecompressStream` (leaks structure; churn for
+little clarity).
+
+### 7. Spike-gated implementation
+
+Do **not** start the mechanical migration until **Open Question B** is closed
+(or explicitly deferred with a written fallback). Tasks §1.2 are the remaining
+spike; §2+ are the refactor. Threads A/C/D/E are locked above.
+
+### 8. BGZF / zstd seekable fit + coordinate seekable-gzip (locked)
+
+SeekTable is **not** backwards-trailer-only: it must support progressive points
+(CLEAR-like), one-shot backwards scans (lzip/xz), and one-shot forward member
+walks (BGZF/mgzip via BC/MZ; zstd seekable footer table). That is enough for
+`seekable-gzip-and-block-writing` to plug in as Decoder + SeekTable without a
+new `DecompressorStream` subclass leaf.
+
+`seekable-gzip-and-block-writing` MUST NOT land another subclass leaf in
+parallel — wait on or re-target this composition model.
 
 ## Risks / Trade-offs
 
 | Risk | Mitigation |
 | --- | --- |
 | Over-abstract SeekTable into a plugin framework | Cap at ~4–5 concrete policies; no registry of registries |
-| XZ progressive enrichment fights clean `record` | Spike task: port `_update_index` behind SeekTable; keep existing seek tests green |
-| Subtle SEEK_END / size / buffer regressions | Existing `test_seekable_streams` + unix-compress seek matrix are the gate; no “improve” seeks in the same PR |
-| Naming churn (`IndexedDecompressStream` vs keep `DecompressorStream`) | Prefer rename that matches composition; keep a thin alias only if imports elsewhere hurt |
-| Specs stay empty while validate wants a delta | Add a **shared seek-surface** clarifying requirement (parity across native indexed codecs) — no caller behavior change |
+| XZ progressive enrichment fights clean `record` | Open Question B; spike before migration; keep seek tests green |
+| Subtle SEEK_END / size / buffer regressions | Existing `test_seekable_streams` + unix-compress seek matrix are the gate |
+| Accidental rename pressure | Decision 6: keep `DecompressorStream` |
 
 ## Open Questions
 
-These are the **loose threads that must be finalized before implementation**.
-Each should leave this section when closed (move the answer into Decisions).
+### B. Where does XZ block enrichment live?
 
-### A. Absolute vs relative ResumeHints
+Today, when a multi-stream XZ file finishes a stream during a forward read, the
+stream subclass seeks the compressed file, reads that stream’s footer/index, and
+registers block-level `SeekPoint`s (with `state=block bounds`) — then restores
+the file position. That is “progressive enrichment.” On a later seek into a
+block, `recreate` builds `_XzBlockChain` from those points.
 
-- **Options:** (1) Decoders emit **relative** `(decomp_delta, comp_delta)` and the
-  stream’s single cursor helper converts to absolute SeekPoints; (2) Decoders emit
-  **absolute** offsets (know cursors or receive them).
-- **Lean:** (1) — keeps state machines I/O-agnostic (current xz/lzip/.Z already
-  return relative units). Format-specific “before vs after” becomes which absolute
-  the SeekTable records, not which way the Decoder orders cursor math.
-- **Finalize when:** write the cursor helper + one lzip and one `.Z` SeekTable in a
-  spike branch; confirm seek tests agree.
+**Still open:** who owns that enrichment after the refactor — a fat SeekTable, a
+thin table plus a stream hook, or a separate Enricher? Options and trade-offs are
+being explored in the change discussion; lock one here before §2.
 
-### B. XZ progressive enrichment under SeekTable.record
-
-- **Question:** Can `_update_index` (seek inner → `_read_xz_index_backwards` for the
-  just-finished stream → restore → add block SeekPoints with `state=bounds`) live
-  entirely in `XzSeekTable.record` without the stream knowing about footers?
-- **Lean:** Yes — `record` receives the completed-stream hint + access to `inner`
-  and the live SeekPoint list; stream only calls `table.record` / `decoder.feed`.
-- **Finalize when:** spike that deletes `_on_completed_segments` branching on
-  `isinstance(_XzState)` and keeps `test_seekable_streams` / size-via-index tests green.
-
-### C. Pending-error / header-commit hooks on Decoder
-
-- **Question:** Is `pending_error` on Decoder enough for `.Z`, or does the stream
-  need a tiny `after_flush` / `on_empty_read` callback protocol?
-- **Lean:** `pending_error` property set by `flush`, cleared by stream after raise;
-  header params for recreate live on the Decoder or a small side object owned by
-  the unix-compress factory — not on the stream subclass.
-- **Finalize when:** spike recreating deferred TruncatedError without overriding
-  `read` on a format-specific stream class.
-
-### D. Naming and module layout
-
-- **Question:** Keep filename `decompressor_stream.py` and rename the class to
-  `IndexedDecompressStream`, or rename module too? Where do `Decoder` adapters live
-  (`decompress.py` vs per-codec modules)?
-- **Lean:** Class rename to `IndexedDecompressStream` (or keep `DecompressorStream`
-  as the one stream class name to limit churn — pick one in spike); module can stay
-  until a follow-up. Adapters stay beside codecs that need them; zlib-family thin
-  adapters can remain in one `decompress.py` as functions/classes implementing
-  Decoder only.
-- **Finalize when:** grepping import sites (`codecs.py`, tests, single_file_reader)
-  and choosing the lower-churn name in Decisions.
-
-### E. (Optional defer) Native zstd frame index
-
-Out of scope for this change’s implementation, but the SeekTable plug shape should
-not paint us into a corner. Confirm the design doesn’t assume “backwards trailer
-only” — progressive CLEAR-like points and one-shot member walks (BGZF) must both fit.
-No spike required beyond a written note in Decisions once A–D close.
+**Also must handle:** while replaying via `_XzBlockChain`, completed units only
+advance cursors (no new points). `recreate` needs subsequent block points from
+the table.

--- a/openspec/changes/spike-indexed-decompress-stream/proposal.md
+++ b/openspec/changes/spike-indexed-decompress-stream/proposal.md
@@ -1,0 +1,56 @@
+## Why
+
+The `DecompressorStream` / `SegmentedDecompressorStream` / per-format `*DecompressorStream`
+hierarchy has grown hard to reason about: three index-building paths, two abstract APIs
+(`_create_*` vs `_make_*`), untyped `SeekPoint.state`, and format subclasses that disagree on
+seek-point semantics (lzip point-then-advance vs `.Z` advance-then-point). XZ further punches
+through the abstraction with a dual decoder (`_XzState` | `_XzBlockChain`). The pending BGZF
+change would add yet another stream subclass. We want the half-size composition shape
+(one stream + Decoder + SeekTable) before more formats land on the inheritance tax.
+
+This change is a **design spike first**: lock the open threads below, then implement a
+behavior-preserving refactor. Caller-visible seek/correctness contracts stay.
+
+## What Changes
+
+- **Spike / design lock**: settle the open threads in `design.md` (hint absolute vs relative,
+  XZ progressive enrichment as SeekTable policy, deferred `.Z` truncation hook, BGZF/zstd fit,
+  accelerator boundary) with small code spikes where needed — **no behavioral change** until
+  those decisions are recorded.
+- **Refactor (after spike)**: replace the inheritance tree with composition —
+  one `IndexedDecompressStream` owning buffer/seek/EOF once; `Decoder` protocol
+  (`feed`/`flush`/`finished`/`recreate`); `SeekTable` policies per format; delete
+  `SegmentedDecompressorStream` and the thin `*DecompressorStream` subclasses in
+  `decompress.py` / lzip / xz / unix_compress stream tails.
+- Keep format parsers and state machines (`_LzipState`, `_XzState`, `_XzBlockChain`, `LzwState`,
+  zlib/brotli/… adapters) — essential complexity stays; hierarchy scaffolding goes.
+- Accelerators (`rapidgzip` / `_AcceleratorStream`) stay outside this model (foreign `BinaryIO`).
+- **Not BREAKING** for the public API: `open_stream` / member-stream seek contracts,
+  diagnostics (`SEEK_INDEX_DEGRADED`, `STREAM_REWIND_REDECOMPRESSES`), and truncation rules
+  remain as specified today.
+
+## Capabilities
+
+### New Capabilities
+
+<!-- none — internal refactor -->
+
+### Modified Capabilities
+
+- `seekable-decompressor-streams`: add a clarifying requirement that native indexed
+  codecs share one seek/EOF/truncation surface (parity matrix). No change to existing
+  xz/lzip/.Z/accelerator scenarios — locks the refactor’s non-divergence invariant so
+  BGZF and later native indexes cannot fork seek semantics.
+
+## Impact
+
+- **Modules**: `internal/streams/decompressor_stream.py`, `decompress.py`, `xz.py`, `lzip.py`,
+  `unix_compress.py`, and the codec `open()` wiring in `codecs.py` that constructs these streams.
+- **Public API**: none intended (types/behavior unchanged).
+- **Extras/deps**: none.
+- **Tests**: existing `test_seekable_streams`, codec/stream input tests, and unix-compress seek
+  matrices are the acceptance gate; spike tasks may add focused unit tests for Decoder/SeekTable
+  seams once shapes stabilize.
+- **Related in-flight**: `seekable-gzip-and-block-writing` (BGZF as another `DecompressorStream`
+  subclass) should wait on or re-target this composition model; do not land another inheritance
+  leaf in parallel without coordinating.

--- a/openspec/changes/spike-indexed-decompress-stream/specs/seekable-decompressor-streams/spec.md
+++ b/openspec/changes/spike-indexed-decompress-stream/specs/seekable-decompressor-streams/spec.md
@@ -1,0 +1,33 @@
+## ADDED Requirements
+
+### Requirement: Native indexed codecs share one seek surface
+
+Random access for native indexed single-stream codecs (xz, lzip, unix-compress CLEAR
+points, and any later native-indexed codec such as BGZF) SHALL share one seek / EOF /
+truncation semantics surface:
+
+- Demand-driven indexes (no seek-point tables or index scans when seekability is undeclared).
+- `SEEK_END` uses a known decompressed size from the index when available; otherwise scans
+  without buffering the entire remainder in RAM.
+- Recoverable index/trailer scan failure emits `SEEK_INDEX_DEGRADED` and falls back to
+  sequential decoding (unless diagnostics escalate).
+- Backward seeks that resume from format-native seek points MUST NOT emit
+  `STREAM_REWIND_REDECOMPRESSES`.
+
+Adding a native-indexed codec MUST NOT introduce a divergent seek/EOF/truncation
+implementation for that shared surface. Optional accelerators (rapidgzip) remain outside
+this surface and keep their existing contracts.
+
+Existing per-codec requirements (xz/lzip native indexes, unix-compress CLEAR points,
+index-less rewind diagnostics, accelerator lifecycle) are unchanged.
+
+#### Scenario: shared surface parity
+
+| Axis | xz / lzip / `.Z` / future native-indexed |
+| --- | --- |
+| Undeclared seekability | No seek-point table; no footer/trailer/CLEAR index retention |
+| `SEEK_END` with index size | Returns size without full redecompress when the index knows it |
+| `SEEK_END` without size | Scans to EOF without holding all remaining output in RAM |
+| Recoverable index scan failure | `SEEK_INDEX_DEGRADED` + sequential fallback |
+| Indexed backward seek | No `STREAM_REWIND_REDECOMPRESSES` |
+| Accelerator path (gzip/bzip2) | Unchanged; not required to share this native surface |

--- a/openspec/changes/spike-indexed-decompress-stream/tasks.md
+++ b/openspec/changes/spike-indexed-decompress-stream/tasks.md
@@ -6,36 +6,31 @@
 > Related: `seekable-gzip-and-block-writing` must not land another `DecompressorStream`
 > subclass leaf in parallel — coordinate or wait.
 
-## 1. Spike — finalize open threads (design.md A–D)
+## 1. Spike — finalize remaining open thread (B); A/C/D/E locked in design.md
 
-- [ ] 1.1 **Thread A (ResumeHint absolute vs relative):** prototype the cursor helper that
-      turns relative `(decomp_delta, comp_delta)` into absolute `SeekPoint`s; implement
-      throwaway SeekTable stubs for lzip (point-before) and unix-compress CLEAR
-      (point-after). Record the choice under Decisions; delete Open Question A.
-- [ ] 1.2 **Thread B (XZ progressive enrichment):** spike moving `_update_index` into an
-      `XzSeekTable.record` that may seek/restore `_inner` and attach block `state` on
-      SeekPoints; remove stream `isinstance(_XzState)` branching. Keep
+- [x] 1.1 **Thread A (ResumeHint absolute vs relative):** locked — relative units +
+      SeekTable before/after policy; enrichment may inject absolute points.
+- [ ] 1.2 **Thread B (XZ progressive enrichment):** still open — choose fat SeekTable /
+      thin+hook / Enricher (see design Open Question B). Spike the chosen shape so
+      `isinstance(_XzState)` branching leaves the stream; keep
       `tests/test_seekable_streams.py` green. Record under Decisions; delete Open Question B.
-- [ ] 1.3 **Thread C (deferred TruncatedError / header commit):** spike `.Z` so
-      `pending_error` + factory-owned header params recreate CLEAR resumes without a
-      format stream subclass overriding `read`/`_decompress_chunk`/`_flush`/`_reset`.
-      Record under Decisions; delete Open Question C.
-- [ ] 1.4 **Thread D (naming / layout):** grep import sites (`codecs.py`, tests,
-      `single_file_reader`); pick `IndexedDecompressStream` vs keeping the
-      `DecompressorStream` name; decide module rename now vs later. Record under Decisions;
-      delete Open Question D.
-- [ ] 1.5 **Thread E (BGZF / zstd fit note):** one short Decision confirming SeekTable
-      supports both backwards scans and member walks / progressive points (no code).
-      Note coordination with `seekable-gzip-and-block-writing`.
+- [x] 1.3 **Thread C (deferred TruncatedError):** locked — formal `Decoder.pending_error`
+      Protocol property (not duck-typed); stream raises on next empty read.
+- [x] 1.4 **Thread D (naming / layout):** locked — keep class name `DecompressorStream`
+      and module `decompressor_stream.py`; adapters beside codecs; no `Indexed…` rename.
+- [x] 1.5 **Thread E (BGZF / zstd fit):** locked — SeekTable supports progressive points,
+      backwards scans, and forward member walks; coordinate with
+      `seekable-gzip-and-block-writing`.
 
 ## 2. Core composition scaffold
 
 - [ ] 2.1 Introduce `DecodeOut` / `ResumeHint`, `Decoder` protocol, and `SeekTable`
       (incl. null/no-op table when seekability undeclared) beside the existing seek
       machinery — per Decisions from §1.
-- [ ] 2.2 Implement the single stream class (name from 1.4) that owns buffer / pos / eof /
+- [ ] 2.2 Implement `DecompressorStream` (kept name) that owns buffer / pos / eof /
       size / `seek` / `read` / `try_get_size` once and delegates decode + index to
       Decoder + SeekTable. Preserve today’s SEEK_END / scan-to-EOF / truncation behavior.
+      `Decoder.pending_error` is a formal Protocol property.
 - [ ] 2.3 Delete `SegmentedDecompressorStream` once no subclass remains.
 
 ## 3. Migrate codecs onto Decoder + SeekTable

--- a/openspec/changes/spike-indexed-decompress-stream/tasks.md
+++ b/openspec/changes/spike-indexed-decompress-stream/tasks.md
@@ -10,9 +10,9 @@
 
 - [x] 1.1 **Thread A (ResumeHint absolute vs relative):** locked — relative units +
       SeekTable before/after policy; enrichment may inject absolute points.
-- [ ] 1.2 **Thread B (XZ progressive enrichment):** still open — choose fat SeekTable /
-      thin+hook / Enricher (see design Open Question B). Spike the chosen shape so
-      `isinstance(_XzState)` branching leaves the stream; keep
+- [ ] 1.2 **Thread B (SeekTable Model 1 vs 2):** still open — per-format SeekTable
+      (lean) vs generic store with format push (see design Open Question B). Spike the
+      chosen shape for lzip one-shot end-index + xz progressive enrichment; keep
       `tests/test_seekable_streams.py` green. Record under Decisions; delete Open Question B.
 - [x] 1.3 **Thread C (deferred TruncatedError):** locked — formal `Decoder.pending_error`
       Protocol property (not duck-typed); stream raises on next empty read.

--- a/openspec/changes/spike-indexed-decompress-stream/tasks.md
+++ b/openspec/changes/spike-indexed-decompress-stream/tasks.md
@@ -1,0 +1,64 @@
+# Tasks — Spike then refactor DecompressorStream → composition
+
+> Spike-first change. **Do not start §2 mechanical migration until §1 open threads are
+> closed and recorded in `design.md` Decisions** (remove them from Open Questions).
+> Run tools through `uv` (`uv run --no-sync pytest`, `pyrefly check`, `ty check`, `ruff`).
+> Related: `seekable-gzip-and-block-writing` must not land another `DecompressorStream`
+> subclass leaf in parallel — coordinate or wait.
+
+## 1. Spike — finalize open threads (design.md A–D)
+
+- [ ] 1.1 **Thread A (ResumeHint absolute vs relative):** prototype the cursor helper that
+      turns relative `(decomp_delta, comp_delta)` into absolute `SeekPoint`s; implement
+      throwaway SeekTable stubs for lzip (point-before) and unix-compress CLEAR
+      (point-after). Record the choice under Decisions; delete Open Question A.
+- [ ] 1.2 **Thread B (XZ progressive enrichment):** spike moving `_update_index` into an
+      `XzSeekTable.record` that may seek/restore `_inner` and attach block `state` on
+      SeekPoints; remove stream `isinstance(_XzState)` branching. Keep
+      `tests/test_seekable_streams.py` green. Record under Decisions; delete Open Question B.
+- [ ] 1.3 **Thread C (deferred TruncatedError / header commit):** spike `.Z` so
+      `pending_error` + factory-owned header params recreate CLEAR resumes without a
+      format stream subclass overriding `read`/`_decompress_chunk`/`_flush`/`_reset`.
+      Record under Decisions; delete Open Question C.
+- [ ] 1.4 **Thread D (naming / layout):** grep import sites (`codecs.py`, tests,
+      `single_file_reader`); pick `IndexedDecompressStream` vs keeping the
+      `DecompressorStream` name; decide module rename now vs later. Record under Decisions;
+      delete Open Question D.
+- [ ] 1.5 **Thread E (BGZF / zstd fit note):** one short Decision confirming SeekTable
+      supports both backwards scans and member walks / progressive points (no code).
+      Note coordination with `seekable-gzip-and-block-writing`.
+
+## 2. Core composition scaffold
+
+- [ ] 2.1 Introduce `DecodeOut` / `ResumeHint`, `Decoder` protocol, and `SeekTable`
+      (incl. null/no-op table when seekability undeclared) beside the existing seek
+      machinery — per Decisions from §1.
+- [ ] 2.2 Implement the single stream class (name from 1.4) that owns buffer / pos / eof /
+      size / `seek` / `read` / `try_get_size` once and delegates decode + index to
+      Decoder + SeekTable. Preserve today’s SEEK_END / scan-to-EOF / truncation behavior.
+- [ ] 2.3 Delete `SegmentedDecompressorStream` once no subclass remains.
+
+## 3. Migrate codecs onto Decoder + SeekTable
+
+- [ ] 3.1 Migrate zlib / brotli / ppmd / deflate64 / bcj to thin Decoder adapters
+      (`hints=[]`); remove `DecompressorStream` subclasses from `decompress.py`.
+- [ ] 3.2 Migrate lzip: keep `_LzipState` + backwards trailer scan; stream subclass tail
+      becomes factory wiring + `LzipSeekTable`.
+- [ ] 3.3 Migrate xz: keep `_XzState` / `_XzBlockChain` / index parsers; `recreate(point)`
+      selects decoder; SeekTable owns progressive + `build_full` (from spike 1.2).
+- [ ] 3.4 Migrate unix-compress: keep `LzwState`; wire CLEAR hints + deferred truncation
+      per spike 1.3; remove format-specific stream overrides.
+- [ ] 3.5 Update `codecs.py` / any `isinstance(DecompressorStream)` call sites
+      (`single_file_reader`, tests) to the new type/name.
+
+## 4. Verify
+
+- [ ] 4.1 `uv run --no-sync pytest tests/test_seekable_streams.py tests/test_stream_inputs.py
+      tests/test_codecs.py` (plus unix-compress / compressed-stream seek coverage) green.
+- [ ] 4.2 `uv run --no-sync pyrefly check` and `uv run --no-sync ty check` clean on touched
+      modules; `uv run --no-sync ruff check` / `ruff format --check`.
+- [ ] 4.3 Confirm no new divergent seek implementation for native indexed codecs (shared
+      surface delta in `seekable-decompressor-streams`).
+- [ ] 4.4 `openspec validate --strict spike-indexed-decompress-stream`.
+- [ ] 4.5 Before push: three-config suite per `CONTRIBUTING.md` (`[all]`, `[all-lowest]`,
+      `[core-only]`), then restore `uv sync --group dev --extra all`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

OpenSpec change `spike-indexed-decompress-stream`: design-spike first, then a behavior-preserving refactor of the `DecompressorStream` hierarchy into composition (one stream + `Decoder` + index wiring).

## Locked decisions (A/C/D/E)

- **A** Relative ResumeHints + before/after policy
- **C** Formal `Decoder.pending_error` Protocol property (not duck-typed)
- **D** Keep class name `DecompressorStream`
- **E** Index wiring fits BGZF forward walks and zstd seekable footers

## Still open: B — where format knowledge lives

Reframed (not fat/thin/enricher):

1. **Model 1 — Per-format SeekTable** (lean): table subclass knows trailers/footers; may read `inner` in `build_full` / progressive `record`
2. **Model 2 — Generic store; format pushes**: table is only `add`/`best_at`; scanners stay in format modules and push points in

See `design.md` Open Question B. Not settled.

## Next

Close B, then implement from remaining spike into migration.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-04d3848d-eb21-4ffc-9736-abeb079b6148"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-04d3848d-eb21-4ffc-9736-abeb079b6148"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

