### PR TITLE
review: crypto correctness deep dive (Brief 2)

### DIFF
--- a/review/next/02-crypto/7z-source-questions.md
+++ b/review/next/02-crypto/7z-source-questions.md
@@ -1,0 +1,56 @@
+# Source-verification checklist (for the 7-Zip / UnRAR source agent)
+
+Questions this crypto review could not settle from Python oracles alone. Each is phrased so a
+source-reading agent can answer it with a file/line citation. Two codebases:
+
+- **7-Zip** (`p7zip` / 7-Zip source): `C/Sha256.c`, `CPP/7zip/Crypto/7zAes.{h,cpp}`,
+  `CPP/7zip/Crypto/MyAes.cpp`.
+- **UnRAR** (RARLAB `unrar` source): `crypt.cpp`, `crypt5.cpp`, `hash.cpp`, `blake2sp.cpp`,
+  `headers.hpp`, `archive.cpp`.
+
+## A. 7z AES key-derivation (`NumCyclesPower`) — for F3
+
+1. In `7zAes.cpp` (`CKeyInfo::CalcKey` / the SHA-256 loop): does the decoder **bound**
+   `NumCyclesPower` before looping `1 << NumCyclesPower` times, or does it loop unbounded on
+   whatever the archive stored? Cite the exact loop and any clamp.
+2. Is there a `0x3F` (63) **special case** ("no hashing: key = salt‖password padded to 32")?
+   py7zr and archivey both implement one. Does official 7-Zip? If **not**, then for a crafted
+   `NumCyclesPower == 0x3F` archivey diverges from 7-Zip (7-Zip would attempt 2⁶³ rounds).
+   Quote the branch (or confirm its absence).
+3. What is the encoder's default `NumCyclesPower`? (Expected: 19.) Any code path that lets a
+   user raise it, and to what maximum?
+4. Confirm the counter fed into SHA-256 is the 64-bit little-endian round index appended to
+   `salt‖password` each round (archivey/py7zr do this) — cite the byte layout.
+
+## B. 7z wrong-password detection without CRC — for F2
+
+5. When an encrypted 7z folder/substream has **no defined CRC** (no `UnpackDigests`,
+   CRC-less members), how does 7-Zip decide the password was wrong? Does it (a) rely solely on
+   CRC and therefore silently return garbage when CRC is absent, or (b) have another gate
+   (padding check, coder-level validation)? Cite the extraction path in
+   `7zHandler`/`7zDecode`. This decides whether archivey's best-effort accept matches 7-Zip.
+
+## C. RAR5 tweaked-checksum transform (`ConvertHashToMAC`) — for F1
+
+6. In `hash.cpp` `ConvertHashToMAC` (or wherever the tweak is applied), confirm the exact
+   transform for **both** hash types:
+   - CRC32: `HMAC-SHA256(HashKey, RawPut4(crc))` → XOR the eight 32-bit words → new CRC32.
+     (archivey-dev implements exactly this — confirm bit layout: little-endian `RawPut4`,
+     little-endian `RawGet4` on the digest words.)
+   - **BLAKE2sp**: confirm it is `HMAC-SHA256(HashKey, blake2sp_digest[32])` copied over the
+     32-byte digest (my reading). This is the piece archivey-dev never implemented; v2 needs
+     it to verify tweaked `-htb` members.
+7. Confirm the **HashKey** used by `ConvertHashToMAC` is the PBKDF2-HMAC-SHA256 output at
+   `(1 << Kdf_Count) + 16` iterations (16 iterations past the AES key; PswCheck is at +32).
+   Cite `crypt5.cpp` where Key / HashKey / PswCheck are split out of the single derivation.
+8. Confirm the tweak is applied **only** when the file's encryption record has the
+   `RAR5_XENC_TWEAKED` (0x02) flag, and that header-encrypted archives (encrypted file names)
+   store **un-tweaked** checksums (the WinRAR docs say so; confirm in source).
+
+## D. unrar password channel — for F4
+
+9. Does RARLAB `unrar` support any **non-interactive** password channel other than
+   `-p<password>` on the command line — e.g. reading from stdin, a file, or an environment
+   variable — that avoids exposing the password in `argv`/`/proc`? Check `CmdExtract` /
+   `GetPassword` / option parsing. (If not, `-p<pwd>` is unavoidable and F4 is a documented
+   limitation.)

--- a/review/next/02-crypto/7z-source-questions.md
+++ b/review/next/02-crypto/7z-source-questions.md
@@ -1,5 +1,10 @@
 # Source-verification checklist (for the 7-Zip / UnRAR source agent)
 
+> **STATUS: ANSWERED (2026-07-16).** All items below were answered from the 7-Zip and UnRAR
+> source; the confirmed answers are summarised in the **"Answers"** section at the bottom and
+> folded into `QUESTIONS.md` (final decisions) and the theme files. Kept here as the audit
+> trail.
+
 Questions this crypto review could not settle from Python oracles alone. Each is phrased so a
 source-reading agent can answer it with a file/line citation. Two codebases:
 
@@ -54,3 +59,46 @@ source-reading agent can answer it with a file/line citation. Two codebases:
    variable — that avoids exposing the password in `argv`/`/proc`? Check `CmdExtract` /
    `GetPassword` / option parsing. (If not, `-p<pwd>` is unavoidable and F4 is a documented
    limitation.)
+
+---
+
+# Answers (source-confirmed, 2026-07-16)
+
+## A — 7z AES key-derivation
+- **A1 (bound?)** Yes, but at *property-parse* time, not in the hash loop. `CalcKey` loops
+  `1 << NumCyclesPower` unbounded, but `SetDecoderProperties2` accepts `NumCyclesPower <= 24`
+  (`7zAes.cpp:27` `k_NumCyclesPower_Supported_MAX = 24`) **or** `== 0x3F`, else `E_NOTIMPL`
+  (`7zAes.cpp:260-279`). Values 25–62 never reach `CalcKey`. → **v2 is currently more permissive
+  than 7-Zip**; match 7-Zip (accept ≤24 or ==0x3F).
+- **A2 (0x3F sentinel?)** Yes, official 7-Zip has it: `Key = salt‖password` zero-padded to 32,
+  no SHA-256 (`7zAes.cpp:41-50`). archivey/py7zr match — no divergence.
+- **A3 (encoder default/max)** Hardcoded 19; the `0x3F` line is commented out; `CEncoder` has no
+  `ICompressSetCoderProperties`, so no UI/CLI can change it (`7zAes.cpp:232`). Always writes 19.
+- **A4 (counter layout)** 8-byte little-endian round index appended to `salt‖password`; per round
+  `SetUi32` writes the low 32 bits LE, high 4 bytes stay 0 (`7zAes.cpp:56-67`). Matches
+  archivey's `(s+i).to_bytes(8,"little")`.
+
+## B — 7z wrong-password detection without CRC
+- **B5** 7zAES has **no** password check; AES-CBC just filters. Wrong-password detection is the
+  extraction CRC gate, and only when CRC is defined (`7zExtract.cpp:95` `_calcCrc = CheckCrc &&
+  fi.CrcDefined && !fi.IsDir`; `:128` returns `kOK` when `!_calcCrc`). No CRC + compressed → LZMA
+  usually rejects garbage → `kDataError` (`7zExtract.cpp:397-411`); **no CRC + store/copy →
+  silently OK with garbage.** → archivey's best-effort accept matches 7-Zip; do not invent a
+  password check.
+
+## C — RAR5 tweaked-checksum transform
+- **C6** `ConvertHashToMAC` (`crypt5.cpp:193-211`): CRC32 → XOR-fold of `HMAC-SHA256(HashKey,
+  RawPut4(crc))` (LE, matches archivey-dev); BLAKE2sp → `HMAC-SHA256(HashKey, digest[32])`
+  overwriting the 32 bytes (matches this review's reading; DEV never implemented it).
+- **C7** HashKey = PBKDF2-HMAC-SHA256 at `(1<<Lg2Cnt)+16`; AES key at `1<<Lg2Cnt`, PswCheck at
+  `+32` — one chain, three cutpoints (`crypt5.cpp:104,161`). PswCheck folded to 8 bytes by XOR.
+- **C8** Tweak applies iff the per-file `FHEXTRA_CRYPT_HASHMAC` (0x02) flag is set
+  (`headers5.hpp:103`, `arcread.cpp:1080`, `extract.cpp:934`). Encrypted-header (`-hp`) archives
+  do **not** auto-skip in the reader — unrar keys only off 0x02. v2's `_crc_is_tweaked` already
+  reads exactly this flag.
+
+## D — unrar password channel
+- **D9** No env var, no `-p@file`. But **bare `-p` reads the password from stdin when stdin is
+  redirected** (`GetPasswordText → getwstr`): `printf '%s\n' "$pw" | unrar x -p archive.rar`.
+  Non-interactive, keeps the secret out of `argv`/`/proc`. v2 uses `unrar p` (data on stdout),
+  so stdin is free → directly usable. → F4 is fixable, not just a documented limitation.

--- a/review/next/02-crypto/QUESTIONS.md
+++ b/review/next/02-crypto/QUESTIONS.md
@@ -1,0 +1,41 @@
+# Maintainer decisions — Brief 2 (crypto)
+
+These are the calls I did not want to make silently (CLAUDE.md: pause and ask on
+spec/behaviour discrepancies rather than resolving them).
+
+## Q1 — RAR5 tweaked-checksum BLAKE2sp (F1)
+
+When a RAR5 member is encrypted with tweaked checksums (`RAR5_XENC_TWEAKED`), the stored
+BLAKE2sp is key-tweaked and cannot be checked against the plaintext hash without reproducing
+the inverse tweak. Two options:
+
+- **(recommended) Skip it**, matching rarfile and matching what `_member_hashes` already does
+  for crc32 — drop blake2sp from `member.hashes` when tweaked, optionally emitting a
+  `DIGEST_UNVERIFIABLE` diagnostic. Minimal, restores correct reads immediately.
+- **Implement the inverse tweak** so archivey actually verifies tweaked BLAKE2sp (and could
+  re-enable the tweaked crc32 too). More faithful to WinRAR, but adds crypto surface and
+  needs a `-htb`-encrypted fixture to test.
+
+Either way the current behaviour (raise `CorruptionError` on good data) is wrong. Which
+direction?
+
+## Q2 — 7z folders with no integrity anchor (F2)
+
+An encrypted 7z folder with no folder digest and CRC-less members currently confirms *any*
+password and returns garbage. The safe fix is to **fail closed** — refuse to confirm a
+password when there is no checksum to validate against. Does that conflict with any planned
+"recover what you can from a damaged/odd archive" behaviour? My read of VISION #3 is that a
+*wrong-password-not-detected* is strictly worse than a refusal, so fail-closed is right — but
+confirm you want an encrypted-but-checksum-less member to hard-error rather than hand back
+unverified bytes.
+
+## Q3 — 7z KDF cap and the `0x3F` sentinel (F3)
+
+1. **Cap `NumCyclesPower`?** RAR5 caps its KDF shift at 24; 7z is uncapped below the `0x3F`
+   sentinel, so `0x3E` = ~2⁶² rounds. I recommend capping at 24 (raise
+   `UnsupportedFeatureError` above it). Agree on 24, or a different ceiling?
+2. **Is `0x3F` really a "no-hash" sentinel?** archivey follows py7zr (copy `salt+password`,
+   no hashing). If the 7-Zip C++ reference instead treats `0x3F` as `2^63` iterations, both
+   archivey and py7zr are wrong for that one value — but no creator emits `0x3F`, so it is a
+   crafted-only concern. Worth a one-line confirmation against the reference, or explicitly
+   accept "bit-exact with py7zr (our oracle)" as the contract and move on?

--- a/review/next/02-crypto/QUESTIONS.md
+++ b/review/next/02-crypto/QUESTIONS.md
@@ -1,90 +1,86 @@
-# Maintainer decisions — Brief 2 (crypto) — RESOLVED
+# Maintainer decisions — Brief 2 (crypto) — RESOLVED (source-confirmed)
 
-Answers below fold in davitf's PR #115 review (2026-07-15) plus a check of the `archivey-dev`
-reference at `730275b`. Open source-verification items are collected in
-`7z-source-questions.md`.
+Answers below fold in davitf's PR #115 review (2026-07-15), a check of the `archivey-dev`
+reference at `730275b`, and the **7-Zip + UnRAR source answers** (2026-07-16, see
+`7z-source-questions.md` for the raw citations). All questions are now closed; the "plan"
+lines are the agreed implementation direction.
 
-## Q1 — RAR5 tweaked-checksum BLAKE2sp (F1) — **decided: untweak-and-verify**
+## Q1 — RAR5 tweaked-checksum BLAKE2sp (F1) — **untweak-and-verify (both transforms confirmed)**
 
-davitf: *"DEV had special handling for tweaked rar checksums (maybe only crc32). If we have
-password(s) at open time, could we quickly check which one is correct using the check field,
-then derive the correct checksums from the tweaked ones … if we don't know the password,
-leave the hashes empty (maybe store the tweaked ones in extras)."*
+The tweak is RAR's `ConvertHashToMAC` — a **one-way forward transform**, so we compute the
+real hash from decrypted data, transform it, and compare to the stored value (we cannot
+recover the real checksum from the tweaked one). Both transforms are now confirmed against
+UnRAR `crypt5.cpp`:
 
-Findings from `archivey-dev/src/archivey/formats/rar_reader.py`:
+- **HashKey** = `PBKDF2-HMAC-SHA256(pw_utf8, salt, (1 << kdf_count) + 16)` — the AES key is at
+  `1 << kdf_count`, HashKey at `+16`, PswCheck at `+32` (single PBKDF2 chain, three cutpoints;
+  `crypt5.cpp:104,161`). Matches archivey-dev.
+- **CRC32:** `d = HMAC-SHA256(HashKey, crc.to_bytes(4,"little"))`; fold the 32-byte digest into
+  a 4-byte value by XOR of the eight little-endian uint32 words (UnRAR does it byte-wise with
+  `Digest[I] << ((I & 3) * 8)`, equivalent). Matches archivey-dev's `convert_crc_to_encrypted`.
+- **BLAKE2sp:** `tweaked32 = HMAC-SHA256(HashKey, blake2sp_digest[32])`, overwriting the 32-byte
+  digest (`crypt5.cpp:206`). This is the path archivey-dev never implemented.
+- **Gate:** the tweak is applied **iff** the file's `FHEXTRA_CRYPT_HASHMAC` (0x02) flag is set
+  (`arcread.cpp:1080`, `extract.cpp:934`) — which is exactly what v2's `_crc_is_tweaked` already
+  reads. **Correction to the earlier writeup:** encrypted-header (`-hp`) archives do **not**
+  auto-skip the tweak in the reader; unrar honours only the per-file 0x02 flag (untweaked
+  checksums under `-hp` are a *writer* choice to omit the flag). So no header-encryption
+  special-case is needed — key off 0x02 alone.
 
-- DEV implements `convert_crc_to_encrypted` = RAR's `ConvertHashToMAC`. The tweak is a
-  **one-way forward transform**, not reversible: `tweaked = f(hash_key, real_hash)`. So you
-  **cannot** "derive the correct checksums from the tweaked ones" — the real CRC/BLAKE2sp is
-  not recoverable from the stored tweaked value. What you *can* do (and what DEV does) is
-  compute the real hash from decrypted data, apply the same forward transform, and compare to
-  the stored tweaked value.
-- Key derivations (all PBKDF2-HMAC-SHA256 over UTF-8 password + 16-byte salt):
-  - AES key: `1 << kdf_count` iterations.
-  - **HashKey** (the tweak/MAC key): `(1 << kdf_count) + 16`.
-  - PswCheck: `(1 << kdf_count) + 32`.
-- CRC32 transform: `d = HMAC-SHA256(HashKey, crc.to_bytes(4,"little"))`; XOR the eight
-  little-endian uint32 words of `d` → 4-byte tweaked CRC.
-- BLAKE2sp transform (per UnRAR `ConvertHashToMAC`, **flagged for source confirmation** in
-  `7z-source-questions.md`): `tweaked32 = HMAC-SHA256(HashKey, real_blake2sp_32)` — the stored
-  32 bytes are an HMAC of the real digest. **DEV implemented the CRC path only; it never
-  untweaked BLAKE2sp** — it just dropped the tweaked crc32 (`crc32 = None`) so it never
-  false-positived. v2 regressed by dropping crc32 but *keeping* the tweaked blake2sp.
+**Plan:**
+1. **Interim correctness fix:** make `_member_hashes` symmetric — drop `blake2sp` when 0x02 is
+   set, exactly as it already drops `crc32`; stash both tweaked values in `member.extra`
+   (`rar.tweaked_crc32` / `rar.tweaked_blake2sp`). Removes the false `CorruptionError`.
+2. **Full fix:** when a password is confirmed at open time, verify by forward-transform
+   (CRC32 + BLAKE2sp) with the HashKey; leave `member.hashes` empty when the password is
+   unknown. Strictly better than DEV (which did CRC only).
 
-**Plan (matches davitf's proposal):**
-1. **Immediate correctness fix (unblocks reads):** make `_member_hashes` symmetric — drop
-   `blake2sp` when tweaked, exactly as it already drops `crc32`. This alone removes the false
-   `CorruptionError`. Store the tweaked values in `member.extra` (`rar.tweaked_crc32`,
-   `rar.tweaked_blake2sp`) so nothing is lost.
-2. **Full fix (restores verification when the password is known):** thread the confirmed
-   password / HashKey into the RAR verification stage and verify by forward-transform (CRC32
-   and BLAKE2sp). When no correct password is known at open time, leave `member.hashes` empty
-   and keep the tweaked values in `extra`. This is strictly better than DEV (which did CRC
-   only) and needs the BLAKE2sp transform confirmed against UnRAR source.
+## Q2 — 7z folders with no integrity anchor (F2) — **best-effort accept confirmed correct**
 
-## Q2 — 7z folders with no integrity anchor (F2) — **decided: best-effort, don't hard-error**
+Source-confirmed: 7zAES has **no password check** of its own (unlike ZipAES/Rar5) — AES-CBC
+just filters, no padding/MAC gate. 7-Zip's only wrong-password gate is the extraction CRC,
+and *only when the CRC is defined* (`7zExtract.cpp:95,128`). With no CRC:
+- compressed member → the LZMA/LZMA2 decoder usually rejects garbage → `kDataError`;
+- **store/copy member → silently returns garbage (`kOK`)**.
 
-davitf: *"I'd rather not hard-error if the data might actually be correct … extremely rare
-… how does 7z itself handle it? doesn't zip have this problem as well … error detection is
-best-effort."*
+So archivey's best-effort accept **exactly matches 7-Zip** — "matching 7-Zip on CRC-less
+streams means accepting when decode succeeds, not inventing a password check 7-Zip doesn't
+have." Decision stands: keep accept-and-return, emit a `DIGEST_UNVERIFIABLE`/
+`DECRYPTION_UNVERIFIED` diagnostic on a no-anchor encrypted member. **F2 stays Low.** (ZIP is
+not exposed the same way — AE-2 has a mandatory HMAC, ZipCrypto STORED has the CD CRC.)
 
-Agreed — retract the "fail closed" recommendation. Rationale:
+## Q3 — 7z KDF cap + `0x3F` sentinel (F3) — **cap at 24 (matches 7-Zip exactly); 0x3F confirmed**
 
-- **7-Zip itself** relies on the folder/stream CRC to reject a wrong password; with no CRC it
-  cannot detect a wrong password either and returns whatever the cipher produced. Matching
-  that = best-effort. (Included as a source-confirmation item in `7z-source-questions.md`.)
-- **ZIP is not actually exposed** the same way: WinZip AE-2 sets CRC=0 but authenticates with
-  a **mandatory** HMAC (checked on close — verified good), and ZipCrypto STORED members are
-  disambiguated by the central-directory CRC-32. So every ZIP encrypted member still has an
-  integrity anchor (HMAC or CRC). 7z is the only format here where an encrypted member can
-  legitimately carry **zero** anchor (AES+COPY, no digest, CRC-less members).
-- The 1/256 ZipCrypto one-byte-check collision is a *different* best-effort case already
-  handled by the multi-candidate CRC pass; it does not apply when there is no CRC at all.
+Source-confirmed in `7zAes.cpp`:
+- **7-Zip *does* clamp** at property-parse time: `SetDecoderProperties2` accepts
+  `NumCyclesPower <= 24` **or** `== 0x3F`, else returns `E_NOTIMPL` (unsupported)
+  (`7zAes.cpp:27` `k_NumCyclesPower_Supported_MAX = 24`, `:260-279`). Values 25–62 never reach
+  the hash loop, so official 7-Zip never attempts 2⁶³ rounds. **v2 is currently *more*
+  permissive than 7-Zip** (accepts 25–62 → the DoS).
+- **`0x3F` special case is real** in official 7-Zip: `Key = salt‖password` zero-padded to 32,
+  no SHA-256 (`7zAes.cpp:41-50`). archivey/py7zr match — **the "is 0x3F really a sentinel?"
+  sub-question is resolved: yes, no divergence.**
+- **Counter layout confirmed:** 8-byte little-endian round index appended to `salt‖password`
+  (`7zAes.cpp:56-67`). archivey's `(s+i).to_bytes(8,"little")` matches.
+- Encoder default is **19**, hardcoded, never user-settable (`7zAes.cpp:232`).
 
-**Plan:** keep the current accept-and-return behaviour, but emit a diagnostic
-(`DIGEST_UNVERIFIABLE` or a new `DECRYPTION_UNVERIFIED`) when an encrypted folder has no
-integrity anchor, so a caller can tell "decrypted but not verifiable" from "verified". **F2
-downgraded to Low** (best-effort limitation, honest-signal gap — not silent-without-notice).
+**Plan:** match 7-Zip exactly — in `derive_sevenzip_aes_key` /
+`parse_sevenzip_aes_properties`, accept `cycles <= 24` or `cycles == 0x3F`, reject 25–62 with
+`UnsupportedFeatureError`. Not merely "our own defensive cap" — it is *the same cap 7-Zip
+enforces*, so it rejects nothing a real archive contains.
 
-## Q3 — 7z KDF `NumCyclesPower`: real cap, user-selectable, max (F3)
+## Q4 — 7-Zip / UnRAR source checklist — **answered** (`7z-source-questions.md`)
 
-What I can state now; the rest is in `7z-source-questions.md`:
+All items A–D answered from source. The only decision-changing surprise is D9 → see F4 below.
 
-- **Default:** 7-Zip encodes with `NumCyclesPower = 19` (2¹⁹ = 524 288 SHA-256 rounds,
-  ~sub-millisecond).
-- **User-selectable?** Not exposed in the 7-Zip GUI/CLI; the encoder is effectively fixed at
-  19. The **format** stores it in the low 6 bits of the AES property byte, so a file can
-  legally carry 0–0x3F regardless of what the official encoder emits.
-- **Max / decoder cap:** the 7z format max is `0x3F`. Whether the official 7-Zip *decoder*
-  caps `NumCyclesPower` (or loops `1 << value` unbounded, making 7-Zip itself DoS-able) is the
-  key source question — see `7z-source-questions.md`.
+## F4 (was "unavoidable") — **unrar password IS avoidable via bare `-p` + stdin**
 
-Regardless of what 7-Zip does, v2 should apply its **own defensive cap**. Recommendation:
-reject `NumCyclesPower > 24` (2²⁴ ≈ 16.7 M rounds, ~100 ms upper bound) with
-`UnsupportedFeatureError` — well above any real archive (19) and mirroring the RAR5 KDF cap of
-24 that v2 already enforces (`_RAR_MAX_KDF_SHIFT`). Confirm 24 or pick another ceiling.
+Source-confirmed correction: unrar supports a non-argv password channel — pass **bare `-p`**
+(no value) and write the password to the child's **stdin** (`GetPasswordText → getwstr` reads
+stdin when it is redirected; `printf '%s\n' "$pw" | unrar x -p archive.rar`). v2 uses
+`unrar p` with the *data* on stdout, so stdin is free — this is directly usable and keeps the
+password out of `argv`/`/proc/<pid>/cmdline`. There is still no env-var or `-p@file` channel.
 
-## Q4 — questions for the 7-Zip / UnRAR source agent
-
-davitf offered to run an agent over the 7-Zip (and we should add UnRAR) source. The full
-checklist is in **`7z-source-questions.md`**.
+**Plan (F4 upgraded from "documented limitation" to actionable):** change `_password_arg` /
+`open_unrar_p` to pass bare `-p` and feed `password + "\n"` via `stdin=PIPE` (keep `-p-` for
+the no-password case). Low severity, but now a concrete fix rather than an accepted leak.

--- a/review/next/02-crypto/QUESTIONS.md
+++ b/review/next/02-crypto/QUESTIONS.md
@@ -1,41 +1,90 @@
-# Maintainer decisions — Brief 2 (crypto)
+# Maintainer decisions — Brief 2 (crypto) — RESOLVED
 
-These are the calls I did not want to make silently (CLAUDE.md: pause and ask on
-spec/behaviour discrepancies rather than resolving them).
+Answers below fold in davitf's PR #115 review (2026-07-15) plus a check of the `archivey-dev`
+reference at `730275b`. Open source-verification items are collected in
+`7z-source-questions.md`.
 
-## Q1 — RAR5 tweaked-checksum BLAKE2sp (F1)
+## Q1 — RAR5 tweaked-checksum BLAKE2sp (F1) — **decided: untweak-and-verify**
 
-When a RAR5 member is encrypted with tweaked checksums (`RAR5_XENC_TWEAKED`), the stored
-BLAKE2sp is key-tweaked and cannot be checked against the plaintext hash without reproducing
-the inverse tweak. Two options:
+davitf: *"DEV had special handling for tweaked rar checksums (maybe only crc32). If we have
+password(s) at open time, could we quickly check which one is correct using the check field,
+then derive the correct checksums from the tweaked ones … if we don't know the password,
+leave the hashes empty (maybe store the tweaked ones in extras)."*
 
-- **(recommended) Skip it**, matching rarfile and matching what `_member_hashes` already does
-  for crc32 — drop blake2sp from `member.hashes` when tweaked, optionally emitting a
-  `DIGEST_UNVERIFIABLE` diagnostic. Minimal, restores correct reads immediately.
-- **Implement the inverse tweak** so archivey actually verifies tweaked BLAKE2sp (and could
-  re-enable the tweaked crc32 too). More faithful to WinRAR, but adds crypto surface and
-  needs a `-htb`-encrypted fixture to test.
+Findings from `archivey-dev/src/archivey/formats/rar_reader.py`:
 
-Either way the current behaviour (raise `CorruptionError` on good data) is wrong. Which
-direction?
+- DEV implements `convert_crc_to_encrypted` = RAR's `ConvertHashToMAC`. The tweak is a
+  **one-way forward transform**, not reversible: `tweaked = f(hash_key, real_hash)`. So you
+  **cannot** "derive the correct checksums from the tweaked ones" — the real CRC/BLAKE2sp is
+  not recoverable from the stored tweaked value. What you *can* do (and what DEV does) is
+  compute the real hash from decrypted data, apply the same forward transform, and compare to
+  the stored tweaked value.
+- Key derivations (all PBKDF2-HMAC-SHA256 over UTF-8 password + 16-byte salt):
+  - AES key: `1 << kdf_count` iterations.
+  - **HashKey** (the tweak/MAC key): `(1 << kdf_count) + 16`.
+  - PswCheck: `(1 << kdf_count) + 32`.
+- CRC32 transform: `d = HMAC-SHA256(HashKey, crc.to_bytes(4,"little"))`; XOR the eight
+  little-endian uint32 words of `d` → 4-byte tweaked CRC.
+- BLAKE2sp transform (per UnRAR `ConvertHashToMAC`, **flagged for source confirmation** in
+  `7z-source-questions.md`): `tweaked32 = HMAC-SHA256(HashKey, real_blake2sp_32)` — the stored
+  32 bytes are an HMAC of the real digest. **DEV implemented the CRC path only; it never
+  untweaked BLAKE2sp** — it just dropped the tweaked crc32 (`crc32 = None`) so it never
+  false-positived. v2 regressed by dropping crc32 but *keeping* the tweaked blake2sp.
 
-## Q2 — 7z folders with no integrity anchor (F2)
+**Plan (matches davitf's proposal):**
+1. **Immediate correctness fix (unblocks reads):** make `_member_hashes` symmetric — drop
+   `blake2sp` when tweaked, exactly as it already drops `crc32`. This alone removes the false
+   `CorruptionError`. Store the tweaked values in `member.extra` (`rar.tweaked_crc32`,
+   `rar.tweaked_blake2sp`) so nothing is lost.
+2. **Full fix (restores verification when the password is known):** thread the confirmed
+   password / HashKey into the RAR verification stage and verify by forward-transform (CRC32
+   and BLAKE2sp). When no correct password is known at open time, leave `member.hashes` empty
+   and keep the tweaked values in `extra`. This is strictly better than DEV (which did CRC
+   only) and needs the BLAKE2sp transform confirmed against UnRAR source.
 
-An encrypted 7z folder with no folder digest and CRC-less members currently confirms *any*
-password and returns garbage. The safe fix is to **fail closed** — refuse to confirm a
-password when there is no checksum to validate against. Does that conflict with any planned
-"recover what you can from a damaged/odd archive" behaviour? My read of VISION #3 is that a
-*wrong-password-not-detected* is strictly worse than a refusal, so fail-closed is right — but
-confirm you want an encrypted-but-checksum-less member to hard-error rather than hand back
-unverified bytes.
+## Q2 — 7z folders with no integrity anchor (F2) — **decided: best-effort, don't hard-error**
 
-## Q3 — 7z KDF cap and the `0x3F` sentinel (F3)
+davitf: *"I'd rather not hard-error if the data might actually be correct … extremely rare
+… how does 7z itself handle it? doesn't zip have this problem as well … error detection is
+best-effort."*
 
-1. **Cap `NumCyclesPower`?** RAR5 caps its KDF shift at 24; 7z is uncapped below the `0x3F`
-   sentinel, so `0x3E` = ~2⁶² rounds. I recommend capping at 24 (raise
-   `UnsupportedFeatureError` above it). Agree on 24, or a different ceiling?
-2. **Is `0x3F` really a "no-hash" sentinel?** archivey follows py7zr (copy `salt+password`,
-   no hashing). If the 7-Zip C++ reference instead treats `0x3F` as `2^63` iterations, both
-   archivey and py7zr are wrong for that one value — but no creator emits `0x3F`, so it is a
-   crafted-only concern. Worth a one-line confirmation against the reference, or explicitly
-   accept "bit-exact with py7zr (our oracle)" as the contract and move on?
+Agreed — retract the "fail closed" recommendation. Rationale:
+
+- **7-Zip itself** relies on the folder/stream CRC to reject a wrong password; with no CRC it
+  cannot detect a wrong password either and returns whatever the cipher produced. Matching
+  that = best-effort. (Included as a source-confirmation item in `7z-source-questions.md`.)
+- **ZIP is not actually exposed** the same way: WinZip AE-2 sets CRC=0 but authenticates with
+  a **mandatory** HMAC (checked on close — verified good), and ZipCrypto STORED members are
+  disambiguated by the central-directory CRC-32. So every ZIP encrypted member still has an
+  integrity anchor (HMAC or CRC). 7z is the only format here where an encrypted member can
+  legitimately carry **zero** anchor (AES+COPY, no digest, CRC-less members).
+- The 1/256 ZipCrypto one-byte-check collision is a *different* best-effort case already
+  handled by the multi-candidate CRC pass; it does not apply when there is no CRC at all.
+
+**Plan:** keep the current accept-and-return behaviour, but emit a diagnostic
+(`DIGEST_UNVERIFIABLE` or a new `DECRYPTION_UNVERIFIED`) when an encrypted folder has no
+integrity anchor, so a caller can tell "decrypted but not verifiable" from "verified". **F2
+downgraded to Low** (best-effort limitation, honest-signal gap — not silent-without-notice).
+
+## Q3 — 7z KDF `NumCyclesPower`: real cap, user-selectable, max (F3)
+
+What I can state now; the rest is in `7z-source-questions.md`:
+
+- **Default:** 7-Zip encodes with `NumCyclesPower = 19` (2¹⁹ = 524 288 SHA-256 rounds,
+  ~sub-millisecond).
+- **User-selectable?** Not exposed in the 7-Zip GUI/CLI; the encoder is effectively fixed at
+  19. The **format** stores it in the low 6 bits of the AES property byte, so a file can
+  legally carry 0–0x3F regardless of what the official encoder emits.
+- **Max / decoder cap:** the 7z format max is `0x3F`. Whether the official 7-Zip *decoder*
+  caps `NumCyclesPower` (or loops `1 << value` unbounded, making 7-Zip itself DoS-able) is the
+  key source question — see `7z-source-questions.md`.
+
+Regardless of what 7-Zip does, v2 should apply its **own defensive cap**. Recommendation:
+reject `NumCyclesPower > 24` (2²⁴ ≈ 16.7 M rounds, ~100 ms upper bound) with
+`UnsupportedFeatureError` — well above any real archive (19) and mirroring the RAR5 KDF cap of
+24 that v2 already enforces (`_RAR_MAX_KDF_SHIFT`). Confirm 24 or pick another ceiling.
+
+## Q4 — questions for the 7-Zip / UnRAR source agent
+
+davitf offered to run an agent over the 7-Zip (and we should add UnRAR) source. The full
+checklist is in **`7z-source-questions.md`**.

--- a/review/next/02-crypto/SUMMARY.md
+++ b/review/next/02-crypto/SUMMARY.md
@@ -18,12 +18,14 @@ py7zr and rarfile as importable libraries.
 
 The KDFs and ciphers themselves are **correct** — bit-exact against the project's own
 oracles (7z KDF vs `py7zr`, RAR3/RAR5 s2k vs `rarfile`, ZipCrypto vs stdlib
-`_ZipDecrypter`, BLAKE2sp vs official KATs). The bugs are all in the **glue that decides
-whether an integrity check runs at all**: one path raises a *dishonest error on good data*,
-one path *silently accepts a wrong password*, and one path lets a hostile archive burn
-unbounded CPU. None of these is caught by the current suite because the RAR data path needs
-an `unrar` binary (absent here) and the 7z/KDF triggers need format-legal-but-crafted
-archives that `py7zr` never emits.
+`_ZipDecrypter`, BLAKE2sp vs official KATs). The findings are all in the **glue that decides
+whether an integrity check runs at all**: one path raises a *dishonest error on good data*
+(F1 — a real bug), one lets a hostile archive burn unbounded CPU (F3 — v2 is more permissive
+than 7-Zip's own cap), and one *silently accepts a wrong password* where no checksum exists
+(F2 — now source-confirmed to match 7-Zip's own best-effort behaviour, so a diagnostic gap,
+not a bug). None is caught by the current suite because the RAR data path needs an `unrar`
+binary (absent here) and the 7z/KDF triggers need format-legal-but-crafted archives that
+`py7zr` never emits.
 
 ## Findings (most severe first)
 
@@ -31,25 +33,32 @@ archives that `py7zr` never emits.
 |---|-----|-------|-----------|-------|--------|
 | F1 | **High** | `rar_reader.py:119` `_member_hashes` | RAR5 tweaked-checksum members keep the key-tweaked BLAKE2sp in `hashes`, so a correctly-decrypted `-htb`-encrypted member fails `VerifyingStream` with a spurious `CorruptionError` | unit (VerifyingStream + tweaked hash) + `_member_hashes` asymmetry; rarfile oracle guard | Confirmed (logic); full e2e needs `unrar` + `-htb` encrypted fixture |
 | F2 | Low *(was Medium — see Q2)* | `sevenzip_reader.py:119` `_verify_decoded_folder` | Encrypted 7z folder with **no folder digest and CRC-less members** (both format-legal) confirms *any* password and returns garbage with no error (no CRC gate, no `VerifyingStream`) | unit (`_verify_decoded_folder` accepts wrong-key garbage) | Confirmed (logic); maintainer: keep best-effort, emit a diagnostic rather than hard-error |
-| F3 | **Medium** | `crypto.py:176` `derive_sevenzip_aes_key` | 7z `NumCyclesPower` is uncapped below the `0x3F` sentinel; a hostile value `0x3E` forces ~2⁶² SHA-256 rounds (CPU DoS) during password confirmation / header decode. RAR5 caps its shift at 24; 7z has no equivalent | `parse_sevenzip_aes_properties` + derive | Confirmed |
-| F4 | Low (hardening) | `rar_unrar.py:53` `_password_arg` | Password passed to `unrar` as `-p<password>` in argv → visible to other local users via `ps`/`/proc` | code read | Confirmed; matches `rarfile` behaviour |
+| F3 | **Medium** | `crypto.py:176` `derive_sevenzip_aes_key` | 7z `NumCyclesPower` is uncapped below the `0x3F` sentinel; a hostile value `0x3E` forces ~2⁶² SHA-256 rounds (CPU DoS) during password confirmation / header decode. **7-Zip itself rejects 25–62 (`k_NumCyclesPower_Supported_MAX = 24`); v2 is more permissive than the reference** | `parse_sevenzip_aes_properties` + derive; 7-Zip source `7zAes.cpp:27,260` | Confirmed; fix = match 7-Zip (accept ≤24 or ==0x3F) |
+| F4 | Low (hardening) | `rar_unrar.py:53` `_password_arg` | Password passed to `unrar` as `-p<password>` in argv → visible to other local users via `ps`/`/proc`. **Fixable:** bare `-p` + password on stdin avoids argv (v2's `unrar p` leaves stdin free) | code read; UnRAR source (`GetPasswordText`) | Confirmed; concrete fix available |
 | F5 | Low (hardening) | `rar_parser.py:1406` `_check_rar5_password` | RAR5 password-check value (key-derived) compared with `!=` rather than `hmac.compare_digest` | code read | Confirmed; WinZip AES correctly uses `compare_digest` |
 
 See `verification.md` (F1, F2, the silent-acceptance analysis — the headline),
 `kdf-and-ciphers.md` (F3, F5, and the bit-exactness oracle diffs), and
 `availability-and-contract.md` (F4, `[crypto]`-absent contract, `[all-lowest]` API floor).
-`QUESTIONS.md` records the resolved maintainer decisions (PR #115 review +
-`archivey-dev` reference check) and `7z-source-questions.md` is the checklist for the
-7-Zip/UnRAR source agent. The "**what is actually fine**" section is at the end of
-`verification.md`.
+`QUESTIONS.md` records the resolved decisions and `7z-source-questions.md` holds the
+source-agent checklist **with the confirmed 7-Zip/UnRAR answers appended**. The "**what is
+actually fine**" section is at the end of `verification.md`.
 
-**Resolution notes (post-review, PR #115):** F1 — fix per DEV's `ConvertHashToMAC`: the tweak
-is a *one-way* forward transform, so untweak-and-verify (compute → transform → compare) rather
-than "recover the real checksum"; interim, make `_member_hashes` symmetric (drop tweaked
-blake2sp like it already drops crc32). F2 — keep best-effort (matches 7-Zip; ZIP always has an
-HMAC/CRC anchor so is not exposed), emit a diagnostic instead of hard-erroring; downgraded to
-Low. F3 — v2 should cap `NumCyclesPower` (recommend 24, mirroring the RAR5 cap). F4/F5 — see
-below.
+**Resolution notes (source-confirmed, 2026-07-16 — 7-Zip + UnRAR source):**
+- **F1** — both `ConvertHashToMAC` transforms confirmed in UnRAR `crypt5.cpp`: CRC32 = XOR-fold
+  of `HMAC-SHA256(HashKey, crc_le4)`, BLAKE2sp = `HMAC-SHA256(HashKey, digest32)`, HashKey =
+  PBKDF2 at `(1<<kdf_count)+16`. Gate is the per-file `HASHMAC` (0x02) flag only (encrypted
+  headers do **not** auto-skip). Plan: interim symmetric blake2sp drop, then forward-transform
+  verify for both hashes.
+- **F2** — 7zAES has **no** password check; 7-Zip returns garbage on a CRC-less store member
+  too. Best-effort accept is confirmed correct; emit a diagnostic. **Low.**
+- **F3** — 7-Zip clamps `NumCyclesPower` to **≤24 or ==0x3F** (`E_NOTIMPL` otherwise), and the
+  `0x3F` "no-hash" sentinel is real. v2 should match exactly (reject 25–62). Not a "defensive
+  cap" — it is *the reference's own cap*. Counter layout + 0x3F verified bit-exact.
+- **F4** — upgraded from "unavoidable" to fixable: pass bare `-p` and feed the password via
+  stdin (unrar reads it there when redirected); v2's `unrar p` uses stdout for data, so stdin
+  is free.
+- **F5** — timing-only; no real attack surface; one-line `compare_digest` for consistency.
 
 ## Ranking against VISION
 

--- a/review/next/02-crypto/SUMMARY.md
+++ b/review/next/02-crypto/SUMMARY.md
@@ -30,7 +30,7 @@ archives that `py7zr` never emits.
 | # | Sev | Where | One-liner | Repro | Status |
 |---|-----|-------|-----------|-------|--------|
 | F1 | **High** | `rar_reader.py:119` `_member_hashes` | RAR5 tweaked-checksum members keep the key-tweaked BLAKE2sp in `hashes`, so a correctly-decrypted `-htb`-encrypted member fails `VerifyingStream` with a spurious `CorruptionError` | unit (VerifyingStream + tweaked hash) + `_member_hashes` asymmetry; rarfile oracle guard | Confirmed (logic); full e2e needs `unrar` + `-htb` encrypted fixture |
-| F2 | **Medium** | `sevenzip_reader.py:119` `_verify_decoded_folder` | Encrypted 7z folder with **no folder digest and CRC-less members** (both format-legal) confirms *any* password and returns garbage with no error (no CRC gate, no `VerifyingStream`) | unit (`_verify_decoded_folder` accepts wrong-key garbage) | Confirmed (logic); full e2e needs crafted AES+COPY CRC-less 7z |
+| F2 | Low *(was Medium — see Q2)* | `sevenzip_reader.py:119` `_verify_decoded_folder` | Encrypted 7z folder with **no folder digest and CRC-less members** (both format-legal) confirms *any* password and returns garbage with no error (no CRC gate, no `VerifyingStream`) | unit (`_verify_decoded_folder` accepts wrong-key garbage) | Confirmed (logic); maintainer: keep best-effort, emit a diagnostic rather than hard-error |
 | F3 | **Medium** | `crypto.py:176` `derive_sevenzip_aes_key` | 7z `NumCyclesPower` is uncapped below the `0x3F` sentinel; a hostile value `0x3E` forces ~2⁶² SHA-256 rounds (CPU DoS) during password confirmation / header decode. RAR5 caps its shift at 24; 7z has no equivalent | `parse_sevenzip_aes_properties` + derive | Confirmed |
 | F4 | Low (hardening) | `rar_unrar.py:53` `_password_arg` | Password passed to `unrar` as `-p<password>` in argv → visible to other local users via `ps`/`/proc` | code read | Confirmed; matches `rarfile` behaviour |
 | F5 | Low (hardening) | `rar_parser.py:1406` `_check_rar5_password` | RAR5 password-check value (key-derived) compared with `!=` rather than `hmac.compare_digest` | code read | Confirmed; WinZip AES correctly uses `compare_digest` |
@@ -38,8 +38,18 @@ archives that `py7zr` never emits.
 See `verification.md` (F1, F2, the silent-acceptance analysis — the headline),
 `kdf-and-ciphers.md` (F3, F5, and the bit-exactness oracle diffs), and
 `availability-and-contract.md` (F4, `[crypto]`-absent contract, `[all-lowest]` API floor).
-`QUESTIONS.md` collects the three maintainer decisions. The "**what is actually fine**"
-section is at the end of `verification.md`.
+`QUESTIONS.md` records the resolved maintainer decisions (PR #115 review +
+`archivey-dev` reference check) and `7z-source-questions.md` is the checklist for the
+7-Zip/UnRAR source agent. The "**what is actually fine**" section is at the end of
+`verification.md`.
+
+**Resolution notes (post-review, PR #115):** F1 — fix per DEV's `ConvertHashToMAC`: the tweak
+is a *one-way* forward transform, so untweak-and-verify (compute → transform → compare) rather
+than "recover the real checksum"; interim, make `_member_hashes` symmetric (drop tweaked
+blake2sp like it already drops crc32). F2 — keep best-effort (matches 7-Zip; ZIP always has an
+HMAC/CRC anchor so is not exposed), emit a diagnostic instead of hard-erroring; downgraded to
+Low. F3 — v2 should cap `NumCyclesPower` (recommend 24, mirroring the RAR5 cap). F4/F5 — see
+below.
 
 ## Ranking against VISION
 

--- a/review/next/02-crypto/SUMMARY.md
+++ b/review/next/02-crypto/SUMMARY.md
@@ -1,0 +1,50 @@
+# Brief 2 — Native crypto correctness deep review — SUMMARY
+
+**Scope:** every native decryption / key-derivation / integrity-verification path added
+since #73 — WinZip AES (`internal/zip_aes.py`), 7z AES + KDF
+(`internal/streams/crypto.py`), ZipCrypto (`internal/zipcrypto.py`), RAR3/RAR5 header &
+data key derivation (`backends/rar_parser.py`), and native BLAKE2sp
+(`internal/hashing/blake2sp.py`), plus the verification wiring
+(`internal/streams/verify.py`) and the reader glue that gates member output in
+`zip_reader.py` / `sevenzip_reader.py` / `rar_reader.py`.
+
+**Baseline (green):** `uv run pytest` → **1540 passed, 120 skipped**, 4 warnings, 84%
+coverage. `pyrefly` 0 errors, `ty` all-pass, `ruff` all-pass. Config: `[all]` (cryptography
+49.0.0, py7zr 1.1.3, rarfile 4.3, pyppmd 1.3.1, rapidgzip 0.16.0, pybcj present; zstandard
+absent; **no `unrar`/`7z` binary** in the container). Oracle diffs below were run with
+py7zr and rarfile as importable libraries.
+
+## Headline
+
+The KDFs and ciphers themselves are **correct** — bit-exact against the project's own
+oracles (7z KDF vs `py7zr`, RAR3/RAR5 s2k vs `rarfile`, ZipCrypto vs stdlib
+`_ZipDecrypter`, BLAKE2sp vs official KATs). The bugs are all in the **glue that decides
+whether an integrity check runs at all**: one path raises a *dishonest error on good data*,
+one path *silently accepts a wrong password*, and one path lets a hostile archive burn
+unbounded CPU. None of these is caught by the current suite because the RAR data path needs
+an `unrar` binary (absent here) and the 7z/KDF triggers need format-legal-but-crafted
+archives that `py7zr` never emits.
+
+## Findings (most severe first)
+
+| # | Sev | Where | One-liner | Repro | Status |
+|---|-----|-------|-----------|-------|--------|
+| F1 | **High** | `rar_reader.py:119` `_member_hashes` | RAR5 tweaked-checksum members keep the key-tweaked BLAKE2sp in `hashes`, so a correctly-decrypted `-htb`-encrypted member fails `VerifyingStream` with a spurious `CorruptionError` | unit (VerifyingStream + tweaked hash) + `_member_hashes` asymmetry; rarfile oracle guard | Confirmed (logic); full e2e needs `unrar` + `-htb` encrypted fixture |
+| F2 | **Medium** | `sevenzip_reader.py:119` `_verify_decoded_folder` | Encrypted 7z folder with **no folder digest and CRC-less members** (both format-legal) confirms *any* password and returns garbage with no error (no CRC gate, no `VerifyingStream`) | unit (`_verify_decoded_folder` accepts wrong-key garbage) | Confirmed (logic); full e2e needs crafted AES+COPY CRC-less 7z |
+| F3 | **Medium** | `crypto.py:176` `derive_sevenzip_aes_key` | 7z `NumCyclesPower` is uncapped below the `0x3F` sentinel; a hostile value `0x3E` forces ~2⁶² SHA-256 rounds (CPU DoS) during password confirmation / header decode. RAR5 caps its shift at 24; 7z has no equivalent | `parse_sevenzip_aes_properties` + derive | Confirmed |
+| F4 | Low (hardening) | `rar_unrar.py:53` `_password_arg` | Password passed to `unrar` as `-p<password>` in argv → visible to other local users via `ps`/`/proc` | code read | Confirmed; matches `rarfile` behaviour |
+| F5 | Low (hardening) | `rar_parser.py:1406` `_check_rar5_password` | RAR5 password-check value (key-derived) compared with `!=` rather than `hmac.compare_digest` | code read | Confirmed; WinZip AES correctly uses `compare_digest` |
+
+See `verification.md` (F1, F2, the silent-acceptance analysis — the headline),
+`kdf-and-ciphers.md` (F3, F5, and the bit-exactness oracle diffs), and
+`availability-and-contract.md` (F4, `[crypto]`-absent contract, `[all-lowest]` API floor).
+`QUESTIONS.md` collects the three maintainer decisions. The "**what is actually fine**"
+section is at the end of `verification.md`.
+
+## Ranking against VISION
+
+F1 and F2 both attack claim #3 ("damaged input → an honest error"): F1 turns *good* data
+into a corruption error (dishonest error), F2 turns a *wrong password* into silently
+returned garbage (no error at all — the worst outcome the brief names). F3 attacks claim #2
+(parse untrusted archives safely): it is memory-safe but CPU-unbounded. F4/F5 are
+threat-model hardening, not release blockers.

--- a/review/next/02-crypto/availability-and-contract.md
+++ b/review/next/02-crypto/availability-and-contract.md
@@ -55,16 +55,17 @@ behaviour. No password leaks into exception text, `repr`, or logs on any path I 
 `EncryptionError(f"Failed to decrypt RAR3 headers: {exc}")` wraps a decrypt-time exception
 that does not carry the password.
 
-**On the maintainer's follow-up (SUMMARY:35 — "any way of avoiding it, passing via stdin?"):**
-to my knowledge RARLAB `unrar` has **no scriptable non-interactive password channel** other
-than `-p<password>` — no env var, no `--password-file`, and its interactive prompt reads from
-the console/tty rather than a plain piped stdin, so it can't be fed reliably from a subprocess
-pipe. That is why `rarfile`, `patool`, etc. all use `-p<pwd>`. So this is largely unavoidable
-without switching the decoder, and is best treated as a **documented threat-model limitation**
-(local-user confidentiality is outside the current trust boundary) — a line in
-`docs/internal/threat-model.md`. I've added a source-verification item
-(`7z-source-questions.md` §D9) to have the UnRAR-source agent confirm there is genuinely no
-stdin/env/file channel before we close it out as "unavoidable".
+**Q/D9 resolved (UnRAR source) — F4 is fixable, not unavoidable:** unrar has no env-var and no
+`-p@file` channel, **but** a bare `-p` (no value) makes it read the password from **stdin** when
+stdin is redirected (`GetPasswordText → getwstr`), e.g. `printf '%s\n' "$pw" | unrar x -p
+archive.rar`. That is non-interactive and keeps the secret out of `argv`/`/proc/<pid>/cmdline`.
+v2 spawns `unrar p` with the *data* on stdout, so the child's stdin is free — this is directly
+usable. (The only caveat the source notes is that stdin is shared with `-si`, which v2 does not
+use.)
+
+**Fix:** change `_password_arg` / `open_unrar_p` to append bare `-p` and pass `password + "\n"`
+via `stdin=subprocess.PIPE` (keep `-p-` for the no-password case). Low severity, but now a
+concrete fix rather than an accepted leak — worth doing since v2 controls the child's stdin.
 
 ## Streaming / seek / lifecycle (§C) — no issues found
 

--- a/review/next/02-crypto/availability-and-contract.md
+++ b/review/next/02-crypto/availability-and-contract.md
@@ -49,14 +49,22 @@ def _password_arg(password):
 
 The password is an argv element of the `unrar` child, so it is visible to any local user via
 `ps auxww` / `/proc/<pid>/cmdline` for the process lifetime. This matches `rarfile`'s
-behaviour and is largely forced by the `unrar` CLI (which has no env/stdin password channel
-that also works non-interactively), so it is a **documented threat-model limitation**, not a
-code bug — worth a line in `docs/internal/threat-model.md` (local-user confidentiality is out
-of the current trust boundary). No password leaks into exception text, `repr`, or logs on any
-path I read: `_UnrarOwnedStream.close` raises a static
+behaviour. No password leaks into exception text, `repr`, or logs on any path I read:
+`_UnrarOwnedStream.close` raises a static
 `EncryptionError("Incorrect RAR password or encrypted member")`, and the RAR parser's
 `EncryptionError(f"Failed to decrypt RAR3 headers: {exc}")` wraps a decrypt-time exception
 that does not carry the password.
+
+**On the maintainer's follow-up (SUMMARY:35 — "any way of avoiding it, passing via stdin?"):**
+to my knowledge RARLAB `unrar` has **no scriptable non-interactive password channel** other
+than `-p<password>` — no env var, no `--password-file`, and its interactive prompt reads from
+the console/tty rather than a plain piped stdin, so it can't be fed reliably from a subprocess
+pipe. That is why `rarfile`, `patool`, etc. all use `-p<pwd>`. So this is largely unavoidable
+without switching the decoder, and is best treated as a **documented threat-model limitation**
+(local-user confidentiality is outside the current trust boundary) — a line in
+`docs/internal/threat-model.md`. I've added a source-verification item
+(`7z-source-questions.md` §D9) to have the UnRAR-source agent confirm there is genuinely no
+stdin/env/file channel before we close it out as "unavoidable".
 
 ## Streaming / seek / lifecycle (§C) — no issues found
 

--- a/review/next/02-crypto/availability-and-contract.md
+++ b/review/next/02-crypto/availability-and-contract.md
@@ -1,0 +1,83 @@
+# Availability & error contract (Brief §D) + streaming/lifecycle (§C)
+
+## `[crypto]` absent → clean typed error (verified good)
+
+With `_crypto_available()` patched to `False` in both `streams.crypto` and `zip_aes` (the
+`[core-only]` simulation), all three native AES entry points raise
+`PackageNotInstalledError` — not a bare `ImportError`, not a misleading `CorruptionError`:
+
+```
+7z AES:     PackageNotInstalledError OK
+WinZip AES: PackageNotInstalledError OK
+RAR hdr:    PackageNotInstalledError OK
+```
+
+- **7z:** `_open_aes_stage` → `open_aes_decrypt_stream` → `get_crypto_backend()` raises
+  before any cipher import (`crypto.py:119`).
+- **WinZip AES:** `open_winzip_aes_member` and `_AesCtrLe.__init__` both check
+  `_crypto_available()` up front (`zip_aes.py:221,101`).
+- **RAR:** `_HeaderDecryptStream.__init__` → `open_aes_decrypt_stage` raises; the parser
+  loops (`_parse_rar3`/`_parse_rar5`) re-raise `PackageNotInstalledError` **before** the
+  catch-all that wraps other exceptions in `EncryptionError` (`rar_parser.py:824,1190`), so
+  the availability error is not mistranslated into a wrong-password error. The KDF/PBKDF2 and
+  the RAR5 `_check_rar5_password` are pure-Python (stdlib `hashlib`), so a wrong password on a
+  crypto-less install still fails as `EncryptionError` (correct) and only the actual
+  header *decrypt* demands the extra.
+
+The KDF/verification glue, BLAKE2sp, and ZipCrypto are pure-Python (stdlib
+`hashlib`/`zlib`), so they run in `[core-only]`; only the AES stages need the extra, matching
+the packaging spec.
+
+## `[all-lowest]` — `cryptography>=45` API floor (verified by inspection)
+
+The only `cryptography` surface used is
+`Cipher(algorithms.AES(key), modes.ECB()/modes.CBC(iv))` with
+`.encryptor()/.decryptor()/.update()/.finalize()` (`crypto.py:69`, `zip_aes.py:106`). These
+are long-stable APIs present for many major versions before 45.0 — nothing added in 45.x or
+later is used, so the minimum-version leg is safe. (Not run live because it needs a
+`--resolution lowest-direct` re-sync; the API set is small and unambiguous by reading.)
+
+## F4 (Low, hardening) — password reaches `unrar` argv
+
+`rar_unrar.py:53`:
+
+```python
+def _password_arg(password):
+    ...
+    return "-p" + password        # -> subprocess.Popen([unrar, "p", ..., "-pSECRET", path])
+```
+
+The password is an argv element of the `unrar` child, so it is visible to any local user via
+`ps auxww` / `/proc/<pid>/cmdline` for the process lifetime. This matches `rarfile`'s
+behaviour and is largely forced by the `unrar` CLI (which has no env/stdin password channel
+that also works non-interactively), so it is a **documented threat-model limitation**, not a
+code bug — worth a line in `docs/internal/threat-model.md` (local-user confidentiality is out
+of the current trust boundary). No password leaks into exception text, `repr`, or logs on any
+path I read: `_UnrarOwnedStream.close` raises a static
+`EncryptionError("Incorrect RAR password or encrypted member")`, and the RAR parser's
+`EncryptionError(f"Failed to decrypt RAR3 headers: {exc}")` wraps a decrypt-time exception
+that does not carry the password.
+
+## Streaming / seek / lifecycle (§C) — no issues found
+
+- **Seek within an encrypted member:** WinZip AES and (by the same `ReadOnlyIOStream` base)
+  the RAR header stream are non-seekable; a WinZip AES member refuses `seek` cleanly rather
+  than returning wrong plaintext (see `verification.md` "what is actually fine"). 7z encrypted
+  members reach the seekable decoder layer only through the codec *after* AES-CBC decrypt has
+  been folded in as a forward-only stage, and `AesDecryptStream` (`crypto.py:132`) is itself
+  forward-only (no `seek`), so a backward seek re-runs from the folder start via the decoder
+  layer's `_reset_to_seek_point`, which re-creates the whole pipeline (including a fresh AES
+  stage) from the pack origin — CBC IV chaining is re-established from the folder's stored IV,
+  not resumed mid-stream. No stale-CTR/stale-IV path observed.
+- **Key caches key on the right tuple.** `SevenZipKeyCache` keys on
+  `(password, salt, cycles)` (`crypto.py:247`), so a different salt/IV never reuses a key it
+  was not derived for. The RAR3 per-archive `_Rar3EncState` cache (`rar_parser.py:963`) keys on
+  the 8-byte salt and only reuses `(key, iv)` when the salt is identical. Both are per-reader
+  instances; no cross-archive reuse. (Concurrency of the caches under CONCURRENT is Brief 3 /
+  concurrency territory; the dicts are plain and not lock-guarded, but 7z/RAR key derivation is
+  deterministic so a race only recomputes, never mixes keys.)
+- **Truncated ciphertext raises.** `WinZipAesDecryptStream._pull` raises
+  `CorruptionError("Truncated WinZip AES ciphertext before HMAC")` / `"Truncated WinZip AES
+  HMAC"` on a short read (`zip_aes.py:158,166`); `AesDecryptStream` finalizes and the 7z folder
+  length check raises `TruncatedError` (`sevenzip_pipeline.py:380`). No unauthenticated tail
+  bytes escape on truncation for WinZip AES.

--- a/review/next/02-crypto/kdf-and-ciphers.md
+++ b/review/next/02-crypto/kdf-and-ciphers.md
@@ -93,10 +93,18 @@ enforce `_RAR_MAX_KDF_SHIFT = 24` (`rar_parser.py:49,1382,1395`). 7z has no equi
 **Fix:** cap `cycles` in `derive_sevenzip_aes_key` (or in `parse_sevenzip_aes_properties`) at
 a sane maximum — 24 mirrors RAR5 and is far above any real archive — raising
 `UnsupportedFeatureError`/`CorruptionError` above it. `py7zr` shares the missing cap, so this
-is not an oracle divergence; it is a hardening gap the brief's threat model asks for. See
-QUESTIONS Q3 (also: is py7zr's `0x3F` "no-hash" shortcut actually spec-correct vs the 7-Zip
-C++ reference, which may intend `0x3F` as `2^63` rather than a sentinel? — a crafted-only
-concern, since no creator emits `0x3F`).
+is not an oracle divergence; it is a hardening gap the brief's threat model asks for.
+
+**On the maintainer's follow-up (Q3 — "what cap does 7-Zip use, is it user-selectable, max?"):**
+7-Zip *encodes* with `NumCyclesPower = 19` (2¹⁹ rounds, ~sub-ms) and does not expose the value
+in its GUI/CLI, so real archives are effectively fixed at 19. The **format** stores it in the
+low 6 bits of the AES property byte, so a hostile file can carry 0–0x3F regardless. Whether the
+7-Zip *decoder* caps it (or loops `1 << value` unbounded, i.e. 7-Zip is itself DoS-able) is the
+open source question — see `7z-source-questions.md` §A. Independent of that, v2 should apply its
+own cap; recommend `NumCyclesPower > 24 → UnsupportedFeatureError`, mirroring the RAR5 cap v2
+already enforces. Also open for the source agent: is py7zr's `0x3F` "no-hash" shortcut actually
+spec-correct vs the 7-Zip reference (which may intend `0x3F` as `2^63`)? — crafted-only, since
+no creator emits `0x3F`.
 
 ---
 
@@ -117,3 +125,10 @@ a secret-derived compare with an `==`/`!=` where a drop-in `compare_digest` exis
 `sha256(hdr_check)[:4] != hdr_sum` check on the same line is over a non-secret and does not
 matter). WinZip AES already uses `hmac.compare_digest` for both its pw-verify and its HMAC;
 7z uses CRC (non-secret) so `!=` is fine there.
+
+**On the maintainer's follow-up (SUMMARY:36 — "is the difference just timing-attack
+resilience?"):** yes. The only thing `compare_digest` buys here is resistance to a timing
+side-channel on the password-check value, and for a local archive library there is no remote
+attacker measuring decrypt timing and no server-side secret — so there is effectively **no
+attack surface**. It is worth the one-line change purely for correctness/consistency (v2
+already uses `compare_digest` elsewhere), but it is not security-relevant. Lowest priority.

--- a/review/next/02-crypto/kdf-and-ciphers.md
+++ b/review/next/02-crypto/kdf-and-ciphers.md
@@ -95,16 +95,20 @@ a sane maximum — 24 mirrors RAR5 and is far above any real archive — raising
 `UnsupportedFeatureError`/`CorruptionError` above it. `py7zr` shares the missing cap, so this
 is not an oracle divergence; it is a hardening gap the brief's threat model asks for.
 
-**On the maintainer's follow-up (Q3 — "what cap does 7-Zip use, is it user-selectable, max?"):**
-7-Zip *encodes* with `NumCyclesPower = 19` (2¹⁹ rounds, ~sub-ms) and does not expose the value
-in its GUI/CLI, so real archives are effectively fixed at 19. The **format** stores it in the
-low 6 bits of the AES property byte, so a hostile file can carry 0–0x3F regardless. Whether the
-7-Zip *decoder* caps it (or loops `1 << value` unbounded, i.e. 7-Zip is itself DoS-able) is the
-open source question — see `7z-source-questions.md` §A. Independent of that, v2 should apply its
-own cap; recommend `NumCyclesPower > 24 → UnsupportedFeatureError`, mirroring the RAR5 cap v2
-already enforces. Also open for the source agent: is py7zr's `0x3F` "no-hash" shortcut actually
-spec-correct vs the 7-Zip reference (which may intend `0x3F` as `2^63`)? — crafted-only, since
-no creator emits `0x3F`.
+**Q3 resolved (7-Zip source, `7zAes.cpp`):** 7-Zip's decoder **does** clamp — at property-parse
+time, not in the hash loop. `SetDecoderProperties2` accepts `NumCyclesPower <= 24`
+(`k_NumCyclesPower_Supported_MAX = 24`, line 27) **or** `== 0x3F`, otherwise returns `E_NOTIMPL`
+(lines 260-279); values 25–62 never reach the hash loop, so official 7-Zip never attempts 2⁶³
+rounds. **v2 is currently *more permissive* than the reference** — it accepts 25–62 and drives
+`derive_sevenzip_aes_key` into the DoS. The `0x3F` "no-hash" sentinel is **real** in official
+7-Zip (`Key = salt‖password` zero-padded to 32, no SHA-256; lines 41-50), so archivey/py7zr do
+**not** diverge on it, and the counter layout (8-byte LE round index appended to `salt‖password`,
+lines 56-67) matches archivey's `(s+i).to_bytes(8,"little")`. Encoder default is 19, hardcoded,
+never user-settable (line 232).
+
+**Fix:** match 7-Zip exactly — accept `cycles <= 24` **or** `cycles == 0x3F`, reject 25–62 with
+`UnsupportedFeatureError`. This is not a "defensive cap we invented"; it is *the same cap the
+reference enforces*, so it rejects nothing a real archive contains and closes the DoS.
 
 ---
 

--- a/review/next/02-crypto/kdf-and-ciphers.md
+++ b/review/next/02-crypto/kdf-and-ciphers.md
@@ -1,0 +1,119 @@
+# KDF & cipher correctness (Brief §B) + const-time (§E)
+
+## Oracle diffs — everything bit-exact
+
+Every KDF and cipher was diffed against the project's stated oracle. All passed with **0
+mismatches**.
+
+### 7z SHA-256 cycle KDF — `derive_sevenzip_aes_key` vs `py7zr.helpers.calculate_key`
+
+archivey's function is line-for-line `py7zr._calculate_key3` (same `cat_cycle = 6` batching,
+same `salt+password`, same 8-byte little-endian counter, same `0x3F` "no-hash" sentinel).
+Diff over the cartesian product of `cycles ∈ {0,1,5,6,7,8,12,19,0x3F}`,
+`salt ∈ {b"", b"\x00", 16-random}`, `password ∈ {b"", "pw"·utf16le, "münchen"·utf16le}`:
+
+```
+KDF done, mismatches: 0
+```
+
+Covered explicitly: the `cat_cycle` batching boundary (cycles 6 vs 7), the empty-salt case,
+and the `cycles == 0x3F` sentinel (returns `(salt+password+zeros)[:32]`, matching py7zr).
+
+### `parse_sevenzip_aes_properties`
+
+Salt/IV flag decode and the 2 + salt + iv length check are correct: `bytes([0xC0, 0x00])`
+(both flags set, sizes 0) correctly raises `ValueError: length 2 != expected 4`; a
+well-formed `[0x80|0x40|cycles, 0x00] + salt + iv` parses and zero-pads the IV to 16.
+
+### RAR3 / RAR5 s2k vs `rarfile`
+
+`_rar3_s2k` vs `rarfile.rar3_s2k` and `_rar5_s2k` vs `rarfile.rar5_s2k`, over
+`password ∈ {"pw","münchen","","correct horse"}`, random + zero salts, and RAR5
+`kdf_count ∈ {2¹⁵, 2¹⁵+32}`:
+
+```
+RAR s2k mismatches: 0
+```
+
+This confirms the **password-normalization split** the brief flagged as high-risk:
+`_normalize_password_utf16le` (RAR3: UTF-16LE, truncate to `127*2` bytes, **no** re-encode)
+vs `_normalize_password_utf8` (RAR5: UTF-16LE-truncate → decode → **UTF-8**) both match
+rarfile exactly, including the `münchen` non-ASCII case. A swap here would silently fail
+valid passwords; it is correct. The `_Rar3Sha1(rarbug=True)` deliberate-corruption path is
+exercised transitively by the RAR3 diff (it feeds the s2k) and matches.
+
+### WinZip AES PBKDF2 — `derive_winzip_aes_keys`
+
+PBKDF2-HMAC-SHA1, 1000 iterations, `dklen = key_len*2 + 2`, split `enc ‖ auth ‖ verify(2)`.
+Per-strength geometry is correct: `salt_len = key_bits//16` → 8/12/16 bytes for
+AE-128/192/256, `key_len = key_bits//8` → 16/24/32, 2-byte pw-verify. Round-trips through the
+existing `test_zip_aes.py` builders and the manual AE-1/AE-2 STORED+deflate archives built
+during this review.
+
+### ZipCrypto vs stdlib `zipfile._ZipDecrypter`
+
+Keystream/decrypt identical over 64 random bytes; `parallel_plaintext_crc32` produces the
+correct plaintext CRC for the right password and `password_matches_check_byte` matches the
+1-byte header check:
+
+```
+ZipCrypto decrypt matches stdlib: True
+parallel crc for correct pw: 0x194bc2c  expected 0x194bc2c  match: True
+check_byte match: True
+```
+
+The `_crc32_update`/`_make_crc32_table` reflected-polynomial `0xEDB88320` implementation is
+correct (it has to be, or the stdlib diff would fail).
+
+---
+
+## F3 (Medium) — 7z `NumCyclesPower` is uncapped → CPU DoS from a hostile archive
+
+`derive_sevenzip_aes_key` (`crypto.py:184`) validates only `0 <= cycles <= 0x3F` and treats
+`0x3F` as the no-hash sentinel. Every value `0x01..0x3E` is taken literally as `2^cycles`
+SHA-256 rounds. There is **no upper bound below the sentinel**, so a crafted AES coder
+property byte with `cycles = 0x3E` forces ~2⁶² hash rounds:
+
+```python
+first  = 0x80 | 0x40 | 0x3E      # salt+iv flags, cycles = 62
+props  = bytes([first, 0x00]) + b"\xAA" + b"\xBB"
+cycles, salt, iv = parse_sevenzip_aes_properties(props)   # -> cycles = 62
+# derive_sevenzip_aes_key(...) would attempt 2**62 SHA-256 rounds before returning
+```
+
+This runs during **password confirmation** (`_password_for_folder` → `confirm`) and during
+**encrypted-header decode** (`decode_encoded_header`), i.e. on attacker-controlled input as
+soon as a password is supplied — a memory-safe but unbounded-CPU hostile input that hangs the
+calling thread. It undercuts VISION #2 (parse untrusted archives safely). Real archives use
+`NumCyclesPower = 19` (2¹⁹, ~sub-millisecond); 7-Zip's own UI caps the slider well below 24.
+
+**Contrast:** RAR5 got this right — `_rar5_decrypt_header` and `_check_rar5_password` both
+enforce `_RAR_MAX_KDF_SHIFT = 24` (`rar_parser.py:49,1382,1395`). 7z has no equivalent.
+
+**Fix:** cap `cycles` in `derive_sevenzip_aes_key` (or in `parse_sevenzip_aes_properties`) at
+a sane maximum — 24 mirrors RAR5 and is far above any real archive — raising
+`UnsupportedFeatureError`/`CorruptionError` above it. `py7zr` shares the missing cap, so this
+is not an oracle divergence; it is a hardening gap the brief's threat model asks for. See
+QUESTIONS Q3 (also: is py7zr's `0x3F` "no-hash" shortcut actually spec-correct vs the 7-Zip
+C++ reference, which may intend `0x3F` as `2^63` rather than a sentinel? — a crafted-only
+concern, since no creator emits `0x3F`).
+
+---
+
+## F5 (Low, hardening) — RAR5 password-check compared with `!=`
+
+`_check_rar5_password` (`rar_parser.py:1406`) compares the key-derived 8-byte password-check
+value with a plain `!=`:
+
+```python
+if bytes(pwd_check) != hdr_check:
+    raise EncryptionError("Wrong password for RAR5 header encryption")
+```
+
+`pwd_check` is derived from the PBKDF2 output, so it is a secret-derived comparison; a
+constant-time `hmac.compare_digest` would be the hardened form. Per the brief this is a
+**low-severity note for a local archive library**, not a blocker — flagged only because it is
+a secret-derived compare with an `==`/`!=` where a drop-in `compare_digest` exists (the
+`sha256(hdr_check)[:4] != hdr_sum` check on the same line is over a non-secret and does not
+matter). WinZip AES already uses `hmac.compare_digest` for both its pw-verify and its HMAC;
+7z uses CRC (non-secret) so `!=` is fine there.

--- a/review/next/02-crypto/verification.md
+++ b/review/next/02-crypto/verification.md
@@ -106,11 +106,17 @@ the stored tweaked value. Two-step plan:
 2. **Full fix (restore verification when the password is known):** verify by forward-transform
    — compute the real CRC32/BLAKE2sp over the decrypted data, apply `ConvertHashToMAC` with the
    HashKey `= PBKDF2-HMAC-SHA256(pw_utf8, salt, (1<<kdf_count)+16)`, and compare to the stored
-   tweaked value. CRC32 transform is `XOR of the eight uint32 words of
-   HMAC-SHA256(HashKey, crc_le32)`; BLAKE2sp is (per UnRAR, pending source confirmation in
-   `7z-source-questions.md`) `HMAC-SHA256(HashKey, blake2sp32)`. Needs the confirmed password /
-   HashKey threaded into the RAR verification stage; leave `member.hashes` empty when no
-   correct password is known at open time.
+   tweaked value. **Both transforms now confirmed against UnRAR `crypt5.cpp:193-211`:** CRC32 =
+   XOR-fold of `HMAC-SHA256(HashKey, crc.to_bytes(4,"little"))` into 4 bytes; BLAKE2sp =
+   `HMAC-SHA256(HashKey, blake2sp_digest[32])` overwriting the 32-byte digest. Needs the
+   confirmed password / HashKey threaded into the RAR verification stage; leave `member.hashes`
+   empty when no correct password is known at open time.
+
+**Gate (source-confirmed):** the tweak applies **iff** the per-file `FHEXTRA_CRYPT_HASHMAC`
+(0x02) flag is set (`arcread.cpp:1080`, `extract.cpp:934`) — exactly the flag `_crc_is_tweaked`
+already reads. Encrypted-header (`-hp`) archives do **not** auto-skip the tweak in the reader;
+unrar keys only off 0x02 (untweaked checksums under `-hp` are a writer choice to omit the
+flag). So no header-encryption special-case is needed.
 
 ---
 
@@ -172,7 +178,12 @@ _verify_decoded_folder(folder, garbage, member_digests=[(16, None)])
 ### Fix (resolved with maintainer — see QUESTIONS Q2) — best-effort, not fail-closed
 
 Maintainer call: do **not** hard-error (error detection is best-effort, and the data might be
-correct). This matches 7-Zip, which also cannot detect a wrong password when no CRC is present.
+correct). This matches 7-Zip, which also cannot detect a wrong password when no CRC is present
+— **source-confirmed:** 7zAES has no password check of its own; the only gate is the
+extraction CRC and only when `fi.CrcDefined` (`7zExtract.cpp:95,128`), so a CRC-less store
+member returns garbage as `kOK` (`7zExtract.cpp:397-411` maps a codec failure to `kDataError`,
+but a copy coder never fails). "Matching 7-Zip on CRC-less streams means accepting when decode
+succeeds, not inventing a password check 7-Zip doesn't have."
 Note ZIP is **not** exposed the same way — WinZip AE-2 authenticates with a mandatory HMAC and
 ZipCrypto STORED is disambiguated by the central-directory CRC — so 7z is the only format here
 where an encrypted member can carry zero integrity anchor. Recommendation: keep the

--- a/review/next/02-crypto/verification.md
+++ b/review/next/02-crypto/verification.md
@@ -1,0 +1,196 @@
+# Silent-acceptance & verification analysis (Brief §A)
+
+This is the headline surface: for every native path, does authentication actually run and
+gate output, or can wrong/tampered data reach the caller without an honest error?
+
+---
+
+## F1 (High) — RAR5 tweaked-checksum BLAKE2sp raises a spurious `CorruptionError` on *correct* data
+
+### What the code does
+
+`rar_reader.py:119`:
+
+```python
+def _crc_is_tweaked(info: RarMemberInfo) -> bool:
+    enc = info.file_encryption
+    if enc is None:
+        return False
+    return bool(enc.flags & _RAR_ENCDATA_FLAG_TWEAKED_CHECKSUMS)  # 0x02
+
+def _member_hashes(info: RarMemberInfo) -> dict[str, int | bytes]:
+    hashes: dict[str, int | bytes] = {}
+    if info.crc32 is not None and not _crc_is_tweaked(info):   # crc32 guarded
+        hashes["crc32"] = info.crc32
+    if info.blake2sp_hash is not None:                          # blake2sp NOT guarded
+        hashes["blake2sp"] = info.blake2sp_hash
+    return hashes
+```
+
+When a RAR5 member is encrypted with the "tweaked checksums" option
+(`RAR5_XENC_TWEAKED = 0x02`, set by WinRAR whenever file *data* is encrypted), WinRAR stores
+`checksum XOR key_derived_tweak` rather than the raw checksum, so identical plaintext under
+different passwords produces different stored checksums. The correct handling is to **not**
+verify the stored value against the plaintext hash unless you reproduce the inverse tweak.
+
+`_member_hashes` does this correctly for **crc32** (drops it when tweaked) but **not for
+blake2sp** — the BLAKE2sp hash is surfaced unconditionally. It then flows to
+`VerifyingStream` in `rar_reader.py:509` (`_wrap_payload_stream`), which recomputes BLAKE2sp
+over the plaintext `unrar` emits and compares it to the *tweaked* stored value → guaranteed
+mismatch → `CorruptionError` on a member that decrypted perfectly.
+
+### Oracle: rarfile does the opposite
+
+`rarfile 4.3` only arms BLAKE2sp verification when the member is **not** tweaked:
+
+```python
+# rarfile.py, RAR5 file-hash parse
+if (h.file_encryption[1] & RAR5_XENC_TWEAKED) == 0:
+    h._md_class = Blake2SP
+    h._md_expect = h.blake2sp_hash
+```
+
+i.e. rarfile treats a tweaked BLAKE2sp as unverifiable and skips it. archivey should do the
+same (it already does for crc32).
+
+### Why this bites `-htb` archives specifically
+
+RAR5 stores *either* CRC32 *or* BLAKE2sp per file, not both. WinRAR uses BLAKE2sp only with
+`-htb`. So for a `-htb`-encrypted member: `crc32 is None` (dropped anyway) and
+`blake2sp_hash` is present-but-tweaked → `hashes == {"blake2sp": <tweaked>}` → false
+corruption. There is no crc32 fallback. The existing `encryption__.rar` fixture happens to
+use CRC32 (not `-htb`), so it stores `crc32` + tweaked flag and dodges the bug — which is
+exactly why the suite is green.
+
+### Reproductions
+
+**(a) reader-level asymmetry** — a tweaked member keeps blake2sp, drops crc32:
+
+```
+tweaked? True
+surfaced hashes keys: ['blake2sp']
+crc32 present: False   blake2sp present: True
+```
+(constructed a `RarMemberInfo` with `RarEncryptionInfo(flags=0x02)`, `crc32=…`,
+`blake2sp_hash=…`; called `_member_hashes`.)
+
+**(b) mechanism end-to-end at the stream level** — `VerifyingStream` raises on *correct*
+plaintext when the stored blake2sp is tweaked:
+
+```python
+plaintext = b"stored payload"
+real = blake2sp(plaintext)
+tweaked_stored = bytes(b ^ 0x5A for b in real)          # WinRAR stores real XOR tweak
+vs = VerifyingStream(io.BytesIO(plaintext), {"blake2sp": tweaked_stored})
+vs.read(); vs.read()          # -> CorruptionError: Digest mismatch for 'blake2sp'
+# control: {"blake2sp": real} verifies cleanly
+```
+
+A full archive→`unrar`→VerifyingStream repro needs the `unrar` binary (absent here) and a
+`-htb`-encrypted RAR5 fixture; the two units above pin the exact defect and the oracle pins
+the intended behaviour.
+
+### Fix
+
+Guard blake2sp with the same predicate: `if info.blake2sp_hash is not None and not
+_crc_is_tweaked(info):`. (Rename `_crc_is_tweaked` → `_checksums_tweaked` since it now covers
+both.) Optionally add a `DIGEST_UNVERIFIABLE` diagnostic so a tweaked member reports "not
+verified" rather than silently unverified — matching how `VerifyingStream` already emits that
+code for unknown algorithms.
+
+---
+
+## F2 (Medium) — 7z confirms *any* password when the folder carries no integrity anchor
+
+### What the code does
+
+`sevenzip_reader.py:119`:
+
+```python
+def _verify_decoded_folder(folder, decoded, *, member_digests=None):
+    if folder.digest_defined:
+        expected = (folder.crc if folder.crc is not None else 0) & 0xFFFFFFFF
+        if zlib.crc32(decoded) & 0xFFFFFFFF != expected:
+            raise EncryptionError("Wrong password or corrupt 7z folder")
+        return
+    if not member_digests:
+        return                      # <-- no folder digest AND no member digests: accept
+    offset = 0
+    for size, raw_expected in member_digests:
+        chunk = decoded[offset:offset+size]; offset += size
+        if raw_expected is None:
+            continue                # <-- CRC-less member: skipped
+        ...
+```
+
+This is the wrong-password oracle for 7z: `_password_for_folder` (`sevenzip_reader.py:505`)
+decodes the whole folder with a candidate key and calls `_verify_decoded_folder`. If the
+folder has **no folder-level digest** *and* **every member is CRC-less** (`raw_expected is
+None`), the function returns without raising, so `confirm()` returns the candidate as the
+accepted password. The member read then goes through `_wrap_folder_member`
+(`sevenzip_reader.py:544`), which only wraps `VerifyingStream` `if member.hashes:` — empty
+here — so there is **no second gate either**. Result: a wrong password yields garbage
+plaintext returned with no error.
+
+### Why it is reachable but narrow
+
+The normal 7z coder chain is AES→LZMA2, and a wrong AES-CBC key feeds garbage to the LZMA2
+decoder, which raises `LZMAError` (→ translated). So a *compressed* encrypted folder is
+gated by the codec even without CRC. The gap is a folder whose chain is **AES + COPY**
+(stored, no compressing codec) — `plan_folder` accepts it (COPY is skipped, AES stage runs;
+`sevenzip_pipeline.py:122`) — combined with **no folder digest and CRC-less members**. All of
+`digest_defined = False`, absent member CRCs, and AES-only coders are legal in the 7z
+container; `py7zr` never emits them (it always writes CRCs and defaults to LZMA2), so this is
+a *hostile/crafted-archive* finding, squarely in the brief's threat model ("an archive with
+CRC absent doesn't silently accept any password").
+
+### Reproduction
+
+```python
+folder = SevenZipFolder(coders=[], bind_pairs=[], packed_indices=[0],
+                        unpack_sizes=[16], crc=None, digest_defined=False)
+garbage = b"\x00"*16                      # AES(wrong key) over a COPY folder
+_verify_decoded_folder(folder, garbage, member_digests=[(16, None)])
+# -> returns, no exception  == wrong password accepted, garbage handed back
+# control: digest_defined=True, crc=0x12345678 -> EncryptionError (correctly rejected)
+```
+
+### Fix
+
+Fail closed: when an *encrypted* folder has neither a folder digest nor any member CRC,
+`_password_for_folder` should refuse to confirm a password (raise a typed
+`EncryptionError`/`UnsupportedFeatureError` — "cannot verify password: this encrypted 7z
+folder has no checksum") rather than accept the first candidate. This preserves VISION #3
+(honest error) at the cost of refusing a pathological archive that no real tool produces.
+See QUESTIONS Q2 — this trades against any "recover what you can" goal.
+
+---
+
+## What is actually fine (verified good — do not "fix")
+
+- **WinZip AES HMAC genuinely gates output.** `WinZipAesDecryptStream.close()`
+  (`zip_aes.py:194`) drains the remaining ciphertext + MAC and verifies, so even a caller
+  that does a single `read(member.size)` (which returns all plaintext without pulling the
+  MAC in `read`) still gets a `CorruptionError` on the `with`-block close. Verified with a
+  *correctly* constructed tamper (valid MAC over the original ciphertext, then one ciphertext
+  byte flipped) for both AE-2 STORED and AE-2 deflate — both raised
+  `CorruptionError: WinZip AES HMAC mismatch`. (An earlier "silent acceptance" reading was a
+  flawed test that recomputed the MAC over the already-tampered ciphertext.) Bytes are
+  delivered before the terminal raise, which is the same documented AE/`VerifyingStream`
+  streaming trade-off, not a new bug. Both the 2-byte pw-verify and the HMAC use
+  `hmac.compare_digest`.
+- **WinZip AES members are non-seekable.** `WinZipAesDecryptStream` extends
+  `ReadOnlyIOStream` (not `DelegatingStream`), so `seekable()` is `False` and `seek` raises
+  `io.UnsupportedOperation`; the STORED-over-AES member likewise reports `seekable() == False`
+  and refuses `seek(500)` / `seek(0)` cleanly. The hand-rolled sequential `_AesCtrLe` counter
+  is therefore never asked to reposition, so there is no wrong-plaintext-after-seek.
+- **`_AesCtrLe` counter is correct across the 32/128-bit boundary** — it is a Python
+  arbitrary-precision `int` serialized with `to_bytes(16, "little")` and `+= 1`, so no 32-bit
+  wrap bug is possible (and 2³² blocks = 64 GiB is unreachable anyway).
+- **BLAKE2sp is bit-exact** — `test_blake2sp.py` already checks official KATs at lengths
+  0/1/63/64/65/127/128/255, i.e. across the 64-byte block boundary and the 512-byte
+  8-lane-stride boundary (the classic blake2sp bug locations), plus an odd-7-byte incremental
+  feed. All pass on the baseline.
+- **7z folder CRC gates wrong passwords on the normal path** (`digest_defined = True`,
+  `sevenzip_reader.py:127`) — a wrong key over a compressed folder is rejected by both the
+  codec and the CRC.

--- a/review/next/02-crypto/verification.md
+++ b/review/next/02-crypto/verification.md
@@ -90,13 +90,27 @@ A full archive→`unrar`→VerifyingStream repro needs the `unrar` binary (absen
 `-htb`-encrypted RAR5 fixture; the two units above pin the exact defect and the oracle pins
 the intended behaviour.
 
-### Fix
+### Fix (resolved with maintainer — see QUESTIONS Q1)
 
-Guard blake2sp with the same predicate: `if info.blake2sp_hash is not None and not
-_crc_is_tweaked(info):`. (Rename `_crc_is_tweaked` → `_checksums_tweaked` since it now covers
-both.) Optionally add a `DIGEST_UNVERIFIABLE` diagnostic so a tweaked member reports "not
-verified" rather than silently unverified — matching how `VerifyingStream` already emits that
-code for unknown algorithms.
+The DEV reference (`archivey-dev/src/archivey/formats/rar_reader.py`) shows the tweak is RAR's
+`ConvertHashToMAC` — a **one-way forward transform**
+(`tweaked = HMAC-based(HashKey, real_hash)`), so the real checksum is *not* recoverable from
+the stored tweaked value. Two-step plan:
+
+1. **Interim correctness fix:** make `_member_hashes` symmetric — guard blake2sp with the
+   same predicate that already guards crc32 (`… and not _crc_is_tweaked(info)`; rename to
+   `_checksums_tweaked`). Stash the tweaked values in `member.extra`
+   (`rar.tweaked_crc32` / `rar.tweaked_blake2sp`). This removes the false `CorruptionError`
+   immediately. DEV did exactly this for crc32 (set `crc32 = None` when tweaked) and never
+   surfaced a tweaked blake2sp — which is why DEV never hit this bug.
+2. **Full fix (restore verification when the password is known):** verify by forward-transform
+   — compute the real CRC32/BLAKE2sp over the decrypted data, apply `ConvertHashToMAC` with the
+   HashKey `= PBKDF2-HMAC-SHA256(pw_utf8, salt, (1<<kdf_count)+16)`, and compare to the stored
+   tweaked value. CRC32 transform is `XOR of the eight uint32 words of
+   HMAC-SHA256(HashKey, crc_le32)`; BLAKE2sp is (per UnRAR, pending source confirmation in
+   `7z-source-questions.md`) `HMAC-SHA256(HashKey, blake2sp32)`. Needs the confirmed password /
+   HashKey threaded into the RAR verification stage; leave `member.hashes` empty when no
+   correct password is known at open time.
 
 ---
 
@@ -155,14 +169,17 @@ _verify_decoded_folder(folder, garbage, member_digests=[(16, None)])
 # control: digest_defined=True, crc=0x12345678 -> EncryptionError (correctly rejected)
 ```
 
-### Fix
+### Fix (resolved with maintainer — see QUESTIONS Q2) — best-effort, not fail-closed
 
-Fail closed: when an *encrypted* folder has neither a folder digest nor any member CRC,
-`_password_for_folder` should refuse to confirm a password (raise a typed
-`EncryptionError`/`UnsupportedFeatureError` — "cannot verify password: this encrypted 7z
-folder has no checksum") rather than accept the first candidate. This preserves VISION #3
-(honest error) at the cost of refusing a pathological archive that no real tool produces.
-See QUESTIONS Q2 — this trades against any "recover what you can" goal.
+Maintainer call: do **not** hard-error (error detection is best-effort, and the data might be
+correct). This matches 7-Zip, which also cannot detect a wrong password when no CRC is present.
+Note ZIP is **not** exposed the same way — WinZip AE-2 authenticates with a mandatory HMAC and
+ZipCrypto STORED is disambiguated by the central-directory CRC — so 7z is the only format here
+where an encrypted member can carry zero integrity anchor. Recommendation: keep the
+accept-and-return behaviour but **emit a diagnostic** (`DIGEST_UNVERIFIABLE` or a new
+`DECRYPTION_UNVERIFIED`) when an encrypted folder has no anchor, so the caller can distinguish
+"decrypted but unverifiable" from "verified". **Downgraded to Low** (honest-signal gap, not
+silent-without-notice).
 
 ---
 


### PR DESCRIPTION
Deep review commissioned by `review/next/02-crypto.md` — every native decryption / key-derivation / integrity-verification path added since #73. Docs only, no source changes. Deliverables under `review/next/02-crypto/`.

## Baseline
`uv run pytest` → **1540 passed, 120 skipped**; `pyrefly` 0 errors, `ty` all-pass, `ruff` all-pass. Config `[all]` (cryptography 49, py7zr 1.1.3, rarfile 4.3); no `unrar`/`7z` binary in-container. Oracle diffs run against py7zr / rarfile / stdlib as libraries.

## Headline
The KDFs and ciphers are **correct** — bit-exact vs the project's own oracles (7z KDF vs py7zr, RAR3/RAR5 s2k vs rarfile, ZipCrypto vs stdlib `_ZipDecrypter`, BLAKE2sp vs official KATs, 0 mismatches). The bugs are in the **glue that decides whether an integrity check runs at all**. None is caught by the current suite (RAR data path needs `unrar`; the 7z/KDF triggers need format-legal-but-crafted archives py7zr never emits).

## Findings

| # | Sev | Where | One-liner |
|---|-----|-------|-----------|
| F1 | **High** | `rar_reader.py:119` | RAR5 tweaked-checksum members keep the key-tweaked BLAKE2sp in `member.hashes`, so a correctly-decrypted `-htb`-encrypted member fails `VerifyingStream` with a spurious `CorruptionError`. `_member_hashes` already drops crc32 when tweaked but not blake2sp; rarfile skips blake2sp when tweaked. |
| F2 | **Medium** | `sevenzip_reader.py:119` | An encrypted 7z folder with no folder digest and CRC-less members (both format-legal) confirms *any* password and returns garbage — no CRC gate, no `VerifyingStream`. Reachable for an AES+COPY (stored) folder where no codec rejects the garbage. |
| F3 | **Medium** | `crypto.py:176` | 7z `NumCyclesPower` is uncapped below the `0x3F` sentinel; a hostile `0x3E` forces ~2⁶² SHA-256 rounds (CPU DoS) during password confirmation / header decode. RAR5 caps its shift at 24; 7z has no equivalent. |
| F4 | Low | `rar_unrar.py:53` | Password passed to `unrar` as `-p<password>` in argv → visible via `ps`/`/proc` (matches rarfile; threat-model note). |
| F5 | Low | `rar_parser.py:1406` | RAR5 key-derived password-check compared with `!=` rather than `hmac.compare_digest` (WinZip AES correctly uses `compare_digest`). |

Each finding has a reproduction (unit-level + oracle diff) in the theme files. `QUESTIONS.md` collects three maintainer decisions (tweaked-blake2sp skip-vs-untweak; 7z fail-closed on checksum-less encrypted folders; 7z KDF cap + the `0x3F` sentinel). A "**what is actually fine**" section (verified-good: WinZip AES HMAC gating, non-seekable AES members, CTR boundary, `[crypto]`-absent contract, `cryptography>=45` floor) is in `verification.md` / `availability-and-contract.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VLyDWN8P1somMdMiq8pPi9

---
_Generated by [Claude Code](https://claude.ai/code/session_01VLyDWN8P1somMdMiq8pPi9)_