### PR TITLE
docs: warm up acknowledgements page tone (suggestion for #91)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Python library for reading, streaming, and safely extracting archives (ZIP, TAR,
 
 ## Documentation
 
-- **User guide** (MkDocs): [Philosophy](docs/philosophy.md) · [Usage](docs/usage.md) · [Costs & pitfalls](docs/costs.md) · [Formats](docs/formats.md) · [Safe extraction](docs/safe-extraction.md) · [API](docs/api.md)
+- **User guide** (MkDocs): [Philosophy](docs/philosophy.md) · [Usage](docs/usage.md) · [Costs & pitfalls](docs/costs.md) · [Formats](docs/formats.md) · [Safe extraction](docs/safe-extraction.md) · [API](docs/api.md) · [Acknowledgements](docs/acknowledgements.md)
 - **[VISION.md](VISION.md)** — full maintainer vision and trade-off priorities
 - **[Decision log](docs/decisions/index.md)** — why key design choices were made
 - **[Threat model](docs/internal/threat-model.md)** — trust boundaries and open gaps

--- a/docs/acknowledgements.md
+++ b/docs/acknowledgements.md
@@ -10,6 +10,15 @@ License texts for adapted kernels live next to the code
 `src/archivey/internal/backends/rar_parser.py`). Packaging extras and codec rationale:
 [Formats](formats.md), [library analysis](internal/library-analysis.md).
 
+## Thanks
+
+Thanks to the maintainers and contributors of every project below — especially those
+whose work Archivey learned from without taking as a dependency. Where we built our own
+parsers and stream layers instead of wrapping a library, it is so the code can plug into
+Archivey’s architecture and use modes (streaming vs random access, seekability,
+concurrency, cost reporting, diagnostics) and keep one consistent API and behaviour
+across formats. If something is missing from this list, please open an issue or PR.
+
 ## Adapted source
 
 | Project | Role in Archivey | License |
@@ -82,9 +91,3 @@ Declared in the PEP 735 `dev` / `docs` / `fuzz` groups (not user-facing extras):
 | `ruff`, `pyrefly`, `ty`, `pre-commit` | Lint and type-check |
 | `mkdocs`, `mkdocs-material`, `mkdocstrings`, … | Docs site (`docs` group) |
 | [atheris](https://github.com/google/atheris) | Coverage-guided fuzz (`fuzz` group; CI-only) |
-
-## Thanks
-
-Thanks to the maintainers and contributors of every project above — especially those
-whose work Archivey learned from without taking as a dependency. If something is missing
-from this list, please open an issue or PR.

--- a/docs/acknowledgements.md
+++ b/docs/acknowledgements.md
@@ -1,0 +1,90 @@
+# Acknowledgements
+
+Archivey’s core is MIT-licensed and mostly stdlib / native parsers, but it stands on
+other people’s formats, libraries, fixtures, and design work. This page records that —
+whether each project is a runtime dependency, a test oracle, adapted source, or only a
+design reference.
+
+License texts for adapted kernels live next to the code
+(`src/archivey/internal/streams/unix_compress.py`,
+`src/archivey/internal/backends/rar_parser.py`). Packaging extras and codec rationale:
+[Formats](formats.md), [library analysis](internal/library-analysis.md).
+
+## Adapted source
+
+| Project | Role in Archivey | License |
+| --- | --- | --- |
+| [uncompresspy](https://github.com/kYwzor/uncompresspy) (Tiago Gomes) | LZW kernel for unix-compress (`.Z`) adapted into `UnixCompressDecompressorStream` / `LzwState`. **Not** a runtime dependency; `[unix-compress]` was removed when the kernel was vendored into core. | BSD-3-Clause |
+| [rarfile](https://github.com/markokr/rarfile) (Marko Kreen) | RAR3 SHA-1 / string-to-key and Unicode filename decompression ported into the native RAR metadata parser. Also a **dev-only** oracle and fixture source (below). | ISC |
+
+## Format references, oracles, and corpora
+
+These are not on the primary read path (except where noted).
+
+| Project | Role |
+| --- | --- |
+| [py7zr](https://github.com/miurahr/py7zr) (Hiroshi Miura et al.) | 7z **format reference**, write backend under `[7z-write]`, and **dev oracle** / optional external corpus (`ARCHIVEY_PY7ZR_TEST_FILES`). Reading is native — see [ADR 0001](decisions/0001-native-7z-not-py7zr.md). |
+| [rarfile](https://github.com/markokr/rarfile) | RAR **format reference**, **dev oracle**, optional corpus (`ARCHIVEY_RARFILE_TEST_FILES`), and two legacy fixtures under `tests/fixtures/rar/` (RAR 1.5 / 2.0). Reading metadata is native; data uses RARLAB `unrar` — see [ADR 0002](decisions/0002-native-rar-metadata-unrar-data.md). |
+| [libarchive](https://github.com/libarchive/libarchive) (+ [libarchive-c](https://github.com/Changaco/python-libarchive-c)) | Optional **cross-format corpus** oracle (`ARCHIVEY_LIBARCHIVE_TEST_FILES` → libarchive’s `libarchive/test` uuencoded archives). Dev-only; not a runtime backend. |
+| [archivey-dev](https://github.com/davitf/archivey-dev) | Predecessor (v1) codebase: declarative corpus shapes, stream-layer ideas, and native 7z/RAR explorations that informed v2. |
+| 7-Zip / `7z` CLI (`p7zip`) | Fixture builder and anti-item / encrypted-ZIP oracle in tests (when installed). |
+| RARLAB `unrar` / `rar` | Runtime decompressor for RAR **member data**; fixture generator for committed RAR samples. |
+
+## Seekable-stream design references
+
+Indexed / seekable decompressors shaped the stream layer even when Archivey does **not**
+depend on them. Full scoring lives in [library analysis](internal/library-analysis.md);
+the single-accelerator constraint is in [ADR 0008](decisions/0008-single-accelerator-rapidgzip.md)
+and [known issues](internal/known-issues.md).
+
+| Project | Role |
+| --- | --- |
+| [python-xz](https://github.com/Rogdham/python-xz) (Rogdham) | Design reference for native XZ block-index seeking / synthetic single-block streams (`xz.py` over stdlib `lzma`). Evaluated and **not** used as a dependency (was briefly pinned dead in `[all]`, then removed). Provenance: [archivey-dev#214](https://github.com/davitf/archivey-dev/pull/214). |
+| [rapidgzip](https://github.com/mxmlnkn/rapidgzip) (mxmlnkn) | Runtime `[seekable]` accelerator for gzip **and** bzip2 (`IndexedBzip2File` bundled inside rapidgzip). |
+| [indexed_bzip2](https://github.com/mxmlnkn/indexed_bzip2) / [indexed_gzip](https://github.com/pauldmccarthy/indexed_gzip) | Evaluated for random access; standalone `indexed_bzip2` is **deliberately not** imported (macOS dual-load heap corruption with rapidgzip). Same author lineage as rapidgzip; also relevant via [ratarmount](https://github.com/mxmlnkn/ratarmount). |
+| [indexed_zstd](https://github.com/martinellimarco/indexed_zstd) (martinellimarco) | Evaluated for efficient seeking over arbitrary `.zst`; **deferred** (frame-granularity only; C++ coexistence risk). Tracked in `IDEAS.md`. |
+| [pyzstd](https://github.com/animalize/pyzstd) | Evaluated for zstd decode / `SeekableZstdFile` (Seekable Zstd container only). Decode instead targets stdlib `compression.zstd` / [backports.zstd](https://github.com/Rogdham/backports.zstd) — see [ADR 0009](decisions/0009-zstd-stdlib-backports.md). |
+| [zstandard](https://github.com/indygreg/python-zstandard) | Former zstd backend; replaced after the compression-library evaluation. |
+
+## Runtime dependencies (optional extras)
+
+Bare `pip install archivey` has **no** third-party runtime deps. Named extras pull:
+
+| Extra | Packages |
+| --- | --- |
+| `[7z]` | [pyppmd](https://github.com/miurahr/pyppmd), [inflate64](https://github.com/miurahr/inflate64), [brotli](https://github.com/google/brotli), [lz4](https://github.com/python-lz4/python-lz4), [cryptography](https://github.com/pyca/cryptography), [pybcj](https://github.com/miurahr/pybcj), [backports.zstd](https://github.com/Rogdham/backports.zstd) (Python before 3.14) |
+| `[rar]` / `[crypto]` | [cryptography](https://github.com/pyca/cryptography) (Blake2sp backend still TBD) |
+| `[7z-write]` | [py7zr](https://github.com/miurahr/py7zr) |
+| `[iso]` | [pycdlib](https://github.com/clalancette/pycdlib) |
+| `[zstd]` | [backports.zstd](https://github.com/Rogdham/backports.zstd) on Python before 3.14; 3.14+ uses stdlib `compression.zstd` |
+| `[lz4]` | [lz4](https://github.com/python-lz4/python-lz4) |
+| `[cli]` | [tqdm](https://github.com/tqdm/tqdm) |
+| `[seekable]` | [rapidgzip](https://github.com/mxmlnkn/rapidgzip) |
+
+`[recommended]` / `[recommended-lite]` / `[all]` are convenience aliases over the table
+above (`[all]` currently equals `[recommended]`).
+
+**Stdlib** (always): `zipfile`, `tarfile`, `gzip`, `bz2`, `lzma`, `zlib`, and on 3.14+
+`compression.zstd`.
+
+## Development and test dependencies
+
+Declared in the PEP 735 `dev` / `docs` / `fuzz` groups (not user-facing extras):
+
+| Package | Use |
+| --- | --- |
+| `py7zr`, `rarfile`, `libarchive-c` | Format oracles / optional external corpora |
+| [ncompress](https://github.com/valgur/ncompress) | LZW **compressor** for `.Z` fixtures (decode is native) |
+| `pycdlib`, `cryptography`, `backports.zstd`, `lz4`, `brotli` | Exercise optional backends in the default dev env |
+| `urllib3`, `fsspec` | Real third-party stream objects in input tests |
+| `hypothesis` | Property tests for safety logic |
+| `pytest`, `pytest-cov`, `pytest-timeout`, `coverage` | Test runner / coverage |
+| `ruff`, `pyrefly`, `ty`, `pre-commit` | Lint and type-check |
+| `mkdocs`, `mkdocs-material`, `mkdocstrings`, … | Docs site (`docs` group) |
+| [atheris](https://github.com/google/atheris) | Coverage-guided fuzz (`fuzz` group; CI-only) |
+
+## Thanks
+
+Thanks to the maintainers and contributors of every project above — especially those
+whose work Archivey learned from without taking as a dependency. If something is missing
+from this list, please open an issue or PR.

--- a/docs/acknowledgements.md
+++ b/docs/acknowledgements.md
@@ -1,9 +1,9 @@
 # Acknowledgements
 
-Archivey’s core is MIT-licensed and mostly stdlib / native parsers, but it stands on
-other people’s formats, libraries, fixtures, and design work. This page records that —
-whether each project is a runtime dependency, a test oracle, adapted source, or only a
-design reference.
+None of this would exist without the people who built the formats, libraries, and tools
+Archivey leans on — whether we depend on their code directly, learned from their design,
+or just used their project to check our own work. This page is where we say thanks and
+give credit properly.
 
 License texts for adapted kernels live next to the code
 (`src/archivey/internal/streams/unix_compress.py`,
@@ -12,13 +12,12 @@ License texts for adapted kernels live next to the code
 
 ## Thanks
 
-Thanks to the maintainers and contributors of every project below — especially those
-whose work Archivey learned from without taking as a dependency. Where we built our own
-parsers and stream layers instead of wrapping a library, it is so the code can plug into
-Archivey’s architecture, use modes (streaming vs random access, seekability,
-concurrency, cost reporting, diagnostics), and extraction behaviour, and keep one
-consistent API and behaviour across formats. If something is missing from this list,
-please open an issue or PR.
+Thanks to the maintainers and contributors of every project below — especially the ones
+whose work shaped our design without ever becoming a dependency. When we built our own
+parser or stream layer instead of wrapping a library, it’s usually because it needed to
+fit Archivey’s architecture and behave consistently across formats, not because the
+original wasn’t good. If we missed a project that should be here, open an issue or a
+PR — genuinely.
 
 ## Adapted source
 

--- a/docs/acknowledgements.md
+++ b/docs/acknowledgements.md
@@ -15,9 +15,10 @@ License texts for adapted kernels live next to the code
 Thanks to the maintainers and contributors of every project below — especially those
 whose work Archivey learned from without taking as a dependency. Where we built our own
 parsers and stream layers instead of wrapping a library, it is so the code can plug into
-Archivey’s architecture and use modes (streaming vs random access, seekability,
-concurrency, cost reporting, diagnostics) and keep one consistent API and behaviour
-across formats. If something is missing from this list, please open an issue or PR.
+Archivey’s architecture, use modes (streaming vs random access, seekability,
+concurrency, cost reporting, diagnostics), and extraction behaviour, and keep one
+consistent API and behaviour across formats. If something is missing from this list,
+please open an issue or PR.
 
 ## Adapted source
 
@@ -35,9 +36,8 @@ These are not on the primary read path (except where noted).
 | [py7zr](https://github.com/miurahr/py7zr) (Hiroshi Miura et al.) | 7z **format reference**, write backend under `[7z-write]`, and **dev oracle** / optional external corpus (`ARCHIVEY_PY7ZR_TEST_FILES`). Reading is native — see [ADR 0001](decisions/0001-native-7z-not-py7zr.md). |
 | [rarfile](https://github.com/markokr/rarfile) | RAR **format reference**, **dev oracle**, optional corpus (`ARCHIVEY_RARFILE_TEST_FILES`), and two legacy fixtures under `tests/fixtures/rar/` (RAR 1.5 / 2.0). Reading metadata is native; data uses RARLAB `unrar` — see [ADR 0002](decisions/0002-native-rar-metadata-unrar-data.md). |
 | [libarchive](https://github.com/libarchive/libarchive) (+ [libarchive-c](https://github.com/Changaco/python-libarchive-c)) | Optional **cross-format corpus** oracle (`ARCHIVEY_LIBARCHIVE_TEST_FILES` → libarchive’s `libarchive/test` uuencoded archives). Dev-only; not a runtime backend. |
-| [archivey-dev](https://github.com/davitf/archivey-dev) | Predecessor (v1) codebase: declarative corpus shapes, stream-layer ideas, and native 7z/RAR explorations that informed v2. |
-| 7-Zip / `7z` CLI (`p7zip`) | Fixture builder and anti-item / encrypted-ZIP oracle in tests (when installed). |
-| RARLAB `unrar` / `rar` | Runtime decompressor for RAR **member data**; fixture generator for committed RAR samples. |
+| [7-Zip](https://www.7-zip.org/) / `7z` CLI ([p7zip](https://github.com/p7zip-project/p7zip)) | Fixture builder and anti-item / encrypted-ZIP oracle in tests (when installed). |
+| [RARLAB](https://www.rarlab.com/) `unrar` / `rar` | Runtime decompressor for RAR **member data**; fixture generator for committed RAR samples. |
 
 ## Seekable-stream design references
 
@@ -48,7 +48,7 @@ and [known issues](internal/known-issues.md).
 
 | Project | Role |
 | --- | --- |
-| [python-xz](https://github.com/Rogdham/python-xz) (Rogdham) | Design reference for native XZ block-index seeking / synthetic single-block streams (`xz.py` over stdlib `lzma`). Evaluated and **not** used as a dependency (was briefly pinned dead in `[all]`, then removed). Provenance: [archivey-dev#214](https://github.com/davitf/archivey-dev/pull/214). |
+| [python-xz](https://github.com/Rogdham/python-xz) (Rogdham) | Design reference for native XZ block-index seeking / synthetic single-block streams (`xz.py` over stdlib `lzma`). Evaluated and **not** used as a dependency (was briefly pinned dead in `[all]`, then removed). |
 | [rapidgzip](https://github.com/mxmlnkn/rapidgzip) (mxmlnkn) | Runtime `[seekable]` accelerator for gzip **and** bzip2 (`IndexedBzip2File` bundled inside rapidgzip). |
 | [indexed_bzip2](https://github.com/mxmlnkn/indexed_bzip2) / [indexed_gzip](https://github.com/pauldmccarthy/indexed_gzip) | Evaluated for random access; standalone `indexed_bzip2` is **deliberately not** imported (macOS dual-load heap corruption with rapidgzip). Same author lineage as rapidgzip; also relevant via [ratarmount](https://github.com/mxmlnkn/ratarmount). |
 | [indexed_zstd](https://github.com/martinellimarco/indexed_zstd) (martinellimarco) | Evaluated for efficient seeking over arbitrary `.zst`; **deferred** (frame-granularity only; C++ coexistence risk). Tracked in `IDEAS.md`. |
@@ -73,8 +73,13 @@ Bare `pip install archivey` has **no** third-party runtime deps. Named extras pu
 `[recommended]` / `[recommended-lite]` / `[all]` are convenience aliases over the table
 above (`[all]` currently equals `[recommended]`).
 
-**Stdlib** (always): `zipfile`, `tarfile`, `gzip`, `bz2`, `lzma`, `zlib`, and on 3.14+
-`compression.zstd`.
+**Stdlib** (always): [`zipfile`](https://docs.python.org/3/library/zipfile.html),
+[`tarfile`](https://docs.python.org/3/library/tarfile.html),
+[`gzip`](https://docs.python.org/3/library/gzip.html),
+[`bz2`](https://docs.python.org/3/library/bz2.html),
+[`lzma`](https://docs.python.org/3/library/lzma.html),
+[`zlib`](https://docs.python.org/3/library/zlib.html), and on 3.14+
+[`compression.zstd`](https://docs.python.org/3/library/compression.zstd.html).
 
 ## Development and test dependencies
 
@@ -82,12 +87,12 @@ Declared in the PEP 735 `dev` / `docs` / `fuzz` groups (not user-facing extras):
 
 | Package | Use |
 | --- | --- |
-| `py7zr`, `rarfile`, `libarchive-c` | Format oracles / optional external corpora |
+| [py7zr](https://github.com/miurahr/py7zr), [rarfile](https://github.com/markokr/rarfile), [libarchive-c](https://github.com/Changaco/python-libarchive-c) | Format oracles / optional external corpora |
 | [ncompress](https://github.com/valgur/ncompress) | LZW **compressor** for `.Z` fixtures (decode is native) |
-| `pycdlib`, `cryptography`, `backports.zstd`, `lz4`, `brotli` | Exercise optional backends in the default dev env |
-| `urllib3`, `fsspec` | Real third-party stream objects in input tests |
-| `hypothesis` | Property tests for safety logic |
-| `pytest`, `pytest-cov`, `pytest-timeout`, `coverage` | Test runner / coverage |
-| `ruff`, `pyrefly`, `ty`, `pre-commit` | Lint and type-check |
-| `mkdocs`, `mkdocs-material`, `mkdocstrings`, … | Docs site (`docs` group) |
+| [pycdlib](https://github.com/clalancette/pycdlib), [cryptography](https://github.com/pyca/cryptography), [backports.zstd](https://github.com/Rogdham/backports.zstd), [lz4](https://github.com/python-lz4/python-lz4), [brotli](https://github.com/google/brotli) | Exercise optional backends in the default dev env |
+| [urllib3](https://github.com/urllib3/urllib3), [fsspec](https://github.com/fsspec/filesystem_spec) | Real third-party stream objects in input tests |
+| [hypothesis](https://github.com/HypothesisWorks/hypothesis) | Property tests for safety logic |
+| [pytest](https://github.com/pytest-dev/pytest), [pytest-cov](https://github.com/pytest-dev/pytest-cov), [pytest-timeout](https://github.com/pytest-dev/pytest-timeout), [coverage](https://github.com/nedbat/coveragepy) | Test runner / coverage |
+| [ruff](https://github.com/astral-sh/ruff), [pyrefly](https://github.com/facebook/pyrefly), [ty](https://github.com/astral-sh/ty), [pre-commit](https://github.com/pre-commit/pre-commit) | Lint and type-check |
+| [mkdocs](https://github.com/mkdocs/mkdocs), [mkdocs-material](https://github.com/squidfunk/mkdocs-material), [mkdocstrings](https://github.com/mkdocstrings/mkdocstrings), … | Docs site (`docs` group) |
 | [atheris](https://github.com/google/atheris) | Coverage-guided fuzz (`fuzz` group; CI-only) |

--- a/docs/formats.md
+++ b/docs/formats.md
@@ -21,6 +21,7 @@ most often surprise callers. Authoritative detail lives in `openspec/specs/forma
 
 Recommended installs: `archivey[recommended]` or `archivey[recommended-lite]` (no
 `rapidgzip`). Full codec rationale: [library analysis](internal/library-analysis.md).
+Third-party credits (deps, oracles, design refs): [Acknowledgements](acknowledgements.md).
 
 ## ZIP
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,6 +19,7 @@ with archivey.open_archive("photos.zip") as reader:
 4. **[Formats and extras](formats.md)** — per-format quirks, required libraries, limitations
 5. **[Safe extraction](safe-extraction.md)** — what “safe by default” means in practice
 6. **[API reference](api.md)** — generated from source
+7. **[Acknowledgements](acknowledgements.md)** — libraries, oracles, and design references
 
 ## For contributors
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,7 @@ nav:
   - Formats and extras: formats.md
   - Safe extraction: safe-extraction.md
   - API reference: api.md
+  - Acknowledgements: acknowledgements.md
   - Decisions:
       - Overview: decisions/index.md
       - Native 7z (not py7zr): decisions/0001-native-7z-not-py7zr.md

--- a/src/archivey/internal/backends/rar_parser.py
+++ b/src/archivey/internal/backends/rar_parser.py
@@ -3,6 +3,10 @@
 Parses archive headers into :class:`RarArchive` / :class:`RarMemberInfo` without
 decompressing member data and without importing ``rarfile``. Header encryption uses
 :mod:`archivey.internal.streams.crypto` (never ``cryptography`` directly).
+
+RAR3 SHA-1 / string-to-key and Unicode filename decompression are adapted from
+``rarfile`` 4.3 (https://github.com/markokr/rarfile), Copyright (c) 2005-2024
+Marko Kreen, used under the ISC License (see the notice at the bottom of this file).
 """
 
 from __future__ import annotations
@@ -1518,3 +1522,23 @@ def _parse_rar5_file_encryption(xdata: bytes, pos: int) -> RarEncryptionInfo:
         iv=iv,
         check_value=check_value,
     )
+
+
+# ---------------------------------------------------------------------------
+# ISC License notice for algorithms adapted from rarfile
+# (RAR3 SHA-1 / string-to-key and Unicode filename decompression above)
+# ---------------------------------------------------------------------------
+#
+# Copyright (c) 2005-2024 Marko Kreen <markokr@gmail.com>
+#
+# Permission to use, copy, modify, and/or distribute this software for any
+# purpose with or without fee is hereby granted, provided that the above
+# copyright notice and this permission notice appear in all copies.
+#
+# THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+# WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+# MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+# ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+# WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+# ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+# OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.

--- a/uv.lock
+++ b/uv.lock
@@ -37,7 +37,6 @@ all = [
     { name = "pyppmd" },
     { name = "rapidgzip" },
     { name = "tqdm" },
-    { name = "uncompresspy" },
 ]
 cli = [
     { name = "tqdm" },
@@ -66,7 +65,6 @@ recommended = [
     { name = "pyppmd" },
     { name = "rapidgzip" },
     { name = "tqdm" },
-    { name = "uncompresspy" },
 ]
 recommended-lite = [
     { name = "backports-zstd", marker = "python_full_version < '3.14'" },
@@ -79,13 +77,9 @@ recommended-lite = [
     { name = "pycdlib" },
     { name = "pyppmd" },
     { name = "tqdm" },
-    { name = "uncompresspy" },
 ]
 seekable = [
     { name = "rapidgzip" },
-]
-unix-compress = [
-    { name = "uncompresspy" },
 ]
 zstd = [
     { name = "backports-zstd", marker = "python_full_version < '3.14'" },
@@ -112,7 +106,6 @@ dev = [
     { name = "rarfile" },
     { name = "ruff" },
     { name = "ty" },
-    { name = "uncompresspy" },
     { name = "urllib3" },
 ]
 docs = [
@@ -129,7 +122,7 @@ fuzz = [
 
 [package.metadata]
 requires-dist = [
-    { name = "archivey", extras = ["7z", "rar", "7z-write", "iso", "zstd", "lz4", "unix-compress", "cli"], marker = "extra == 'recommended-lite'" },
+    { name = "archivey", extras = ["7z", "rar", "7z-write", "iso", "zstd", "lz4", "cli"], marker = "extra == 'recommended-lite'" },
     { name = "archivey", extras = ["recommended"], marker = "extra == 'all'" },
     { name = "archivey", extras = ["recommended-lite", "seekable"], marker = "extra == 'recommended'" },
     { name = "backports-zstd", marker = "python_full_version < '3.14' and extra == '7z'", specifier = ">=1.0.0" },
@@ -147,9 +140,8 @@ requires-dist = [
     { name = "pyppmd", marker = "extra == '7z'", specifier = ">=1.1.0" },
     { name = "rapidgzip", marker = "extra == 'seekable'", specifier = ">=0.16.0" },
     { name = "tqdm", marker = "extra == 'cli'", specifier = ">=4.67.0" },
-    { name = "uncompresspy", marker = "extra == 'unix-compress'", specifier = ">=0.4.0" },
 ]
-provides-extras = ["7z", "rar", "crypto", "7z-write", "iso", "zstd", "lz4", "unix-compress", "cli", "seekable", "recommended-lite", "recommended", "all"]
+provides-extras = ["7z", "rar", "crypto", "7z-write", "iso", "zstd", "lz4", "cli", "seekable", "recommended-lite", "recommended", "all"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -172,7 +164,6 @@ dev = [
     { name = "rarfile", specifier = ">=4.2" },
     { name = "ruff", specifier = ">=0.11.0" },
     { name = "ty", specifier = ">=0.0.1a13" },
-    { name = "uncompresspy", specifier = ">=0.4.0" },
     { name = "urllib3", specifier = ">=2.0.0" },
 ]
 docs = [
@@ -1969,15 +1960,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f6/cc/6253133b5bb138fc3306cebfbda2c520f545d36b5be2c7255cc528bb45d6/typing_extensions-4.16.0.tar.gz", hash = "sha256:dc983d19a509c94dba722ee6abd33940f7c05a89e243c47e907eb4db6f1a43e5", size = 113555, upload-time = "2026-07-02T08:40:05.92Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl", hash = "sha256:481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8", size = 45571, upload-time = "2026-07-02T08:40:04.659Z" },
-]
-
-[[package]]
-name = "uncompresspy"
-version = "0.4.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/eb/fb/8c892ae2d7eb746bfc11f46f475674d2912226d8df966709d66202c88fd0/uncompresspy-0.4.1.tar.gz", hash = "sha256:e79ead66eaed8d42364d807c0ba3f3a8aef0e0087a9beaf1a60f23a808a6c147", size = 10826, upload-time = "2025-10-11T22:42:41.097Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/06/ba/baf49db30801e20a741388a9d456b7330011f45f7c7560cb2c7ab3c3fa0d/uncompresspy-0.4.1-py3-none-any.whl", hash = "sha256:b7afd3c67ec39608bfd86f2c0832deaa1ff89ed0741a2e23cdba7819ee2a47d5", size = 10076, upload-time = "2025-10-11T22:42:39.947Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
Follow-up to a review of #91 — the reference tables and links checked out fine (verified against `pyproject.toml`, `uv.lock`, the ported license notices, and a clean `mkdocs build --strict`), but the prose read more like a technical taxonomy than a thank-you. This PR only touches the two prose blocks in `docs/acknowledgements.md`:

- **Intro paragraph**: replaced the "MIT-licensed / runtime dependency vs test oracle vs design reference" framing with a plainer explanation of why the page exists.
- **Thanks paragraph**: dropped the parenthetical jargon list (streaming vs random access, seekability, concurrency, cost reporting, diagnostics) that duplicates `library-analysis.md`, and reworded the close to sound like a person asking for missing credits rather than a boilerplate notice.

The tables (extras, oracles, design references, dev deps) are untouched — those are meant to be dense reference material, not prose.

## Test plan
- [x] `uv run --group docs mkdocs build --strict` passes
- [x] Diff reviewed for curly-quote consistency with the rest of the file

https://claude.ai/code/session_01NHDnpDCxW3JhE9zRQQwjXA

---
_Generated by [Claude Code](https://claude.ai/code/session_01NHDnpDCxW3JhE9zRQQwjXA)_