### PR TITLE
Propose rapidgzip acceleration for raw deflate and zlib streams

### DIFF
--- a/openspec/changes/rapidgzip-deflate-zlib-acceleration/.openspec.yaml
+++ b/openspec/changes/rapidgzip-deflate-zlib-acceleration/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: library
+created: 2026-07-14

--- a/openspec/changes/rapidgzip-deflate-zlib-acceleration/brief.md
+++ b/openspec/changes/rapidgzip-deflate-zlib-acceleration/brief.md
@@ -1,0 +1,13 @@
+# rapidgzip-deflate-zlib-acceleration — accelerate raw deflate and zlib streams with rapidgzip
+
+**Status:** Ready to implement, with one value to benchmark. Depends on nothing; the ZIP native-codec-streams change benefits from it but does not block it. Not breaking. Effort: small to medium.
+
+**Why it matters:** rapidgzip, which archivey already ships as the seekable gzip and bzip2 accelerator, turns out to also decode raw deflate and zlib natively as of version zero-point-sixteen. Today the deflate and zlib codecs always fall back to standard-library zlib, so seekable deflate and zlib streams get no parallel decode and no real random access. That includes the ZIP deflate members the native-codec change will route through the deflate codec.
+
+**What it does:** It adds a rapidgzip path to the deflate and zlib codecs, gated exactly like gzip, and passes the stream through unwrapped because rapidgzip auto-detects the format. No fake gzip wrapper is needed. The default sequential backend stays standard-library zlib.
+
+**Decided:** No gzip wrapping. The input handed to rapidgzip must be exactly bounded, since it over-reads past the deflate end looking for another member. Standalone zlib and deflate lose standard-library's truncation detection because rapidgzip does not check the zlib checksum and can return a silent short read; container members stay safe because the container's own CRC catches this. And auto mode gains a minimum-input-size gate so tiny members do not pay rapidgzip's setup cost.
+
+**Your call later:** The exact size threshold — chosen from a benchmark across compressed sizes on Linux and macOS — and whether that gate lives in the accelerator-mode helper or at the codec call sites.
+
+**Bottom line:** A small, low-risk extension of existing gzip acceleration to the whole deflate family; land it alongside or just after the ZIP change.

--- a/openspec/changes/rapidgzip-deflate-zlib-acceleration/design.md
+++ b/openspec/changes/rapidgzip-deflate-zlib-acceleration/design.md
@@ -1,0 +1,132 @@
+## Context
+
+`GzipCodec.open` (codecs.py:516) branches on `use_rapidgzip.enabled_for(seekable, available)` and,
+when enabled, wraps `rapidgzip.open(source)` in `_AcceleratorStream` (a `weakref.finalize`
+close-guard) plus, for path sources, `_GzipTruncationCheckStream` (ISIZE backstop). `DeflateCodec`
+(codecs.py:868) and `ZlibCodec` (:880) have no such branch — they unconditionally return
+`ZlibDecompressorStream(source, wbits=-15 | MAX_WBITS)` over stdlib `zlib`. Accelerator selection
+is `AcceleratorMode.enabled_for(*, seekable, available)` (config.py) — a pure tri-state with no
+size input. The `[seekable]` extra pins `rapidgzip>=0.16.0`.
+
+Provenance: this change spun out of the `zip-native-codec-streams` investigation — `rapidgzip`
+0.16.0 turned out to decode raw DEFLATE and zlib natively, not just gzip, so the acceleration is a
+whole-DEFLATE-family concern rather than a ZIP detail. Related in-flight work:
+`rapidgzip-truncation-investigation` (the gzip ISIZE backstop) and `zip-native-codec-streams`
+(routes ZIP method-8 members through `DeflateCodec`).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add a rapidgzip acceleration path to the `deflate` and `zlib` codecs, gated like gzip.
+- Extend accelerator error-translation and slow-rewind diagnostics to deflate/zlib.
+- Introduce a benchmarked `AUTO` minimum-input-size threshold for the whole DEFLATE family
+  (deflate + zlib + gzip) so tiny members don't pay accelerator setup.
+
+**Non-Goals:**
+- Changing the default sequential backend (stays stdlib `zlib`).
+- A truncation backstop for standalone zlib/deflate (accepted gap; see Decision 4).
+- Any ZIP-specific wiring — that lives in `zip-native-codec-streams`, which merely benefits.
+- Revisiting the gzip ISIZE backstop (owned by `rapidgzip-truncation-investigation`).
+
+## Investigations
+
+All measured against the pinned `rapidgzip==0.16.0` in this repo's `[seekable]` extra.
+
+**Format support** — `rapidgzip.determineFileType()` reports `GZIP`/`ZLIB`/`DEFLATE`; the
+`RapidgzipFile` constructor takes **no** format/`wbits` argument (detection is automatic):
+
+| Input | `determineFileType` | Parallel decode | Seek into middle |
+| --- | --- | --- | --- |
+| gzip (`gzip.compress`) | `GZIP` | ✅ correct | ✅ |
+| zlib (`zlib.compress`, wbits 15) | `ZLIB` | ✅ correct | ✅ |
+| raw deflate (wbits −15) | `DEFLATE` | ✅ correct | ✅ |
+
+Confirmed end-to-end for the container case: a raw-deflate blob embedded in a larger buffer
+(local header before, `PK\x03\x04` after) read through a bounded slicing stream decoded and
+seeked correctly — the exact mechanism `zip-native-codec-streams` uses.
+
+**Over-read** — rapidgzip continues past a DEFLATE end-of-stream looking for a concatenated
+member. `BytesIO(raw)` (exact length) → clean decode + stop at EOF. `raw + trailing_bytes` →
+`RuntimeError: Invalid deflate block found!`. So the input must be exactly bounded.
+
+**Truncation / checksum** — no reliable truncation signal, and zlib's Adler-32 is not checked:
+
+| Input | rapidgzip result |
+| --- | --- |
+| zlib, corrupt Adler-32 byte | decodes fully, **no error** (Adler not validated) |
+| zlib, corrupt DEFLATE body | `RuntimeError` (isal error code −3) |
+| zlib, tail/`-1B` cut | `RuntimeError` "Unexpected end of file" |
+| zlib, mid-stream cut | **silent** `len=0` short read |
+| raw deflate, corrupt body | `RuntimeError` (isal −3) |
+| raw deflate, mid/`-1B` cut | **silent** short read |
+
+Contrast: stdlib `zlib` raises `error: incomplete or truncated stream` on these truncations —
+so moving standalone zlib/deflate onto rapidgzip *loses* that truncation detection.
+
+## Decisions
+
+### 1. Wire rapidgzip into `DeflateCodec`/`ZlibCodec`, mirroring `GzipCodec`
+Add the same `use_rapidgzip.enabled_for(...)` branch, `_AcceleratorStream` wrap, and
+accelerator exception translator to both codecs; pass the source through unwrapped (rapidgzip
+auto-detects). Default sequential path (`ZlibDecompressorStream`) is retained for the disabled/
+unavailable/below-threshold cases. **Rejected:** wrapping deflate/zlib in a synthetic gzip
+header+footer — unnecessary given native detection, and it would force a fake CRC/ISIZE.
+
+### 2. The input handed to rapidgzip must be exactly bounded
+Rely on the caller's bounded stream (container `SlicingStream` sized to the compressed length;
+a whole-file source for standalone zlib) so rapidgzip hits real EOF at the stream end rather than
+over-reading into trailing bytes. This is already true for the ZIP path and for single-file
+sources; the codec adds no unbounded wrapper.
+
+### 3. `AUTO` gains a minimum-input-size threshold (the benchmark wrinkle)
+Extend accelerator selection so `AUTO` only picks rapidgzip once the *known* compressed input
+size reaches a threshold; below it, use stdlib `zlib`/`gzip`. `ON` ignores the threshold; `OFF`
+disables. Rationale: rapidgzip spins up worker thread(s) and a chunk index per stream — pure loss
+for the many-tiny-members case (small ZIP entries, small gzip files). The threshold keys off the
+*compressed* size because that is what is knowable at open time (file size / slice length); when
+size is unknown, keep pre-threshold behaviour (enable when otherwise eligible).
+
+Mechanically, thread the size into selection — either widen `AcceleratorMode.enabled_for` with an
+optional `input_size`/`min_size`, or apply the comparison at the codec call sites. Prefer the
+former so gzip/bzip2 share one gate. The threshold is a named constant, its value fixed by the
+benchmark in Open Questions and documented where `use_rapidgzip` is described.
+**Rejected:** gating on *uncompressed* size (not known ahead of decode) or a fixed hardcoded
+member-count heuristic (doesn't generalise across formats).
+
+### 4. No truncation backstop for standalone zlib/deflate; containers use their CRC
+Given the Investigation results, accept that a rapidgzip-accelerated standalone zlib/deflate
+stream can miss a clean mid-stream truncation that stdlib would flag. For container members
+(ZIP/7z) the shared verifying stage already checks the container CRC-32, which catches
+truncation/corruption regardless of backend — so the container path is fully covered. Corruption
+inside a DEFLATE block still raises and is translated to `CorruptionError`. Building a zlib
+Adler-32 / decompressed-length backstop analogous to the gzip ISIZE check is possible but is
+deferred to (and coordinated with) `rapidgzip-truncation-investigation` rather than bundled here.
+**Rejected:** silently regressing truncation detection without recording it (done — spec states
+the limitation); **Rejected:** forcing standalone zlib to stay on stdlib forever (the size
+threshold plus container-CRC coverage make the accelerator worthwhile for large streams).
+
+### 5. Slow-rewind diagnostics name the accelerator for zlib/deflate
+Today the diagnostic spec says "zlib records no accelerator". With a rapidgzip path available,
+the stdlib-fallback rewind for zlib/deflate names the `[seekable]` accelerator, consistent with
+gzip, so the diagnostic tells users an accelerator would have avoided the O(n) rewind.
+
+## Risks / Trade-offs
+
+- **[Truncation regression for standalone zlib/deflate]** → documented in spec (Decision 4);
+  container members are covered by CRC; a future backstop is scoped to the truncation change.
+- **[Over-read on an unbounded slice]** → codec never adds an unbounded wrapper; the bounded-input
+  requirement is normative and tested with a trailing-bytes fixture.
+- **[Wrong/low threshold hurts either tiny or large members]** → the value is chosen from the
+  benchmark below, not guessed; `ON`/`OFF` remain available as explicit overrides.
+- **[Accelerator lifecycle / shutdown abort]** → reuse the existing `_AcceleratorStream`
+  close-guard unchanged (same mechanism as gzip/bzip2).
+
+## Open Questions
+
+- **Threshold value.** Benchmark rapidgzip vs stdlib `zlib` decode+seek across compressed sizes
+  (e.g. 1 KiB → 10 MiB) for raw deflate, zlib, and gzip, on Linux and macOS, measuring the
+  crossover where rapidgzip's setup cost is repaid. Pick a single conservative `AUTO` threshold
+  (likely one value across the family) and record it in design + user docs. Confirm the crossover
+  isn't dominated by the many-small-members aggregate case (repeated per-stream setup).
+- **Threshold location.** `AcceleratorMode.enabled_for(input_size=...)` vs codec-site check —
+  decide during apply based on which keeps gzip/bzip2/deflate/zlib sharing one gate cleanly.

--- a/openspec/changes/rapidgzip-deflate-zlib-acceleration/proposal.md
+++ b/openspec/changes/rapidgzip-deflate-zlib-acceleration/proposal.md
@@ -1,0 +1,52 @@
+## Why
+
+`rapidgzip` (already the `[seekable]` gzip/bzip2 accelerator) natively decodes raw
+DEFLATE and zlib-wrapped DEFLATE as of 0.16.0 — it auto-detects `GZIP`/`ZLIB`/`DEFLATE`
+and gives the same parallel decode + random access it gives gzip, with **no gzip
+wrapper needed** (empirically verified against the pinned 0.16.0). Today the `deflate`
+and `zlib` codecs always use stdlib `zlib`, so declared-seekable deflate/zlib streams —
+including the ZIP DEFLATE members that `zip-native-codec-streams` will route through the
+`deflate` codec — get no accelerator. Wiring rapidgzip into these two codecs extends the
+existing gzip acceleration to the whole DEFLATE family for one small, mechanical change.
+
+## What Changes
+
+- Add a rapidgzip acceleration path to the `deflate` and `zlib` codecs, gated exactly like
+  gzip (`use_rapidgzip` × declared seekability × package availability), wrapped in the same
+  `_AcceleratorStream` close-guard. The default **sequential** backend stays stdlib `zlib`;
+  this only adds the seekable/parallel path. Not ZIP-specific — any deflate/zlib stream benefits.
+- Extend the accelerator error-translation and rewind-warning contracts to cover
+  rapidgzip-backed deflate/zlib (today "zlib records no accelerator").
+- **Add an `AUTO` minimum-input-size gate** for the rapidgzip accelerator across all three
+  members of the family (deflate + zlib + gzip): under `AUTO`, only select rapidgzip once the
+  known compressed input size exceeds a benchmarked threshold, so archives of many tiny
+  members don't pay rapidgzip's per-stream index/thread setup for no gain. `ON` still forces
+  it; `OFF` still disables it. The threshold value is determined by a benchmark in this change.
+- Record the truncation/checksum gap: rapidgzip does **not** validate zlib's Adler-32 and
+  returns a silent short read on mid-stream truncation, so a standalone zlib/deflate stream
+  loses stdlib `zlib`'s truncation detection unless backstopped (see design).
+
+## Capabilities
+
+### New Capabilities
+
+<!-- none -->
+
+### Modified Capabilities
+
+- `seekable-decompressor-streams`: the rapidgzip accelerator extends to raw DEFLATE and
+  zlib-wrapped DEFLATE (not gzip/bzip2 only); accelerator error translation and slow-rewind
+  diagnostics account for deflate/zlib; `AUTO` gains a minimum-input-size threshold before it
+  selects rapidgzip.
+
+## Impact
+
+- `internal/streams/codecs.py`: `DeflateCodec.open` / `ZlibCodec.open` grow a rapidgzip branch
+  mirroring `GzipCodec.open`; accelerator error translator and rewind-warning reused for both.
+- `config.py`: `AcceleratorMode.enabled_for` (or the codec call sites) gains a size input so
+  `AUTO` can apply the minimum-size threshold; new threshold constant.
+- No new dependency or extra — reuses `[seekable]` `rapidgzip>=0.16.0`.
+- Tests: deflate/zlib acceleration parity + error-translation cases; benchmark to pick and
+  document the `AUTO` size threshold; corruption/truncation behaviour for accelerated deflate/zlib.
+- Interacts with `zip-native-codec-streams` (its ZIP DEFLATE members become accelerable) and
+  `rapidgzip-truncation-investigation` (the truncation-backstop discussion extends to zlib/deflate).

--- a/openspec/changes/rapidgzip-deflate-zlib-acceleration/specs/seekable-decompressor-streams/spec.md
+++ b/openspec/changes/rapidgzip-deflate-zlib-acceleration/specs/seekable-decompressor-streams/spec.md
@@ -1,0 +1,116 @@
+## ADDED Requirements
+
+### Requirement: DEFLATE-family random access uses rapidgzip
+
+The system SHALL use `rapidgzip` (the `[seekable]` accelerator, `>=0.16.0`) as the optional
+random-access/parallel backend for raw DEFLATE (`deflate` codec) and zlib-wrapped DEFLATE
+(`zlib` codec), in addition to gzip. rapidgzip auto-detects `GZIP`/`ZLIB`/`DEFLATE`, so the
+codec SHALL pass the stream through unwrapped — no synthetic gzip header/footer. Selection is
+gated identically to gzip (`use_rapidgzip` × declared seekability × availability, plus the
+`AUTO` minimum-input-size threshold) and the raw accelerator SHALL be wrapped in the same
+close-on-finalize guard. The default sequential backend is unchanged: when rapidgzip is
+unavailable, `OFF`, or below the `AUTO` threshold, deflate/zlib decode through stdlib `zlib`.
+
+rapidgzip over-reads past a DEFLATE end-of-stream looking for a concatenated member, so the
+codec SHALL feed it an exactly-bounded input (e.g. the container's `SlicingStream` sized to
+the member's compressed length); an unbounded or over-long stream MAY raise a spurious
+"Invalid deflate block" error on the trailing bytes.
+
+#### Scenario: deflate/zlib accelerator matrix
+
+| Case | Expected |
+| --- | --- |
+| Declared-seekable raw deflate, `use_rapidgzip` enabled, size ≥ threshold | rapidgzip decodes/seeks without full re-decompression; input passed unwrapped |
+| Declared-seekable zlib stream, accelerator enabled | rapidgzip auto-detects ZLIB and decodes; backward seek without re-decompress from start |
+| rapidgzip absent, `OFF`, or size < `AUTO` threshold | stdlib `zlib` (`-15` / `MAX_WBITS`); backward seek re-decompresses from start |
+| Accelerator fed an over-long/unbounded slice | May raise a spurious decode error on trailing bytes; callers MUST bound the input |
+
+## MODIFIED Requirements
+
+### Requirement: Seek machinery is demand-driven
+
+The system SHALL construct seek support only when seekability is declared:
+`MemberStreams.SEEKABLE` on `open_archive()` or `seekable=True` on the
+single-stream API. Undeclared streams SHALL NOT parse XZ footers, scan lzip
+trailers, instantiate rapidgzip accelerators, retain rewind buffers, or retain
+seek-point tables; they are forward-only.
+
+`use_rapidgzip` and `use_indexed_bzip2` SHALL resolve their `AUTO` / `ON` / `OFF`
+configuration against declared seek demand, not the `streaming` access-mode
+proxy. For declared-seekable streams, native XZ/lzip indexes, rapidgzip-backed
+gzip/bzip2 indexes, and stdlib fallback rewinds retain their contracts. The
+stdlib O(n)-per-rewind path MAY serve the seek but MUST emit the documented
+slow-rewind diagnostic/warning.
+
+Under `AUTO`, the system SHALL additionally require the known compressed input size to reach a
+documented minimum threshold before selecting rapidgzip for any DEFLATE-family stream (deflate,
+zlib, gzip), so per-stream accelerator setup is not paid for members too small to benefit. The
+threshold value is fixed by benchmark and recorded in design. When the input size is not known
+in advance, `AUTO` SHALL behave as it did before this threshold existed (select the accelerator
+when otherwise eligible). `ON` ignores the threshold; `OFF` never selects rapidgzip.
+
+#### Scenario: demand matrix
+
+| Case | Expected |
+| --- | --- |
+| gzip/xz/bzip2/lzip opened without seekability under `AUTO` | No index, no accelerator, forward-only |
+| Same stream opened with seekability, `AUTO`, accelerator installed, size ≥ threshold | Accelerator or native index provides random access |
+| Declared-seekable deflate/zlib/gzip under `AUTO`, known size < threshold | rapidgzip not selected; stdlib backend used |
+| Declared-seekable DEFLATE-family stream, `use_rapidgzip=ON`, size below threshold | rapidgzip still selected (threshold ignored) |
+| Declared-seekable gzip without accelerator, caller seeks backward | Seek re-decompresses from start and warns/names `[seekable]` accelerator |
+
+### Requirement: Accelerator errors translate uniformly
+
+The system SHALL translate corrupt/truncated input from rapidgzip-backed gzip,
+bzip2, deflate, and zlib into the same `compressed-streams` errors as stdlib paths:
+`CorruptionError` or `TruncatedError`, never raw third-party exceptions. This
+translator SHALL account for platform-varying rapidgzip exception types/messages.
+
+For seekable-source gzip through rapidgzip, the system SHALL backstop truncation
+by comparing full-read decompressed length modulo 2^32 with the gzip ISIZE
+trailer. A conservative multi-member scan SHALL prevent valid concatenated gzip
+streams from being misreported when the trailer records only the last member.
+
+rapidgzip does not validate zlib's Adler-32 and returns a silent short read on some
+mid-stream DEFLATE truncations, and raw DEFLATE carries no checksum, so there is no
+ISIZE-equivalent truncation backstop for the deflate/zlib accelerator path. A DEFLATE-family
+member decoded inside a container (e.g. a ZIP member) SHALL rely on the container's own
+checksum (CRC-32 via the shared verifying stage) to catch truncation/corruption. A standalone
+zlib/deflate stream accelerated by rapidgzip MAY therefore miss a truncation that stdlib `zlib`
+would report; this is an accepted limitation of the accelerator path (tracked with the gzip
+truncation work), and corruption inside a DEFLATE block SHALL still surface as `CorruptionError`.
+
+#### Scenario: accelerator error matrix
+
+| Case | Expected |
+| --- | --- |
+| Corrupt gzip/bzip2/deflate/zlib through rapidgzip | `CorruptionError`; raw accelerator exception never escapes |
+| Truncated gzip through rapidgzip from seekable source | `TruncatedError` via ISIZE backstop or `CorruptionError` from accelerator; never silent short read |
+| Truncated standalone deflate/zlib through rapidgzip | Corruption in a block → `CorruptionError`; a clean mid-stream cut MAY return a short read undetected (no checksum backstop) |
+| Truncated/corrupt container DEFLATE member (e.g. ZIP) | Container CRC mismatch → `CorruptionError`/`TruncatedError` via the verifying stage |
+| Valid concatenated multi-member gzip | Decompresses fully without false truncation |
+
+### Requirement: Index-less rewinds emit diagnostic data
+
+When an index-less codec first services a backward seek by re-decompressing from
+the start, the system SHALL emit `STREAM_REWIND_REDECOMPRESSES` with codec,
+before/after offsets, and accelerator name or `None`. It SHALL emit at most once
+per stream. Forward/no-op seeks SHALL emit nothing.
+
+The event SHALL live on the stream operation and cumulative owning-reader
+aggregate, never on `CostReceipt` or `ArchiveInfo`. Gzip/bzip2/deflate/zlib context names the
+`[seekable]` accelerator when a rapidgzip path was eligible; brotli, lz4, and zstd record no
+accelerator. XZ, lzip, and unix-compress indexed seeks SHALL NOT emit this event.
+Stdlib zstd SHALL rewind in place like other index-less codecs. When a deflate/zlib stream
+falls back to stdlib `zlib` (accelerator absent, `OFF`, or below the `AUTO` threshold), its
+rewind SHALL name the `[seekable]` accelerator, consistent with the gzip fallback.
+
+#### Scenario: slow rewind matrix
+
+| Case | Expected |
+| --- | --- |
+| One index-less stream performs many backward seeks | One `STREAM_REWIND_REDECOMPRESSES` occurrence; later rewinds no duplicate |
+| Rewind diagnostic resolves to `RAISE` | `DiagnosticRaisedError` is raised from that seek |
+| Only forward/no-op seeks occur | No rewind occurrence |
+| zstd stream rewinds via stdlib backend | Re-decompresses from start in place and emits one occurrence |
+| Stdlib-fallback zlib/deflate stream rewinds | Emits one occurrence naming the `[seekable]` accelerator |

--- a/openspec/changes/rapidgzip-deflate-zlib-acceleration/tasks.md
+++ b/openspec/changes/rapidgzip-deflate-zlib-acceleration/tasks.md
@@ -1,0 +1,45 @@
+## 1. Benchmark the AUTO size threshold
+
+- [ ] 1.1 Add a benchmark (scripts/ or a bench test) decoding+seeking raw deflate, zlib, and gzip
+      via rapidgzip vs stdlib across compressed sizes (~1 KiB → ~10 MiB) on Linux and macOS
+- [ ] 1.2 Identify the crossover size where rapidgzip's per-stream setup is repaid; account for the
+      many-small-members aggregate case
+- [ ] 1.3 Choose a single conservative `AUTO` threshold constant and record its value + rationale
+      in design.md and the `use_rapidgzip` user docs
+
+## 2. AUTO minimum-size gate
+
+- [ ] 2.1 Thread the known compressed input size into accelerator selection (widen
+      `AcceleratorMode.enabled_for` with an optional size, or gate at the codec call sites — per
+      design Decision 3), keeping gzip/bzip2/deflate/zlib on one gate
+- [ ] 2.2 Apply the threshold only under `AUTO`; `ON` ignores it, `OFF` disables; unknown size keeps
+      pre-threshold behaviour
+- [ ] 2.3 Wire the gzip call site (`GzipCodec.open`) to the size-aware gate as well
+
+## 3. rapidgzip acceleration for deflate/zlib
+
+- [ ] 3.1 Add the rapidgzip branch to `DeflateCodec.open` and `ZlibCodec.open`, mirroring
+      `GzipCodec.open`: `enabled_for(...)` check, unwrapped `rapidgzip.open(source)`,
+      `_AcceleratorStream` close-guard; retain `ZlibDecompressorStream` fallback
+- [ ] 3.2 Route both codecs through the accelerator exception translator so corrupt input →
+      `CorruptionError` (never a raw rapidgzip exception); no ISIZE-style backstop added
+- [ ] 3.3 Update the slow-rewind diagnostic so stdlib-fallback zlib/deflate names the `[seekable]`
+      accelerator, consistent with gzip
+
+## 4. Tests
+
+- [ ] 4.1 Parity: accelerated deflate/zlib decode + mid-stream seek match stdlib output (declared
+      seekable, accelerator on)
+- [ ] 4.2 Gating: `OFF`, accelerator-absent, and below-`AUTO`-threshold all use stdlib; `ON` forces
+      rapidgzip below the threshold
+- [ ] 4.3 Error translation: corrupt deflate/zlib body → `CorruptionError`; assert the standalone
+      mid-cut truncation limitation is the documented behaviour
+- [ ] 4.4 Bounded-input: a deflate stream with trailing bytes fed through the codec's bounded slice
+      decodes correctly (no over-read error)
+- [ ] 4.5 Run the suite in `[all]`, `[all-lowest]`, and `[core-only]` (core-only exercises the
+      stdlib fallback path)
+
+## 5. Verify
+
+- [ ] 5.1 `uv run pyrefly check` and `uv run ty check` stay clean
+- [ ] 5.2 `openspec validate --strict rapidgzip-deflate-zlib-acceleration`


### PR DESCRIPTION
## Summary

Adds a new OpenSpec change, `rapidgzip-deflate-zlib-acceleration` (proposal only — no implementation yet). It proposes extending the `[seekable]` rapidgzip accelerator — today wired for gzip and bzip2 only — to raw DEFLATE (`deflate` codec) and zlib-wrapped DEFLATE (`zlib` codec).

This spun out of the `zip-native-codec-streams` investigation but is deliberately **not** ZIP-specific: it accelerates the whole DEFLATE family, and the ZIP change (whose method-8 members route through the `deflate` codec) is just a beneficiary.

## Key findings (verified against the pinned `rapidgzip==0.16.0`)

- rapidgzip **natively decodes** raw deflate and zlib, not just gzip — `determineFileType()` auto-detects `GZIP`/`ZLIB`/`DEFLATE`, and parallel decode + random-access seek all work. **No gzip wrapper needed.** (The old upstream "unimplemented" issue is stale.)
- rapidgzip **over-reads** past a DEFLATE end-of-stream looking for a concatenated member, so the input must be exactly bounded (the container `SlicingStream` already does this).
- rapidgzip does **not** validate zlib's Adler-32 and returns a **silent short read** on some mid-stream truncations, so accelerating *standalone* zlib/deflate regresses stdlib's truncation detection. Container members stay safe via the container CRC; the standalone backstop is scoped to `rapidgzip-truncation-investigation` rather than bundled here.

## What the change proposes

- Add a rapidgzip branch to `DeflateCodec.open` / `ZlibCodec.open`, gated like gzip, wrapped in the existing `_AcceleratorStream` close-guard; default sequential backend stays stdlib `zlib`.
- Extend accelerator error-translation and slow-rewind diagnostics to deflate/zlib.
- Add an **`AUTO` minimum-input-size gate** across deflate + zlib + gzip so archives of many tiny members don't pay per-stream accelerator setup. The threshold value is a benchmark deliverable in this change.

Modified capability: `seekable-decompressor-streams` (1 ADDED requirement, 3 MODIFIED). Validates clean under `openspec validate --strict`.

## Artifacts

- `proposal.md`, `design.md` (carries the empirical findings + 5 numbered decisions), `specs/seekable-decompressor-streams/spec.md`, `tasks.md`, `brief.md`.

## Open question for the maintainer

The `design.md` open question is the benchmark: pick the `AUTO` size threshold from a Linux/macOS sweep across compressed sizes, and decide whether the gate lives in `AcceleratorMode.enabled_for` or at the codec call sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TKmc9FfYX1jHF4Rj65o3Lo

---
_Generated by [Claude Code](https://claude.ai/code/session_01TKmc9FfYX1jHF4Rj65o3Lo)_