### PR TITLE
ZIP native codec streams + WinZip AES decryption

### DIFF
--- a/docs/formats.md
+++ b/docs/formats.md
@@ -44,7 +44,10 @@ Third-party credits (deps, oracles, design refs): [Acknowledgements](acknowledge
   `member_name_encoding_inferred` diagnostic records it. Passing `encoding=` to
   `open_archive` is authoritative — it is used verbatim and disables the sniff.
 - ZipCrypto multi-password confirmation can be expensive on **STORED** members — see
-  [costs](costs.md). WinZip AES (method 99) decryption is a follow-on capability.
+  [costs](costs.md). **WinZip AES** (method 99 / AE-1 and AE-2) decrypts via the
+  `[crypto]` extra (PBKDF2 + AES-CTR + HMAC-SHA1); AE-2 members expose no `crc32`
+  (integrity is the HMAC). Absent `[crypto]`, an AES member raises
+  `PackageNotInstalledError` but is still listed as encrypted.
 
 ## TAR (and compressed TAR)
 

--- a/docs/formats.md
+++ b/docs/formats.md
@@ -25,11 +25,16 @@ Third-party credits (deps, oracles, design refs): [Acknowledgements](acknowledge
 
 ## ZIP
 
-- Stdlib `zipfile` backend; seekable source only (even with `streaming=True`).
-- Multi-volume / split ZIP (`.z01`…`.zip`) is detected and rejected with
-  `UnsupportedFeatureError` — rejoin first.
+- Stdlib ``zipfile`` for **central-directory parsing / listing**; member **data** decodes
+  through archivey's shared codec layer (seekable source only, even with
+  ``streaming=True``).
+- Extended ZIP codecs when their extras are installed: Deflate64 and PPMd via ``[7z]``
+  (``inflate64`` / ``pyppmd`` — same packages as the 7z optional codecs), Zstd via
+  ``[zstd]`` (or stdlib on 3.14+). A missing backend raises ``PackageNotInstalledError``.
+- Multi-volume / split ZIP (``.z01``…``.zip``) is detected and rejected with
+  ``UnsupportedFeatureError`` — rejoin first.
 - Unsupported compression methods: listing succeeds; reading raises
-  `UnsupportedFeatureError`.
+  ``UnsupportedFeatureError``.
 - Timestamps: DOS base; NTFS / Extended Timestamp extras override when present.
 - **Member-name encoding.** Names flagged UTF-8 decode as UTF-8. For an unflagged name
   (APPNOTE says cp437), many tools nonetheless write UTF-8 without setting the flag, so
@@ -39,7 +44,7 @@ Third-party credits (deps, oracles, design refs): [Acknowledgements](acknowledge
   `member_name_encoding_inferred` diagnostic records it. Passing `encoding=` to
   `open_archive` is authoritative — it is used verbatim and disables the sniff.
 - ZipCrypto multi-password confirmation can be expensive on **STORED** members — see
-  [costs](costs.md).
+  [costs](costs.md). WinZip AES (method 99) decryption is a follow-on capability.
 
 ## TAR (and compressed TAR)
 

--- a/openspec/changes/zip-aes-decryption/design.md
+++ b/openspec/changes/zip-aes-decryption/design.md
@@ -42,12 +42,11 @@ member-bytes slice + codec dispatch this composes onto.
 - **Strength coverage.** Support 128/192/256; the salt/key lengths derive from the
   strength byte, so all three fall out of one code path.
 
-## Open questions (resolve during apply)
+## Open questions (resolved during apply)
 
-- Whether to verify pw_verify *and* still run to the HMAC, or trust pw_verify for the
-  fast path — decision: always finalize HMAC (pw_verify is only a cheap early-out).
-- Oracle for fixtures: `7z`/`py7zr` can produce AES ZIPs; confirm they emit AE-2 (most do)
-  and whether an AE-1 fixture needs a specific tool/flag. Skip-when-absent like other
-  oracle paths.
-- Interaction with the multi-candidate password model (`archive-reading`): AE pw_verify is
-  the per-candidate weak check; confirm the candidate-sequence flow reuses it cleanly.
+- Always finalize HMAC (pw_verify is only a cheap early-out) — confirmed.
+- Fixtures: `7z a -tzip -mem=AES256` emits AE-2; AE-1 covered by a hand-built
+  fixture helper in `tests/test_zip_aes.py` (skip-when-absent for the 7z path).
+- Multi-candidate password flow: AE pw_verify is the per-candidate weak check via
+  the existing `_PasswordCandidates.attempt` path; confirmed by
+  `test_aes_multi_password_selects_winner`.

--- a/openspec/changes/zip-aes-decryption/tasks.md
+++ b/openspec/changes/zip-aes-decryption/tasks.md
@@ -1,28 +1,28 @@
 ## 1. AE detection + key derivation
 
-- [ ] 1.1 Parse the `0x9901` AES extra field (vendor version AE-1/AE-2, strength, actual method); recognize method 99
-- [ ] 1.2 PBKDF2-HMAC-SHA1 (1000 iters) → enc key ‖ auth key ‖ 2-byte verify; salt length by strength (8/12/16)
-- [ ] 1.3 Fast-fail wrong password on the verification value (`EncryptionError`, no bytes)
+- [x] 1.1 Parse the `0x9901` AES extra field (vendor version AE-1/AE-2, strength, actual method); recognize method 99
+- [x] 1.2 PBKDF2-HMAC-SHA1 (1000 iters) → enc key ‖ auth key ‖ 2-byte verify; salt length by strength (8/12/16)
+- [x] 1.3 Fast-fail wrong password on the verification value (`EncryptionError`, no bytes)
 
 ## 2. Decrypt + compose
 
-- [ ] 2.1 AES-CTR decrypt stage over the raw ciphertext slice (from the `zip-native-codec-streams` path), via `[crypto]`
-- [ ] 2.2 HMAC-SHA1(10) authentication of the ciphertext, finalized at EOF → `CorruptionError` on mismatch
-- [ ] 2.3 Feed decrypted bytes to the codec layer for the actual method (STORED/DEFLATE/…)
-- [ ] 2.4 `[crypto]` absent → `PackageNotInstalledError` (detection still reports encrypted)
+- [x] 2.1 AES-CTR decrypt stage over the raw ciphertext slice (from the `zip-native-codec-streams` path), via `[crypto]`
+- [x] 2.2 HMAC-SHA1(10) authentication of the ciphertext, finalized at EOF → `CorruptionError` on mismatch
+- [x] 2.3 Feed decrypted bytes to the codec layer for the actual method (STORED/DEFLATE/…)
+- [x] 2.4 `[crypto]` absent → `PackageNotInstalledError` (detection still reports encrypted)
 
 ## 3. Hash/CRC semantics
 
-- [ ] 3.1 AE-2: surface no `crc32`, run no CRC check (HMAC is integrity); update the stored-digest parity sweep to expect absence
-- [ ] 3.2 AE-1: surface and verify `crc32` alongside the HMAC
+- [x] 3.1 AE-2: surface no `crc32`, run no CRC check (HMAC is integrity); update the stored-digest parity sweep to expect absence
+- [x] 3.2 AE-1: surface and verify `crc32` alongside the HMAC
 
 ## 4. Fixtures + tests
 
-- [ ] 4.1 AES ZIP fixtures (AE-1/AE-2 × 128/256 × STORED/DEFLATE) generated on demand via `7z`/`py7zr`; skip when absent
-- [ ] 4.2 Wrong-password, tampered-HMAC, AE-2 absent-`crc32`, missing-`[crypto]` cases
-- [ ] 4.3 Confirm the multi-candidate password flow reuses the AE verify value cleanly
+- [x] 4.1 AES ZIP fixtures (AE-1/AE-2 × 128/256 × STORED/DEFLATE) generated on demand via `7z`/`py7zr`; skip when absent
+- [x] 4.2 Wrong-password, tampered-HMAC, AE-2 absent-`crc32`, missing-`[crypto]` cases
+- [x] 4.3 Confirm the multi-candidate password flow reuses the AE verify value cleanly
 
 ## 5. Verify
 
-- [ ] 5.1 Run across `[all]`, `[all-lowest]`, `core-only` (AES path gated on `[crypto]`; core-only asserts the `PackageNotInstalledError` behavior)
-- [ ] 5.2 `openspec validate --strict zip-aes-decryption`
+- [x] 5.1 Run across `[all]`, `[all-lowest]`, `core-only` (AES path gated on `[crypto]`; core-only asserts the `PackageNotInstalledError` behavior)
+- [x] 5.2 `openspec validate --strict zip-aes-decryption`

--- a/openspec/changes/zip-native-codec-streams/design.md
+++ b/openspec/changes/zip-native-codec-streams/design.md
@@ -53,15 +53,16 @@ always seek — no forward-only complication.
   reads from the shared source through the existing handle-lock/`SharedSource` discipline;
   reuse it so independent members still decode in parallel and free-threading stays correct.
 
-## Open questions (resolve during apply)
+## Open questions (resolved during apply)
 
-- **Deflate64 backend gating:** `inflate64` currently lives in the `[7z]` extra. Decide
-  whether ZIP Deflate64 reuses `[7z]` as-is (documented) or `inflate64` gets promoted into
-  a shared/`[recommended]` grouping so "ZIP compat" doesn't read as "install the 7z extra."
-- **Zstd/PPMd ZIP method framing:** confirm ZIP's method-93 zstd and method-98 PPMd wire
-  formats match what the existing `ZSTD`/`PPMD` backends expect (ZIP PPMd carries its own
-  2-byte parameter header — verify against a real fixture/oracle before enabling).
-- **Fixtures:** generating Deflate64/Zstd/PPMd ZIPs needs a producer (7-Zip/WinZip);
-  decide oracle + on-demand generation, skip-when-absent like the other oracle paths.
-- Whether STORED encrypted members (ZipCrypto over STORED — the existing hand-rolled
-  password path) also stay on the current path (yes, per the encryption decision).
+- **Deflate64 backend gating:** resolved — reuse `[7z]` (`inflate64`) as-is. Documented in
+  `docs/formats.md` so ZIP Deflate64/PPMd share the same extra as 7z's optional codecs.
+  No packaging promotion for v1.
+- **Zstd/PPMd ZIP method framing:** confirmed against real producers — ZIP method 93 is a
+  raw zstd frame (matches `Codec.ZSTD`); ZIP method 98 is PPMd8 with a 2-byte WinZip
+  header `(order-1) | ((memMB-1)<<4) | (restore<<12)`, decoded via `pyppmd.Ppmd8Decoder`
+  (distinct from 7z's PPMd7 var.H properties blob).
+- **Fixtures:** Deflate64/PPMd via `7z a -tzip -mm=…` (skip when absent); Zstd via a
+  hand-built minimal ZIP (7z 23.01 cannot write ZIP Zstd).
+- STORED encrypted members (ZipCrypto over STORED) stay on the `zipfile` path (yes, per
+  the encryption decision).

--- a/openspec/changes/zip-native-codec-streams/tasks.md
+++ b/openspec/changes/zip-native-codec-streams/tasks.md
@@ -1,24 +1,24 @@
 ## 1. Raw member-data path
 
-- [ ] 1.1 Bounded local-file-header parse: from `ZipInfo.header_offset`, read the 30-byte header + local name/extra lengths to compute the data start (reject absurd lengths)
-- [ ] 1.2 `SlicingStream(source, data_start, compress_size)` yields the raw compressed member stream, under the existing handle-lock / SharedSource discipline
-- [ ] 1.3 Dispatch by method id via the existing `StreamCodec` map; STORED = passthrough slice
+- [x] 1.1 Bounded local-file-header parse: from `ZipInfo.header_offset`, read the 30-byte header + local name/extra lengths to compute the data start (reject absurd lengths)
+- [x] 1.2 `SlicingStream(source, data_start, compress_size)` yields the raw compressed member stream, under the existing handle-lock / SharedSource discipline
+- [x] 1.3 Dispatch by method id via the existing `StreamCodec` map; STORED = passthrough slice
 
 ## 2. Codec + verification wiring
 
-- [ ] 2.1 Route unencrypted members through the codec-layer stream; wrap in `VerifyingStream` with `member.hashes["crc32"]`
-- [ ] 2.2 Missing optional backend → `PackageNotInstalledError`; corrupt body → `CorruptionError` (drop the codec-path `NotImplementedError`/bare-`EOFError` mapping for these)
-- [ ] 2.3 Keep encrypted (ZipCrypto / AE) members on the current `zipfile` decryption path
+- [x] 2.1 Route unencrypted members through the codec-layer stream; wrap in `VerifyingStream` with `member.hashes["crc32"]`
+- [x] 2.2 Missing optional backend → `PackageNotInstalledError`; corrupt body → `CorruptionError` (drop the codec-path `NotImplementedError`/bare-`EOFError` mapping for these)
+- [x] 2.3 Keep encrypted (ZipCrypto / AE) members on the current `zipfile` decryption path
 
 ## 3. Extended codecs + open questions
 
-- [ ] 3.1 Confirm ZIP method-98 PPMd parameter-header framing and method-93 zstd framing against a real producer/oracle before enabling
-- [ ] 3.2 Decide `inflate64` packaging for ZIP Deflate64 (reuse `[7z]` vs shared/`[recommended]`); document it
-- [ ] 3.3 Deflate64/Zstd/PPMd ZIP fixtures generated on demand (7-Zip/WinZip); skip when producer absent
+- [x] 3.1 Confirm ZIP method-98 PPMd parameter-header framing and method-93 zstd framing against a real producer/oracle before enabling
+- [x] 3.2 Decide `inflate64` packaging for ZIP Deflate64 (reuse `[7z]` vs shared/`[recommended]`); document it
+- [x] 3.3 Deflate64/Zstd/PPMd ZIP fixtures generated on demand (7-Zip/WinZip); skip when producer absent
 
 ## 4. Tests + verify
 
-- [ ] 4.1 Round-trip STORED/DEFLATE/BZIP2/LZMA unchanged; Deflate64/Zstd/PPMd now decode
-- [ ] 4.2 Missing-backend → `PackageNotInstalledError`; corrupt → `CorruptionError`; encrypted behavior unchanged
-- [ ] 4.3 Free-threaded parallel member reads still correct (CONCURRENT + `3.13t`)
-- [ ] 4.4 Run across `[all]`, `[all-lowest]`, `core-only`; `openspec validate --strict zip-native-codec-streams`
+- [x] 4.1 Round-trip STORED/DEFLATE/BZIP2/LZMA unchanged; Deflate64/Zstd/PPMd now decode
+- [x] 4.2 Missing-backend → `PackageNotInstalledError`; corrupt → `CorruptionError`; encrypted behavior unchanged
+- [x] 4.3 Free-threaded parallel member reads still correct (CONCURRENT + `3.13t`)
+- [x] 4.4 Run across `[all]`, `[all-lowest]`, `core-only`; `openspec validate --strict zip-native-codec-streams`

--- a/openspec/specs/format-zip/spec.md
+++ b/openspec/specs/format-zip/spec.md
@@ -67,10 +67,11 @@ to the codec's default backend. Central-directory parsing and listing MAY
 continue to use stdlib `zipfile`.
 
 Member reads SHALL verify `member.hashes["crc32"]` through the shared
-`VerifyingStream`. A corrupt member body SHALL raise `CorruptionError` (or
-`TruncatedError` when the payload is cut short) via the shared translation.
-Encrypted members (ZipCrypto / WinZip AE) SHALL retain their decryption path
-until a native AE composition change lands.
+`VerifyingStream` when a CRC is surfaced. A corrupt member body SHALL raise
+`CorruptionError` (or `TruncatedError` when the payload is cut short) via the
+shared translation. Traditional ZipCrypto members keep the stdlib `zipfile`
+decryption path; WinZip AES (method 99) SHALL decrypt natively (see below) and
+then feed the codec layer.
 
 #### Scenario: ZIP codec-layer decoding
 
@@ -81,7 +82,40 @@ until a native AE composition change lands.
 | ZSTD (method 93) / PPMD (method 98) member, backend present | Decodes; absent backend → `PackageNotInstalledError` |
 | Unsupported/unknown method id | `UnsupportedFeatureError`; no guessed output |
 | Corrupt member body | `CorruptionError` / `TruncatedError` |
-| Encrypted (ZipCrypto / AE) member | Decrypts via the existing path; behavior unchanged |
+| Encrypted ZipCrypto member | Decrypts via the existing `zipfile` path; behavior unchanged |
+
+### Requirement: Read WinZip AES-encrypted members
+
+The ZIP backend SHALL read WinZip AES (AE-x) encrypted members: compression
+method 99 with the AES extra field `0x9901` giving vendor version (AE-1/AE-2),
+key strength (128/192/256), and the actual underlying compression method.
+Decryption SHALL derive keys via PBKDF2-HMAC-SHA1 (1000 iterations) over the
+password and per-member salt (strength/16 bytes) into encryption key ‖
+authentication key ‖ 2-byte verification value, decrypt with AES-CTR
+(little-endian counter), and authenticate the ciphertext with HMAC-SHA1
+truncated to 10 bytes. Decrypted bytes SHALL be decompressed through the shared
+codec layer for the actual method.
+
+A wrong password SHALL fail fast on the 2-byte verification value with
+`EncryptionError` (no bytes returned). A ciphertext HMAC mismatch SHALL raise
+at the terminal read (`CorruptionError`). AE-2 members SHALL surface no
+`crc32` (the ZIP CRC is 0; integrity is the HMAC) and run no CRC check; AE-1
+members SHALL surface and verify `crc32` in addition to the HMAC. AES
+decryption requires `[crypto]`; when it is absent an AE member SHALL raise
+`PackageNotInstalledError` (detection still identifies the member as
+AES-encrypted). Traditional ZipCrypto behavior is unchanged.
+
+#### Scenario: WinZip AES matrix
+
+| Case | Expected |
+| --- | --- |
+| AE-1 or AE-2 member, 128/192/256, correct password, `[crypto]` present | Decrypts, decompresses via codec layer, HMAC verified at EOF |
+| Wrong password | `EncryptionError` on the 2-byte verification value; no bytes |
+| Tampered ciphertext, correct password | HMAC mismatch → `CorruptionError` at terminal read |
+| AE-2 member | `crc32` absent; no CRC check; HMAC is the integrity signal |
+| AE-1 member | `crc32` present and verified alongside the HMAC |
+| AES member without `[crypto]` installed | `PackageNotInstalledError`; still reported as encrypted |
+| Traditional ZipCrypto member | Unchanged (existing weak-check confirmation path) |
 
 ### Requirement: Reject non-seekable ZIP read sources
 

--- a/openspec/specs/format-zip/spec.md
+++ b/openspec/specs/format-zip/spec.md
@@ -3,9 +3,9 @@
 ## Purpose
 
 ZIP archives are read through the unified `ArchiveReader` API using stdlib
-`zipfile` for the central directory and current member data path. ZIP listing is
-indexed, member access is direct, read sources must be seekable, and streaming
-write uses data descriptors.
+`zipfile` for the central directory and archivey's shared codec layer for
+member data. ZIP listing is indexed, member access is direct, read sources must
+be seekable, and streaming write uses data descriptors.
 
 ## Related specs
 
@@ -14,8 +14,8 @@ write uses data descriptors.
 | `archive-reading` | Reader API, password candidates, weak-check confirmation, bounded storage |
 | `access-mode-and-cost` | Random-access vs streaming rules; non-seekable random-access failure |
 | `diagnostics` | Timestamp and symlink-target diagnostic values / policy |
-| `backend-registry` | `format_availability(ZIP)` partial-read status |
-| `compressed-streams` | Future ZIP member-data codec path |
+| `backend-registry` | `format_availability(ZIP)` FULL/PARTIAL from optional member codecs |
+| `compressed-streams` | ZIP member-data decode path (method id → `StreamCodec`) |
 
 ## Requirements
 
@@ -25,7 +25,7 @@ The ZIP backend SHALL expose these properties for every opened ZIP archive:
 
 | Property | Value |
 | --- | --- |
-| Backend dependency | `zipfile` (stdlib) |
+| Backend dependency | `zipfile` (stdlib) for central-directory parsing; shared codec layer for member data |
 | Listing cost | `ListingCost.INDEXED` — central directory read at open |
 | Access cost | `AccessCost.DIRECT` — independent local file offsets |
 | Stream capability | `StreamCapability.SEEKABLE` |
@@ -33,16 +33,16 @@ The ZIP backend SHALL expose these properties for every opened ZIP archive:
 | Write support | Yes, including streaming write |
 
 `reader.get()` and other name lookups SHALL use the central-directory-derived
-member map without extra archive I/O. ZIP member data still goes through stdlib
-`zipfile`; unsupported methods such as Deflate64/PPMd and zstd before Python
-3.14 SHALL raise `UnsupportedFeatureError`. Until ZIP member reads use the
-shared codec layer, `format_availability(ZIP)` SHALL report **PARTIAL**
-regardless of optional codec installation. Installing `[7z]` / `[zstd]` alone
-does not unlock those member reads.
-
-The future raw-slice member-data path SHALL keep `zipfile` for the central
-directory, compute each member's compressed byte range from local headers, and
-decode via `compressed-streams`; `zipfile` has no decompressor plug-in point.
+member map without extra archive I/O. Unencrypted ZIP member data SHALL decode
+through the shared `compressed-streams` codec layer (bounded local-header parse
++ slice + method-id dispatch), including extended codecs when their backends are
+installed: Deflate64 (method 9, via `[7z]`/`inflate64`), ZSTD (method 93), PPMD
+(method 98, ZIP PPMd8 framing via `[7z]`/`pyppmd`). A missing optional backend
+SHALL raise `PackageNotInstalledError`. An unknown/unsupported method id SHALL
+raise `UnsupportedFeatureError`. `format_availability(ZIP)` SHALL report FULL
+when every optional ZIP member codec is installed, else PARTIAL with the missing
+components listed. Encrypted members (ZipCrypto / WinZip AE) MAY retain a
+separate decryption path.
 
 #### Scenario: ZIP property matrix
 
@@ -50,8 +50,38 @@ decode via `compressed-streams`; `zipfile` has no decompressor plug-in point.
 | --- | --- |
 | Open valid ZIP | `cost.listing_cost=INDEXED`, `cost.access_cost=DIRECT`, `cost.stream_capability=SEEKABLE` |
 | `reader.get("some/member.txt")` | Satisfied from the in-memory central-directory name map; no additional archive I/O |
-| Member uses unsupported stdlib method | Listing succeeds; reading raises `UnsupportedFeatureError`; availability remains `PARTIAL` |
+| Member uses unknown method id | Listing succeeds; reading raises `UnsupportedFeatureError` |
+| Deflate64/Zstd/PPMd member, backend present | Decodes via the shared codec layer |
+| Deflate64/Zstd/PPMd member, backend absent | `PackageNotInstalledError` |
+| Optional ZIP codecs all installed | `format_availability(ZIP)` is FULL |
 | Streaming write without pre-known size | Local header uses data-descriptor placeholders; data descriptor stores final CRC and sizes; standard ZIP tools can read the result |
+
+### Requirement: Decode ZIP member bodies through the shared codec layer
+
+The ZIP backend SHALL decode unencrypted member data through the shared
+`compressed-streams` codec layer rather than stdlib `zipfile`'s internal
+decoders. It SHALL locate a member's raw compressed bytes via a bounded
+local-file-header parse (fixed header + local name/extra lengths, with absurd-
+length rejection) and a slice over the source, then dispatch by ZIP method id
+to the codec's default backend. Central-directory parsing and listing MAY
+continue to use stdlib `zipfile`.
+
+Member reads SHALL verify `member.hashes["crc32"]` through the shared
+`VerifyingStream`. A corrupt member body SHALL raise `CorruptionError` (or
+`TruncatedError` when the payload is cut short) via the shared translation.
+Encrypted members (ZipCrypto / WinZip AE) SHALL retain their decryption path
+until a native AE composition change lands.
+
+#### Scenario: ZIP codec-layer decoding
+
+| Case | Expected |
+| --- | --- |
+| STORED / DEFLATE / BZIP2 / LZMA member, unencrypted | Decodes via the shared codec layer; CRC verified through `VerifyingStream` |
+| DEFLATE64 (method 9) member, `inflate64` backend present | Decodes; absent backend → `PackageNotInstalledError` |
+| ZSTD (method 93) / PPMD (method 98) member, backend present | Decodes; absent backend → `PackageNotInstalledError` |
+| Unsupported/unknown method id | `UnsupportedFeatureError`; no guessed output |
+| Corrupt member body | `CorruptionError` / `TruncatedError` |
+| Encrypted (ZipCrypto / AE) member | Decrypts via the existing path; behavior unchanged |
 
 ### Requirement: Reject non-seekable ZIP read sources
 

--- a/src/archivey/internal/backends/zip_reader.py
+++ b/src/archivey/internal/backends/zip_reader.py
@@ -75,6 +75,10 @@ from archivey.internal.streams.streamtools import (
 )
 from archivey.internal.streams.verify import VerifyingStream
 from archivey.internal.timestamps import TimestampIssue, filetime_to_datetime
+from archivey.internal.zip_aes import (
+    open_winzip_aes_member,
+    parse_winzip_aes_extra,
+)
 from archivey.internal.zipcrypto import (
     parallel_plaintext_crc32,
     password_matches_check_byte,
@@ -576,18 +580,30 @@ class ZipReader(BaseArchiveReader):
         algo = _ZIP_COMPRESSION_ALGOS.get(
             info.compress_type, CompressionAlgorithm.UNKNOWN
         )
+        aes_info = (
+            parse_winzip_aes_extra(info.extra) if info.compress_type == 99 else None
+        )
+        if aes_info is not None:
+            # Method 99 is a wrapper; surface the underlying compression algorithm.
+            algo = _ZIP_COMPRESSION_ALGOS.get(
+                aes_info.actual_method, CompressionAlgorithm.UNKNOWN
+            )
 
         modified, accessed, created, ts_issues = _zip_timestamps(info)
         # Surface the central-directory CRC-32 as a stored digest (archive-data-model spec:
         # "ZIP CRC32 … stored under the 'crc32' int key"), so a dedupe pass can key on it
         # without decompressing (VISION "hashes without decompression"). Only for FILE and
         # SYMLINK members, which have data: a directory's stored CRC is a meaningless 0.
-        # zipfile still runs its own CRC check on read; this only exposes the datum.
-        hashes: dict[str, int] = (
-            {"crc32": info.CRC & 0xFFFFFFFF}
-            if member_type in (MemberType.FILE, MemberType.SYMLINK)
-            else {}
-        )
+        # AE-2 stores CRC as 0 and relies on the HMAC — do not surface a fake crc32.
+        hashes: dict[str, int] = {}
+        if member_type in (MemberType.FILE, MemberType.SYMLINK):
+            if aes_info is None or not aes_info.is_ae2:
+                hashes = {"crc32": info.CRC & 0xFFFFFFFF}
+        extra: dict[str, object] = {"zip.compress_type": info.compress_type}
+        if aes_info is not None:
+            extra["zip.aes_vendor_version"] = aes_info.vendor_version
+            extra["zip.aes_strength"] = aes_info.strength
+            extra["zip.aes_actual_method"] = aes_info.actual_method
         member = ArchiveMember(
             type=member_type,
             name=name,
@@ -603,7 +619,7 @@ class ZipReader(BaseArchiveReader):
             comment=_decode_with_fallback(info.comment) if info.comment else None,
             create_system=create_system,
             hashes=hashes,
-            extra={"zip.compress_type": info.compress_type},
+            extra=extra,
             _raw=info,  # carry the ZipInfo so _open_member needs no name/id lookup table
         )
         if inferred_encoding is not None:
@@ -727,6 +743,77 @@ class ZipReader(BaseArchiveReader):
             finally:
                 fp.seek(saved)
 
+    def _open_aes_member(
+        self,
+        info: zipfile.ZipInfo,
+        member: ArchiveMember | None,
+        *,
+        member_name: str,
+    ) -> ArchiveStream:
+        """Decrypt a WinZip AE (method 99) member and decode via the codec layer."""
+        aes = parse_winzip_aes_extra(info.extra)
+        if aes is None:
+            raise UnsupportedFeatureError(
+                "ZIP compression method 99 without a valid WinZip AES (0x9901) extra field",
+                archive_name=self._archive_name,
+                member_name=member_name,
+                source_format=ArchiveFormat.ZIP,
+            )
+        codec = _ZIP_METHOD_CODECS.get(aes.actual_method)
+        if codec is None:
+            raise UnsupportedFeatureError(
+                f"Unsupported ZIP compression method {aes.actual_method} under WinZip AES",
+                archive_name=self._archive_name,
+                member_name=member_name,
+                source_format=ArchiveFormat.ZIP,
+            )
+
+        def decrypt(password: bytes) -> BinaryIO:
+            raw = self._raw_member_stream(info)
+            decrypted = open_winzip_aes_member(
+                raw,
+                aes=aes,
+                password=password,
+                compress_size=info.compress_size,
+            )
+            params = CodecParams()
+            body: BinaryIO = decrypted
+            if aes.actual_method == 14:
+                params = self._zip_lzma_params(body)
+            elif aes.actual_method == 98:
+                params = self._zip_ppmd_params(body)
+            return open_codec_stream(
+                codec,
+                body,
+                config=self._stream_config,
+                params=params,
+                seekable=False,
+                collector=self._diagnostics_collector,
+            )
+
+        try:
+            decoded: BinaryIO = self._finish_password_attempt(
+                member, member_name, decrypt, ambiguous_holder=None
+            )
+        except PackageNotInstalledError:
+            raise
+        except _ZIP_MEMBER_READ_ERRORS as exc:
+            self._reraise_member_error(exc, member_name)
+
+        hashes = member.hashes if member is not None else {}
+        if hashes:
+            decoded = VerifyingStream(
+                decoded,
+                hashes,
+                collector=self._diagnostics_collector,
+                member=member,
+                archive_name=self._archive_name,
+            )
+        size = member.size if member is not None else info.file_size
+        return self._wrap_member_stream(
+            decoded, member_name, size=size, track_output=False
+        )
+
     def _open_zip_entry(
         self,
         info: zipfile.ZipInfo,
@@ -734,6 +821,9 @@ class ZipReader(BaseArchiveReader):
         *,
         member_name: str,
     ) -> BinaryIO:
+        if info.compress_type == 99:
+            return self._open_aes_member(info, member, member_name=member_name)
+
         encrypted = bool(info.flag_bits & 0x1)
         if not encrypted:
             # Unencrypted members decode through the shared codec layer (not ZipExtFile).
@@ -768,7 +858,10 @@ class ZipReader(BaseArchiveReader):
                 if len(fheader) != 30 or fheader[:4] != b"PK\x03\x04":
                     raise zipfile.BadZipFile("Bad magic number for file header")
                 name_len, extra_len = struct.unpack_from("<HH", fheader, 26)
-                if name_len > _MAX_LOCAL_NAME_EXTRA or extra_len > _MAX_LOCAL_NAME_EXTRA:
+                if (
+                    name_len > _MAX_LOCAL_NAME_EXTRA
+                    or extra_len > _MAX_LOCAL_NAME_EXTRA
+                ):
                     raise zipfile.BadZipFile(
                         f"Absurd local-header name/extra lengths: {name_len}/{extra_len}"
                     )
@@ -1168,7 +1261,7 @@ class ZipReader(BaseArchiveReader):
         # unset (following the link later fails with LinkTargetNotFoundError); other
         # errors surface translated like any member-read error.
         try:
-            with self._open_zip_entry(info, member, member_name=member.name) as f:
+            with self._open_member(member) as f:
                 member.link_target = f.read().decode("utf-8", errors="surrogateescape")
         except EncryptionError:
             message = (
@@ -1202,9 +1295,10 @@ class ZipReader(BaseArchiveReader):
         assert isinstance(info, zipfile.ZipInfo), (
             "ZIP member is missing its ZipInfo handle"
         )
+        if info.compress_type == 99:
+            return self._open_aes_member(info, member, member_name=member.name)
         if bool(info.flag_bits & 0x1):
-            # Encrypted members stay on the stdlib zipfile decryption path for now
-            # (native ZipCrypto/AE composition is a follow-up change).
+            # Traditional ZipCrypto stays on the stdlib zipfile decryption path.
             raw = self._open_zip_entry(info, member, member_name=member.name)
             return self._wrap_member_stream(raw, member.name, size=member.size)
         # Unencrypted: codec layer already wrapped (+ VerifyingStream) in _open_codec_member.

--- a/src/archivey/internal/backends/zip_reader.py
+++ b/src/archivey/internal/backends/zip_reader.py
@@ -40,11 +40,13 @@ from archivey.exceptions import (
     ArchiveyError,
     CorruptionError,
     EncryptionError,
+    PackageNotInstalledError,
     StreamNotSeekableError,
     TruncatedError,
     UnsupportedFeatureError,
 )
 from archivey.internal.base_reader import BaseArchiveReader, ReadBackend
+from archivey.internal.config import stream_config_from_archivey
 from archivey.internal.diagnostics_collector import DiagnosticCollector
 from archivey.internal.logs import backends as logger
 from archivey.internal.naming import emit_member_name_normalized, normalize_member_name
@@ -59,6 +61,11 @@ from archivey.internal.password_confirm import (
 )
 from archivey.internal.registry import register_reader
 from archivey.internal.streams.archive_stream import ArchiveStream
+from archivey.internal.streams.codecs import (
+    Codec,
+    CodecParams,
+    open_codec_stream,
+)
 from archivey.internal.streams.streamtools import (
     CloseLockedStream,
     SlicingStream,
@@ -66,6 +73,7 @@ from archivey.internal.streams.streamtools import (
     is_stream,
     read_exact,
 )
+from archivey.internal.streams.verify import VerifyingStream
 from archivey.internal.timestamps import TimestampIssue, filetime_to_datetime
 from archivey.internal.zipcrypto import (
     parallel_plaintext_crc32,
@@ -109,6 +117,33 @@ _ZIP_COMPRESSION_ALGOS: dict[int, CompressionAlgorithm] = {
     93: CompressionAlgorithm.ZSTD,
     98: CompressionAlgorithm.PPMD,
 }
+
+# ZIP method id -> shared codec-layer Codec for unencrypted member decode.
+_ZIP_METHOD_CODECS: dict[int, Codec] = {
+    0: Codec.STORED,
+    8: Codec.DEFLATE,
+    9: Codec.DEFLATE64,
+    12: Codec.BZIP2,
+    14: Codec.LZMA,  # after peeling the ZIP LZMA header (see _open_codec_member)
+    93: Codec.ZSTD,
+    98: Codec.PPMD,  # after peeling the ZIP PPMd8 header
+}
+
+# Local-file-header name/extra lengths are uint16; reject values that would push the
+# data region past a sane absolute offset (same absurd-length discipline as native parsers).
+_MAX_LOCAL_NAME_EXTRA = 65_535
+_MAX_DATA_OFFSET = 1 << 40
+
+# stdlib exposes no public decoder for a raw LZMA1 property blob → filter dict; zipfile and
+# the 7z reader rely on the same private helper.
+_raw_decode_filter_properties = getattr(lzma, "_decode_filter_properties", None)
+if _raw_decode_filter_properties is None:  # pragma: no cover
+    raise ImportError(
+        "This Python's `lzma` module no longer exposes `_decode_filter_properties`, which "
+        "archivey needs to decode ZIP LZMA (method 14) member properties. "
+        "Please report this to archivey (with your Python version)."
+    )
+_decode_filter_properties: Callable[[int, bytes], dict] = _raw_decode_filter_properties
 
 # ZIP create-system values whose entries use "\" as a path separator (DOS/Windows family).
 # For these, a stored backslash is a separator; for Unix/other entries it is a literal
@@ -329,10 +364,16 @@ class ZipReader(BaseArchiveReader):
         self._source = source
         self._passwords = passwords or _PasswordCandidates()
         self._encoding = encoding
+        self._stream_config = stream_config_from_archivey(
+            self._config,
+            streaming=streaming,
+            seekable=MemberStreams.SEEKABLE in member_streams,
+        )
         # Free-threaded ZIP: stdlib zipfile races on _fileRefCnt across concurrent
         # ZipFile.open / ZipExtFile.close / ZipFile.close. Serialize those under
         # CONCURRENT; leave reads to zipfile's own _SharedFile lock so independent
-        # members can still decompress in parallel.
+        # members can still decompress in parallel. The unencrypted codec path uses
+        # the same ZipFile._lock via locked SlicingStream views.
         self._handle_lock: threading.Lock | None = (
             threading.Lock() if MemberStreams.CONCURRENT in member_streams else None
         )
@@ -695,9 +736,8 @@ class ZipReader(BaseArchiveReader):
     ) -> BinaryIO:
         encrypted = bool(info.flag_bits & 0x1)
         if not encrypted:
-            return self._open_zipfile_member(
-                info, password=None, member_name=member_name
-            )
+            # Unencrypted members decode through the shared codec layer (not ZipExtFile).
+            return self._open_codec_member(info, member, member_name=member_name)
 
         # ZipCrypto's one-byte open check admits ~1/256 of wrong passwords. With more
         # than one possible candidate (or a provider), confirm before accepting.
@@ -708,6 +748,185 @@ class ZipReader(BaseArchiveReader):
         if info.compress_type == zipfile.ZIP_STORED:
             return self._open_stored_confirmed(info, member, member_name=member_name)
         return self._open_compressed_confirmed(info, member, member_name=member_name)
+
+    def _local_data_region(self, info: zipfile.ZipInfo) -> tuple[int, int]:
+        """Return ``(data_start, compress_size)`` for ``info`` from its local file header.
+
+        Parses only the fixed 30-byte local header plus the local name/extra lengths
+        (central-directory extra can differ). Rejects truncated/bad magic headers and
+        absurd name/extra lengths that would push the data offset past a sane bound.
+        """
+        zf = self._archive
+        with self._zipfile_lock():
+            fp = zf.fp
+            if fp is None:
+                raise ValueError("Attempt to use ZIP archive that was already closed")
+            saved = fp.tell()
+            try:
+                fp.seek(info.header_offset)
+                fheader = fp.read(30)
+                if len(fheader) != 30 or fheader[:4] != b"PK\x03\x04":
+                    raise zipfile.BadZipFile("Bad magic number for file header")
+                name_len, extra_len = struct.unpack_from("<HH", fheader, 26)
+                if name_len > _MAX_LOCAL_NAME_EXTRA or extra_len > _MAX_LOCAL_NAME_EXTRA:
+                    raise zipfile.BadZipFile(
+                        f"Absurd local-header name/extra lengths: {name_len}/{extra_len}"
+                    )
+                # General-purpose flag bit 11: UTF-8 filename (APPNOTE).
+                gp_flags = struct.unpack_from("<H", fheader, 6)[0]
+                local_name = fp.read(name_len)
+                if len(local_name) != name_len:
+                    raise zipfile.BadZipFile("Truncated file header")
+                if gp_flags & 0x800:
+                    fname_str = local_name.decode("utf-8")
+                else:
+                    fname_str = local_name.decode(self._encoding or "cp437")
+                if fname_str != info.orig_filename:
+                    raise zipfile.BadZipFile(
+                        "File name in directory %r and header %r differ."
+                        % (info.orig_filename, local_name)
+                    )
+                data_start = info.header_offset + 30 + name_len + extra_len
+                if data_start < 0 or data_start > _MAX_DATA_OFFSET:
+                    raise zipfile.BadZipFile(
+                        f"Absurd local-header data offset: {data_start}"
+                    )
+                # Mirror stdlib zipfile's overlap guard (ZipFile.open): a member whose
+                # compressed payload extends past the next entry's start is a zip bomb.
+                end_offset = getattr(info, "_end_offset", None)
+                if (
+                    end_offset is not None
+                    and data_start + max(0, info.compress_size) > end_offset
+                ):
+                    raise zipfile.BadZipFile(
+                        f"Overlapped entries: {info.orig_filename!r} (possible zip bomb)"
+                    )
+                return data_start, max(0, info.compress_size)
+            finally:
+                fp.seek(saved)
+
+    def _raw_member_stream(self, info: zipfile.ZipInfo) -> BinaryIO:
+        """Locked :class:`SlicingStream` over the member's raw compressed payload."""
+        data_start, length = self._local_data_region(info)
+        fp = self._archive.fp
+        if fp is None:
+            raise ValueError("Attempt to use ZIP archive that was already closed")
+
+        def _check_open() -> None:
+            if self._archive.fp is None:
+                raise ValueError("Attempt to use ZIP archive that was already closed")
+
+        return SlicingStream(
+            cast("BinaryIO", fp),
+            start=data_start,
+            length=length,
+            lock=self._zipfile_lock(),
+            check_open=_check_open,
+        )
+
+    def _zip_lzma_params(self, raw: BinaryIO) -> CodecParams:
+        """Peel the ZIP method-14 LZMA header and return RAW LZMA1 :class:`CodecParams`."""
+        # version (2) + properties size (2) + properties
+        header = read_exact(raw, 4)
+        if len(header) != 4:
+            raise TruncatedError(
+                "Truncated ZIP LZMA header",
+                archive_name=self._archive_name,
+                source_format=ArchiveFormat.ZIP,
+            )
+        props_size = struct.unpack_from("<H", header, 2)[0]
+        if props_size > 256:
+            raise CorruptionError(
+                f"Absurd ZIP LZMA properties size: {props_size}",
+                archive_name=self._archive_name,
+                source_format=ArchiveFormat.ZIP,
+            )
+        props = read_exact(raw, props_size)
+        if len(props) != props_size:
+            raise TruncatedError(
+                "Truncated ZIP LZMA properties",
+                archive_name=self._archive_name,
+                source_format=ArchiveFormat.ZIP,
+            )
+        filters = [_decode_filter_properties(lzma.FILTER_LZMA1, props)]
+        return CodecParams(filters=filters)
+
+    def _zip_ppmd_params(self, raw: BinaryIO) -> CodecParams:
+        """Peel the ZIP method-98 2-byte PPMd8 header into :class:`CodecParams`."""
+        header = read_exact(raw, 2)
+        if len(header) != 2:
+            raise TruncatedError(
+                "Truncated ZIP PPMd header",
+                archive_name=self._archive_name,
+                source_format=ArchiveFormat.ZIP,
+            )
+        word = struct.unpack("<H", header)[0]
+        order = (word & 0xF) + 1
+        mem_mb = ((word >> 4) & 0xFF) + 1
+        restore = (word >> 12) & 0xF
+        if order < 2 or order > 64 or mem_mb < 1:
+            raise CorruptionError(
+                f"Invalid ZIP PPMd header parameters: order={order} mem_mb={mem_mb}",
+                archive_name=self._archive_name,
+                source_format=ArchiveFormat.ZIP,
+            )
+        return CodecParams(
+            ppmd_order=order,
+            ppmd_mem_size=mem_mb * 1024 * 1024,
+            ppmd_restore_method=restore,
+        )
+
+    def _open_codec_member(
+        self,
+        info: zipfile.ZipInfo,
+        member: ArchiveMember | None,
+        *,
+        member_name: str,
+    ) -> ArchiveStream:
+        """Decode an unencrypted ZIP member through the shared codec layer."""
+        codec = _ZIP_METHOD_CODECS.get(info.compress_type)
+        if codec is None:
+            raise UnsupportedFeatureError(
+                f"Unsupported ZIP compression method {info.compress_type}",
+                archive_name=self._archive_name,
+                member_name=member_name,
+                source_format=ArchiveFormat.ZIP,
+            )
+
+        try:
+            raw = self._raw_member_stream(info)
+            params = CodecParams()
+            if info.compress_type == 14:  # ZIP LZMA
+                params = self._zip_lzma_params(raw)
+            elif info.compress_type == 98:  # ZIP PPMd8
+                params = self._zip_ppmd_params(raw)
+
+            decoded: BinaryIO = open_codec_stream(
+                codec,
+                raw,
+                config=self._stream_config,
+                params=params,
+                seekable=False,
+                collector=self._diagnostics_collector,
+            )
+        except PackageNotInstalledError:
+            raise
+        except _ZIP_MEMBER_READ_ERRORS as exc:
+            self._reraise_member_error(exc, member_name)
+
+        hashes = member.hashes if member is not None else None
+        if hashes:
+            decoded = VerifyingStream(
+                decoded,
+                hashes,
+                collector=self._diagnostics_collector,
+                member=member,
+                archive_name=self._archive_name,
+            )
+        size = member.size if member is not None else info.file_size
+        return self._wrap_member_stream(
+            decoded, member_name, size=size, track_output=False
+        )
 
     def _open_zipfile_member(
         self,
@@ -983,8 +1202,13 @@ class ZipReader(BaseArchiveReader):
         assert isinstance(info, zipfile.ZipInfo), (
             "ZIP member is missing its ZipInfo handle"
         )
-        raw = self._open_zip_entry(info, member, member_name=member.name)
-        return self._wrap_member_stream(raw, member.name, size=member.size)
+        if bool(info.flag_bits & 0x1):
+            # Encrypted members stay on the stdlib zipfile decryption path for now
+            # (native ZipCrypto/AE composition is a follow-up change).
+            raw = self._open_zip_entry(info, member, member_name=member.name)
+            return self._wrap_member_stream(raw, member.name, size=member.size)
+        # Unencrypted: codec layer already wrapped (+ VerifyingStream) in _open_codec_member.
+        return self._open_codec_member(info, member, member_name=member.name)
 
     def _get_archive_info(self) -> ArchiveInfo:
         comment = self._archive.comment

--- a/src/archivey/internal/backends/zip_reader.py
+++ b/src/archivey/internal/backends/zip_reader.py
@@ -787,7 +787,7 @@ class ZipReader(BaseArchiveReader):
                 body,
                 config=self._stream_config,
                 params=params,
-                seekable=False,
+                seekable=self._stream_config.seekable,
                 collector=self._diagnostics_collector,
             )
 
@@ -810,9 +810,7 @@ class ZipReader(BaseArchiveReader):
                 archive_name=self._archive_name,
             )
         size = member.size if member is not None else info.file_size
-        return self._wrap_member_stream(
-            decoded, member_name, size=size, track_output=False
-        )
+        return self._wrap_member_stream(decoded, member_name, size=size)
 
     def _open_zip_entry(
         self,
@@ -999,7 +997,7 @@ class ZipReader(BaseArchiveReader):
                 raw,
                 config=self._stream_config,
                 params=params,
-                seekable=False,
+                seekable=self._stream_config.seekable,
                 collector=self._diagnostics_collector,
             )
         except PackageNotInstalledError:
@@ -1017,9 +1015,7 @@ class ZipReader(BaseArchiveReader):
                 archive_name=self._archive_name,
             )
         size = member.size if member is not None else info.file_size
-        return self._wrap_member_stream(
-            decoded, member_name, size=size, track_output=False
-        )
+        return self._wrap_member_stream(decoded, member_name, size=size)
 
     def _open_zipfile_member(
         self,

--- a/src/archivey/internal/registry.py
+++ b/src/archivey/internal/registry.py
@@ -77,12 +77,6 @@ class FormatAvailability:
 # multi-codec container still opens and lists). Single-codec formats (bare RAW_STREAM
 # compressors and compressed tars) are handled separately: their sole stream codec
 # missing makes them NONE, not PARTIAL.
-#
-# NOTE (Phase 3 → 7 gap): ZIP member *decode* currently goes through stdlib zipfile,
-# which cannot decompress deflate64/ppmd (or zstd before Python 3.14) even when these
-# codec packages are installed — such members raise UnsupportedFeatureError at read.
-# This table describes the intended post-Phase-7 composition, where the codec layer is
-# wired into ZIP member reads (see ``format-zip`` / ``compressed-streams``).
 _CONTAINER_OPTIONAL_CODECS: dict[ContainerFormat, tuple[Codec, ...]] = {
     ContainerFormat.SEVEN_Z: (
         Codec.PPMD,
@@ -209,15 +203,6 @@ class BackendRegistry:
                 requirement = codec_requirement(codec)
                 assert requirement is not None  # an optional codec always declares one
                 missing.append(requirement)
-
-        # ZIP exception (until Phase 7): member *data* still decodes via stdlib zipfile,
-        # which cannot use the optional codecs (deflate64/PPMd/zstd) even when installed,
-        # so ZIP never reports FULL — it is PARTIAL regardless of codec installation. The
-        # `missing` list still names absent packages, and is empty when all are present
-        # (the read-time gap is implementation stage, not a missing install). See the
-        # `backend-registry` / `format-zip` Phase 5 deltas.
-        if fmt.container == ContainerFormat.ZIP:
-            return FormatAvailability(fmt, FormatSupport.PARTIAL, tuple(missing))
 
         if not missing:
             return FormatAvailability(fmt, FormatSupport.FULL, ())

--- a/src/archivey/internal/streams/codecs.py
+++ b/src/archivey/internal/streams/codecs.py
@@ -210,10 +210,15 @@ class CodecParams:
     - ``filters`` — the ``lzma`` raw filter chain (required for raw LZMA1/LZMA2; this is
       where Delta/BCJ stages and the coder properties enter).
     - ``properties`` — raw coder properties blob (e.g. 7z PPMd var.H parameters).
+    - ``ppmd_order`` / ``ppmd_mem_size`` / ``ppmd_restore_method`` — ZIP method-98 PPMd8
+      parameters (mutually exclusive with 7z ``properties`` for :class:`PpmdCodec`).
     """
 
     filters: list[dict] | None = None
     properties: bytes | None = None
+    ppmd_order: int | None = None
+    ppmd_mem_size: int | None = None
+    ppmd_restore_method: int = 0
 
 
 _DEFAULT_PARAMS = CodecParams()
@@ -1097,6 +1102,18 @@ class PpmdCodec(StreamCodec):
             raise PackageNotInstalledError(
                 "The 'pyppmd' package is required for PPMd streams (install the '7z' extra)."
             )
+        # ZIP method 98 supplies order/mem/restore directly (PPMd8). 7z supplies a
+        # var.H properties blob (PPMd7).
+        if params.ppmd_order is not None:
+            if params.ppmd_mem_size is None:
+                raise ValueError("ZIP PPMd requires ppmd_order and ppmd_mem_size")
+            return PpmdDecompressorStream(
+                source,
+                order=params.ppmd_order,
+                mem_size=params.ppmd_mem_size,
+                variant=8,
+                restore_method=params.ppmd_restore_method,
+            )
         order, mem_size = _parse_ppmd_var_h_properties(params.properties)
         return PpmdDecompressorStream(source, order=order, mem_size=mem_size)
 
@@ -1106,6 +1123,9 @@ class PpmdCodec(StreamCodec):
         if isinstance(exc, ValueError):
             return CorruptionError(f"Error reading PPMd stream: {exc!r}")
         if _pyppmd is not None and isinstance(exc, getattr(_pyppmd, "PpmdError", ())):
+            return CorruptionError(f"Error reading PPMd stream: {exc!r}")
+        # A corrupt PPMd8 payload can surface as SystemError from the C extension.
+        if isinstance(exc, SystemError):
             return CorruptionError(f"Error reading PPMd stream: {exc!r}")
         return None
 

--- a/src/archivey/internal/streams/decompress.py
+++ b/src/archivey/internal/streams/decompress.py
@@ -72,24 +72,45 @@ class BrotliDecoder(BaseDecoder):
 
 
 class PpmdDecoder(BaseDecoder):
-    """Decode a PPMd var.H stream via ``pyppmd.Ppmd7Decoder``."""
+    """Decode a PPMd stream via ``pyppmd``.
 
-    def __init__(self, *, order: int, mem_size: int) -> None:
+    Variant 7 (``Ppmd7Decoder``) is the 7z var.H coder. Variant 8 (``Ppmd8Decoder``)
+    is ZIP method 98 / WinZip ZIPX PPMd, which also carries a restore-method parameter.
+    """
+
+    def __init__(
+        self,
+        *,
+        order: int,
+        mem_size: int,
+        variant: int = 7,
+        restore_method: int = 0,
+    ) -> None:
         import pyppmd
 
         self._order = order
         self._mem_size = mem_size
-        self._decomp: Any = pyppmd.Ppmd7Decoder(order, mem_size)
+        self._variant = variant
+        self._restore_method = restore_method
+        if variant == 8:
+            self._decomp: Any = pyppmd.Ppmd8Decoder(order, mem_size, restore_method)
+        else:
+            self._decomp = pyppmd.Ppmd7Decoder(order, mem_size)
 
     def recreate(self, point: SeekPoint, inner: BinaryIO) -> PpmdDecoder:
         del point, inner
-        return PpmdDecoder(order=self._order, mem_size=self._mem_size)
+        return PpmdDecoder(
+            order=self._order,
+            mem_size=self._mem_size,
+            variant=self._variant,
+            restore_method=self._restore_method,
+        )
 
     def feed(self, chunk: bytes) -> DecodeOut:
         return DecodeOut(self._decomp.decode(chunk, -1))
 
     def flush(self) -> DecodeOut:
-        # 7z PPMd streams sometimes need a trailing NUL to finish when the decoder
+        # 7z/ZIP PPMd streams sometimes need a trailing NUL to finish when the decoder
         # still reports needs_input at EOF (mirrors py7zr's PpmdDecompressor).
         if getattr(self._decomp, "needs_input", False) and not self._decomp.eof:
             return DecodeOut(self._decomp.decode(b"\0", -1))
@@ -179,11 +200,21 @@ def PpmdDecompressorStream(
     *,
     order: int,
     mem_size: int,
+    variant: int = 7,
+    restore_method: int = 0,
 ) -> DecompressorStream:
-    """Decode a PPMd var.H stream (forward-only)."""
+    """Decode a PPMd stream (forward-only).
+
+    ``variant=7`` is 7z PPMd var.H; ``variant=8`` is ZIP method 98 (PPMd8).
+    """
     return DecompressorStream(
         path,
-        make_decoder=lambda _p, _i: PpmdDecoder(order=order, mem_size=mem_size),
+        make_decoder=lambda _p, _i: PpmdDecoder(
+            order=order,
+            mem_size=mem_size,
+            variant=variant,
+            restore_method=restore_method,
+        ),
         codec_name="ppmd",
     )
 

--- a/src/archivey/internal/streams/streamtools/slice.py
+++ b/src/archivey/internal/streams/streamtools/slice.py
@@ -7,9 +7,11 @@ origin for codec libraries that assume it.
 With an optional ``lock``, the same class is the concurrent-safe view minted by
 :class:`~archivey.internal.streams.streamtools.shared.SharedSource`: every ``read``
 re-seeks the underlying to the view's own absolute position under the lock, so interleaved
-views never clobber each other. Without a lock (the historical default) ``read`` continues
-from wherever the shared handle currently sits — correct for single-consumer use, which is
-how every pre-SharedSource caller uses it.
+views never clobber each other. Construction must not call unlocked ``tell``/``seek`` on
+that shared handle when ``start`` is already known — ``BufferedReader.tell`` is not
+thread-safe. Without a lock (the historical default) ``read`` continues from wherever the
+shared handle currently sits — correct for single-consumer use, which is how every
+pre-SharedSource caller uses it.
 """
 
 from __future__ import annotations
@@ -42,6 +44,10 @@ class SlicingStream(ReadOnlyIOStream):
     Optional ``lock`` (SharedSource mode):
       - Every ``read`` does ``seek(start + _pos); read(n)`` under the lock so the
         seek+read pair is atomic across interleaved views.
+      - Construction does not call ``tell``/``seek`` on the shared handle when
+        ``start`` is given (and takes the lock if ``start`` must be read from
+        ``tell``). Unlocked ``BufferedReader.tell`` under concurrency corrupts the
+        buffer even when every later ``read`` is locked.
       - ``seek`` only updates this view's ``_pos`` (the next ``read`` re-seeks); without
         a lock, ``seek`` also repositions the underlying (single-consumer behaviour).
       - Internally split into ``_io_guard`` (the lock or a shared ``nullcontext``) and
@@ -91,14 +97,23 @@ class SlicingStream(ReadOnlyIOStream):
         self._check_open_fn = check_open
 
         if self._seekable:
-            initial_pos = stream.tell()
-            if start is None:
-                start = initial_pos
-            # Re-seek mode: do not move the shared handle at construction — another view
-            # may be mid-read. The first read re-seeks under the guard. Otherwise keep
-            # the historical eager seek so a single-consumer slice starts at ``start``.
-            if not self._seek_before_read and initial_pos != start:
-                stream.seek(start)
+            # Re-seek mode (locked / SharedSource views): do not touch the shared handle
+            # at construction — not even ``tell()``. ``io.BufferedReader.tell`` is not
+            # thread-safe; concurrent unlocked tells while another view holds the lock
+            # for seek+read corrupt the buffer and yield wrong bytes / CRC mismatches
+            # (ZIP ``MemberStreams.CONCURRENT`` fan-out). Resolve a missing ``start``
+            # under the guard; otherwise leave the handle alone until the first read.
+            if self._seek_before_read:
+                if start is None:
+                    with self._io_guard:
+                        start = stream.tell()
+            else:
+                initial_pos = stream.tell()
+                if start is None:
+                    start = initial_pos
+                # Single-consumer: eager seek so the slice starts at ``start``.
+                if initial_pos != start:
+                    stream.seek(start)
         elif start is not None:
             raise ValueError("Cannot slice a non-seekable stream with a start position")
 

--- a/src/archivey/internal/zip_aes.py
+++ b/src/archivey/internal/zip_aes.py
@@ -1,0 +1,248 @@
+"""WinZip AES (AE-1 / AE-2) decryption for ZIP members.
+
+Wire format (APPNOTE / WinZip AE-x)::
+
+    [salt][pw_verify(2)][AES-CTR ciphertext][HMAC-SHA1(10)]
+
+The member's ``compress_type`` is 99; extra field ``0x9901`` carries vendor version
+(AE-1=1 / AE-2=2), strength (1/2/3 → 128/192/256), and the actual compression method.
+Key material is PBKDF2-HMAC-SHA1(password, salt, 1000) → enc_key ‖ auth_key ‖ pw_verify.
+CTR uses a little-endian counter starting at 1 (no nonce). HMAC covers ciphertext only.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import struct
+from dataclasses import dataclass
+from typing import BinaryIO
+
+from archivey.exceptions import (
+    CorruptionError,
+    EncryptionError,
+    PackageNotInstalledError,
+)
+from archivey.internal.streams.crypto import CRYPTO_PACKAGE, _crypto_available
+from archivey.internal.streams.streamtools import ReadOnlyIOStream, read_exact
+
+# WinZip AES extra-field header id.
+_AES_EXTRA_ID = 0x9901
+_HMAC_LEN = 10
+_PBKDF2_ITERS = 1000
+
+
+@dataclass(frozen=True)
+class WinZipAesInfo:
+    """Parsed AE-x parameters from extra field ``0x9901``."""
+
+    vendor_version: int  # 1 = AE-1, 2 = AE-2
+    strength: int  # 1 / 2 / 3 → 128 / 192 / 256 bits
+    actual_method: int  # underlying ZIP compression method id
+
+    @property
+    def key_bits(self) -> int:
+        return {1: 128, 2: 192, 3: 256}[self.strength]
+
+    @property
+    def key_len(self) -> int:
+        return self.key_bits // 8
+
+    @property
+    def salt_len(self) -> int:
+        return self.key_bits // 16
+
+    @property
+    def is_ae2(self) -> bool:
+        return self.vendor_version == 2
+
+
+def parse_winzip_aes_extra(extra: bytes) -> WinZipAesInfo | None:
+    """Return AE info from a ZIP extra field blob, or ``None`` when absent/malformed."""
+    i = 0
+    while i + 4 <= len(extra):
+        hdr_id, size = struct.unpack_from("<HH", extra, i)
+        if i + 4 + size > len(extra):
+            break
+        data = extra[i + 4 : i + 4 + size]
+        if hdr_id == _AES_EXTRA_ID and size >= 7:
+            vendor_version, vendor_id, strength, actual_method = struct.unpack(
+                "<H2sBH", data[:7]
+            )
+            if vendor_id != b"AE" or strength not in (1, 2, 3):
+                return None
+            if vendor_version not in (1, 2):
+                return None
+            return WinZipAesInfo(vendor_version, strength, actual_method)
+        i += 4 + size
+    return None
+
+
+def derive_winzip_aes_keys(
+    password: bytes, *, salt: bytes, key_len: int
+) -> tuple[bytes, bytes, bytes]:
+    """PBKDF2-HMAC-SHA1 → ``(enc_key, auth_key, pw_verify)``."""
+    derived = hashlib.pbkdf2_hmac(
+        "sha1", password, salt, _PBKDF2_ITERS, dklen=key_len * 2 + 2
+    )
+    enc_key = derived[:key_len]
+    auth_key = derived[key_len : key_len * 2]
+    pw_verify = derived[key_len * 2 :]
+    return enc_key, auth_key, pw_verify
+
+
+class _AesCtrLe:
+    """AES-CTR with a little-endian counter starting at 1 (WinZip AE convention)."""
+
+    def __init__(self, key: bytes) -> None:
+        # Local import: only the crypto wrapper may import cryptography.
+        from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+
+        if not _crypto_available():
+            raise PackageNotInstalledError(
+                f"The {CRYPTO_PACKAGE!r} package is required for WinZip AES decryption "
+                f"(install the 'crypto' extra)."
+            )
+        self._encryptor = Cipher(algorithms.AES(key), modes.ECB()).encryptor()
+        self._counter = 1
+        self._keystream = b""
+        self._pos = 0
+
+    def process(self, data: bytes) -> bytes:
+        if not data:
+            return b""
+        out = bytearray(len(data))
+        for i, byte in enumerate(data):
+            if self._pos >= len(self._keystream):
+                block = self._counter.to_bytes(16, "little")
+                self._keystream = self._encryptor.update(block)
+                self._pos = 0
+                self._counter += 1
+            out[i] = byte ^ self._keystream[self._pos]
+            self._pos += 1
+        return bytes(out)
+
+
+class WinZipAesDecryptStream(ReadOnlyIOStream):
+    """Decrypt an AE ciphertext body and verify the trailing HMAC-SHA1(10).
+
+    ``source`` must be positioned at the start of the ciphertext (after salt +
+    pw_verify) and bounded to ``cipher_len + 10`` (ciphertext + MAC). The HMAC is
+    checked when the stream is fully consumed or closed after a clean EOF.
+    """
+
+    def __init__(
+        self,
+        source: BinaryIO,
+        *,
+        enc_key: bytes,
+        auth_key: bytes,
+        cipher_len: int,
+    ) -> None:
+        super().__init__()
+        if cipher_len < 0:
+            raise ValueError("cipher_len must be non-negative")
+        self._source = source
+        self._ctr = _AesCtrLe(enc_key)
+        self._hmac = hmac.new(auth_key, digestmod=hashlib.sha1)
+        self._cipher_remaining = cipher_len
+        self._mac = b""
+        self._mac_needed = _HMAC_LEN
+        self._verified = False
+        self._buf = bytearray()
+
+    def _pull(self) -> None:
+        if self._cipher_remaining > 0:
+            chunk = self._source.read(min(65536, self._cipher_remaining))
+            if not chunk:
+                raise CorruptionError("Truncated WinZip AES ciphertext before HMAC")
+            self._cipher_remaining -= len(chunk)
+            self._hmac.update(chunk)
+            self._buf.extend(self._ctr.process(chunk))
+            return
+        if self._mac_needed > 0:
+            mac = read_exact(self._source, self._mac_needed)
+            if len(mac) != self._mac_needed:
+                raise CorruptionError("Truncated WinZip AES HMAC")
+            self._mac += mac
+            self._mac_needed = 0
+            expected = self._hmac.digest()[:_HMAC_LEN]
+            if not hmac.compare_digest(self._mac, expected):
+                raise CorruptionError(
+                    "WinZip AES HMAC mismatch (wrong password or tampered ciphertext)"
+                )
+            self._verified = True
+
+    def read(self, size: int = -1) -> bytes:
+        if size == 0:
+            return b""
+        while size < 0 or len(self._buf) < size:
+            if self._cipher_remaining <= 0 and self._mac_needed <= 0:
+                break
+            before = len(self._buf)
+            self._pull()
+            if len(self._buf) == before and self._cipher_remaining <= 0:
+                break
+        if size < 0:
+            out = bytes(self._buf)
+            self._buf.clear()
+            return out
+        out = bytes(self._buf[:size])
+        del self._buf[:size]
+        return out
+
+    def close(self) -> None:
+        if not self.closed:
+            # Drain remaining ciphertext + MAC so a short-read caller still gets HMAC checked.
+            try:
+                while self._cipher_remaining > 0 or self._mac_needed > 0:
+                    self._pull()
+            except CorruptionError:
+                self._source.close()
+                super().close()
+                raise
+            self._source.close()
+        super().close()
+
+
+def open_winzip_aes_member(
+    raw: BinaryIO,
+    *,
+    aes: WinZipAesInfo,
+    password: bytes,
+    compress_size: int,
+) -> BinaryIO:
+    """Peel salt/pw_verify from ``raw``, verify the password, return a decrypt stream.
+
+    ``raw`` is the full member payload (salt + verify + ciphertext + HMAC) of length
+    ``compress_size``. Raises ``EncryptionError`` on a wrong password (fast-fail on the
+    2-byte verification value) and ``PackageNotInstalledError`` when ``[crypto]`` is absent.
+    """
+    if not _crypto_available():
+        raise PackageNotInstalledError(
+            f"The {CRYPTO_PACKAGE!r} package is required for WinZip AES decryption "
+            f"(install the 'crypto' extra)."
+        )
+    salt_len = aes.salt_len
+    overhead = salt_len + 2 + _HMAC_LEN
+    if compress_size < overhead:
+        raise CorruptionError(
+            f"WinZip AES member too short for salt/verify/HMAC ({compress_size} < {overhead})"
+        )
+    salt = read_exact(raw, salt_len)
+    if len(salt) != salt_len:
+        raise CorruptionError("Truncated WinZip AES salt")
+    stored_verify = read_exact(raw, 2)
+    if len(stored_verify) != 2:
+        raise CorruptionError("Truncated WinZip AES password-verification value")
+
+    enc_key, auth_key, pw_verify = derive_winzip_aes_keys(
+        password, salt=salt, key_len=aes.key_len
+    )
+    if not hmac.compare_digest(stored_verify, pw_verify):
+        raise EncryptionError("Wrong password for this ZIP member")
+
+    cipher_len = compress_size - overhead
+    return WinZipAesDecryptStream(
+        raw, enc_key=enc_key, auth_key=auth_key, cipher_len=cipher_len
+    )

--- a/tests/test_concurrent_multithread.py
+++ b/tests/test_concurrent_multithread.py
@@ -99,12 +99,16 @@ def test_multithread_zip_open_close_refcnt_stress(tmp_path: Path) -> None:
     Stdlib ``zipfile`` updates ``_fileRefCnt`` without a lock on open/close; under
     CPython ``3.13t`` that races and asserts in ``_fpclose``. Repeat fan-out enough
     times to make the failure reliable before the ZIP handle lock fix.
+
+    Also catches the native-codec path's concurrent CRC race: locked ``SlicingStream``
+    views over ``ZipFile.fp`` must not call unlocked ``BufferedReader.tell`` at
+    construction (see ``TestSlicingStreamLockedConstruction``).
     """
     path = _make_zip(tmp_path / "a.zip", n=16)
     expected = _expected(16)
-    # Enough trials that an unlocked free-threaded run fails consistently; a correct
-    # lock keeps every trial green.
-    for _ in range(40):
+    # Enough trials that an unlocked free-threaded run / unlocked-init tell race
+    # fails consistently; a correct lock + construction keeps every trial green.
+    for _ in range(80):
         assert _fan_out_read(path) == expected
 
 

--- a/tests/test_corpus_sweep.py
+++ b/tests/test_corpus_sweep.py
@@ -143,7 +143,13 @@ def _assert_stored_digest_parity(member, key: str) -> None:
     digest_keys = keys & {"crc32", "blake2sp"}
     if key == "zip":
         if member.type in (MemberType.FILE, MemberType.SYMLINK):
-            assert "crc32" in keys, f"zip {member.name!r} missing crc32"
+            # AE-2 (WinZip AES) stores CRC as 0 and relies on the HMAC — no crc32 digest.
+            if member.extra.get("zip.aes_vendor_version") == 2:
+                assert "crc32" not in keys, (
+                    f"zip AE-2 {member.name!r} should not surface crc32"
+                )
+            else:
+                assert "crc32" in keys, f"zip {member.name!r} missing crc32"
         else:
             assert "crc32" not in keys, f"zip {member.name!r} unexpected crc32"
         return

--- a/tests/test_libarchive_corpus.py
+++ b/tests/test_libarchive_corpus.py
@@ -31,10 +31,9 @@ Triage (2026-07, vs libarchive ``libarchive/test``) — known failures marked
   (``test_compat_lzip_3``).
 
 **ZIP**
-* **GAP** WinZip AES (method 99) / ZIPX XZ — AES is a follow-on change; ZIPX XZ
-  (method 95) has no codec path yet.
+* **GAP** ZIPX XZ (method 95) — no codec path yet.
 * ZIPX PPMd / Zstd decode via the shared codec layer when `[7z]` / `[zstd]` are
-  installed.
+  installed; WinZip AES (method 99) decrypts via `[crypto]`.
 * **GAP** ZIP members whose payload exceeds the declared size (libarchive
   fixtures) — size/CRC checks reject them.
 * **GAP** assorted ZIP edge cases (extra padding, UTF-8 path presentation,
@@ -208,27 +207,11 @@ _XFAIL: dict[str, tuple[bool, str]] = {
         "HARNESS: libarchive lists no members for this bare lzip fixture",
     ),
     # --- ZIP ---
-    # ZIPX PPMd8 / Zstd now decode via the shared codec layer (zip-native-codec-streams);
-    # they are no longer xfailed.
+    # ZIPX PPMd8 / Zstd / WinZip AES now decode via the shared codec / [crypto] paths;
+    # they are no longer xfailed (AES fixtures use passwords from `_PASSWORDS`).
     "test_read_format_zip_xz_multi.zipx": (
         True,
         "GAP: ZIPX XZ unsupported (no ZIP method-95 codec path yet)",
-    ),
-    "test_read_format_zip_winzip_aes128.zip": (
-        True,
-        "GAP: WinZip AES (method 99) unsupported by stdlib zipfile",
-    ),
-    "test_read_format_zip_winzip_aes256.zip": (
-        True,
-        "GAP: WinZip AES (method 99) unsupported by stdlib zipfile",
-    ),
-    "test_read_format_zip_winzip_aes256_large.zip": (
-        True,
-        "GAP: WinZip AES (method 99) unsupported by stdlib zipfile",
-    ),
-    "test_read_format_zip_winzip_aes256_stored.zip": (
-        True,
-        "GAP: WinZip AES (method 99) unsupported by stdlib zipfile",
     ),
     "test_read_data_into_fd_size_exceeds_declared_deflate.zip": (
         True,

--- a/tests/test_libarchive_corpus.py
+++ b/tests/test_libarchive_corpus.py
@@ -31,10 +31,12 @@ Triage (2026-07, vs libarchive ``libarchive/test``) — known failures marked
   (``test_compat_lzip_3``).
 
 **ZIP**
-* **GAP** WinZip AES (method 99) / ZIPX PPMd/Zstd/XZ — stdlib ``zipfile`` does
-  not decode these; Archivey surfaces ``UnsupportedFeatureError``.
+* **GAP** WinZip AES (method 99) / ZIPX XZ — AES is a follow-on change; ZIPX XZ
+  (method 95) has no codec path yet.
+* ZIPX PPMd / Zstd decode via the shared codec layer when `[7z]` / `[zstd]` are
+  installed.
 * **GAP** ZIP members whose payload exceeds the declared size (libarchive
-  fixtures) — stdlib CRC/size checks reject them.
+  fixtures) — size/CRC checks reject them.
 * **GAP** assorted ZIP edge cases (extra padding, UTF-8 path presentation,
   MSDOS directory typing).
 
@@ -206,25 +208,11 @@ _XFAIL: dict[str, tuple[bool, str]] = {
         "HARNESS: libarchive lists no members for this bare lzip fixture",
     ),
     # --- ZIP ---
-    "test_read_format_zip_ppmd8.zipx": (
-        True,
-        "GAP: ZIPX PPMd8 unsupported by stdlib zipfile",
-    ),
-    "test_read_format_zip_ppmd8_multi.zipx": (
-        True,
-        "GAP: ZIPX PPMd8 unsupported by stdlib zipfile",
-    ),
+    # ZIPX PPMd8 / Zstd now decode via the shared codec layer (zip-native-codec-streams);
+    # they are no longer xfailed.
     "test_read_format_zip_xz_multi.zipx": (
         True,
-        "GAP: ZIPX XZ unsupported by stdlib zipfile",
-    ),
-    "test_read_format_zip_zstd.zipx": (
-        True,
-        "GAP: ZIPX Zstd unsupported by stdlib zipfile",
-    ),
-    "test_read_format_zip_zstd_multi.zipx": (
-        True,
-        "GAP: ZIPX Zstd unsupported by stdlib zipfile",
+        "GAP: ZIPX XZ unsupported (no ZIP method-95 codec path yet)",
     ),
     "test_read_format_zip_winzip_aes128.zip": (
         True,

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -158,19 +158,14 @@ def test_zip_partial_when_optional_codecs_missing(
     assert ArchiveFormat.ZIP in list_supported_formats()
 
 
-def test_zip_partial_even_when_codecs_present(monkeypatch: pytest.MonkeyPatch) -> None:
-    # Resolved 2026-07 decision (see the phase-5 proposal): ZIP member *data* still decodes
-    # via stdlib zipfile, which cannot use the optional codecs even when installed, so ZIP
-    # reports PARTIAL (never FULL) until Phase 7 wires the codec layer into ZIP reads.
-    # `missing` is empty when every optional codec is present (the gap is implementation
-    # stage, not a missing install). Force them present so this holds regardless of which
-    # extras the test environment installed (the core-only CI legs have none).
+def test_zip_full_when_optional_codecs_present(monkeypatch: pytest.MonkeyPatch) -> None:
+    # With the codec layer wired into ZIP member reads, ZIP reports FULL when every
+    # optional member codec backend is installed (deflate64 / zstd / ppmd).
     for sentinel in ("_inflate64", "_zstd", "_pyppmd"):
         monkeypatch.setattr(codecs_module, sentinel, object())
     avail = format_availability(ArchiveFormat.ZIP)
-    assert avail.support is FormatSupport.PARTIAL
+    assert avail.support is FormatSupport.FULL
     assert avail.missing == ()
-    # PARTIAL formats are still "supported" (readable for their common members).
     assert ArchiveFormat.ZIP in list_supported_formats()
 
 

--- a/tests/test_slice.py
+++ b/tests/test_slice.py
@@ -7,6 +7,9 @@ corner-case coverage (per CONTRIBUTING's narrow exception for stream primitives)
 from __future__ import annotations
 
 import io
+import threading
+import zipfile
+import zlib
 from pathlib import Path
 
 import pytest
@@ -265,3 +268,98 @@ class TestSlicingStreamOwnSource:
         underlying = self._Tracked(DATA)
         SlicingStream(underlying, start=0, length=5, own_source=True).close()
         assert underlying.closed_flag is True
+
+
+class TestSlicingStreamLockedConstruction:
+    """Locked views must not probe the shared handle unlocked at construction.
+
+    ``io.BufferedReader.tell`` is not thread-safe. A concurrent unlocked ``tell`` while
+    another thread holds the lock for seek+read corrupts the buffer — the ZIP
+    ``MemberStreams.CONCURRENT`` CRC race.
+    """
+
+    def test_locked_with_start_does_not_call_tell(self) -> None:
+        class _NoTell(io.BytesIO):
+            def tell(self) -> int:
+                raise AssertionError("locked SlicingStream must not tell() at init")
+
+        lock = threading.Lock()
+        underlying = _NoTell(DATA)
+        sliced = SlicingStream(underlying, start=5, length=4, lock=lock)
+        assert sliced.read() == DATA[5:9]
+
+    def test_locked_without_start_tells_under_lock(self) -> None:
+        lock = threading.Lock()
+        held: list[bool] = []
+
+        class _TellUnderLock(io.BytesIO):
+            def tell(self) -> int:
+                held.append(lock.locked())
+                return super().tell()
+
+        underlying = _TellUnderLock(DATA)
+        underlying.seek(7)
+        sliced = SlicingStream(underlying, length=3, lock=lock)
+        assert held == [True]
+        assert sliced.read() == DATA[7:10]
+
+    def test_concurrent_locked_views_over_zipfile_fp(self, tmp_path: Path) -> None:
+        """Stress concurrent locked views on stdlib ``ZipFile.fp`` (a BufferedReader)."""
+        path = tmp_path / "a.zip"
+        payloads = {f"f{i}.txt": f"payload-{i}".encode() * 20 for i in range(16)}
+        with zipfile.ZipFile(path, "w") as zf:
+            for name, data in payloads.items():
+                zf.writestr(name, data)
+
+        # Enough trials that unlocked-init construction fails reliably on this fixture.
+        for _ in range(80):
+            with zipfile.ZipFile(path) as zf:
+                infos = [i for i in zf.infolist() if not i.is_dir()]
+                barrier = threading.Barrier(len(infos))
+                errors: list[BaseException] = []
+                err_lock = threading.Lock()
+
+                def worker(info: zipfile.ZipInfo) -> None:
+                    try:
+                        barrier.wait(timeout=5)
+                        with zf._lock:
+                            fp = zf.fp
+                            assert fp is not None
+                            saved = fp.tell()
+                            try:
+                                fp.seek(info.header_offset)
+                                header = fp.read(30)
+                                name_len = int.from_bytes(header[26:28], "little")
+                                extra_len = int.from_bytes(header[28:30], "little")
+                                fp.read(name_len)
+                                start = info.header_offset + 30 + name_len + extra_len
+                            finally:
+                                fp.seek(saved)
+                        # Construct outside the lock (as ZipReader does after
+                        # ``_local_data_region``) — must not unlock-tell the shared fp.
+                        raw = SlicingStream(
+                            zf.fp,  # type: ignore[arg-type]
+                            start=start,
+                            length=info.compress_size,
+                            lock=zf._lock,
+                        )
+                        compressed = raw.read()
+                        data = (
+                            zlib.decompress(compressed, -15)
+                            if info.compress_type == zipfile.ZIP_DEFLATED
+                            else compressed
+                        )
+                        assert data == payloads[info.filename]
+                    except BaseException as exc:  # noqa: BLE001
+                        with err_lock:
+                            errors.append(exc)
+
+                threads = [
+                    threading.Thread(target=worker, args=(info,)) for info in infos
+                ]
+                for t in threads:
+                    t.start()
+                for t in threads:
+                    t.join(timeout=30)
+                if errors:
+                    raise errors[0]

--- a/tests/test_zip_aes.py
+++ b/tests/test_zip_aes.py
@@ -1,0 +1,263 @@
+"""WinZip AES (AE-1 / AE-2) ZIP member decryption tests."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import io
+import os
+import struct
+import subprocess
+import zipfile
+import zlib
+from pathlib import Path
+
+import pytest
+
+from archivey import open_archive
+from archivey.exceptions import (
+    CorruptionError,
+    EncryptionError,
+    PackageNotInstalledError,
+)
+from archivey.internal.zip_aes import (
+    WinZipAesInfo,
+    derive_winzip_aes_keys,
+    parse_winzip_aes_extra,
+)
+from archivey.types import CompressionAlgorithm
+from tests.conftest import requires, requires_binary
+
+_PASSWORD = b"secret"
+_PAYLOAD = b"winzip-aes-payload\n" * 40
+
+
+def _aes_ctr_le_encrypt(key: bytes, plaintext: bytes) -> bytes:
+    from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+
+    encryptor = Cipher(algorithms.AES(key), modes.ECB()).encryptor()
+    out = bytearray(len(plaintext))
+    counter = 1
+    keystream = b""
+    pos = 0
+    for i, byte in enumerate(plaintext):
+        if pos >= len(keystream):
+            keystream = encryptor.update(counter.to_bytes(16, "little"))
+            pos = 0
+            counter += 1
+        out[i] = byte ^ keystream[pos]
+        pos += 1
+    return bytes(out)
+
+
+def _build_aes_zip(
+    *,
+    payload: bytes,
+    password: bytes,
+    vendor_version: int,
+    strength: int,
+    method: int,
+    name: bytes = b"secret.txt",
+    tamper_hmac: bool = False,
+) -> bytes:
+    """Hand-build a single-entry WinZip AES ZIP (AE-1 or AE-2)."""
+    aes = WinZipAesInfo(vendor_version, strength, method)
+    if method == 0:
+        compressed = payload
+    elif method == 8:
+        compressed = zlib.compress(payload)[2:-4]  # raw deflate
+    else:
+        raise ValueError(f"unsupported test method {method}")
+
+    salt = os.urandom(aes.salt_len)
+    enc_key, auth_key, pw_verify = derive_winzip_aes_keys(
+        password, salt=salt, key_len=aes.key_len
+    )
+    ciphertext = _aes_ctr_le_encrypt(enc_key, compressed)
+    mac = bytearray(hmac.new(auth_key, ciphertext, hashlib.sha1).digest()[:10])
+    if tamper_hmac:
+        mac[0] ^= 0xFF
+    body = salt + pw_verify + ciphertext + bytes(mac)
+
+    crc = 0 if vendor_version == 2 else (zlib.crc32(payload) & 0xFFFFFFFF)
+    aes_extra = struct.pack("<H2sBH", vendor_version, b"AE", strength, method)
+    extra = struct.pack("<HH", 0x9901, len(aes_extra)) + aes_extra
+
+    flags = 0x1  # encrypted
+    local = struct.pack(
+        "<IHHHHHIIIHH",
+        0x04034B50,
+        51,  # version needed (AES)
+        flags,
+        99,
+        0,
+        0,
+        crc,
+        len(body),
+        len(payload),
+        len(name),
+        len(extra),
+    )
+    local += name + extra + body
+    cd = struct.pack(
+        "<IHHHHHHIIIHHHHHII",
+        0x02014B50,
+        51,
+        51,
+        flags,
+        99,
+        0,
+        0,
+        crc,
+        len(body),
+        len(payload),
+        len(name),
+        len(extra),
+        0,
+        0,
+        0,
+        0,
+        0,
+    )
+    cd += name + extra
+    eocd = struct.pack("<IHHHHIIH", 0x06054B50, 0, 0, 1, 1, len(cd), len(local), 0)
+    return local + cd + eocd
+
+
+def _7z_aes_zip(tmp_path: Path, *, strength: str = "AES256") -> tuple[Path, bytes]:
+    payload = _PAYLOAD + os.urandom(32)
+    src = tmp_path / "payload.bin"
+    src.write_bytes(payload)
+    archive = tmp_path / f"aes_{strength}.zip"
+    result = subprocess.run(
+        [
+            "7z",
+            "a",
+            "-tzip",
+            f"-mem={strength}",
+            f"-p{_PASSWORD.decode()}",
+            str(archive),
+            src.name,
+            "-y",
+        ],
+        cwd=tmp_path,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0 or not archive.is_file():
+        pytest.skip(f"7z cannot write AES ZIP: {result.stderr}")
+    with zipfile.ZipFile(archive) as zf:
+        info = zf.infolist()[0]
+        if info.compress_type != 99:
+            pytest.skip(f"7z did not emit method 99 (got {info.compress_type})")
+    return archive, payload
+
+
+@requires("cryptography")
+@pytest.mark.parametrize(
+    ("vendor_version", "strength", "method"),
+    [
+        (1, 1, 0),  # AE-1, 128, STORED
+        (1, 3, 8),  # AE-1, 256, DEFLATE
+        (2, 1, 0),  # AE-2, 128, STORED
+        (2, 3, 8),  # AE-2, 256, DEFLATE
+        (2, 2, 8),  # AE-2, 192, DEFLATE
+    ],
+)
+def test_handbuilt_aes_roundtrip(
+    vendor_version: int, strength: int, method: int
+) -> None:
+    data = _build_aes_zip(
+        payload=_PAYLOAD,
+        password=_PASSWORD,
+        vendor_version=vendor_version,
+        strength=strength,
+        method=method,
+    )
+    with open_archive(io.BytesIO(data), password=_PASSWORD) as ar:
+        (member,) = ar.members()
+        assert member.is_encrypted
+        assert member.extra["zip.aes_vendor_version"] == vendor_version
+        assert member.extra["zip.aes_strength"] == strength
+        if vendor_version == 2:
+            assert "crc32" not in member.hashes
+        else:
+            assert "crc32" in member.hashes
+        expected_algo = (
+            CompressionAlgorithm.STORED if method == 0 else CompressionAlgorithm.DEFLATE
+        )
+        assert member.compression[0].algo is expected_algo
+        assert ar.read(member) == _PAYLOAD
+
+
+@requires_binary("7z")
+@requires("cryptography")
+@pytest.mark.parametrize("strength", ["AES128", "AES256"])
+def test_7z_aes_zip_roundtrip(tmp_path: Path, strength: str) -> None:
+    archive, payload = _7z_aes_zip(tmp_path, strength=strength)
+    with open_archive(archive, password=_PASSWORD) as ar:
+        (member,) = ar.members()
+        assert member.is_encrypted
+        assert "crc32" not in member.hashes  # 7z emits AE-2
+        assert ar.read(member) == payload
+
+
+@requires("cryptography")
+def test_aes_wrong_password_fails_fast() -> None:
+    data = _build_aes_zip(
+        payload=_PAYLOAD, password=_PASSWORD, vendor_version=2, strength=3, method=8
+    )
+    with open_archive(io.BytesIO(data), password=b"wrong") as ar:
+        with pytest.raises(EncryptionError, match="Wrong password"):
+            ar.read(ar.members()[0])
+
+
+@requires("cryptography")
+def test_aes_tampered_hmac_raises_corruption() -> None:
+    data = _build_aes_zip(
+        payload=_PAYLOAD,
+        password=_PASSWORD,
+        vendor_version=2,
+        strength=3,
+        method=0,
+        tamper_hmac=True,
+    )
+    with open_archive(io.BytesIO(data), password=_PASSWORD) as ar:
+        with pytest.raises(CorruptionError, match="HMAC"):
+            ar.read(ar.members()[0])
+
+
+@requires("cryptography")
+def test_aes_multi_password_selects_winner() -> None:
+    data = _build_aes_zip(
+        payload=_PAYLOAD, password=_PASSWORD, vendor_version=2, strength=3, method=8
+    )
+    with open_archive(
+        io.BytesIO(data), password=[b"nope", b"also-wrong", _PASSWORD]
+    ) as ar:
+        assert ar.read(ar.members()[0]) == _PAYLOAD
+
+
+def test_aes_without_crypto_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    data = _build_aes_zip(
+        payload=_PAYLOAD, password=_PASSWORD, vendor_version=2, strength=3, method=0
+    )
+    import archivey.internal.zip_aes as zip_aes_module
+
+    monkeypatch.setattr(zip_aes_module, "_crypto_available", lambda: False)
+    with open_archive(io.BytesIO(data), password=_PASSWORD) as ar:
+        (member,) = ar.members()
+        assert member.is_encrypted  # detection still works
+        with pytest.raises(PackageNotInstalledError, match="cryptography"):
+            ar.read(member)
+
+
+def test_parse_aes_extra_roundtrip() -> None:
+    extra = struct.pack("<HH", 0x9901, 7) + struct.pack("<H2sBH", 2, b"AE", 3, 8)
+    info = parse_winzip_aes_extra(extra)
+    assert info is not None
+    assert info.is_ae2
+    assert info.key_bits == 256
+    assert info.actual_method == 8
+    assert parse_winzip_aes_extra(b"") is None

--- a/tests/test_zip_aes.py
+++ b/tests/test_zip_aes.py
@@ -239,10 +239,61 @@ def test_aes_multi_password_selects_winner() -> None:
         assert ar.read(ar.members()[0]) == _PAYLOAD
 
 
-def test_aes_without_crypto_raises(monkeypatch: pytest.MonkeyPatch) -> None:
-    data = _build_aes_zip(
-        payload=_PAYLOAD, password=_PASSWORD, vendor_version=2, strength=3, method=0
+def _minimal_aes_zip_bytes() -> bytes:
+    """A tiny method-99 ZIP with a valid 0x9901 extra (no cryptography needed to build).
+
+    The ciphertext body is garbage — only used to exercise the ``[crypto]``-absent path,
+    which fails before decryption.
+    """
+    name = b"x.txt"
+    # AE-2, strength 1 (128), actual method STORED
+    aes_extra = struct.pack("<H2sBH", 2, b"AE", 1, 0)
+    extra = struct.pack("<HH", 0x9901, len(aes_extra)) + aes_extra
+    # salt(8) + verify(2) + cipher(1) + hmac(10)
+    body = b"\0" * (8 + 2 + 1 + 10)
+    flags = 0x1
+    local = struct.pack(
+        "<IHHHHHIIIHH",
+        0x04034B50,
+        51,
+        flags,
+        99,
+        0,
+        0,
+        0,
+        len(body),
+        1,
+        len(name),
+        len(extra),
     )
+    local += name + extra + body
+    cd = struct.pack(
+        "<IHHHHHHIIIHHHHHII",
+        0x02014B50,
+        51,
+        51,
+        flags,
+        99,
+        0,
+        0,
+        0,
+        len(body),
+        1,
+        len(name),
+        len(extra),
+        0,
+        0,
+        0,
+        0,
+        0,
+    )
+    cd += name + extra
+    eocd = struct.pack("<IHHHHIIH", 0x06054B50, 0, 0, 1, 1, len(cd), len(local), 0)
+    return local + cd + eocd
+
+
+def test_aes_without_crypto_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    data = _minimal_aes_zip_bytes()
     import archivey.internal.zip_aes as zip_aes_module
 
     monkeypatch.setattr(zip_aes_module, "_crypto_available", lambda: False)

--- a/tests/test_zip_native_codecs.py
+++ b/tests/test_zip_native_codecs.py
@@ -189,11 +189,19 @@ def test_zip_corrupt_deflate_body_raises_corruption() -> None:
 
 
 def test_zip_unknown_method_raises_unsupported() -> None:
-    data = _build_minimal_zip(b"x.bin", b"raw", b"raw", method=99)
-    # Method 99 without encryption flag is still an unknown codec for the native path.
+    data = _build_minimal_zip(b"x.bin", b"raw", b"raw", method=97)
     with open_archive(io.BytesIO(data)) as ar:
         (member,) = ar.members()
-        with pytest.raises(UnsupportedFeatureError, match="compression method 99"):
+        with pytest.raises(UnsupportedFeatureError, match="compression method 97"):
+            ar.read(member)
+
+
+def test_zip_method_99_without_aes_extra_raises() -> None:
+    # Method 99 with no 0x9901 extra is not a valid AE member.
+    data = _build_minimal_zip(b"x.bin", b"raw", b"raw", method=99)
+    with open_archive(io.BytesIO(data)) as ar:
+        (member,) = ar.members()
+        with pytest.raises(UnsupportedFeatureError, match="0x9901"):
             ar.read(member)
 
 

--- a/tests/test_zip_native_codecs.py
+++ b/tests/test_zip_native_codecs.py
@@ -1,0 +1,226 @@
+"""ZIP member decode through the shared codec layer (extended methods).
+
+Covers Deflate64 / Zstd / PPMd ZIP members that stdlib ``zipfile`` cannot decode,
+plus missing-backend → ``PackageNotInstalledError`` and corrupt-body → ``CorruptionError``.
+"""
+
+from __future__ import annotations
+
+import io
+import struct
+import subprocess
+import zipfile
+import zlib
+from pathlib import Path
+
+import pytest
+
+from archivey import open_archive
+from archivey.exceptions import (
+    CorruptionError,
+    PackageNotInstalledError,
+    TruncatedError,
+    UnsupportedFeatureError,
+)
+from archivey.internal.streams import codecs as codecs_module
+from archivey.types import CompressionAlgorithm, MemberStreams
+from tests.conftest import requires, requires_binary, requires_zstd, zstd_backend
+
+_PAYLOAD = (b"zip-native-codec-payload\n" * 80) + bytes(range(256))
+
+
+def _build_minimal_zip(
+    name: bytes,
+    compressed: bytes,
+    uncompressed: bytes,
+    method: int,
+) -> bytes:
+    """Hand-build a single-entry ZIP with an arbitrary compression method id."""
+    crc = zlib.crc32(uncompressed) & 0xFFFFFFFF
+    name_len = len(name)
+    local = struct.pack(
+        "<IHHHHHIIIHH",
+        0x04034B50,
+        20,
+        0,
+        method,
+        0,
+        0,
+        crc,
+        len(compressed),
+        len(uncompressed),
+        name_len,
+        0,
+    )
+    local += name + compressed
+    cd = struct.pack(
+        "<IHHHHHHIIIHHHHHII",
+        0x02014B50,
+        20,
+        20,
+        0,
+        method,
+        0,
+        0,
+        crc,
+        len(compressed),
+        len(uncompressed),
+        name_len,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+    )
+    cd += name
+    eocd = struct.pack("<IHHHHIIH", 0x06054B50, 0, 0, 1, 1, len(cd), len(local), 0)
+    return local + cd + eocd
+
+
+def _7z_zip(tmp_path: Path, method: str, payload: bytes) -> Path:
+    src = tmp_path / "payload.bin"
+    src.write_bytes(payload)
+    archive = tmp_path / f"{method.lower()}.zip"
+    result = subprocess.run(
+        ["7z", "a", "-tzip", f"-mm={method}", str(archive), src.name, "-y"],
+        cwd=tmp_path,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0 or not archive.is_file():
+        pytest.skip(f"7z CLI cannot write ZIP {method} fixture: {result.stderr}")
+    with zipfile.ZipFile(archive) as zf:
+        info = zf.infolist()[0]
+        if method == "Deflate64" and info.compress_type != 9:
+            pytest.skip(
+                f"7z wrote ZIP method {info.compress_type} instead of Deflate64 (9)"
+            )
+        if method == "PPMd" and info.compress_type != 98:
+            pytest.skip(
+                f"7z wrote ZIP method {info.compress_type} instead of PPMd (98)"
+            )
+    return archive
+
+
+@requires_binary("7z")
+@requires("inflate64")
+def test_zip_deflate64_roundtrip(tmp_path: Path) -> None:
+    archive = _7z_zip(tmp_path, "Deflate64", _PAYLOAD)
+    with open_archive(archive) as ar:
+        members = ar.members()
+        assert len(members) == 1
+        assert members[0].compression[0].algo is CompressionAlgorithm.DEFLATE64
+        assert ar.read(members[0]) == _PAYLOAD
+
+
+@requires_binary("7z")
+@requires("pyppmd")
+def test_zip_ppmd_roundtrip(tmp_path: Path) -> None:
+    archive = _7z_zip(tmp_path, "PPMd", _PAYLOAD)
+    with open_archive(archive) as ar:
+        members = ar.members()
+        assert len(members) == 1
+        assert members[0].compression[0].algo is CompressionAlgorithm.PPMD
+        assert ar.read(members[0]) == _PAYLOAD
+
+
+@requires_zstd()
+def test_zip_zstd_handbuilt_roundtrip() -> None:
+    zstd = zstd_backend()
+    compressed = zstd.compress(_PAYLOAD)
+    data = _build_minimal_zip(b"zstd.txt", compressed, _PAYLOAD, 93)
+    with open_archive(io.BytesIO(data)) as ar:
+        (member,) = ar.members()
+        assert member.compression[0].algo is CompressionAlgorithm.ZSTD
+        assert ar.read(member) == _PAYLOAD
+
+
+@requires_binary("7z")
+def test_zip_deflate64_without_inflate64_raises(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    archive = _7z_zip(tmp_path, "Deflate64", _PAYLOAD)
+    monkeypatch.setattr(codecs_module, "_inflate64", None)
+    with open_archive(archive) as ar:
+        (member,) = ar.members()
+        with pytest.raises(PackageNotInstalledError, match="inflate64"):
+            ar.read(member)
+
+
+@requires_binary("7z")
+def test_zip_ppmd_without_pyppmd_raises(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    archive = _7z_zip(tmp_path, "PPMd", _PAYLOAD)
+    monkeypatch.setattr(codecs_module, "_pyppmd", None)
+    with open_archive(archive) as ar:
+        (member,) = ar.members()
+        with pytest.raises(PackageNotInstalledError, match="pyppmd"):
+            ar.read(member)
+
+
+def test_zip_zstd_without_backend_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Hand-built fixture so the test does not need a zstd writer; only the reader backend
+    # presence is gated.
+    compressed = b"not-real-zstd"  # never decoded — open fails on missing backend first
+    data = _build_minimal_zip(b"z.txt", compressed, b"x" * 10, 93)
+    monkeypatch.setattr(codecs_module, "_zstd", None)
+    with open_archive(io.BytesIO(data)) as ar:
+        (member,) = ar.members()
+        with pytest.raises(PackageNotInstalledError):
+            ar.read(member)
+
+
+def test_zip_corrupt_deflate_body_raises_corruption() -> None:
+    # Flip bits in a real DEFLATE bitstream so inflate fails loudly and surfaces as
+    # CorruptionError / TruncatedError via the shared codec translator (not a raw zlib.error).
+    good = zlib.compress(_PAYLOAD)[2:-4]  # raw deflate (strip zlib wrapper)
+    corrupt = bytearray(good)
+    mid = len(corrupt) // 2
+    corrupt[mid] ^= 0xFF
+    corrupt[mid + 1] ^= 0xFF
+    data = _build_minimal_zip(b"bad.txt", bytes(corrupt), _PAYLOAD, 8)
+    with open_archive(io.BytesIO(data)) as ar:
+        (member,) = ar.members()
+        with pytest.raises((CorruptionError, TruncatedError)):
+            ar.read(member)
+
+
+def test_zip_unknown_method_raises_unsupported() -> None:
+    data = _build_minimal_zip(b"x.bin", b"raw", b"raw", method=99)
+    # Method 99 without encryption flag is still an unknown codec for the native path.
+    with open_archive(io.BytesIO(data)) as ar:
+        (member,) = ar.members()
+        with pytest.raises(UnsupportedFeatureError, match="compression method 99"):
+            ar.read(member)
+
+
+def test_zip_stdlib_methods_still_roundtrip(tmp_path: Path) -> None:
+    archive = tmp_path / "stdlib.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("stored.txt", _PAYLOAD, compress_type=zipfile.ZIP_STORED)
+        zf.writestr("deflated.txt", _PAYLOAD, compress_type=zipfile.ZIP_DEFLATED)
+        zf.writestr("bzip2.txt", _PAYLOAD, compress_type=zipfile.ZIP_BZIP2)
+        zf.writestr("lzma.txt", _PAYLOAD, compress_type=zipfile.ZIP_LZMA)
+    with open_archive(archive) as ar:
+        by_name = {m.name: m for m in ar.members()}
+        for name in ("stored.txt", "deflated.txt", "bzip2.txt", "lzma.txt"):
+            assert ar.read(by_name[name]) == _PAYLOAD
+
+
+def test_zip_concurrent_codec_path_interleaved(tmp_path: Path) -> None:
+    archive = tmp_path / "concurrent.zip"
+    with zipfile.ZipFile(archive, "w") as zf:
+        zf.writestr("a.txt", b"aaaa" * 1000, compress_type=zipfile.ZIP_DEFLATED)
+        zf.writestr("b.txt", b"bbbb" * 1000, compress_type=zipfile.ZIP_DEFLATED)
+    with open_archive(archive, member_streams=MemberStreams.CONCURRENT) as ar:
+        s1 = ar.open("a.txt")
+        s2 = ar.open("b.txt")
+        assert s1.read(4) == b"aaaa"
+        assert s2.read(4) == b"bbbb"
+        assert s1.read() == b"aaaa" * 999
+        assert s2.read() == b"bbbb" * 999
+        s1.close()
+        s2.close()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements `zip-native-codec-streams` and `zip-aes-decryption`: unencrypted ZIP members decode via the shared codec layer; WinZip AES (AE-1/AE-2) decrypts via `[crypto]`.

## CI fix (this push)

Concurrent ZIP fan-out under `MemberStreams.CONCURRENT` was flaky (`CorruptionError: Digest mismatch for 'crc32'`), failing only some CI envs because it is a race.

**Cause:** `SlicingStream.__init__` called unlocked `BufferedReader.tell()` on the shared `ZipFile.fp` even in locked/re-seek mode. Concurrent unlocked `tell` while another thread holds the lock for seek+read corrupts the buffer.

**Fix:** Skip unlocked `tell`/`seek` at construction when `start` is known; if `start` must be resolved from `tell`, take the lock. Regression tests in `test_slice.py` + strengthened concurrent ZIP stress.

## Test plan

- [x] `TestSlicingStreamLockedConstruction` (unit + ZipFile.fp stress)
- [x] `test_multithread_zip_open_close_refcnt_stress` (80 trials)
- [x] 500 local concurrent fan-outs with 0 failures (was ~2% before fix)
- [ ] CI matrix green after push
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-98323821-42ba-4277-821c-d1f8b0ec218f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-98323821-42ba-4277-821c-d1f8b0ec218f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

