### PR TITLE
Split Atheris CI: short PR gate + 3-day change-guarded nightly

### DIFF
--- a/.github/workflows/atheris-fuzz.yml
+++ b/.github/workflows/atheris-fuzz.yml
@@ -3,7 +3,8 @@ name: Atheris fuzz
 # Coverage-guided parser/entry-point fuzz (threat-model O5).
 #
 # Mirrors the benchmark split:
-# - pull_request: short partitioned budgets (blocks the PR; finds crashers cheaply)
+# - pull_request: short budgets, 3-way sharded (each target pays ~30s Atheris cold
+#   start; sharding cuts PR wall time roughly 3× while keeping the full target set)
 # - schedule (nightly) + change guard: full partition only when default-branch HEAD
 #   moved in the last ~3 days (dormant stretches cost only the guard step)
 # - workflow_dispatch: force the full partition on demand (optional budget_scale)
@@ -25,10 +26,15 @@ concurrency:
 
 jobs:
   fuzz:
-    name: Atheris (${{ github.event_name == 'pull_request' && 'PR short' || 'full' }})
+    name: Atheris (${{ github.event_name == 'pull_request' && format('PR short {0}/3', matrix.shard) || 'full' }})
     runs-on: ubuntu-latest
-    # PR: short budgets + seed build. Nightly/full: ~4–5+ min fuzz + headroom.
-    timeout-minutes: ${{ github.event_name == 'pull_request' && 25 || 60 }}
+    # PR shards: ~6–7 targets × ~30s startup + short fuzz. Nightly: full partition.
+    timeout-minutes: ${{ github.event_name == 'pull_request' && 15 || 60 }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # PR: three parallel shards. Nightly/dispatch: one sequential full run.
+        shard: ${{ github.event_name == 'pull_request' && fromJSON('[0, 1, 2]') || fromJSON('[0]') }}
     steps:
       - uses: actions/checkout@v4
 
@@ -92,32 +98,35 @@ jobs:
           ARCHIVEY_FUZZ_ARTIFACT_DIR: artifacts/atheris
           BUDGET_SCALE: ${{ github.event.inputs.budget_scale || '1' }}
           ATHERIS_MODE: ${{ steps.guard.outputs.mode }}
+          ARCHIVEY_FUZZ_SHARD_INDEX: ${{ matrix.shard }}
+          # PR: 3 shards; nightly/dispatch: single sequential job (count=1).
+          ARCHIVEY_FUZZ_SHARD_COUNT: ${{ github.event_name == 'pull_request' && 3 || 1 }}
         run: |
           mode="${ATHERIS_MODE:-full}"
           scale="${BUDGET_SCALE:-1}"
           if [ "$mode" = "pr" ]; then
-            # Short PR partition (~1 min of fuzz wall across all required targets).
-            # Still covers every target; depth comes from the change-guarded nightly.
-            export ARCHIVEY_FUZZ_BUDGET_SEVENZIP_HEADER=8
-            export ARCHIVEY_FUZZ_BUDGET_SEVENZIP_OPEN=4
-            export ARCHIVEY_FUZZ_BUDGET_DETECT_FORMAT=3
-            export ARCHIVEY_FUZZ_BUDGET_ZIP=5
-            export ARCHIVEY_FUZZ_BUDGET_TAR=2
-            export ARCHIVEY_FUZZ_BUDGET_ISO=2
-            export ARCHIVEY_FUZZ_BUDGET_RAR_HEADER=5
-            export ARCHIVEY_FUZZ_BUDGET_RAR=3
-            export ARCHIVEY_FUZZ_BUDGET_UNIX_COMPRESS=3
-            export ARCHIVEY_FUZZ_BUDGET_XZ=3
-            export ARCHIVEY_FUZZ_BUDGET_LZIP=2
-            export ARCHIVEY_FUZZ_BUDGET_GZIP=2
-            export ARCHIVEY_FUZZ_BUDGET_BZIP2=2
-            export ARCHIVEY_FUZZ_BUDGET_LZMA_ALONE=2
-            export ARCHIVEY_FUZZ_BUDGET_ZLIB=2
-            export ARCHIVEY_FUZZ_BUDGET_ZSTD=2
-            export ARCHIVEY_FUZZ_BUDGET_BROTLI=2
-            export ARCHIVEY_FUZZ_BUDGET_LZ4=2
-            export ARCHIVEY_FUZZ_BUDGET_DEFLATE64=2
-            echo "PR short budgets: sevenzip_header=$ARCHIVEY_FUZZ_BUDGET_SEVENZIP_HEADER zip=$ARCHIVEY_FUZZ_BUDGET_ZIP rar=$ARCHIVEY_FUZZ_BUDGET_RAR"
+            # Short PR budgets — wall time is dominated by per-target Atheris startup
+            # (~30s), so shards matter more than seconds. Depth stays on the nightly.
+            export ARCHIVEY_FUZZ_BUDGET_SEVENZIP_HEADER=3
+            export ARCHIVEY_FUZZ_BUDGET_SEVENZIP_OPEN=2
+            export ARCHIVEY_FUZZ_BUDGET_DETECT_FORMAT=2
+            export ARCHIVEY_FUZZ_BUDGET_ZIP=2
+            export ARCHIVEY_FUZZ_BUDGET_TAR=1
+            export ARCHIVEY_FUZZ_BUDGET_ISO=1
+            export ARCHIVEY_FUZZ_BUDGET_RAR_HEADER=2
+            export ARCHIVEY_FUZZ_BUDGET_RAR=1
+            export ARCHIVEY_FUZZ_BUDGET_UNIX_COMPRESS=2
+            export ARCHIVEY_FUZZ_BUDGET_XZ=1
+            export ARCHIVEY_FUZZ_BUDGET_LZIP=1
+            export ARCHIVEY_FUZZ_BUDGET_GZIP=1
+            export ARCHIVEY_FUZZ_BUDGET_BZIP2=1
+            export ARCHIVEY_FUZZ_BUDGET_LZMA_ALONE=1
+            export ARCHIVEY_FUZZ_BUDGET_ZLIB=1
+            export ARCHIVEY_FUZZ_BUDGET_ZSTD=1
+            export ARCHIVEY_FUZZ_BUDGET_BROTLI=1
+            export ARCHIVEY_FUZZ_BUDGET_LZ4=1
+            export ARCHIVEY_FUZZ_BUDGET_DEFLATE64=1
+            echo "PR short budgets (shard $ARCHIVEY_FUZZ_SHARD_INDEX/$ARCHIVEY_FUZZ_SHARD_COUNT): sevenzip_header=$ARCHIVEY_FUZZ_BUDGET_SEVENZIP_HEADER zip=$ARCHIVEY_FUZZ_BUDGET_ZIP"
           else
             export ARCHIVEY_FUZZ_BUDGET_SEVENZIP_HEADER=$((45 * scale))
             export ARCHIVEY_FUZZ_BUDGET_SEVENZIP_OPEN=$((20 * scale))
@@ -146,7 +155,7 @@ jobs:
         if: failure() && steps.guard.outputs.run == 'true'
         uses: actions/upload-artifact@v4
         with:
-          name: atheris-crashes
+          name: atheris-crashes-${{ matrix.shard }}
           path: artifacts/atheris/
           if-no-files-found: ignore
           retention-days: 30

--- a/.github/workflows/atheris-fuzz.yml
+++ b/.github/workflows/atheris-fuzz.yml
@@ -1,78 +1,149 @@
 name: Atheris fuzz
 
-# Coverage-guided parser/entry-point fuzz (threat-model O5). Runs when main moves and
-# on manual dispatch — not on the default PR test matrix (see testing-contract).
+# Coverage-guided parser/entry-point fuzz (threat-model O5).
+#
+# Mirrors the benchmark split:
+# - pull_request: short partitioned budgets (blocks the PR; finds crashers cheaply)
+# - schedule (nightly) + change guard: full partition only when default-branch HEAD
+#   moved in the last ~3 days (dormant stretches cost only the guard step)
+# - workflow_dispatch: force the full partition on demand (optional budget_scale)
 on:
-  push:
-    branches: [main]
+  pull_request:
+  schedule:
+    # Offset from benchmark-wall (17 6) so the two nightlies do not start together.
+    - cron: "47 6 * * *"
   workflow_dispatch:
     inputs:
       budget_scale:
-        description: "Multiply default per-target budgets (e.g. 3 for a longer soak)"
+        description: "Multiply full (nightly) per-target budgets (e.g. 3 for a longer soak)"
         required: false
         default: "1"
 
 concurrency:
-  group: atheris-fuzz-${{ github.ref }}
+  group: atheris-fuzz-${{ github.event_name == 'pull_request' && github.ref || 'nightly' }}
   cancel-in-progress: true
 
 jobs:
   fuzz:
-    name: Atheris (partitioned)
+    name: Atheris (${{ github.event_name == 'pull_request' && 'PR short' || 'full' }})
     runs-on: ubuntu-latest
-    # Full partition is ~4–5+ min before budget_scale; leave headroom for sync + seeds.
-    timeout-minutes: 60
+    # PR: short budgets + seed build. Nightly/full: ~4–5+ min fuzz + headroom.
+    timeout-minutes: ${{ github.event_name == 'pull_request' && 25 || 60 }}
     steps:
       - uses: actions/checkout@v4
 
+      - name: Decide whether to run (skip unchanged nightly)
+        id: guard
+        env:
+          EVENT: ${{ github.event_name }}
+        run: |
+          if [ "$EVENT" = "pull_request" ] || [ "$EVENT" = "workflow_dispatch" ]; then
+            echo "Event=$EVENT — running."
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            if [ "$EVENT" = "pull_request" ]; then
+              echo "mode=pr" >> "$GITHUB_OUTPUT"
+            else
+              echo "mode=full" >> "$GITHUB_OUTPUT"
+            fi
+            exit 0
+          fi
+          # Scheduled: run only if default-branch HEAD was committed within ~3 days.
+          # Daily cron + 72h window → up to a few nightlies after a burst, then skip
+          # until the next change (same idea as benchmark-wall's 25h guard).
+          last=$(git log -1 --format=%ct)
+          age=$(( $(date +%s) - last ))
+          window=$((3 * 24 * 3600))
+          if [ "$age" -lt "$window" ]; then
+            echo "HEAD committed ${age}s ago (< ${window}s / 3d) — changes recently; running full."
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            echo "mode=full" >> "$GITHUB_OUTPUT"
+          else
+            echo "HEAD committed ${age}s ago (>= ${window}s / 3d) — no recent changes; skipping."
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "mode=full" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Install uv
+        if: steps.guard.outputs.run == 'true'
         uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
 
       - name: Set up Python
+        if: steps.guard.outputs.run == 'true'
         run: uv python install 3.12
 
       # RAR open+list target needs RARLAB unrar (header-only target does not). Mirror
       # ci.yml so the partitioned fuzz job does not silently skip the rar slice.
       - name: Install unrar
+        if: steps.guard.outputs.run == 'true'
         run: sudo apt-get update && sudo apt-get install -y unrar
 
       # fuzz = atheris; dev = fixture builders (py7zr, …); all = ISO/codecs the targets need.
       # Python 3.12: atheris publishes current wheels here (3.11 is capped at atheris 3.0.x).
       - name: Sync (fuzz + dev + all extras)
+        if: steps.guard.outputs.run == 'true'
         run: uv sync --python 3.12 --group fuzz --group dev --extra all
 
       - name: Run Atheris harness
+        if: steps.guard.outputs.run == 'true'
         env:
           ARCHIVEY_FUZZ_ARTIFACT_DIR: artifacts/atheris
           BUDGET_SCALE: ${{ github.event.inputs.budget_scale || '1' }}
+          ATHERIS_MODE: ${{ steps.guard.outputs.mode }}
         run: |
+          mode="${ATHERIS_MODE:-full}"
           scale="${BUDGET_SCALE:-1}"
-          export ARCHIVEY_FUZZ_BUDGET_SEVENZIP_HEADER=$((45 * scale))
-          export ARCHIVEY_FUZZ_BUDGET_SEVENZIP_OPEN=$((20 * scale))
-          export ARCHIVEY_FUZZ_BUDGET_DETECT_FORMAT=$((12 * scale))
-          export ARCHIVEY_FUZZ_BUDGET_ZIP=$((25 * scale))
-          export ARCHIVEY_FUZZ_BUDGET_TAR=$((10 * scale))
-          export ARCHIVEY_FUZZ_BUDGET_ISO=$((8 * scale))
-          export ARCHIVEY_FUZZ_BUDGET_RAR_HEADER=$((30 * scale))
-          export ARCHIVEY_FUZZ_BUDGET_RAR=$((15 * scale))
-          export ARCHIVEY_FUZZ_BUDGET_UNIX_COMPRESS=$((15 * scale))
-          export ARCHIVEY_FUZZ_BUDGET_XZ=$((12 * scale))
-          export ARCHIVEY_FUZZ_BUDGET_LZIP=$((10 * scale))
-          export ARCHIVEY_FUZZ_BUDGET_GZIP=$((10 * scale))
-          export ARCHIVEY_FUZZ_BUDGET_BZIP2=$((10 * scale))
-          export ARCHIVEY_FUZZ_BUDGET_LZMA_ALONE=$((8 * scale))
-          export ARCHIVEY_FUZZ_BUDGET_ZLIB=$((8 * scale))
-          export ARCHIVEY_FUZZ_BUDGET_ZSTD=$((8 * scale))
-          export ARCHIVEY_FUZZ_BUDGET_BROTLI=$((8 * scale))
-          export ARCHIVEY_FUZZ_BUDGET_LZ4=$((8 * scale))
-          export ARCHIVEY_FUZZ_BUDGET_DEFLATE64=$((8 * scale))
-          echo "Budgets (scale=$scale): sevenzip_header=$ARCHIVEY_FUZZ_BUDGET_SEVENZIP_HEADER zip=$ARCHIVEY_FUZZ_BUDGET_ZIP tar=$ARCHIVEY_FUZZ_BUDGET_TAR rar=$ARCHIVEY_FUZZ_BUDGET_RAR unix_compress=$ARCHIVEY_FUZZ_BUDGET_UNIX_COMPRESS"
+          if [ "$mode" = "pr" ]; then
+            # Short PR partition (~1 min of fuzz wall across all required targets).
+            # Still covers every target; depth comes from the change-guarded nightly.
+            export ARCHIVEY_FUZZ_BUDGET_SEVENZIP_HEADER=8
+            export ARCHIVEY_FUZZ_BUDGET_SEVENZIP_OPEN=4
+            export ARCHIVEY_FUZZ_BUDGET_DETECT_FORMAT=3
+            export ARCHIVEY_FUZZ_BUDGET_ZIP=5
+            export ARCHIVEY_FUZZ_BUDGET_TAR=2
+            export ARCHIVEY_FUZZ_BUDGET_ISO=2
+            export ARCHIVEY_FUZZ_BUDGET_RAR_HEADER=5
+            export ARCHIVEY_FUZZ_BUDGET_RAR=3
+            export ARCHIVEY_FUZZ_BUDGET_UNIX_COMPRESS=3
+            export ARCHIVEY_FUZZ_BUDGET_XZ=3
+            export ARCHIVEY_FUZZ_BUDGET_LZIP=2
+            export ARCHIVEY_FUZZ_BUDGET_GZIP=2
+            export ARCHIVEY_FUZZ_BUDGET_BZIP2=2
+            export ARCHIVEY_FUZZ_BUDGET_LZMA_ALONE=2
+            export ARCHIVEY_FUZZ_BUDGET_ZLIB=2
+            export ARCHIVEY_FUZZ_BUDGET_ZSTD=2
+            export ARCHIVEY_FUZZ_BUDGET_BROTLI=2
+            export ARCHIVEY_FUZZ_BUDGET_LZ4=2
+            export ARCHIVEY_FUZZ_BUDGET_DEFLATE64=2
+            echo "PR short budgets: sevenzip_header=$ARCHIVEY_FUZZ_BUDGET_SEVENZIP_HEADER zip=$ARCHIVEY_FUZZ_BUDGET_ZIP rar=$ARCHIVEY_FUZZ_BUDGET_RAR"
+          else
+            export ARCHIVEY_FUZZ_BUDGET_SEVENZIP_HEADER=$((45 * scale))
+            export ARCHIVEY_FUZZ_BUDGET_SEVENZIP_OPEN=$((20 * scale))
+            export ARCHIVEY_FUZZ_BUDGET_DETECT_FORMAT=$((12 * scale))
+            export ARCHIVEY_FUZZ_BUDGET_ZIP=$((25 * scale))
+            export ARCHIVEY_FUZZ_BUDGET_TAR=$((10 * scale))
+            export ARCHIVEY_FUZZ_BUDGET_ISO=$((8 * scale))
+            export ARCHIVEY_FUZZ_BUDGET_RAR_HEADER=$((30 * scale))
+            export ARCHIVEY_FUZZ_BUDGET_RAR=$((15 * scale))
+            export ARCHIVEY_FUZZ_BUDGET_UNIX_COMPRESS=$((15 * scale))
+            export ARCHIVEY_FUZZ_BUDGET_XZ=$((12 * scale))
+            export ARCHIVEY_FUZZ_BUDGET_LZIP=$((10 * scale))
+            export ARCHIVEY_FUZZ_BUDGET_GZIP=$((10 * scale))
+            export ARCHIVEY_FUZZ_BUDGET_BZIP2=$((10 * scale))
+            export ARCHIVEY_FUZZ_BUDGET_LZMA_ALONE=$((8 * scale))
+            export ARCHIVEY_FUZZ_BUDGET_ZLIB=$((8 * scale))
+            export ARCHIVEY_FUZZ_BUDGET_ZSTD=$((8 * scale))
+            export ARCHIVEY_FUZZ_BUDGET_BROTLI=$((8 * scale))
+            export ARCHIVEY_FUZZ_BUDGET_LZ4=$((8 * scale))
+            export ARCHIVEY_FUZZ_BUDGET_DEFLATE64=$((8 * scale))
+            echo "Full budgets (scale=$scale): sevenzip_header=$ARCHIVEY_FUZZ_BUDGET_SEVENZIP_HEADER zip=$ARCHIVEY_FUZZ_BUDGET_ZIP rar=$ARCHIVEY_FUZZ_BUDGET_RAR unix_compress=$ARCHIVEY_FUZZ_BUDGET_UNIX_COMPRESS"
+          fi
           uv run --python 3.12 --no-sync python -m tests.atheris_fuzz
+
       - name: Upload crash artifacts
-        if: failure()
+        if: failure() && steps.guard.outputs.run == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: atheris-crashes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -146,7 +146,8 @@ workflow must pass `--python <matrix>` (and `UV_PYTHON`) on every `uv sync` /
 Atheris lives in the PEP 735 `fuzz` dependency group (`atheris`) and runs via
 `.github/workflows/atheris-fuzz.yml` — same shape as the benchmark wall split:
 
-- **Every PR:** short partitioned budgets over all targets (blocks the PR).
+- **Every PR:** short partitioned budgets over all targets (blocks the PR; sharded
+  across parallel jobs because each target pays a large Atheris cold-start).
 - **Nightly schedule:** full partition, but only if default-branch HEAD moved in the
   last ~3 days (commit-recency guard; dormant stretches skip the expensive run).
 - **`workflow_dispatch`:** force the full partition (optional `budget_scale`).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -143,12 +143,15 @@ workflow must pass `--python <matrix>` (and `UV_PYTHON`) on every `uv sync` /
 
 ### Coverage-guided fuzz (Atheris)
 
-Atheris is **not** part of the everyday `pytest` / PR matrix. It lives in the PEP 735
-`fuzz` dependency group (`atheris`) and runs as a separate main-branch gate
-(`.github/workflows/atheris-fuzz.yml`: `push` to `main` + `workflow_dispatch`,
-partitioned ~4–5+ min across 7z/RAR headers+open, `detect_format`, deepened ZIP
-read, TAR/ISO, and all standalone stream/codec targets; CI installs `unrar` so RAR
-open runs). Mutation fuzz (`tests/test_mutation_fuzz.py`) and `ARCHIVEY_FUZZ=1` /
+Atheris lives in the PEP 735 `fuzz` dependency group (`atheris`) and runs via
+`.github/workflows/atheris-fuzz.yml` — same shape as the benchmark wall split:
+
+- **Every PR:** short partitioned budgets over all targets (blocks the PR).
+- **Nightly schedule:** full partition, but only if default-branch HEAD moved in the
+  last ~3 days (commit-recency guard; dormant stretches skip the expensive run).
+- **`workflow_dispatch`:** force the full partition (optional `budget_scale`).
+
+Mutation fuzz (`tests/test_mutation_fuzz.py`) and `ARCHIVEY_FUZZ=1` /
 `tests/fuzz_sevenzip_parser.py` / `tests/fuzz_rar_parser.py` stay as they are.
 
 Local smoke (Linux; needs corpus fixture builders). Prefer Python 3.12 for current

--- a/docs/internal/threat-model.md
+++ b/docs/internal/threat-model.md
@@ -137,11 +137,12 @@ not the in-tree gate:
    member read (native codec/AES), TAR/ISO open+list, and standalone stream/codec
    targets (unix-compress, xz, lzip, gzip, bzip2, lzma-alone, zlib; optional
    zstd/brotli/lz4/deflate64 skip-clean when absent). CI runs a **short** partition on
-   every **pull request**, and the **full** partition on a **change-guarded nightly**
-   (skip unless default-branch HEAD moved in ~3 days) plus **`workflow_dispatch`** —
-   same pattern as the benchmark wall job; not an always-on nightly and not a full
-   run on every `main` push. `atheris` lives in the PEP 735 `fuzz` dependency group
-   only — never a runtime extra. See `openspec/specs/testing-contract/spec.md`.
+   every **pull request** (sharded for wall time), and the **full** partition on a
+   **change-guarded nightly** (skip unless default-branch HEAD moved in ~3 days) plus
+   **`workflow_dispatch`** — same pattern as the benchmark wall job; not an always-on
+   nightly and not a full run on every `main` push. `atheris` lives in the PEP 735
+   `fuzz` dependency group only — never a runtime extra. See
+   `openspec/specs/testing-contract/spec.md`.
 4. **Still open (public release):** OSS-Fuzz onboarding; `SECURITY.md` with a disclosure
    process. Accelerator hang sandbox (below) remains a separate follow-up.
 

--- a/docs/internal/threat-model.md
+++ b/docs/internal/threat-model.md
@@ -136,10 +136,12 @@ not the in-tree gate:
    RARLAB `unrar` so RAR open is not skipped), `detect_format`, ZIP open+list+bounded
    member read (native codec/AES), TAR/ISO open+list, and standalone stream/codec
    targets (unix-compress, xz, lzip, gzip, bzip2, lzma-alone, zlib; optional
-   zstd/brotli/lz4/deflate64 skip-clean when absent). CI runs on **push to `main`** +
-   **`workflow_dispatch`** (partitioned ~4–5+ min; not the PR matrix; not always-on
-   nightly). `atheris` lives in the PEP 735 `fuzz` dependency group only — never a
-   runtime extra. See `openspec/specs/testing-contract/spec.md`.
+   zstd/brotli/lz4/deflate64 skip-clean when absent). CI runs a **short** partition on
+   every **pull request**, and the **full** partition on a **change-guarded nightly**
+   (skip unless default-branch HEAD moved in ~3 days) plus **`workflow_dispatch`** —
+   same pattern as the benchmark wall job; not an always-on nightly and not a full
+   run on every `main` push. `atheris` lives in the PEP 735 `fuzz` dependency group
+   only — never a runtime extra. See `openspec/specs/testing-contract/spec.md`.
 4. **Still open (public release):** OSS-Fuzz onboarding; `SECURITY.md` with a disclosure
    process. Accelerator hang sandbox (below) remains a separate follow-up.
 

--- a/openspec/specs/testing-contract/spec.md
+++ b/openspec/specs/testing-contract/spec.md
@@ -316,16 +316,17 @@ mutation harness). Filter-only codecs (BCJ, Delta) are not required as standalon
 stream targets.
 
 CI SHALL run a **short** partitioned harness on every pull request (same target
-set, reduced per-target budgets — enough to catch crashers without a multi-minute
-tax). The **full** partition SHALL run off the PR path as a separate scheduled
-nightly job, guarded so the expensive run is SKIPPED unless the default branch
-changed within roughly the past 3 days (commit-recency guard), and MAY be forced
-on demand via `workflow_dispatch` (longer budgets allowed). A plain always-on
-nightly and a full partition on every `main` push are NOT required — same bursty /
-dormant trade-off as the change-guarded benchmark wall job. On failure the job
-SHALL upload reproducing inputs as artifacts and print a one-line local re-run
-command. The workflow job timeout MUST accommodate the active partition (short
-for PRs; full for nightly/dispatch).
+set, reduced per-target budgets, and MAY shard targets across parallel jobs so
+wall time stays on the order of a few minutes — each Atheris target pays a large
+process cold-start cost). The **full** partition SHALL run off the PR path as a
+separate scheduled nightly job, guarded so the expensive run is SKIPPED unless
+the default branch changed within roughly the past 3 days (commit-recency
+guard), and MAY be forced on demand via `workflow_dispatch` (longer budgets
+allowed). A plain always-on nightly and a full partition on every `main` push
+are NOT required — same bursty / dormant trade-off as the change-guarded
+benchmark wall job. On failure the job SHALL upload reproducing inputs as
+artifacts and print a one-line local re-run command. The workflow job timeout
+MUST accommodate the active partition (short for PRs; full for nightly/dispatch).
 
 The existing corpus mutation harness and Hypothesis property tests remain
 mandatory complementary layers; Atheris does not replace them. `atheris` is
@@ -335,7 +336,7 @@ installed only via the CI `fuzz` dependency group (`packaging-and-extras`).
 
 | Case | Expected |
 | --- | --- |
-| Pull request | Short partitioned budgets over the full target set; green if no crash/hang/raw exception |
+| Pull request | Short partitioned budgets over the full target set (MAY be sharded across parallel jobs); green if no crash/hang/raw exception |
 | Scheduled nightly, HEAD commit within ~3 days | Full partitioned target set runs |
 | Scheduled nightly, HEAD older than ~3 days | Expensive fuzz skipped (guard only) |
 | `workflow_dispatch` (optional longer env budget) | Full partition; extended exploration allowed |

--- a/openspec/specs/testing-contract/spec.md
+++ b/openspec/specs/testing-contract/spec.md
@@ -288,9 +288,9 @@ NOT rely on unaided libFuzzer CMP feedback to solve CRC32. A minority of inputs
 (or a small dedicated budget) SHALL retain broken CRCs so the reject path stays
 exercised.
 
-The default main-branch run SHALL partition wall-clock budget across the targets
-below (exact seconds MAY be env-overridable). The partition MUST size the total
-budget to include every required stream/codec target — there is no hard short
+The default main-branch / nightly run SHALL partition wall-clock budget across the
+targets below (exact seconds MAY be env-overridable). The partition MUST size the
+total budget to include every required stream/codec target — there is no hard short
 ceiling that permits dropping those slices. `workflow_dispatch` MAY lengthen
 budgets further.
 
@@ -315,11 +315,17 @@ Full member **extract** remains out of scope for this harness (covered by the
 mutation harness). Filter-only codecs (BCJ, Delta) are not required as standalone
 stream targets.
 
-CI SHALL run the harness on every push to `main` and via `workflow_dispatch`
-(longer budgets allowed). It MUST NOT be part of the default pull-request test
-matrix. On failure the job SHALL upload reproducing inputs as artifacts and
-print a one-line local re-run command. Always-on nightly schedules are not
-required. The workflow job timeout MUST accommodate the full partition.
+CI SHALL run a **short** partitioned harness on every pull request (same target
+set, reduced per-target budgets — enough to catch crashers without a multi-minute
+tax). The **full** partition SHALL run off the PR path as a separate scheduled
+nightly job, guarded so the expensive run is SKIPPED unless the default branch
+changed within roughly the past 3 days (commit-recency guard), and MAY be forced
+on demand via `workflow_dispatch` (longer budgets allowed). A plain always-on
+nightly and a full partition on every `main` push are NOT required — same bursty /
+dormant trade-off as the change-guarded benchmark wall job. On failure the job
+SHALL upload reproducing inputs as artifacts and print a one-line local re-run
+command. The workflow job timeout MUST accommodate the active partition (short
+for PRs; full for nightly/dispatch).
 
 The existing corpus mutation harness and Hypothesis property tests remain
 mandatory complementary layers; Atheris does not replace them. `atheris` is
@@ -329,9 +335,11 @@ installed only via the CI `fuzz` dependency group (`packaging-and-extras`).
 
 | Case | Expected |
 | --- | --- |
-| Push to `main` | Fuzz workflow runs the full partitioned target set (including all required stream/codec slices); green if no crash/hang/raw exception |
-| `workflow_dispatch` with longer env budget | Same targets; extended exploration |
-| Pull request (default matrix) | Atheris job not required |
+| Pull request | Short partitioned budgets over the full target set; green if no crash/hang/raw exception |
+| Scheduled nightly, HEAD commit within ~3 days | Full partitioned target set runs |
+| Scheduled nightly, HEAD older than ~3 days | Expensive fuzz skipped (guard only) |
+| `workflow_dispatch` (optional longer env budget) | Full partition; extended exploration allowed |
+| Push to `main` alone | Full Atheris job not required (covered by PR short + change-guarded nightly) |
 | RAR backend absent | RAR targets skipped; other targets still run |
 | RAR backend present + `unrar` installed (Atheris CI) | RAR open+list target runs (not skipped for missing binary) |
 | Fuzzer finds a crashing input | Job fails; repro bytes uploaded; re-run command printed |

--- a/tests/atheris_fuzz/__init__.py
+++ b/tests/atheris_fuzz/__init__.py
@@ -10,7 +10,8 @@ from __future__ import annotations
 
 __all__ = ["TARGET_NAMES", "DEFAULT_BUDGETS"]
 
-# Default main-push partition (~4–5+ min). Overridable via ARCHIVEY_FUZZ_BUDGET_<NAME>.
+# Default full / nightly partition (~4–5+ min). Overridable via ARCHIVEY_FUZZ_BUDGET_<NAME>.
+# CI PR jobs set shorter env budgets; local defaults match the nightly depth.
 # Keep header slices well-fed; stream/codec slices are required (not dropped to fit).
 DEFAULT_BUDGETS: dict[str, int] = {
     "sevenzip_header": 45,

--- a/tests/atheris_fuzz/__main__.py
+++ b/tests/atheris_fuzz/__main__.py
@@ -102,6 +102,31 @@ def _spawn_target(name: str, *, smoke: bool, repro: Path | None) -> int:
     return int(completed.returncode)
 
 
+def _apply_shard(names: list[str]) -> list[str]:
+    """Optional CI sharding: ``ARCHIVEY_FUZZ_SHARD_INDEX`` / ``ARCHIVEY_FUZZ_SHARD_COUNT``.
+
+    Used on PR to cut wall time: each target pays a large Atheris cold-start cost, so
+    running shards in parallel is much cheaper than cutting per-target budgets alone.
+    """
+    raw_count = os.environ.get("ARCHIVEY_FUZZ_SHARD_COUNT", "1")
+    raw_index = os.environ.get("ARCHIVEY_FUZZ_SHARD_INDEX", "0")
+    try:
+        count = max(1, int(raw_count))
+        index = int(raw_index)
+    except ValueError:
+        return names
+    if count <= 1:
+        return names
+    if index < 0 or index >= count:
+        print(
+            f"[atheris] invalid shard {index}/{count}; running no targets",
+            file=sys.stderr,
+            flush=True,
+        )
+        return []
+    return [name for i, name in enumerate(names) if i % count == index]
+
+
 def main(argv: list[str] | None = None) -> int:
     from tests.atheris_fuzz import DEFAULT_BUDGETS, TARGET_NAMES
 
@@ -143,6 +168,15 @@ def main(argv: list[str] | None = None) -> int:
         return _spawn_target(args.target, smoke=False, repro=args.repro)
 
     selected = [args.target] if args.target else list(TARGET_NAMES)
+    if args.target is None:
+        selected = _apply_shard(selected)
+        shard_idx = os.environ.get("ARCHIVEY_FUZZ_SHARD_INDEX", "0")
+        shard_count = os.environ.get("ARCHIVEY_FUZZ_SHARD_COUNT", "1")
+        if int(shard_count) > 1:
+            print(
+                f"[atheris] shard {shard_idx}/{shard_count}: {', '.join(selected) or '(empty)'}",
+                flush=True,
+            )
     exit_code = 0
     for name in selected:
         # Always spawn: libFuzzer Setup() is once-per-process.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Atheris’s full partition is too slow for every `main` push. Mirror the [benchmark-wall](.github/workflows/benchmark-wall.yml) pattern, with a faster PR gate:

| Trigger | What runs |
| --- | --- |
| **Pull request** | Short budgets over the **same** target set, **3-way sharded** in parallel (each target pays ~30s Atheris cold-start; sequential was ~8 min — aim ~3–4 min wall) |
| **Nightly** (`47 6 * * *`) | Full partition, but **only if** default-branch HEAD was committed within ~**3 days** |
| **`workflow_dispatch`** | Force full partition (`budget_scale` still works) |

Removed the always-on full run on every `main` push.

### Also updates
- `openspec/specs/testing-contract/spec.md` (Atheris gate matrix + sharding note)
- `CONTRIBUTING.md` / `docs/internal/threat-model.md`
- Harness: `ARCHIVEY_FUZZ_SHARD_INDEX` / `ARCHIVEY_FUZZ_SHARD_COUNT`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0a6c507f-83c2-4282-a22b-e039ecb29db4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0a6c507f-83c2-4282-a22b-e039ecb29db4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

