### PR TITLE
Propose extraction-progress-in-file: intra-member progress callbacks

### DIFF
--- a/openspec/changes/extraction-progress-in-file/.openspec.yaml
+++ b/openspec/changes/extraction-progress-in-file/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: library
+created: 2026-07-15

--- a/openspec/changes/extraction-progress-in-file/brief.md
+++ b/openspec/changes/extraction-progress-in-file/brief.md
@@ -1,0 +1,20 @@
+<!--
+The "coffee brief": a spoken-word-friendly summary of this change, readable (or
+read aloud) in under a minute. Prose only — NO tables, NO code blocks, minimal
+symbols — so text-to-speech reads cleanly. Aim for ~200–280 words. Derive it from
+proposal.md / design.md / tasks.md; do not introduce new decisions here.
+-->
+
+# extraction-progress-in-file — progress bars that move within a large file
+
+**Status:** Small, ready to implement. Enables the nicer command-line progress bar but is a library change on its own. Not breaking for published users, since nothing is published yet. Effort: small.
+
+**Why it matters:** Today the extraction progress callback fires once per member, after the member is fully written, and the byte count it reports is the running total for the whole operation. So when you extract one big file, the progress bar sits frozen and then jumps by the entire file size in a single step. There is no way to draw a bar that fills as a single large member is written.
+
+**The key insight:** the number we need already exists. The decompression-bomb guard is fed every one-megabyte copy chunk, and it already keeps a running count of the current member's output, because the per-file ratio check needs it. That in-file position is measured on every chunk; it just never leaves the guard.
+
+**What it does:** Expose that per-member byte count and add it to the progress payload as member-bytes-written. Emit the progress callback from inside the copy loop, not only at the file boundary, throttled naturally by the one-megabyte chunk — so about one update per megabyte, and still a single update for small files. The callback may now fire several times per file, and a final update always lands exactly at the file's size so a consumer can complete the bar. Directories and links keep their single update. When no callback is set, nothing extra happens.
+
+**Your call later:** Whether one update per megabyte is the right cadence or wants a coarser floor for very large files.
+
+**Bottom line:** Reuse the bomb guard's existing per-chunk count; surface it; extract gets real in-file progress bars.

--- a/openspec/changes/extraction-progress-in-file/design.md
+++ b/openspec/changes/extraction-progress-in-file/design.md
@@ -1,0 +1,112 @@
+## Context
+
+`ExtractionCoordinator` drives one forward pass over `(member, stream)` pairs and
+owns progress callbacks (`safe-extraction`). Today progress is emitted once per
+member:
+
+- `_report_progress` (`extraction.py`) builds an `ExtractionProgress` and is
+  called at the member boundary, right after `members_done += 1`.
+- `ExtractionProgress.bytes_written` = `tracker.total_bytes` — cumulative for the
+  whole call.
+
+Member bytes are copied to disk by `_copy_to_fileobj`, a `@staticmethod` that
+loops reading `_CHUNK = 1 MiB` slices and calls `tracker.count(len(chunk))` for
+each. `BombTracker.count()` updates `_total_bytes` **and** `_member_bytes`
+(reset in `start_member`) on every chunk — the per-member ratio guard needs the
+running in-file figure. So intra-member position is already computed per chunk;
+it is just never surfaced.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Expose the already-tracked in-file byte position and emit progress during a
+  member's copy, so front-ends can draw per-file bars.
+- Keep the change tiny and localized; reuse the existing `BombTracker` counter.
+- Preserve the zero-`on_progress` fast path.
+
+**Non-Goals:**
+- Read/verify (`test`) progress — a separate seam, not through the coordinator.
+- Progress for non-FILE members (no streamed bytes).
+- Time-based throttling machinery (the 1 MiB chunk is a sufficient natural throttle).
+- Changing ratio-guard, limits, or result semantics.
+
+## Decisions
+
+### 1. Reuse `BombTracker._member_bytes`; do not add a parallel counter
+
+The tracker already maintains `_member_bytes` per chunk. Expose it as a
+`member_bytes` property (mirroring `total_bytes`) and read it when emitting
+progress. No new counting wrapper, no second traversal — the number is a
+by-product of the bomb guard that already runs on the hot path.
+
+**Rejected:** a dedicated progress counter / stream wrapper — redundant with the
+guard that must run anyway; more hot-path work for the same number.
+
+### 2. Emit from inside the copy loop, throttled by the copy chunk
+
+Call the progress emit inside `_copy_to_fileobj`'s read loop, after
+`tracker.count(...)`. The loop already reads in `_CHUNK = 1 MiB` slices, so this
+is ≈1 callback per MiB of output: 1024 for a 1 GiB member, and exactly one for a
+member smaller than a chunk (unchanged from today). No separate time throttle is
+needed; if a finer/coarser cadence is ever wanted it is a local change to the
+emit condition.
+
+`_copy_to_fileobj` is currently a `@staticmethod` receiving only the tracker. It
+needs `on_progress` plus the member/estimate/counter context to emit. Options:
+make it an instance method, or pass a small `emit_progress` closure built by the
+caller. Prefer the **closure**: it keeps `_copy_to_fileobj` a pure copy helper,
+carries no coordinator state it does not need, and is trivially a no-op when
+`on_progress is None`.
+
+**Rejected:** emitting per `write()` regardless of chunk size (needs its own
+throttle); a background timer thread (sync-only library; overkill).
+
+### 3. Progress contract for intra-member reporting
+
+- **During** a FILE member: zero or more reports with `member` = current,
+  `members_done` = members fully completed *before* this one, and
+  `member_bytes_written` strictly increasing toward `size`.
+- **Terminal** per-member report: still fires (as today) with
+  `member_bytes_written == member.size`; when `size` is unknown (`None`), it
+  equals the final observed byte count. This guarantees a consumer can always
+  finish the per-file bar, even if intermediate reports were coalesced.
+- `bytes_written` (cumulative) now advances within a member too. It was already
+  documented as "cumulative for the operation," so the value stays correct; only
+  the *frequency* increases.
+- Non-FILE members (dir/symlink/hardlink) have no streamed bytes and emit only
+  their single boundary report, `member_bytes_written == 0`.
+
+### 4. `member.size is None` → indeterminate bar, not an error
+
+Late-bound / streaming members may have `size is None`. The callback still
+reports `member_bytes_written`; the consumer shows an indeterminate/running-byte
+bar (e.g. tqdm `total=None`). No special-casing in the coordinator beyond the
+terminal-report rule in Decision 3.
+
+### 5. Field placement / compatibility
+
+Add `member_bytes_written: int` to `ExtractionProgress`. The library is the sole
+constructor (handed to a callback), so adding a field is compatible for readers.
+Place it after the existing fields; give it a default only if needed to satisfy
+dataclass ordering (existing fields have no defaults, so a trailing
+no-default field is fine).
+
+## Risks / Trade-offs
+
+- [More callbacks per operation] → Consumers that did O(work) per callback now do
+  it up to ~1×/MiB. Mitigated: only when `on_progress` is set, and 1 MiB
+  granularity is coarse. Document the frequency change.
+- [`_copy_to_fileobj` no longer a pure staticmethod helper] → Kept pure via the
+  closure (Decision 2); the coordinator owns the progress context.
+- [Cumulative `bytes_written` now intra-member] → Benign per its existing
+  "cumulative" documentation, but flagged for any consumer keying off
+  boundary-only cadence.
+
+## Open Questions
+
+1. **Throttle policy:** is 1 callback/MiB acceptable as the fixed cadence, or do
+   we want a coarser floor (e.g. ≥N MiB or ≥X% of `size`) to bound callbacks for
+   very large members? Recommend shipping the natural 1 MiB cadence and only
+   adding a floor if a consumer reports overhead.
+2. **Coordinate with the `cli-v1` `test`/read-side progress seam** so both verbs
+   feel consistent — tracked in `cli-v1`, not blocking here.

--- a/openspec/changes/extraction-progress-in-file/proposal.md
+++ b/openspec/changes/extraction-progress-in-file/proposal.md
@@ -1,0 +1,68 @@
+## Why
+
+`on_progress` fires **once per member**, after the member is fully written
+(`ExtractionCoordinator._report_progress`, called at the member boundary), and
+`ExtractionProgress.bytes_written` is the cumulative operation total. So a
+front-end (the `cli-v1` progress bar, or any library consumer) cannot draw an
+*in-file* bar: extracting one large member shows a frozen bar that jumps by the
+whole member size in a single step at completion.
+
+The data to do better already exists. `BombTracker` — the decompression-ratio
+guard — is fed **per 1 MiB copy chunk** and already maintains both a cumulative
+total (`_total_bytes`) and the current member's output so far (`_member_bytes`),
+because the per-member ratio check needs the running in-file figure. The
+intra-member byte position is measured on every chunk; it simply never leaves the
+tracker. This change exposes it and emits progress from inside the copy loop.
+
+## What Changes
+
+- Add `ExtractionProgress.member_bytes_written: int` — the current member's output
+  bytes so far (denominator for a per-file bar is the member's `size`, already on
+  `ArchiveMember`).
+- Emit `on_progress` **during** a FILE member's copy, not only at the member
+  boundary, sourced from `BombTracker`'s existing per-chunk `_member_bytes`
+  (exposed via a new `member_bytes` property). Throttled by the existing 1 MiB
+  copy chunk (≈1 callback/MiB); small members keep a single callback as today.
+- Clarify the progress contract: intra-member reports carry `members_done` =
+  members *completed* (excluding the current one) and `member_bytes_written <
+  size`; a terminal report per member SHALL still fire with `member_bytes_written
+  == size` (or the final byte count when `size` is unknown) so consumers can
+  complete the bar. Directories, links, and hardlinks keep their single
+  boundary report (no streamed bytes).
+- Preserve the zero-cost path: when `on_progress is None`, no per-chunk work
+  beyond the byte counting the `BombTracker` already does.
+
+- **BREAKING** (pre-release only): widens the `on_progress` contract — the
+  callback may now be invoked multiple times per member, and `bytes_written`
+  advances *within* a member rather than only at boundaries. A new field is added
+  to the `ExtractionProgress` dataclass. No published package yet, so no user
+  breakage.
+
+## Capabilities
+
+### New Capabilities
+
+<!-- none — extends existing `safe-extraction` -->
+
+### Modified Capabilities
+
+- `safe-extraction` — `on_progress` may fire multiple times per FILE member;
+  `ExtractionProgress` gains `member_bytes_written`; the per-member terminal
+  report and `members_done` semantics are clarified for intra-member reporting.
+
+## Impact
+
+- `src/archivey/internal/extraction_types.py` — new `ExtractionProgress` field.
+- `src/archivey/internal/extraction.py` — `BombTracker.member_bytes` property;
+  `_copy_to_fileobj` gains a throttled progress emit (needs `on_progress` +
+  member/counter context, currently a `@staticmethod` taking only the tracker).
+- `src/archivey/__init__.py` — no export change (`ExtractionProgress` already
+  public); docstring/field docs updated.
+- Enables the `cli-v1` extract progress bar to show in-file progress; `cli-v1`
+  depends on this landing for that UX (falls back to per-member bars without it).
+- Tests: `on_progress` fires more than once for a large FILE member with
+  monotonically non-decreasing `member_bytes_written` ending at `size`; single
+  callback for a sub-chunk member; no extra callbacks for dirs/links; unchanged
+  behavior when `on_progress is None`.
+- Read-side `test`/verify progress is a **separate seam** (it does not go through
+  `ExtractionCoordinator`/`BombTracker`) and is out of scope here.

--- a/openspec/changes/extraction-progress-in-file/specs/safe-extraction/spec.md
+++ b/openspec/changes/extraction-progress-in-file/specs/safe-extraction/spec.md
@@ -1,0 +1,52 @@
+## MODIFIED Requirements
+
+### Requirement: Progress Reporting via on_progress Callback
+
+The system SHALL accept optional `on_progress` callbacks on both extraction APIs
+and report progress with `ExtractionProgress`:
+
+```python
+@dataclass
+class ExtractionProgress:
+    member: ArchiveMember
+    bytes_written: int
+    total_bytes_estimated: int | None
+    members_done: int
+    members_total: int | None
+    member_bytes_written: int
+```
+
+`bytes_written` is cumulative for the operation. `member_bytes_written` is the
+output bytes written for the **current** member so far. `total_bytes_estimated`
+is `None` when the format lacks uncompressed size information; `members_total` is
+`None` when the attempted member count cannot be known without a scan. When a
+free member list exists and a `members` selector is provided, totals SHALL cover
+only selected members. `members_done` counts every selected member processed,
+including user-filter skips and failures, so it reaches `members_total`;
+selector-excluded members are invisible. Predicate selectors evaluated against an
+upfront index MUST be pure functions of the member.
+
+For a FILE member with a streamed body, the callback MAY be invoked **more than
+once** as bytes are written: intra-member reports carry `member` = the current
+member, `members_done` = the number of members fully completed *before* this one,
+and a non-decreasing `member_bytes_written` that has not yet reached the member's
+size. Each processed member SHALL additionally produce a terminal report in which
+`member_bytes_written` equals the member's `size` (or, when `size` is unknown,
+the final observed byte count), so a consumer can always complete a per-member
+progress bar. Members without a streamed body (directories, symlinks, hardlinks)
+SHALL produce a single report with `member_bytes_written == 0`. The reporting
+frequency is bounded by the extraction copy chunk size; when `on_progress` is
+`None`, no additional per-chunk work is performed beyond existing byte counting.
+
+#### Scenario: progress matrix
+
+| Case | Expected |
+| --- | --- |
+| `extract(..., on_progress=cb)` | `cb` called with cumulative bytes, per-member bytes, and counters |
+| Large FILE member streamed | `cb` invoked multiple times with non-decreasing `member_bytes_written`, ending at the member `size` |
+| FILE member smaller than one copy chunk | `cb` invoked once with `member_bytes_written == size` |
+| Directory / symlink / hardlink member | Single report with `member_bytes_written == 0` |
+| Member with unknown `size` (late-bound / streaming) | `member_bytes_written` still reported; terminal report equals final observed byte count |
+| Format cannot provide uncompressed sizes | `total_bytes_estimated is None` |
+| Free list + selector | Totals cover selected members only; filter skips/failures still advance `members_done` |
+| `on_progress is None` | No callback; no extra per-chunk work beyond byte counting |

--- a/openspec/changes/extraction-progress-in-file/tasks.md
+++ b/openspec/changes/extraction-progress-in-file/tasks.md
@@ -1,0 +1,27 @@
+## 1. Expose the in-file counter
+
+- [ ] 1.1 Add a `member_bytes` property to `BombTracker` (mirrors `total_bytes`; returns `_member_bytes`)
+
+## 2. Progress payload
+
+- [ ] 2.1 Add `member_bytes_written: int` to `ExtractionProgress` (trailing field; update docstring)
+
+## 3. Emit during the copy loop
+
+- [ ] 3.1 Give `_copy_to_fileobj` a throttled progress emit (pass an `emit_progress` closure / member+counter context; keep it a no-op when `on_progress is None`)
+- [ ] 3.2 Emit inside the read loop after `tracker.count(...)`, bounded by the 1 MiB copy chunk
+- [ ] 3.3 Keep the terminal per-member report firing with `member_bytes_written == size` (or final byte count when `size is None`)
+- [ ] 3.4 Non-FILE members (dir/link/hardlink) emit a single report with `member_bytes_written == 0`
+
+## 4. Tests
+
+- [ ] 4.1 Large FILE member: `on_progress` fires >1× with non-decreasing `member_bytes_written` ending at `size`
+- [ ] 4.2 Sub-chunk FILE member: exactly one callback with `member_bytes_written == size`
+- [ ] 4.3 Directory / symlink / hardlink: single callback, `member_bytes_written == 0`
+- [ ] 4.4 Unknown-`size` member: terminal report equals final observed byte count
+- [ ] 4.5 `on_progress is None`: behavior and byte totals unchanged (no regressions in ratio/limits)
+
+## 5. Validate
+
+- [ ] 5.1 `uv run pyrefly check` and `uv run ty check` clean
+- [ ] 5.2 `openspec validate --strict extraction-progress-in-file`


### PR DESCRIPTION
## Summary

OpenSpec change `extraction-progress-in-file` proposing **in-file** extraction progress so front-ends (the `cli-v1` progress bar, or any library consumer) can draw a bar that fills *within* a single large member.

**Problem:** `on_progress` fires once per member, at the write boundary, and `ExtractionProgress.bytes_written` is the cumulative operation total — so extracting one big file shows a frozen bar that jumps by the whole file size in one step.

**Insight:** the number is already computed. `BombTracker` (the decompression-ratio guard) is fed every 1 MiB copy chunk and already maintains `_member_bytes` (the current member's output so far) for the per-file ratio check. It just never leaves the tracker.

**Change:**
- Expose it via `BombTracker.member_bytes`.
- Add `ExtractionProgress.member_bytes_written: int` (denominator for a per-file bar is the member's `size`).
- Emit `on_progress` from inside `_copy_to_fileobj`'s copy loop, throttled by the 1 MiB chunk (~1 callback/MiB; one callback for sub-chunk members, as today).
- Contract clarified: intra-member reports carry `members_done` = members completed before this one and `member_bytes_written < size`; a terminal report per member still fires with `member_bytes_written == size` (or final byte count when `size` is unknown) so consumers can complete the bar. Dirs/links keep a single report with `member_bytes_written == 0`.
- Zero-`on_progress` path stays free (no extra per-chunk work beyond existing byte counting).

## Artifacts

`openspec/changes/extraction-progress-in-file/` — proposal, design, `safe-extraction` delta spec, tasks, brief. Validated with `openspec validate --strict extraction-progress-in-file`.

## Relationship to cli-v1

`cli-v1` (#110) depends on this for in-file extract progress bars; without it, the CLI falls back to per-member bars. The **read-side `test`/verify progress** is a *separate seam* (it does not go through `ExtractionCoordinator`/`BombTracker`) and is out of scope here.

## Open question

Whether ~1 callback/MiB is the right fixed cadence or wants a coarser floor for very large members (recommend shipping the natural cadence, add a floor only if a consumer reports overhead).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01D5WmrQ3XyQaGZSo3jwn4qX

---
_Generated by [Claude Code](https://claude.ai/code/session_01D5WmrQ3XyQaGZSo3jwn4qX)_