### PR TITLE
Propose: refactor DecompressorStream hierarchy to composition

### DIFF
--- a/openspec/changes/decompressor-stream-composition/.openspec.yaml
+++ b/openspec/changes/decompressor-stream-composition/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: library
+created: 2026-07-14

--- a/openspec/changes/decompressor-stream-composition/design.md
+++ b/openspec/changes/decompressor-stream-composition/design.md
@@ -1,0 +1,170 @@
+## Context
+
+The seekable decompressor layer lives in
+`internal/streams/decompressor_stream.py` and its codec backends
+(`decompress.py`, `xz.py`, `lzip.py`, `unix_compress.py`). Current shape:
+
+```
+ReadOnlyIOStream
+  └─ DecompressorStream[DecompressorT]         (seek engine + INTERFACE #1)
+       ├─ Zlib / Brotli / Ppmd / Bcj / Deflate64   (forward-only leaves)
+       └─ SegmentedDecompressorStream[_SDT]     (reifies #1 via INTERFACE #2)
+            ├─ XzDecompressorStream
+            ├─ LzipDecompressorStream
+            └─ UnixCompressDecompressorStream
+```
+
+- **INTERFACE #1** (base abstract): `_create_decompressor(point)`,
+  `_decompress_chunk(chunk)`, `_flush_decompressor()`, `_is_decompressor_finished()`.
+- **INTERFACE #2** (segmented abstract): `_make_decompressor(point)`,
+  `_on_completed_segments(units)` over a `_SegmentDecompressor` protocol
+  (`feed/flush → (bytes, list[(dec,comp)])`, `is_finished`).
+  `SegmentedDecompressorStream` exists mostly to express #1 in terms of #2.
+
+Constraints that make this load-bearing (from `seekable-decompressor-streams`
+and `compressed-streams` specs — all must survive byte-for-byte):
+demand-driven index (`_index_enabled`); O(n) seek-from-origin even with the index
+off (compressed TAR); `_ensure_index_built` restoring inner position; the dual XZ
+decoder (`_XzState` sequential vs `_XzBlockChain` post-index); `SEEK_INDEX_DEGRADED`
+/ `STREAM_REWIND_REDECOMPRESSES` diagnostics; truncation/digest at clean EOF; the
+unix-compress CLEAR-seekpoint + pending-truncation rules.
+
+The accelerator lineage (`_AcceleratorStream`, `_GzipTruncationCheckStream`,
+rapidgzip) descends from `DelegatingStream`, **not** `DecompressorStream`, and is
+out of scope.
+
+`review/complexity.md` (external review, PR #73) blessed
+`SegmentedDecompressorStream` as "correct abstraction — don't touch." The
+maintainer has reviewed that note in light of the leaks below and judged it stale;
+it does not constrain this change.
+
+## Goals / Non-Goals
+
+**Goals:**
+- One concrete `DecompressorStream`; codecs are `Decoder` strategy objects, not
+  subclasses.
+- Exactly one codec plug-in interface (the `feed/flush/is_finished → (bytes,
+  segments)` protocol), with index-building folded in as a defaulted method.
+- Delete `SegmentedDecompressorStream` as a class and the construction-order
+  landmine.
+- Preserve every behavioral guarantee; the existing stream tests are the oracle.
+
+**Non-Goals:**
+- No change to the accelerator/rapidgzip path, `codecs.py` dispatch semantics,
+  `ArchiveStream`, `verify.py`, or any public API.
+- No merge of the five forward-only adapters into one config-driven adapter
+  (explicitly rejected below).
+- No new random-access capability for codecs that lack one today.
+
+## Investigations
+
+**Where the confusion concentrates (evidence for the collapse):**
+
+| Symptom | Location | Root cause |
+| --- | --- | --- |
+| Two plug-in interfaces to learn per segmented codec | base #1 + segmented #2 | #2 is translated back into #1 by the middle class |
+| Construction-order landmine (cursors pre-set before `super().__init__`) | `decompressor_stream.py:323`, `unix_compress.py:308-311` | base calls `_create_decompressor` inside `__init__` while cursors live in the subclass |
+| Near-homonym hooks | `_create_decompressor` vs `_make_decompressor` | one wraps the other |
+| "Shared" segmented base doesn't actually shield the leaf | `unix_compress.py:322-352` re-overrides `_decompress_chunk`, `_flush_decompressor`, `read`, `_reset_to_seek_point` | header-commit + pending-truncation have nowhere else to live |
+
+**Interface unification is free:** the segmented `_SegmentDecompressor` protocol
+(`feed/flush → (bytes, units)`, `is_finished`) already subsumes the forward-only
+4-method interface — a forward-only decoder is just one that always returns
+`units == []` and whose `flush()` emits any tail. So #1 is redundant, not #2.
+
+**Cursor/bookkeeping is identical across xz and lzip** (`_on_completed_segments`
+loops the same `_comp_cursor`/`_decomp_cursor` += pattern; unix-compress adds a
+header commit). That logic is base-worthy once the decoder owns nothing but decode.
+
+## Decisions
+
+### 1. One concrete `DecompressorStream` parameterized by a `Decoder`
+
+`DecompressorStream` stops being generic/abstract. It takes a decoder **factory**
+`make_decoder: Callable[[SeekPoint], Decoder]` at construction. The base owns the
+buffer, `_pos`/`_size`, the seek-point table, the seek algorithm, the cursors, and
+the demand-driven index orchestration. It calls `make_decoder(point)` on init and
+on every `_reset_to_seek_point`.
+
+**Rejected:** keeping `DecompressorStream` abstract with a single
+`_make_decoder` hook. That preserves an inheritance step for no gain — a factory
+callable removes the subclass entirely and lets the base set cursors from `point`
+before any decoder exists, deleting the landmine.
+
+### 2. One `Decoder` protocol, index folded in with a default no-op
+
+```python
+class Decoder(Protocol):
+    def feed(self, data: bytes) -> tuple[bytes, list[Segment]]: ...
+    def flush(self) -> tuple[bytes, list[Segment]]: ...
+    def is_finished(self) -> bool: ...
+    def build_index(self, inner: BinaryIO, last_known: SeekPoint
+                    ) -> tuple[list[SeekPoint], int | None]: ...
+```
+
+`Segment = tuple[int, int]` (decompressed_size, compressed_size), as today. A
+small `BaseDecoder` supplies `build_index → ([], None)` so forward-only adapters
+inherit the no-op and implement only feed/flush/is_finished. xz/lzip override
+`build_index`; the shared backward-scan helper (`_build_index_backwards`) becomes a
+free function they call.
+
+**Rejected:** a separate `Indexer` strategy object. Per maintainer preference,
+keeping index-building on the decoder means "everything about a codec" is one
+object, and the default stub keeps forward-only decoders trivial.
+
+### 3. Base owns cursors + segment→seek-point bookkeeping
+
+`_comp_cursor`/`_decomp_cursor` and the `add_seek_points` loop move into the base's
+feed path: after each `feed`/`flush`, the base consumes the returned `segments` and
+advances cursors + registers seek points. The decoder returns *what completed*; the
+base decides *what that means for seeking*. unix-compress's header commit (which
+shifts the origin seek point past the 3-byte header and sets cursors to
+`_HEADER_SIZE`) is expressed as a first-segment signal the base already handles, or
+kept inside `LzwState` and surfaced via the same segment channel — chosen during
+apply to keep the CLEAR-seekpoint spec scenarios green.
+
+### 4. Five explicit forward-only adapters
+
+`ZlibDecoder`, `BrotliDecoder`, `PpmdDecoder`, `BcjDecoder`, `Deflate64Decoder` —
+each a small `BaseDecoder` subclass wrapping its library object, with the same
+quirks they carry today (ppmd trailing-NUL, bcj `unpack_size` tracking, zlib
+`flush()` tail). They are decoders now, not streams.
+
+**Rejected:** collapsing zlib/brotli/deflate64 into one config-driven adapter.
+Saves ~20 lines but bcj/ppmd can't join it, so the win is partial and the
+indirection (method-name/flush-policy config) hurts readability more than three
+near-identical 6-line classes do.
+
+### 5. XZ dual decoder stays inside the XZ `make_decoder`
+
+The `_XzState` (sequential) vs `_XzBlockChain` (post-index, chosen on
+`point.state`) selection currently in `_make_decompressor` moves verbatim into the
+XZ decoder factory closure — same inputs (`point`, the seek-point table), same
+output. No base awareness of the duality.
+
+### 6. `codecs.py` construction sites call thin factories
+
+Where `codecs.py` builds `XzDecompressorStream(src, …)` today, it builds
+`DecompressorStream(src, make_decoder=_xz_decoder_factory(...), …)` (or a one-line
+`open_xz(...)` helper beside each decoder). Dispatch semantics, availability gates,
+and exception translation are unchanged.
+
+## Risks / Trade-offs
+
+- **[Behavioral regression in a subtle seek/truncation path]** → The change is
+  pure restructuring; `test_seekable_streams.py`, `test_stream_inputs.py`, and
+  `streams_util.py` are the oracle. Run all three dep configs (`[all]`,
+  `[all-lowest]`, `[core-only]`) before pushing, per CONTRIBUTING.
+- **[unix-compress header-commit is the trickiest port]** (it mutates the origin
+  seek point and gates cursor init on header params) → land it behind the existing
+  `.Z` seek/truncation scenarios; decide method-3 placement empirically against
+  those tests rather than up front.
+- **[`Decoder` protocol widened by `build_index` may tempt future misuse]** →
+  `BaseDecoder` default keeps it invisible to forward-only codecs; only index-
+  bearing codecs override it.
+
+## Open Questions
+
+- None blocking. The one implementation choice left open (unix-compress header
+  commit as a base-visible first segment vs decoder-internal state) is settled
+  during apply against the `.Z` spec scenarios.

--- a/openspec/changes/decompressor-stream-composition/design.md
+++ b/openspec/changes/decompressor-stream-composition/design.md
@@ -31,30 +31,47 @@ unix-compress CLEAR-seekpoint + pending-truncation rules.
 
 The accelerator lineage (`_AcceleratorStream`, `_GzipTruncationCheckStream`,
 rapidgzip) descends from `DelegatingStream`, **not** `DecompressorStream`, and is
-out of scope.
+out of scope (foreign `BinaryIO`; `weakref.finalize` lifecycle stays at the
+object's birth site in `codecs.py`).
 
 `review/complexity.md` (external review, PR #73) blessed
 `SegmentedDecompressorStream` as "correct abstraction — don't touch." The
 maintainer has reviewed that note in light of the leaks below and judged it stale;
 it does not constrain this change.
 
+**Prior art incorporated:** PR #92 (`spike-indexed-decompress-stream`) is an
+independent spike on the same problem that converged on the same architecture
+(one stream + `Decoder`; delete `SegmentedDecompressorStream`; keep parsers;
+accelerators out). This design adopts its sharper concepts — `pending_error`,
+the before/after placement policy, the three-index-path enumeration, `DecodeOut`,
+and the BGZF coordination — while keeping index discovery **folded into the
+`Decoder`** (a maintainer decision that dissolves PR #92's still-open
+SeekTable-placement question; see Decision 3).
+
+**Related in-flight:** `seekable-gzip-and-block-writing` plans another
+`DecompressorStream` subclass leaf (BGZF). It MUST NOT land that leaf in parallel;
+it re-targets onto this composition model as a `Decoder` (Decision 7).
+
 ## Goals / Non-Goals
 
 **Goals:**
-- One concrete `DecompressorStream`; codecs are `Decoder` strategy objects, not
-  subclasses.
-- Exactly one codec plug-in interface (the `feed/flush/is_finished → (bytes,
-  segments)` protocol), with index-building folded in as a defaulted method.
+- One concrete `DecompressorStream` (name kept); codecs are `Decoder` strategy
+  objects, not subclasses.
+- Exactly one codec plug-in interface — `feed`/`flush`/`finished`/`recreate` over
+  a `DecodeOut`, with index discovery folded in and a defaulted no-op for
+  forward-only codecs.
 - Delete `SegmentedDecompressorStream` as a class and the construction-order
-  landmine.
+  landmine; keep the base format-agnostic.
 - Preserve every behavioral guarantee; the existing stream tests are the oracle.
+- Leave a clean plug shape for BGZF / future native zstd frame index.
 
 **Non-Goals:**
 - No change to the accelerator/rapidgzip path, `codecs.py` dispatch semantics,
   `ArchiveStream`, `verify.py`, or any public API.
 - No merge of the five forward-only adapters into one config-driven adapter
-  (explicitly rejected below).
+  (rejected below).
 - No new random-access capability for codecs that lack one today.
+- Implementing BGZF itself (coordinate only).
 
 ## Investigations
 
@@ -65,106 +82,161 @@ it does not constrain this change.
 | Two plug-in interfaces to learn per segmented codec | base #1 + segmented #2 | #2 is translated back into #1 by the middle class |
 | Construction-order landmine (cursors pre-set before `super().__init__`) | `decompressor_stream.py:323`, `unix_compress.py:308-311` | base calls `_create_decompressor` inside `__init__` while cursors live in the subclass |
 | Near-homonym hooks | `_create_decompressor` vs `_make_decompressor` | one wraps the other |
-| "Shared" segmented base doesn't actually shield the leaf | `unix_compress.py:322-352` re-overrides `_decompress_chunk`, `_flush_decompressor`, `read`, `_reset_to_seek_point` | header-commit + pending-truncation have nowhere else to live |
+| "Shared" segmented base doesn't shield the leaf | `unix_compress.py:322-352` re-overrides `_decompress_chunk`, `_flush_decompressor`, `read`, `_reset_to_seek_point` | header-commit + deferred-truncation have nowhere else to live |
+| Untyped resume state | `SeekPoint.state: Any` (`None` → `_XzState`, block bounds → `_XzBlockChain`) | resume strategy stuffed into the decoder *type* instead of a `recreate(point)` choice |
+
+**Three index-building paths exist today** (from PR #92's spike — all must survive):
+
+| Path | Trigger | Today |
+| --- | --- | --- |
+| Progressive boundary | during `feed`, on completed segment | `_on_completed_segments` → `add_seek_points` |
+| Progressive enrichment (XZ only) | during `feed`, on completed stream | `_update_index` seeks `_inner`, scans that stream's footer, restores pos |
+| One-shot | `SEEK_END` / seek past known frontier | `_build_index` (backward trailer/footer scan) |
+
+A future forward member walk (BGZF/mgzip via `BC`/`MZ`; zstd seekable footer) is a
+fourth shape of the one-shot path. The discovery surface must admit all four.
+
+**Seek-point placement disagrees per format** (folklore today; named here):
+
+| Format | On completed unit | Meaning |
+| --- | --- | --- |
+| lzip / xz stream boundary | point **before** advancing cursors | resume *at* member/stream start |
+| unix-compress CLEAR | advance cursors, **then** point | resume *after* the CLEAR realignment |
 
 **Interface unification is free:** the segmented `_SegmentDecompressor` protocol
-(`feed/flush → (bytes, units)`, `is_finished`) already subsumes the forward-only
-4-method interface — a forward-only decoder is just one that always returns
-`units == []` and whose `flush()` emits any tail. So #1 is redundant, not #2.
-
-**Cursor/bookkeeping is identical across xz and lzip** (`_on_completed_segments`
-loops the same `_comp_cursor`/`_decomp_cursor` += pattern; unix-compress adds a
-header commit). That logic is base-worthy once the decoder owns nothing but decode.
+already subsumes the forward-only 4-method interface — a forward-only decoder is
+one whose output carries no seek points and whose `flush()` emits any tail. So
+INTERFACE #1 is the redundant one.
 
 ## Decisions
 
 ### 1. One concrete `DecompressorStream` parameterized by a `Decoder`
 
-`DecompressorStream` stops being generic/abstract. It takes a decoder **factory**
-`make_decoder: Callable[[SeekPoint], Decoder]` at construction. The base owns the
-buffer, `_pos`/`_size`, the seek-point table, the seek algorithm, the cursors, and
-the demand-driven index orchestration. It calls `make_decoder(point)` on init and
-on every `_reset_to_seek_point`.
+`DecompressorStream` stops being generic/abstract and **keeps its name** (it is the
+external vocabulary — specs, docs, and `single_file_reader.py:222`'s
+`isinstance(stream, DecompressorStream)` gate around `try_get_size()`). It holds a
+`Decoder`, created via `recreate(point, inner)` on init and on every
+`_reset_to_seek_point`. The base owns the buffer, `_pos`/`_size`, the seek-point
+table, the seek algorithm, and the demand-driven index orchestration — and nothing
+format-specific.
 
-**Rejected:** keeping `DecompressorStream` abstract with a single
-`_make_decoder` hook. That preserves an inheritance step for no gain — a factory
-callable removes the subclass entirely and lets the base set cursors from `point`
-before any decoder exists, deleting the landmine.
+**Rejected:** rename to `IndexedDecompressStream` (leaks structure; churns the
+isinstance site and specs for no clarity). **Rejected:** keep `DecompressorStream`
+abstract with a single `_make_decoder` hook (preserves an inheritance step; a
+`recreate` factory removes the subclass and lets the base build the decoder from
+`point` with no pre-existing subclass state — deleting the landmine).
 
-### 2. One `Decoder` protocol, index folded in with a default no-op
+### 2. One `Decoder` protocol; `DecodeOut`; `recreate`; `pending_error`
 
 ```python
+@dataclass
+class DecodeOut:
+    data: bytes
+    points: list[SeekPoint] = field(default_factory=list)  # absolute; usually empty
+
 class Decoder(Protocol):
-    def feed(self, data: bytes) -> tuple[bytes, list[Segment]]: ...
-    def flush(self) -> tuple[bytes, list[Segment]]: ...
-    def is_finished(self) -> bool: ...
-    def build_index(self, inner: BinaryIO, last_known: SeekPoint
-                    ) -> tuple[list[SeekPoint], int | None]: ...
+    def recreate(self, point: SeekPoint, inner: BinaryIO) -> Decoder: ...
+    def feed(self, chunk: bytes) -> DecodeOut: ...
+    def flush(self) -> DecodeOut: ...
+    @property
+    def finished(self) -> bool: ...
+    @property
+    def pending_error(self) -> BaseException | None: ...
+    def build_index(
+        self, inner: BinaryIO, last_known: SeekPoint
+    ) -> tuple[list[SeekPoint], int | None]: ...
 ```
 
-`Segment = tuple[int, int]` (decompressed_size, compressed_size), as today. A
-small `BaseDecoder` supplies `build_index → ([], None)` so forward-only adapters
-inherit the no-op and implement only feed/flush/is_finished. xz/lzip override
-`build_index`; the shared backward-scan helper (`_build_index_backwards`) becomes a
-free function they call.
+A small `BaseDecoder` supplies `points=[]`, `pending_error = None`, and a no-op
+`build_index → ([], None)`. Forward-only adapters (zlib/brotli/ppmd/bcj/deflate64)
+implement only `recreate`/`feed`/`flush`/`finished` and inherit the rest.
 
-**Rejected:** a separate `Indexer` strategy object. Per maintainer preference,
-keeping index-building on the decoder means "everything about a codec" is one
-object, and the default stub keeps forward-only decoders trivial.
+- **`pending_error`** (from PR #92, adopted) is a real Protocol property, not
+  duck-typing. unix-compress sets it to `TruncatedError` after `flush` when leftover
+  bits are nonzero; the base raises and clears it on the next empty `read` after
+  delivering bytes. This deletes unix-compress's `read`/`_reset_to_seek_point`
+  overrides.
+- **`recreate`** replaces both `_create_decompressor` and `_make_decompressor`. XZ's
+  `_XzState`-vs-`_XzBlockChain` choice lives inside XZ's `recreate` (keyed on
+  `point.state`), not a union on the stream type.
 
-### 3. Base owns cursors + segment→seek-point bookkeeping
+**Rejected:** flat `Segment = (int, int)` return (PR #95's first draft) — too narrow
+for XZ enrichment points, which carry block-bounds `state`. **Rejected:**
+duck-typed `truncated` attribute for `.Z`.
 
-`_comp_cursor`/`_decomp_cursor` and the `add_seek_points` loop move into the base's
-feed path: after each `feed`/`flush`, the base consumes the returned `segments` and
-advances cursors + registers seek points. The decoder returns *what completed*; the
-base decides *what that means for seeking*. unix-compress's header commit (which
-shifts the origin seek point past the 3-byte header and sets cursors to
-`_HEADER_SIZE`) is expressed as a first-segment signal the base already handles, or
-kept inside `LzwState` and surfaced via the same segment channel — chosen during
-apply to keep the CLEAR-seekpoint spec scenarios green.
+### 3. Index discovery is folded into the `Decoder`, and the Decoder emits points
+
+Index building stays **on the `Decoder`** (defaulted no-op), not a separate
+`SeekTable`. Consequently the `Decoder` — which knows its start offset from
+`recreate(point, …)` and already tracks byte deltas (`member_size`, `_bytes_fed`) —
+**emits absolute `SeekPoint`s directly** in `DecodeOut.points`. The base just stores
+them. This covers all three progressive paths without base-side format branching:
+
+- **Progressive boundary:** the decoder puts a point at each member/stream start,
+  choosing before/after placement itself (Investigation table) — the base never
+  encodes the asymmetry.
+- **Progressive enrichment (XZ):** the XZ decoder retains `inner` from `recreate`
+  (as `_XzBlockChain` already does), scans the just-completed stream's footer, and
+  returns block points in `DecodeOut.points`; it restores `inner`'s position itself.
+- **One-shot / forward walk:** `build_index(inner, last_known)` handles `SEEK_END`
+  and forward member walks (BGZF); the base still saves/restores `inner` around it
+  and keeps the `SEEK_INDEX_DEGRADED` fallback via the shared `_build_index_backwards`
+  free function.
+
+This moves the compressed/decompressed cursor bookkeeping **out of the base and into
+the three indexed decoders** (net-neutral on lines — they already track those
+deltas) and dissolves PR #92's Open Question B: with discovery on the decoder there
+is no SeekTable, so "does the table own format I/O or do formats push into it" never
+arises. The base is fully format-agnostic.
+
+**Rejected:** a separate `SeekTable` strategy (PR #92 Model 1/2). It re-splits
+"store" from "discover" and forces the unresolved placement question; folding into
+the decoder keeps "everything about a codec" in one object per the maintainer's
+thread-2 decision. **Rejected:** decoder returns relative units, base converts to
+absolute points (keeps before/after folklore in the base and can't carry enrichment
+`state` cleanly).
 
 ### 4. Five explicit forward-only adapters
 
 `ZlibDecoder`, `BrotliDecoder`, `PpmdDecoder`, `BcjDecoder`, `Deflate64Decoder` —
-each a small `BaseDecoder` subclass wrapping its library object, with the same
-quirks they carry today (ppmd trailing-NUL, bcj `unpack_size` tracking, zlib
-`flush()` tail). They are decoders now, not streams.
+each a small `BaseDecoder` subclass wrapping its library object, preserving each
+quirk (zlib `flush()` tail, ppmd trailing-NUL, bcj `unpack_size` tracking). They are
+decoders now, not streams.
 
-**Rejected:** collapsing zlib/brotli/deflate64 into one config-driven adapter.
-Saves ~20 lines but bcj/ppmd can't join it, so the win is partial and the
-indirection (method-name/flush-policy config) hurts readability more than three
-near-identical 6-line classes do.
+**Rejected:** collapsing zlib/brotli/deflate64 into one config-driven adapter. Saves
+~20 lines but bcj/ppmd can't join it, so the win is partial and the method-name/flush
+config hurts readability more than three near-identical 6-line classes do.
 
-### 5. XZ dual decoder stays inside the XZ `make_decoder`
+### 5. `codecs.py` construction sites call thin factories
 
-The `_XzState` (sequential) vs `_XzBlockChain` (post-index, chosen on
-`point.state`) selection currently in `_make_decompressor` moves verbatim into the
-XZ decoder factory closure — same inputs (`point`, the seek-point table), same
-output. No base awareness of the duality.
-
-### 6. `codecs.py` construction sites call thin factories
-
-Where `codecs.py` builds `XzDecompressorStream(src, …)` today, it builds
-`DecompressorStream(src, make_decoder=_xz_decoder_factory(...), …)` (or a one-line
+Where `codecs.py` builds `XzDecompressorStream(src, …)` today it builds
+`DecompressorStream(src, make_decoder=_xz_decoder(...), …)` (or a one-line
 `open_xz(...)` helper beside each decoder). Dispatch semantics, availability gates,
 and exception translation are unchanged.
 
+### 6. Migration touches the `isinstance` gate, not the contract
+
+`single_file_reader.py:222` keeps `isinstance(stream, DecompressorStream)` working
+because the name is kept (Decision 1). No call-site logic changes.
+
+### 7. Coordinate `seekable-gzip-and-block-writing` (no parallel subclass leaf)
+
+BGZF plugs in as a `Decoder` + a forward-member-walk `build_index`, not a new
+`DecompressorStream` subclass. The two changes coordinate: whichever lands second
+targets the `Decoder` shape. This design leaves that plug explicitly open (the
+forward-walk path in Decision 3).
+
 ## Risks / Trade-offs
 
-- **[Behavioral regression in a subtle seek/truncation path]** → The change is
-  pure restructuring; `test_seekable_streams.py`, `test_stream_inputs.py`, and
-  `streams_util.py` are the oracle. Run all three dep configs (`[all]`,
-  `[all-lowest]`, `[core-only]`) before pushing, per CONTRIBUTING.
-- **[unix-compress header-commit is the trickiest port]** (it mutates the origin
-  seek point and gates cursor init on header params) → land it behind the existing
-  `.Z` seek/truncation scenarios; decide method-3 placement empirically against
-  those tests rather than up front.
-- **[`Decoder` protocol widened by `build_index` may tempt future misuse]** →
-  `BaseDecoder` default keeps it invisible to forward-only codecs; only index-
-  bearing codecs override it.
+| Risk | Mitigation |
+| --- | --- |
+| Subtle seek/SEEK_END/size/truncation regression | `test_seekable_streams.py`, `test_stream_inputs.py`, unix-compress `.Z` seek matrix are the gate; run all three dep configs before push |
+| XZ progressive enrichment + `inner` save/restore inside `feed` | Decoder owns the save/restore (mirrors today's `_update_index`); base defensively restores in `_ensure_index_built` as now |
+| unix-compress header-commit (origin `SeekPoint(0,3)` shift + gated cursor init) is the trickiest port | Land behind the `.Z` scenarios; the decoder emits the shifted origin point directly rather than the base mutating `_seek_points[0]` |
+| Decoder-emits-absolute-points couples decoder to offsets | It is arithmetic over deltas the decoder already tracks, not new I/O; `recreate(point,…)` supplies the base offset |
+| BGZF change forks seek semantics | Decision 7 — it re-targets onto `Decoder`; no new subclass leaf |
 
 ## Open Questions
 
-- None blocking. The one implementation choice left open (unix-compress header
-  commit as a base-visible first segment vs decoder-internal state) is settled
-  during apply against the `.Z` spec scenarios.
+- None blocking. The one micro-choice (unix-compress origin-point shift emitted by
+  the decoder vs. a base helper) is settled during apply against the `.Z` scenarios.

--- a/openspec/changes/decompressor-stream-composition/proposal.md
+++ b/openspec/changes/decompressor-stream-composition/proposal.md
@@ -1,0 +1,50 @@
+## Why
+
+The seekable decompressor layer is a two-level inheritance tree
+(`DecompressorStream` → `SegmentedDecompressorStream` → 8 codec subclasses) with
+**two** distinct codec plug-in interfaces (a 4-method one on the base, a 2-method
+one on the segmented subclass, the latter implemented in terms of the former).
+The split forces a construction-order landmine (cursors pre-declared before
+`super().__init__`), near-homonym hooks (`_create_decompressor` vs
+`_make_decompressor`), and leaks: `UnixCompressDecompressorStream` re-overrides the
+base's feed/flush plumbing anyway. Same guarantees are reachable with one concrete
+stream and one codec interface.
+
+## What Changes
+
+- Collapse the tree into **one concrete `DecompressorStream`** that holds a
+  `Decoder` strategy object instead of being subclassed per codec.
+- Unify on the **single `feed/flush/is_finished → (bytes, segments)` protocol**
+  already used by the segmented decoders; forward-only codecs return empty
+  segments. Removes the second (4-method) interface.
+- **Fold index-building into the `Decoder`** as a method with a default no-op stub,
+  so forward-only decoders stay trivial and xz/lzip override just that one method.
+- Move segment→seek-point bookkeeping and the compressed/decompressed cursors
+  **into the base** (identical across xz/lzip today), deleting the construction
+  landmine.
+- **Delete `SegmentedDecompressorStream` as a class.** The five forward-only
+  codecs become five small explicit `Decoder` adapters (no config-driven merge);
+  xz/lzip/unix-compress decoders keep their existing parsers verbatim.
+- **BREAKING (internal only):** the `DecompressorStream[T]` / `SegmentedDecompressorStream`
+  subclass API is removed. No public API changes — `open_stream`, `ArchiveStream`,
+  and codec dispatch in `codecs.py` keep their signatures.
+
+## Capabilities
+
+### New Capabilities
+<!-- none -->
+
+### Modified Capabilities
+- `compressed-streams` — the "Read-only stream wrappers share one internal base"
+  requirement gains the composition contract (single stream + one `Decoder`
+  protocol; adding a codec adds no stream subclass). Behavior/guarantees unchanged.
+
+## Impact
+
+- Modules: `internal/streams/decompressor_stream.py` (rewritten, smaller),
+  `decompress.py` (5 adapters), `xz.py` / `lzip.py` / `unix_compress.py` (decoders
+  keep parsers, drop subclass shells), construction sites in `codecs.py`.
+- Public API: none. Extras/deps: none.
+- Tests: existing `test_seekable_streams.py` / `test_stream_inputs.py` are the
+  behavior oracle and must stay green in `[all]` / `[all-lowest]` / `[core-only]`;
+  no new required behavior.

--- a/openspec/changes/decompressor-stream-composition/proposal.md
+++ b/openspec/changes/decompressor-stream-composition/proposal.md
@@ -6,28 +6,35 @@ The seekable decompressor layer is a two-level inheritance tree
 one on the segmented subclass, the latter implemented in terms of the former).
 The split forces a construction-order landmine (cursors pre-declared before
 `super().__init__`), near-homonym hooks (`_create_decompressor` vs
-`_make_decompressor`), and leaks: `UnixCompressDecompressorStream` re-overrides the
-base's feed/flush plumbing anyway. Same guarantees are reachable with one concrete
-stream and one codec interface.
+`_make_decompressor`), untyped `SeekPoint.state`, and leaks:
+`UnixCompressDecompressorStream` re-overrides the base's feed/flush/read plumbing
+anyway. The same guarantees are reachable with one concrete stream and one codec
+interface. (PR #92 is an independent spike that converged on the same
+architecture; this change adopts its sharper concepts — see design.md.)
 
 ## What Changes
 
-- Collapse the tree into **one concrete `DecompressorStream`** that holds a
-  `Decoder` strategy object instead of being subclassed per codec.
-- Unify on the **single `feed/flush/is_finished → (bytes, segments)` protocol**
-  already used by the segmented decoders; forward-only codecs return empty
-  segments. Removes the second (4-method) interface.
-- **Fold index-building into the `Decoder`** as a method with a default no-op stub,
-  so forward-only decoders stay trivial and xz/lzip override just that one method.
-- Move segment→seek-point bookkeeping and the compressed/decompressed cursors
-  **into the base** (identical across xz/lzip today), deleting the construction
-  landmine.
-- **Delete `SegmentedDecompressorStream` as a class.** The five forward-only
-  codecs become five small explicit `Decoder` adapters (no config-driven merge);
-  xz/lzip/unix-compress decoders keep their existing parsers verbatim.
-- **BREAKING (internal only):** the `DecompressorStream[T]` / `SegmentedDecompressorStream`
-  subclass API is removed. No public API changes — `open_stream`, `ArchiveStream`,
-  and codec dispatch in `codecs.py` keep their signatures.
+- Collapse the tree into **one concrete `DecompressorStream`** (name kept) that
+  holds a `Decoder` strategy object instead of being subclassed per codec.
+- **One `Decoder` protocol** — `recreate`/`feed`/`flush`/`finished` over a
+  `DecodeOut(data, points)`, plus a formal `pending_error` property and a folded-in
+  `build_index`. Replaces both old interfaces and the `_create_`/`_make_` pair.
+- **Fold index discovery into the `Decoder`** (default no-op), and have the decoder
+  **emit absolute `SeekPoint`s directly** — so before/after placement and XZ
+  progressive enrichment live in the decoder and the base stays format-agnostic.
+  No separate `SeekTable`.
+- Deferred unix-compress `TruncatedError` moves to `Decoder.pending_error`; XZ's
+  `_XzState`/`_XzBlockChain` choice moves inside `recreate`. Both delete leaf-level
+  base overrides.
+- **Delete `SegmentedDecompressorStream` as a class.** Five small explicit
+  forward-only `Decoder` adapters (no config-driven merge); xz/lzip/unix-compress
+  keep their parsers verbatim, losing only the stream-subclass tails.
+- Coordinate with in-flight `seekable-gzip-and-block-writing`: BGZF plugs in as a
+  `Decoder` + forward-member-walk index, **not** a new subclass leaf.
+- **BREAKING (internal only):** the `DecompressorStream[T]` /
+  `SegmentedDecompressorStream` subclass API is removed. No public API changes —
+  `open_stream`, `ArchiveStream`, `try_get_size`, and codec dispatch keep their
+  signatures.
 
 ## Capabilities
 
@@ -37,14 +44,19 @@ stream and one codec interface.
 ### Modified Capabilities
 - `compressed-streams` — the "Read-only stream wrappers share one internal base"
   requirement gains the composition contract (single stream + one `Decoder`
-  protocol; adding a codec adds no stream subclass). Behavior/guarantees unchanged.
+  protocol that also owns index discovery; adding a codec adds no stream subclass).
+  Behavior/guarantees unchanged.
 
 ## Impact
 
 - Modules: `internal/streams/decompressor_stream.py` (rewritten, smaller),
   `decompress.py` (5 adapters), `xz.py` / `lzip.py` / `unix_compress.py` (decoders
-  keep parsers, drop subclass shells), construction sites in `codecs.py`.
+  keep parsers, drop subclass shells), construction sites in `codecs.py`. The
+  `isinstance(stream, DecompressorStream)` gate in `single_file_reader.py:222`
+  keeps working (name kept).
 - Public API: none. Extras/deps: none.
-- Tests: existing `test_seekable_streams.py` / `test_stream_inputs.py` are the
-  behavior oracle and must stay green in `[all]` / `[all-lowest]` / `[core-only]`;
-  no new required behavior.
+- Tests: existing `test_seekable_streams.py` / `test_stream_inputs.py` /
+  unix-compress `.Z` seek matrix are the behavior oracle and must stay green in
+  `[all]` / `[all-lowest]` / `[core-only]`; no new required behavior.
+- Related in-flight: `seekable-gzip-and-block-writing` must re-target onto this
+  `Decoder` model rather than landing another `DecompressorStream` subclass.

--- a/openspec/changes/decompressor-stream-composition/specs/compressed-streams/spec.md
+++ b/openspec/changes/decompressor-stream-composition/specs/compressed-streams/spec.md
@@ -1,0 +1,49 @@
+## MODIFIED Requirements
+
+### Requirement: Read-only stream wrappers share one internal base
+
+Read-only wrappers in this layer SHALL share an internal base for the read-only
+`BinaryIO` surface (`readable`, `writable`, `write`) and canonical `readinto` /
+`readall` built from each wrapper's `read`. The public codec-stream path SHALL
+return an `ArchiveStream` carrying stream-level presentation metadata; internal
+`backend.open()` calls MAY return raw backend streams.
+
+The seekable decompressor path SHALL be a single concrete stream class
+parameterized by a `Decoder` strategy, not a per-codec subclass hierarchy. Every
+codec — forward-only and segmented alike — SHALL plug in through **one** decoder
+protocol:
+
+```python
+Segment = tuple[int, int]  # (decompressed_size, compressed_size)
+
+class Decoder(Protocol):
+    def feed(self, data: bytes) -> tuple[bytes, list[Segment]]: ...
+    def flush(self) -> tuple[bytes, list[Segment]]: ...
+    def is_finished(self) -> bool: ...
+    # Default no-op; only index-bearing codecs (xz, lzip) override it.
+    def build_index(
+        self, inner: BinaryIO, last_known: SeekPoint
+    ) -> tuple[list[SeekPoint], int | None]: ...
+```
+
+Forward-only codecs SHALL return an empty segment list and inherit the no-op
+`build_index`. The stream — not the decoder — SHALL own the buffer, position,
+compressed/decompressed cursors, seek-point table, and seek algorithm, deriving
+seek points from the segments each `feed`/`flush` reports. Adding a codec SHALL
+add a `Decoder`, and MUST NOT require a new stream subclass.
+
+#### Scenario: wrapper surface matrix
+
+| Case | Expected |
+| --- | --- |
+| Any read-only stream wrapper is used | Shared base supplies read-only surface and `readinto` / `readall` |
+| Public codec stream is opened | Returned object is an `ArchiveStream` with stream presentation metadata |
+
+#### Scenario: decoder composition matrix
+
+| Case | Expected |
+| --- | --- |
+| Forward-only codec (zlib, brotli, ppmd, bcj, deflate64) | Implements `feed`/`flush`/`is_finished`; `feed`/`flush` return empty segments; inherits no-op `build_index` |
+| Segmented codec (xz, lzip, unix-compress) | Reports completed `Segment`s; stream derives seek points and advances cursors |
+| Index-bearing codec (xz, lzip) | Overrides `build_index`; stream drives it demand-driven per `seekable-decompressor-streams` |
+| A new codec is added | One `Decoder` added; no new stream subclass; no `SegmentedDecompressorStream` layer |

--- a/openspec/changes/decompressor-stream-composition/specs/compressed-streams/spec.md
+++ b/openspec/changes/decompressor-stream-composition/specs/compressed-streams/spec.md
@@ -9,28 +9,40 @@ return an `ArchiveStream` carrying stream-level presentation metadata; internal
 `backend.open()` calls MAY return raw backend streams.
 
 The seekable decompressor path SHALL be a single concrete stream class
-parameterized by a `Decoder` strategy, not a per-codec subclass hierarchy. Every
-codec — forward-only and segmented alike — SHALL plug in through **one** decoder
-protocol:
+(`DecompressorStream`) parameterized by a `Decoder` strategy, not a per-codec
+subclass hierarchy. Every codec — forward-only and segmented alike — SHALL plug in
+through **one** decoder protocol, which also owns seek-index discovery:
 
 ```python
-Segment = tuple[int, int]  # (decompressed_size, compressed_size)
+@dataclass
+class DecodeOut:
+    data: bytes
+    points: list[SeekPoint]  # absolute; empty for forward-only codecs
 
 class Decoder(Protocol):
-    def feed(self, data: bytes) -> tuple[bytes, list[Segment]]: ...
-    def flush(self) -> tuple[bytes, list[Segment]]: ...
-    def is_finished(self) -> bool: ...
-    # Default no-op; only index-bearing codecs (xz, lzip) override it.
+    def recreate(self, point: SeekPoint, inner: BinaryIO) -> Decoder: ...
+    def feed(self, chunk: bytes) -> DecodeOut: ...
+    def flush(self) -> DecodeOut: ...
+    @property
+    def finished(self) -> bool: ...
+    @property
+    def pending_error(self) -> BaseException | None: ...
+    # Default no-op; only index-bearing codecs (xz, lzip, future BGZF) override it.
     def build_index(
         self, inner: BinaryIO, last_known: SeekPoint
     ) -> tuple[list[SeekPoint], int | None]: ...
 ```
 
-Forward-only codecs SHALL return an empty segment list and inherit the no-op
-`build_index`. The stream — not the decoder — SHALL own the buffer, position,
-compressed/decompressed cursors, seek-point table, and seek algorithm, deriving
-seek points from the segments each `feed`/`flush` reports. Adding a codec SHALL
-add a `Decoder`, and MUST NOT require a new stream subclass.
+The stream — not the decoder — SHALL own the buffer, position, seek-point table,
+and seek algorithm; it SHALL be format-agnostic, storing whatever `SeekPoint`s a
+decoder emits. The `Decoder` SHALL choose seek-point placement (member/stream start
+vs. post-realignment) and MAY perform progressive index enrichment during `feed`
+using the `inner` it retained from `recreate`, restoring `inner`'s position itself.
+Forward-only codecs SHALL emit empty `points`, keep `pending_error` `None`, and
+inherit the no-op `build_index`. Deferred truncation (e.g. unix-compress leftover
+bits) SHALL surface through `pending_error`, raised on the next empty `read` after
+delivering bytes. Adding a codec SHALL add a `Decoder` and MUST NOT require a new
+stream subclass or a `SegmentedDecompressorStream` layer.
 
 #### Scenario: wrapper surface matrix
 
@@ -43,7 +55,9 @@ add a `Decoder`, and MUST NOT require a new stream subclass.
 
 | Case | Expected |
 | --- | --- |
-| Forward-only codec (zlib, brotli, ppmd, bcj, deflate64) | Implements `feed`/`flush`/`is_finished`; `feed`/`flush` return empty segments; inherits no-op `build_index` |
-| Segmented codec (xz, lzip, unix-compress) | Reports completed `Segment`s; stream derives seek points and advances cursors |
-| Index-bearing codec (xz, lzip) | Overrides `build_index`; stream drives it demand-driven per `seekable-decompressor-streams` |
+| Forward-only codec (zlib, brotli, ppmd, bcj, deflate64) | Implements `recreate`/`feed`/`flush`/`finished`; emits empty `points`; `pending_error` `None`; inherits no-op `build_index` |
+| Segmented boundary codec (lzip, xz stream start) | `feed` emits a `SeekPoint` at the boundary with the codec's own before/after placement; stream stores it |
+| Progressive enrichment (xz block index) | `feed` scans the completed stream's footer via retained `inner` and emits block `SeekPoint`s (carrying resume `state`); restores `inner` position |
+| One-shot / forward walk (xz, lzip backward scan; future BGZF forward walk) | `build_index` returns points + size; stream drives it demand-driven per `seekable-decompressor-streams` |
+| Deferred truncation (unix-compress leftover bits) | `pending_error` set after `flush`; base raises it on the next empty `read` |
 | A new codec is added | One `Decoder` added; no new stream subclass; no `SegmentedDecompressorStream` layer |

--- a/openspec/changes/decompressor-stream-composition/tasks.md
+++ b/openspec/changes/decompressor-stream-composition/tasks.md
@@ -1,21 +1,23 @@
 ## 1. Decoder protocol + base stream
 
-- [ ] 1.1 Define `Segment`, the `Decoder` `Protocol`, and a `BaseDecoder` with a no-op `build_index` in `decompressor_stream.py` (keep `SeekPoint`).
-- [ ] 1.2 Rewrite `DecompressorStream` as one concrete, non-generic class taking `make_decoder: Callable[[SeekPoint], Decoder]`; move `_comp_cursor`/`_decomp_cursor` and the segment→seek-point bookkeeping into its `feed`/`flush` path.
-- [ ] 1.3 Drive index-building through `decoder.build_index` inside `_ensure_index_built`; keep `_index_enabled`, O(n) seek-from-origin, and inner-position restore intact.
-- [ ] 1.4 Delete `SegmentedDecompressorStream` and INTERFACE #1 abstracts (`_create_decompressor`, `_decompress_chunk`, `_flush_decompressor`, `_is_decompressor_finished`); extract `_build_index_backwards` as a shared free function.
+- [ ] 1.1 Define `DecodeOut`, the `Decoder` `Protocol` (`recreate`/`feed`/`flush`/`finished`/`pending_error`/`build_index`), and a `BaseDecoder` with empty `points`, `pending_error = None`, and no-op `build_index` in `decompressor_stream.py` (keep `SeekPoint`, keep the class name `DecompressorStream`).
+- [ ] 1.2 Rewrite `DecompressorStream` as one concrete, non-generic, **format-agnostic** class holding a decoder built via `recreate(point, inner)`; it stores whatever `SeekPoint`s `feed`/`flush` emit and drops all per-format cursor/placement branching.
+- [ ] 1.3 Wire `pending_error`: base raises and clears it on the next empty `read` after delivering bytes. Preserve SEEK_END / scan-to-EOF / size semantics.
+- [ ] 1.4 Drive one-shot discovery through `decoder.build_index` inside `_ensure_index_built` (save/restore `inner`, keep `_index_enabled`, O(n) seek-from-origin, and `SEEK_INDEX_DEGRADED` fallback via the shared `_build_index_backwards` free function).
+- [ ] 1.5 Delete `SegmentedDecompressorStream` and INTERFACE #1 abstracts (`_create_decompressor`, `_decompress_chunk`, `_flush_decompressor`, `_is_decompressor_finished`).
 
 ## 2. Port codecs to decoders
 
-- [ ] 2.1 `decompress.py`: turn the five forward-only streams into five explicit `BaseDecoder` adapters (`ZlibDecoder`, `BrotliDecoder`, `PpmdDecoder`, `BcjDecoder`, `Deflate64Decoder`), preserving each quirk (zlib flush tail, ppmd trailing-NUL, bcj `unpack_size`).
-- [ ] 2.2 `xz.py`: keep `_XzState`/`_XzBlockChain`/parsers; expose an XZ decoder factory that reproduces the `point.state` dual-decoder selection and overrides `build_index`.
-- [ ] 2.3 `lzip.py`: keep `_LzipState`/trailer scan; expose a lzip decoder overriding `build_index` via the shared backward-scan helper.
-- [ ] 2.4 `unix_compress.py`: fold header-commit + pending-truncation into the LZW decoder/its factory (surfaced through the segment channel); preserve CLEAR seek points and the `.Z` truncation rules with no base overrides.
+- [ ] 2.1 `decompress.py`: five explicit `BaseDecoder` adapters (`ZlibDecoder`, `BrotliDecoder`, `PpmdDecoder`, `BcjDecoder`, `Deflate64Decoder`), preserving each quirk (zlib flush tail, ppmd trailing-NUL, bcj `unpack_size`).
+- [ ] 2.2 `xz.py`: keep `_XzState`/`_XzBlockChain`/parsers; XZ decoder `recreate` selects the sub-decoder on `point.state`, retains `inner`, and emits stream-start + progressive block-enrichment `SeekPoint`s from `feed`; `build_index` = backward footer/index scan.
+- [ ] 2.3 `lzip.py`: keep `_LzipState`/trailer scan; lzip decoder emits member-start points (before-placement) from `feed`; `build_index` = backward trailer scan via the shared helper.
+- [ ] 2.4 `unix_compress.py`: keep `LzwState`; decoder emits CLEAR points (after-placement), shifts the origin point past the 3-byte header itself, and sets `pending_error` for leftover-bit truncation — no base overrides.
 - [ ] 2.5 `codecs.py`: update construction sites to build `DecompressorStream(src, make_decoder=…)` via thin per-codec factories; leave dispatch, availability gates, and exception translation unchanged.
+- [ ] 2.6 Confirm `single_file_reader.py:222` `isinstance(stream, DecompressorStream)` → `try_get_size()` still resolves (name kept; no logic change).
 
 ## 3. Verify
 
-- [ ] 3.1 `uv run pytest tests/test_seekable_streams.py tests/test_stream_inputs.py tests/test_binaryio.py` — the behavior oracle — green.
+- [ ] 3.1 `uv run pytest tests/test_seekable_streams.py tests/test_stream_inputs.py tests/test_binaryio.py` — the behavior oracle — green (incl. the unix-compress `.Z` seek/truncation matrix).
 - [ ] 3.2 Full suite green in all three dep configs (`[all]`, `[all-lowest]`, `[core-only]`) per CONTRIBUTING "Before pushing".
 - [ ] 3.3 `uv run pyrefly check` and `uv run ty check` clean; no lingering references to `SegmentedDecompressorStream` or the removed abstracts.
 - [ ] 3.4 `openspec validate --strict decompressor-stream-composition`.

--- a/openspec/changes/decompressor-stream-composition/tasks.md
+++ b/openspec/changes/decompressor-stream-composition/tasks.md
@@ -1,0 +1,21 @@
+## 1. Decoder protocol + base stream
+
+- [ ] 1.1 Define `Segment`, the `Decoder` `Protocol`, and a `BaseDecoder` with a no-op `build_index` in `decompressor_stream.py` (keep `SeekPoint`).
+- [ ] 1.2 Rewrite `DecompressorStream` as one concrete, non-generic class taking `make_decoder: Callable[[SeekPoint], Decoder]`; move `_comp_cursor`/`_decomp_cursor` and the segment→seek-point bookkeeping into its `feed`/`flush` path.
+- [ ] 1.3 Drive index-building through `decoder.build_index` inside `_ensure_index_built`; keep `_index_enabled`, O(n) seek-from-origin, and inner-position restore intact.
+- [ ] 1.4 Delete `SegmentedDecompressorStream` and INTERFACE #1 abstracts (`_create_decompressor`, `_decompress_chunk`, `_flush_decompressor`, `_is_decompressor_finished`); extract `_build_index_backwards` as a shared free function.
+
+## 2. Port codecs to decoders
+
+- [ ] 2.1 `decompress.py`: turn the five forward-only streams into five explicit `BaseDecoder` adapters (`ZlibDecoder`, `BrotliDecoder`, `PpmdDecoder`, `BcjDecoder`, `Deflate64Decoder`), preserving each quirk (zlib flush tail, ppmd trailing-NUL, bcj `unpack_size`).
+- [ ] 2.2 `xz.py`: keep `_XzState`/`_XzBlockChain`/parsers; expose an XZ decoder factory that reproduces the `point.state` dual-decoder selection and overrides `build_index`.
+- [ ] 2.3 `lzip.py`: keep `_LzipState`/trailer scan; expose a lzip decoder overriding `build_index` via the shared backward-scan helper.
+- [ ] 2.4 `unix_compress.py`: fold header-commit + pending-truncation into the LZW decoder/its factory (surfaced through the segment channel); preserve CLEAR seek points and the `.Z` truncation rules with no base overrides.
+- [ ] 2.5 `codecs.py`: update construction sites to build `DecompressorStream(src, make_decoder=…)` via thin per-codec factories; leave dispatch, availability gates, and exception translation unchanged.
+
+## 3. Verify
+
+- [ ] 3.1 `uv run pytest tests/test_seekable_streams.py tests/test_stream_inputs.py tests/test_binaryio.py` — the behavior oracle — green.
+- [ ] 3.2 Full suite green in all three dep configs (`[all]`, `[all-lowest]`, `[core-only]`) per CONTRIBUTING "Before pushing".
+- [ ] 3.3 `uv run pyrefly check` and `uv run ty check` clean; no lingering references to `SegmentedDecompressorStream` or the removed abstracts.
+- [ ] 3.4 `openspec validate --strict decompressor-stream-composition`.


### PR DESCRIPTION
## Why

The seekable decompressor layer is a two-level inheritance tree (`DecompressorStream` → `SegmentedDecompressorStream` → 8 codec subclasses) with **two** distinct codec plug-in interfaces. The split forces a construction-order landmine (cursors pre-declared before `super().__init__`), near-homonym hooks (`_create_decompressor` vs `_make_decompressor`), and leaks — `UnixCompressDecompressorStream` re-overrides the base's feed/flush plumbing anyway. The same guarantees are reachable with one concrete stream and one codec interface.

## What this PR contains

OpenSpec change **`decompressor-stream-composition`** only — proposal, design, delta spec, and tasks. **No code changes yet.**

- Collapse the tree into one concrete `DecompressorStream` holding a `Decoder` strategy object.
- Unify on the single `feed/flush/is_finished → (bytes, segments)` protocol; forward-only codecs return empty segments.
- Fold index-building into the `Decoder` with a default no-op stub (per maintainer preference — no separate `Indexer`).
- Keep **five small explicit** forward-only adapters (config-driven merge rejected).
- Delete `SegmentedDecompressorStream` as a class; move cursors + seek-point bookkeeping into the base, removing the construction landmine.

## Preserved guarantees

Every `seekable-decompressor-streams` / `compressed-streams` contract survives: demand-driven index, O(n) seek-from-origin for compressed TAR, the dual XZ decoder, `SEEK_INDEX_DEGRADED` / `STREAM_REWIND_REDECOMPRESSES` diagnostics, truncation/digest at clean EOF, and the unix-compress CLEAR-seekpoint rules. The accelerator/rapidgzip lineage (`DelegatingStream`) is out of scope. The existing stream test suites are the behavior oracle.

## Impact

Public API: none. Extras/deps: none. Internal-only breaking change (removes the `DecompressorStream[T]` / `SegmentedDecompressorStream` subclass API).

## Open item

One implementation choice is deliberately deferred to apply-time — whether unix-compress's header-commit becomes a base-visible first segment or stays decoder-internal — to be settled against the `.Z` spec scenarios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VNtTPs3NrTkXgm6ytQgmNr

---
_Generated by [Claude Code](https://claude.ai/code/session_01VNtTPs3NrTkXgm6ytQgmNr)_