### PR TITLE
Add readable markdown report for nightly benchmark runs

### DIFF
--- a/.github/workflows/benchmark-wall.yml
+++ b/.github/workflows/benchmark-wall.yml
@@ -69,9 +69,20 @@ jobs:
           uv run --no-sync python -m benchmarks.harness
           --mode full --scale realistic
           --json-out benchmark-wall-realistic.json
+          --text-out benchmark-wall-realistic.md
+      - name: Publish report to job summary
+        if: always() && steps.guard.outputs.run == 'true'
+        run: |
+          if [ -f benchmark-wall-realistic.md ]; then
+            cat benchmark-wall-realistic.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "No benchmark report produced (harness did not write text output)." >> "$GITHUB_STEP_SUMMARY"
+          fi
       - name: Upload wall-time results
         if: always() && steps.guard.outputs.run == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: benchmark-wall-realistic
-          path: benchmark-wall-realistic.json
+          path: |
+            benchmark-wall-realistic.md
+            benchmark-wall-realistic.json

--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -4,8 +4,9 @@
 decode-once). Wall-time / VISION ≤1.3× runs off the PR path as a **change-guarded
 nightly** (`benchmark-wall.yml`): a daily schedule whose expensive realistic run is
 skipped unless the default branch changed since the previous run (this project is
-bursty/dormant, and per-PR taxed every PR). It records drift (JSON artifact +
-informational VISION print) and goes red only on a gross regression.
+bursty/dormant, and per-PR taxed every PR). It records drift (JSON + markdown report
+artifacts, job summary table, and informational VISION print) and goes red only on a gross
+regression.
 
 Re-run with:
 
@@ -117,7 +118,9 @@ lock baseline lives in `benchmarks/tar_iso_lock_baseline.py`).
 
 - **PR CI (blocking):** `--mode structural --scale ci` + unit decode-once tests.
 - **Change-guarded nightly (off the PR path, `benchmark-wall.yml`):** `--mode full
-  --scale realistic` with JSON artifact upload — a daily schedule that skips its
-  expensive run unless the default branch changed since the previous run (bursty/dormant
-  project; per-PR was rejected for taxing every PR). `workflow_dispatch` forces a run.
+  --scale realistic` with JSON + markdown report artifact upload (the markdown is also
+  written to the Actions job summary so it is readable without downloading) — a daily
+  schedule that skips its expensive run unless the default branch changed since the previous
+  run (bursty/dormant project; per-PR was rejected for taxing every PR). `workflow_dispatch`
+  forces a run.
 - Wall timing: unmeasured archivey vs stdlib; VISION band informational.

--- a/benchmarks/harness.py
+++ b/benchmarks/harness.py
@@ -601,6 +601,129 @@ def load_json(path: Path) -> dict[str, Any] | None:
     return json.loads(path.read_text())
 
 
+def _fmt_seconds(seconds: float) -> str:
+    if seconds <= 0:
+        return "—"
+    if seconds < 1.0:
+        return f"{seconds * 1000:.1f} ms"
+    return f"{seconds:.3f} s"
+
+
+def _fmt_bytes(n: int | None) -> str:
+    if n is None:
+        return "—"
+    if n < 1024:
+        return str(n)
+    if n < 1024 * 1024:
+        return f"{n / 1024:.1f} KiB"
+    return f"{n / (1024 * 1024):.2f} MiB"
+
+
+def _vision_label(ratio: float | None) -> str:
+    if ratio is None:
+        return "—"
+    if ratio <= WALL_RATIO_VISION:
+        return f"within ≤{WALL_RATIO_VISION}×"
+    if ratio <= WALL_RATIO_VISION_SAFETY:
+        return f"above {WALL_RATIO_VISION}×, under {WALL_RATIO_VISION_SAFETY}×"
+    return f"above {WALL_RATIO_VISION_SAFETY}× safety"
+
+
+def format_text_report(payload: dict[str, Any]) -> str:
+    """Render a human-friendly markdown report from harness JSON payload."""
+    results = [
+        CaseResult(**r) if isinstance(r, dict) else r for r in payload["results"]
+    ]
+    scale = payload.get("scale", "?")
+    detail = payload.get("scale_detail") or {}
+    lines: list[str] = [
+        "# Benchmark report",
+        "",
+        f"- **mode:** `{payload.get('mode', '?')}`",
+        f"- **scale:** `{scale}`",
+        f"- **warmup:** `{payload.get('warmup', False)}`",
+    ]
+    if detail:
+        lines.extend(
+            [
+                "",
+                "## Corpus",
+                "",
+                f"- common members: {detail.get('common_members', '?')} × "
+                f"{_fmt_bytes(detail.get('common_member_size'))}",
+                f"- gzip size: {_fmt_bytes(detail.get('gzip_size'))}",
+                f"- solid members: {detail.get('solid_members', '?')} × "
+                f"{_fmt_bytes(detail.get('solid_member_size'))}",
+            ]
+        )
+
+    wall_cases = [r for r in results if r.wall_ratio is not None]
+    other_cases = [r for r in results if r.wall_ratio is None]
+
+    if wall_cases:
+        lines.extend(
+            [
+                "",
+                "## Wall-time vs stdlib",
+                "",
+                "| Case | archivey | stdlib | ratio | vs VISION |",
+                "| --- | ---: | ---: | ---: | --- |",
+            ]
+        )
+        for r in wall_cases:
+            ratio = f"{r.wall_ratio:.2f}×" if r.wall_ratio is not None else "—"
+            lines.append(
+                f"| `{r.case}` | {_fmt_seconds(r.wall_s)} | "
+                f"{_fmt_seconds(r.stdlib_wall_s or 0.0)} | {ratio} | "
+                f"{_vision_label(r.wall_ratio)} |"
+            )
+
+    lines.extend(
+        [
+            "",
+            "## All cases",
+            "",
+            "| Case | format | op | wall | bytes_dec | seeks | notes |",
+            "| --- | --- | --- | ---: | ---: | ---: | --- |",
+        ]
+    )
+    for r in results:
+        notes = r.notes.replace("|", "\\|") if r.notes else ""
+        lines.append(
+            f"| `{r.case}` | {r.format} | {r.operation} | "
+            f"{_fmt_seconds(r.wall_s)} | {_fmt_bytes(r.bytes_decompressed)} | "
+            f"{r.source_seek_count} | {notes} |"
+        )
+
+    if other_cases and any(r.case.endswith("_sequential") for r in other_cases):
+        lines.extend(["", "## Solid decode notes", ""])
+        for r in results:
+            if not r.case.endswith(("_sequential", "_random")):
+                continue
+            unpacked = r.unpacked_bytes or 0
+            factor = (r.bytes_decompressed / unpacked) if unpacked else None
+            factor_s = f"{factor:.2f}× unpacked" if factor is not None else "—"
+            lines.append(
+                f"- `{r.case}`: bytes_decompressed={_fmt_bytes(r.bytes_decompressed)} "
+                f"({factor_s}); seeks={r.source_seek_count}"
+            )
+
+    lines.extend(
+        [
+            "",
+            "## Policy reminder",
+            "",
+            f"- VISION target ≤{WALL_RATIO_VISION}× stdlib on common paths "
+            f"(~{WALL_RATIO_VISION_SAFETY}× safety band is informational on nightly).",
+            f"- Sanity ceiling {WALL_RATIO_BUDGET:.0f}× fails the job; VISION band "
+            "jitter is printed, not failed.",
+            "- Structural seek/bytes gates live on the PR path (`ci.yml`), not here.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -630,6 +753,12 @@ def main(argv: list[str] | None = None) -> int:
         type=Path,
         default=None,
         help="Write full results JSON to this path",
+    )
+    parser.add_argument(
+        "--text-out",
+        type=Path,
+        default=None,
+        help="Write a human-friendly markdown report to this path",
     )
     parser.add_argument(
         "--fixture-dir",
@@ -671,11 +800,18 @@ def main(argv: list[str] | None = None) -> int:
         "warmup": warmup,
         "results": [asdict(r) for r in results],
     }
+    report = format_text_report(payload)
     if args.json_out is not None:
         args.json_out.parent.mkdir(parents=True, exist_ok=True)
         args.json_out.write_text(json.dumps(payload, indent=2) + "\n")
+    if args.text_out is not None:
+        args.text_out.parent.mkdir(parents=True, exist_ok=True)
+        args.text_out.write_text(report)
 
-    print(json.dumps(payload, indent=2))
+    # Friendly table first (CI logs / terminals); full JSON still available via --json-out.
+    print(report)
+    if args.json_out is None:
+        print(json.dumps(payload, indent=2))
 
     if args.update_baselines:
         write_baselines(results)

--- a/openspec/specs/testing-contract/spec.md
+++ b/openspec/specs/testing-contract/spec.md
@@ -456,7 +456,8 @@ Structural invariants SHALL gate (block) every PR. Full wall-time ratio checks S
 off the PR path (non-blocking) as a separate scheduled job on a daily cadence, guarded so
 the expensive run is SKIPPED unless the default branch changed since the previous run
 (commit-recency guard), and MAY be forced on demand via `workflow_dispatch`. The job records
-results (JSON artifact + informational VISION print) and fails visibly (notifying) only on a
+results (JSON + human-readable markdown report artifacts, plus the same report on the GitHub
+Actions job summary) and an informational VISION print, and fails visibly (notifying) only on a
 real structural regression or a gross wall regression past the sanity ceiling. Per-PR
 wall-time execution SHALL NOT be required (it taxes every PR with a multi-minute run), and a
 plain always-on nightly SHALL be avoided in favour of the change-guarded schedule — this

--- a/tests/test_benchmark_gate.py
+++ b/tests/test_benchmark_gate.py
@@ -43,3 +43,55 @@ def test_structural_baseline_committed() -> None:
     assert STRUCTURAL_BASELINE.is_file()
     data = json.loads(STRUCTURAL_BASELINE.read_text())
     assert "sevenzip_solid_sequential" in data["cases"]
+
+
+def test_format_text_report_table() -> None:
+    """Friendly markdown report is readable without downloading JSON."""
+    from benchmarks.harness import format_text_report
+
+    payload = {
+        "mode": "full",
+        "scale": "realistic",
+        "warmup": True,
+        "scale_detail": {
+            "common_members": 64,
+            "common_member_size": 262144,
+            "gzip_size": 33554432,
+            "solid_members": 64,
+            "solid_member_size": 262144,
+        },
+        "results": [
+            {
+                "case": "zip_read_all",
+                "format": "zip",
+                "operation": "read_all",
+                "wall_s": 0.0158,
+                "bytes_decompressed": 1_048_576,
+                "source_seek_count": 3,
+                "unpacked_bytes": 1_048_576,
+                "stdlib_wall_s": 0.0134,
+                "wall_ratio": 1.18,
+                "notes": "",
+            },
+            {
+                "case": "sevenzip_solid_sequential",
+                "format": "7z",
+                "operation": "read_all_sequential",
+                "wall_s": 0.4,
+                "bytes_decompressed": 1_048_576,
+                "source_seek_count": 2,
+                "unpacked_bytes": 1_048_576,
+                "stdlib_wall_s": None,
+                "wall_ratio": None,
+                "notes": "solid invariant",
+            },
+        ],
+    }
+    report = format_text_report(payload)
+    assert "# Benchmark report" in report
+    assert "| Case | archivey | stdlib | ratio | vs VISION |" in report
+    assert "`zip_read_all`" in report
+    assert "1.18×" in report
+    assert "within ≤1.3×" in report
+    assert "solid invariant" in report
+    assert "64 × 256.0 KiB" in report or "64 × 256 KiB" in report


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The change-guarded nightly wall-time workflow (`benchmark-wall.yml`) previously uploaded only a JSON artifact, which is awkward to skim from the Actions UI.

This change:

- Adds `format_text_report()` and a `--text-out` flag on `benchmarks.harness` that renders markdown tables (wall ratios vs VISION, all cases, solid notes).
- Uploads `benchmark-wall-realistic.md` alongside the JSON artifact.
- Appends the same markdown to `$GITHUB_STEP_SUMMARY` so the tables show on the run’s **Summary** tab without downloading anything.

## How to read results after merge

1. Open the workflow run → **Summary** tab (inline tables — no download).
2. Or download the `benchmark-wall-realistic` artifact (now includes `.md` + `.json`).

## Test plan

- [x] Unit test for report formatting
- [x] Smoke `--text-out` on a local harness run (`--mode structural --scale ci`)
- [ ] Confirm lint/typecheck stay clean in CI

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dbf6e3d2-7f40-470d-ab66-c60a2316a462"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dbf6e3d2-7f40-470d-ab66-c60a2316a462"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

