### PR TITLE
Fix Atheris CI crashes: .Z CLEAR seek collisions + 7z MemoryError

### DIFF
--- a/src/archivey/internal/backends/sevenzip_pipeline.py
+++ b/src/archivey/internal/backends/sevenzip_pipeline.py
@@ -27,6 +27,7 @@ from archivey.internal.backends.sevenzip_methods import (
     require,
 )
 from archivey.internal.backends.sevenzip_parser import (
+    _MAX_NEXT_HEADER_SIZE,
     EncodedHeader,
     SevenZipArchive,
     SevenZipCoder,
@@ -403,6 +404,13 @@ def decode_encoded_header(
         compressed_size,
         uncompressed_size,
     ) in encoded_folder_slices(encoded):
+        # Hostile archives can claim a multi-EiB folder unpack size. Cap before
+        # ``read_exact`` / codec buffers allocate (Atheris: raw MemoryError).
+        if uncompressed_size > _MAX_NEXT_HEADER_SIZE:
+            raise CorruptionError(
+                f"Encoded 7z header unpack size {uncompressed_size} exceeds the "
+                f"{_MAX_NEXT_HEADER_SIZE}-byte parser limit"
+            )
         source = SlicingStream(archive_fp, absolute_offset, compressed_size)
         decoded.extend(
             decode_folder_to_bytes(

--- a/src/archivey/internal/streams/decompressor_stream.py
+++ b/src/archivey/internal/streams/decompressor_stream.py
@@ -196,11 +196,13 @@ class DecompressorStream(ReadOnlyIOStream):
         refining the origin's ``compressed_offset`` / ``state`` (unix-compress header
         commit must apply even when the table is not built).
 
-        Same-``decompressed_offset`` collisions: the origin (offset 0) may be refined
-        in place — that is the only intentional last-wins case. For any other offset,
-        codecs must not emit a second point with the same decompressed offset but a
-        different ``compressed_offset`` / ``state`` (xz/lzip filter with ``>`` /
-        ``>=``); we assert rather than silently replace.
+        Same-``decompressed_offset`` collisions:
+        - Origin (offset 0) may always be refined in place (unix-compress header commit).
+        - For other offsets, an exact duplicate is skipped; a *forward* refinement
+          (same ``state``, ``compressed_offset`` moves forward) last-wins — unix-compress
+          empty CLEAR segments legitimately re-emit the same decompressed offset at a
+          later compressed resume point. Divergent ``state`` or a backwards
+          ``compressed_offset`` still asserts (xz/lzip should filter those away).
         """
         for point in points:
             # Origin refinement always applies — resume must skip a committed header
@@ -223,28 +225,33 @@ class DecompressorStream(ReadOnlyIOStream):
             if point < self._seek_points[-1]:
                 i = bisect.bisect_left(self._seek_points, point)
                 if i < len(self._seek_points) and self._seek_points[i] == point:
-                    existing = self._seek_points[i]
-                    assert (
-                        existing.compressed_offset == point.compressed_offset
-                        and existing.state is point.state
-                    ), (
-                        "seek-point collision at the same decompressed_offset with "
-                        f"differing resume data: existing={existing!r} new={point!r}"
-                    )
+                    self._resolve_same_offset_collision(i, point)
                     continue
                 self._seek_points.insert(i, point)
             elif self._seek_points[-1] == point:
-                existing = self._seek_points[-1]
-                assert (
-                    existing.compressed_offset == point.compressed_offset
-                    and existing.state is point.state
-                ), (
-                    "seek-point collision at the same decompressed_offset with "
-                    f"differing resume data: existing={existing!r} new={point!r}"
-                )
+                self._resolve_same_offset_collision(len(self._seek_points) - 1, point)
                 continue
             else:
                 self._seek_points.append(point)
+
+    def _resolve_same_offset_collision(self, index: int, point: SeekPoint) -> None:
+        """Skip duplicates; allow forward compressed-offset refinement; else assert."""
+        existing = self._seek_points[index]
+        if (
+            existing.compressed_offset == point.compressed_offset
+            and existing.state is point.state
+        ):
+            return
+        if (
+            point.compressed_offset >= existing.compressed_offset
+            and existing.state is point.state
+        ):
+            self._seek_points[index] = point
+            return
+        assert False, (
+            "seek-point collision at the same decompressed_offset with "
+            f"differing resume data: existing={existing!r} new={point!r}"
+        )
 
     def _find_best_seek_point(self, pos: int) -> SeekPoint:
         """The last seek point with ``decompressed_offset <= pos``."""

--- a/src/archivey/internal/streams/unix_compress.py
+++ b/src/archivey/internal/streams/unix_compress.py
@@ -374,7 +374,13 @@ class UnixCompressDecoder(BaseDecoder):
             # After-placement: advance past CLEAR realignment, then emit the point.
             self._comp_cursor += comp_size
             self._decomp_cursor += decomp_size
-            points.append(SeekPoint(self._decomp_cursor, self._comp_cursor))
+            point = SeekPoint(self._decomp_cursor, self._comp_cursor)
+            # Consecutive CLEARs (zero decompressed output between them) share a
+            # decompressed_offset; keep the later compressed resume point only.
+            if points and points[-1].decompressed_offset == point.decompressed_offset:
+                points[-1] = point
+            else:
+                points.append(point)
         return points
 
 

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -370,6 +370,31 @@ def test_unix_compress_clear_seek_points() -> None:
         )
 
 
+def test_unix_compress_consecutive_clear_seek_points_no_assert() -> None:
+    """Atheris: consecutive CLEARs at the same decompressed offset must not assert.
+
+    Empty CLEAR segments re-emit a SeekPoint at the prior decompressed offset with a
+    later compressed resume point; indexing must forward-refine rather than crash.
+    """
+    # CI crash input (detect_format target, 2026-07-15): triggers the collision during
+    # a seekable decode of a short hostile .Z prefix.
+    compressed = bytes.fromhex(
+        "1f9d8b008b000000000000000000000000000000000000000000000000000000"
+        "0000000000000000000000000000000000000000000000000000000000000000"
+        "00000000000000000000000000000000002e0100000010000003550100000000"
+        "0000035500e00008"
+    )
+    config = StreamConfig(seekable=True)
+    with open_codec_stream(
+        Codec.UNIX_COMPRESS, io.BytesIO(compressed), config=config
+    ) as stream:
+        # May raise typed ArchiveyError on corrupt payload; must not AssertionError.
+        try:
+            stream.read(4096)
+        except ArchiveyError:
+            pass
+
+
 def test_translated_error_is_stamped() -> None:
     """A stamp callback fills archive/member context on the translated error."""
 

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -321,6 +321,27 @@ def test_unix_compress_without_inner_tar_stays_bare_z() -> None:
     assert info.detected_by == "magic"
 
 
+@pytest.mark.parametrize(
+    "hex_blob",
+    [
+        # Atheris detect_format finds (2026-07-14..15): consecutive LZW CLEARs share a
+        # decompressed_offset; must not raise AssertionError during the inner-TAR probe.
+        "1f9d9d001ffd37250000000000000000000000001b001f9d9d061ffd377a00df0000000900",
+        "1f9d9d28a600000000000000000040f8000020000000ffff00000000f0",
+        "1f9d9e9d009e58000000002600e38623a800288027",
+        "1f9d8d8d00000000000000000000000000000000000000000000000000000000e2000000000000008d0000000000000000000000000000",
+        "1f9d8b008b0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002e01000000100000035501000000000000035500e00008",
+    ],
+    ids=["clear-a", "clear-b", "clear-c", "clear-d", "clear-e"],
+)
+def test_detect_format_atheris_z_clear_collisions_do_not_assert(hex_blob: str) -> None:
+    """Atheris: hostile .Z with consecutive CLEARs must not crash detect_format."""
+    data = bytes.fromhex(hex_blob)
+    info = detect_format(io.BytesIO(data))
+    assert info.format == ArchiveFormat.Z
+    assert info.detected_by == "magic"
+
+
 def test_inner_tar_over_lzma_alone_is_tar_lzma() -> None:
     import lzma
 

--- a/tests/test_sevenzip_reader.py
+++ b/tests/test_sevenzip_reader.py
@@ -905,6 +905,29 @@ def test_archive_property_payload_size_is_bounded() -> None:
         parse_sevenzip_archive(io.BytesIO(blob))
 
 
+def test_encoded_header_huge_unpack_size_is_typed_corruption() -> None:
+    """Hostile encoded-header unpack size must not raise MemoryError (Atheris finding)."""
+    from archivey.exceptions import CorruptionError
+    from archivey.internal.backends.sevenzip_pipeline import parse_sevenzip_archive
+
+    # CI crash input (sevenzip_header, 2026-07-15): ENCODED_HEADER claims ~7.26e17
+    # uncompressed bytes; previously blew up in lzma/read_exact as MemoryError.
+    blob = bytes.fromhex(
+        "377abcaf271c0004b94189d2e30000000000000024000000000000003393e6a2"
+        "e0002800255d00241949986f16028ce8e65bb147c6e8785df977f152c4a859c0"
+        "a9300dd98729229ab2993c9f00e0016d00ae5d0000813307ae0fd0d36d7c9f39"
+        "109c6cea561a8ee1ce421bf7dd8a7d61fa2b2e795eb720494abfaa6e563e7783"
+        "6034574bfe117d9bf2e6acdd947c4c39e3007228af9cc251620efa22eded9bf5"
+        "a5d5098d4562a390f7a8707038e8a889585b98fe0a641968b481d04b24eb5853"
+        "1946a77f37cd1773040ccbc8b9053fefb060f8b4b0b770e4be72e602741c8904"
+        "1b2c1343fbf55ece457ecb05f85ff07810e4d6b1959f3d4a90a6a92f3d532e00"
+        "00000017062d010980b600070b010001212101180cffffffffffffff110a0a0a"
+        "0a01000000000002830a0a0a0a0a0a0a0a0a0a0a0a816e0000"
+    )
+    with pytest.raises(CorruptionError, match="unpack size|parser limit"):
+        parse_sevenzip_archive(io.BytesIO(blob))
+
+
 # py7zr's empty.7z: signature + start_header with nextHeaderSize == 0.
 _EMPTY_7Z = bytes.fromhex(
     "377abcaf271c00038d9bd50f0000000000000000000000000000000000000000"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Triaged the last failing [atheris-fuzz](https://github.com/davitf/archivey-2/actions/workflows/atheris-fuzz.yml) runs (8 failures with artifacts available) and fixed the two bugs that still reproduce on current `main`.

### Findings

| Class | Runs | Verdict |
| --- | --- | --- |
| `detect_format` → `AssertionError: seek-point collision…` on `.Z` | 7 recent failures | **Real bug** |
| `sevenzip_header` → `MemoryError` (huge encoded-header unpack size) | 1 | **Real bug** |
| `sevenzip_header` → libFuzzer OOM/timeout | 1 | Likely same unpack-size / hang class; specific OOM artifact no longer reproduces as raw OOM |
| `OverflowError` / ZIP `EOFError` | first atheris run (#78 era) | **Already fixed** in #80 |

### Fixes

1. **Unix-compress CLEAR collisions** — consecutive CLEARs with zero decompressed output re-emit a `SeekPoint` at the same `decompressed_offset`. Coalesce within the decoder batch, and allow forward compressed-offset refinement in `DecompressorStream` (still assert on divergent `state` / backwards offset).
2. **7z encoded-header unpack cap** — reject claimed unpack sizes above `_MAX_NEXT_HEADER_SIZE` with `CorruptionError` before `read_exact` / lzma can `MemoryError`.

### Tests

Regression tests embed the CI crash inputs in `test_detection.py`, `test_codecs.py`, and `test_sevenzip_reader.py`.

## Test plan

- [x] `pytest` for the new Atheris regression cases
- [x] ruff + pyrefly/ty on touched sources
- [ ] Confirm atheris-fuzz goes green on merge to `main`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0a6c507f-83c2-4282-a22b-e039ecb29db4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0a6c507f-83c2-4282-a22b-e039ecb29db4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

