### PR TITLE
Brief 3 deep review: stream decoder layer, accelerators, vendored LZW

### DIFF
--- a/review/next/03-stream-decoder-layer/QUESTIONS.md
+++ b/review/next/03-stream-decoder-layer/QUESTIONS.md
@@ -1,0 +1,69 @@
+# QUESTIONS.md — maintainer decisions raised by Brief 3
+
+These are the calls the review can't make unilaterally (they touch policy / spec, or a
+"reject vs tolerate" trade-off). Ordered by the finding that raises them.
+
+## Q1 (F1) — divergent same-offset seek-point collision: crash, or `CorruptionError`?
+
+`_resolve_same_offset_collision` (`decompressor_stream.py:251`) `assert False`s when two
+points share a `decompressed_offset` with genuinely divergent resume `state`. The #96 PR
+body already flagged this as a follow-up; F1 shows it's reachable from a hostile `.xz`
+(zero-`uncompressed_size` blocks) and, under `-O`, degrades to a silently-wrong seek.
+
+**Decision needed:** which fix shape?
+- (a) Translate the divergent collision to `CorruptionError` (keeps the file rejected,
+  removes the crash). Minimal, but treats a legal-but-degenerate index as corrupt.
+- (b) Coalesce/drop zero-length-decompressed points before `add_seek_points` (a zero-length
+  block is never a useful seek target). Keeps such files readable.
+- (c) Reject `uncompressed_size == 0` in `_parse_xz_index` (`xz.py:158`). Strictest — confirm
+  no real encoder emits empty blocks first (standard `xz` does not, but do any 7z/embedded
+  producers?).
+
+My lean: (b) or (a). Whichever, the assert must not be the hostile-input boundary.
+
+## Q2 (F2) — accelerated deflate/zlib truncation/corruption: acceptable, or must raise?
+
+deflate/zlib through rapidgzip return 0/partial bytes with no error on damaged input, vs
+`TruncatedError` from stdlib. There is no length trailer to backstop against.
+
+**Decision needed:**
+- Is it acceptable to rely on container-level CRC (ZIP/7z) to catch this, accepting that
+  (i) standalone `.zlib` and verification-off paths stay silent and (ii) the recoverable
+  prefix is lost either way? Or
+- Should the deflate/zlib accelerator raise when rapidgzip returns no bytes / stops before
+  EOS on a non-empty input? Or
+- Should deflate/zlib acceleration be gated more narrowly (mirroring the gzip backstop's
+  "seekable path with a verifiable structure" condition) so the silent path is never the
+  default for large members?
+
+This is the one that most directly contradicts a load-bearing VISION claim (#3), so it
+probably wants an explicit spec line in `compressed-streams` either way.
+
+## Q3 (F3) — LZW `maxbits` cap and an output budget for the decoder
+
+Two sub-decisions:
+- **Cap `maxbits` at 16?** Real `compress`/`gzip` do; `unix_compress.py:51` (and upstream
+  `uncompresspy`) allow up to 31. Capping at 16 restores the format's natural dictionary
+  ceiling and is a one-line change with (as far as I can tell) zero real-file impact.
+- **Give the decoder an output budget?** The base buffers a whole `feed()` (F3a), so LZW's
+  unbounded amplification balloons memory inside a single `read()`. Options: decode at most
+  ~N bytes per `feed` (retaining unconsumed compressed input) so the base's chunking bounds
+  peak memory; and/or extend the `max_ratio` guard (or a hard decompressed-size cap) to the
+  stream layer / `stream_members`, not just `extract`. Is a stream-layer bomb guard in scope
+  for v1, or is this a documented "use extraction limits" caveat?
+
+## Q4 (F4) — `.Z` truncation on single-shot `read()`
+
+Should `.Z` raise `TruncatedError` on the first `read(-1)`/`readall()` like xz/lzip, rather
+than deferring to the next empty read? The fix is small (check `pending_error` in
+`readall`, or raise directly from unix-compress `flush`). The only reason to keep the
+current behavior is if some path deliberately wants "deliver bytes now, error later" — but
+that seems to buy nothing here, since the leftover-bits signal is already known at flush
+time. Confirm the deferred-`pending_error` mechanism is still needed at all, or whether it
+can be simplified away for unix-compress.
+
+## Cross-cutting: is a property-based seek test in scope? (F5)
+
+Old finding #6 (a `seek(k); read(n) == plain[k:k+n]` property test across single/multi-
+stream, multi-block, and empty-member fixtures) is still open. Adding it is low-risk and
+would have caught F1. In scope for this cycle, or tracked as backlog?

--- a/review/next/03-stream-decoder-layer/SUMMARY.md
+++ b/review/next/03-stream-decoder-layer/SUMMARY.md
@@ -1,0 +1,91 @@
+# Brief 3 — Seekable decoder layer & accelerators: findings
+
+**Reviewer pass:** correctness + hostile-input review of the post-#96 stream/decoder
+layer (`decompressor_stream`, `decompress`/`xz`/`lzip`/`unix_compress`, `codecs`
+accelerator path), as it stands at `38a7d72` (#119). Not a re-litigation of the
+composition refactor — that decision is treated as settled per the brief.
+
+## Baseline (green before hunting)
+
+- `uv run pytest -x -q` (config `[all]`): **1555 passed, 120 skipped, 4 warnings** in ~43s.
+- Optional backends present: `rapidgzip 0.16.0` (the pinned floor), `lzma`, `brotli`,
+  `pyppmd`, `inflate64`, `lz4`, `IndexedBzip2File`.
+- Type/lint not re-run for this read-only review pass (no source changes proposed here);
+  the findings below ship with reproducers, not patches.
+
+Every finding below is reproduced by a script under
+`review/next/03-stream-decoder-layer/repro/` and traced to `file:line`.
+
+## Top findings
+
+| # | Sev | Finding | Where | VISION | Status |
+|---|-----|---------|-------|--------|--------|
+| F1 | **High** | Crafted `.xz` with ≥2 zero-`uncompressed_size` blocks trips `assert False` → **AssertionError crash** when the seek index is built (`seek(0, SEEK_END)` / `try_get_size`). | `decompressor_stream.py:251`; reached via `xz.py:608`/`xz.py:582` | #2 | Open |
+| F2 | **High** | Accelerated **deflate/zlib** silently swallow **truncation *and* mid-stream corruption** — 0/partial bytes, no error — where stdlib raises `TruncatedError`. No backstop exists for deflate/zlib (only gzip+path). | `codecs.py:953`, `codecs.py:987` | #3 | Open |
+| F3 | **Med** | LZW decodes an entire `feed()` eagerly with no output budget; the base buffers the whole thing. A **52 KB `.Z` → 450 MB** buffered on `read(1)` (peak 1.4 GB). `maxbits` accepted up to 31 (real `compress` caps at 16), so the dictionary ceiling is 2³¹, not 2¹⁶. | `unix_compress.py:143`, `unix_compress.py:51`; `decompressor_stream.py:302` | #2/#4 | Open |
+| F4 | **Med** | `.Z` truncation is deferred via `pending_error` and **not raised on a single-shot `read(-1)`/`readall()`** — partial bytes returned, error only on the *next* read. xz/lzip raise on the first `read(-1)`. | `decompressor_stream.py:286`, `unix_compress.py:347` | #3 | Open |
+| F5 | Low | No property-based seek-math test exists (old finding #6 still open); seek tests are example-based over fixed offsets. | `tests/test_seekable_streams.py` | — | Open |
+
+## Headline
+
+The refactor itself is clean — the base is genuinely format-agnostic, the
+before/after placement policy lives entirely in the decoders, and lzip/xz/unix-compress
+each emit their own absolute `SeekPoint`s exactly as the #96 design describes. The
+correctness problems are **not** in the collapse; they are in two spots the collapse
+*inherited or newly exposed*:
+
+1. **The collision assert became a hostile-input crash surface (F1).** The #96 PR body
+   itself flagged the "assert on non-origin collisions" as a follow-up. It is reachable:
+   XZ is the one decoder that stores a non-`None` `state` (block bounds) on its points, so
+   two same-offset points carry *distinct* objects and fall straight through to
+   `assert False`. lzip's points carry `state=None`, so its same-offset collisions
+   resolve last-wins and are safe — which is exactly why this bites XZ and only XZ.
+
+2. **The accelerator hot-path change (#105) widened a silent-truncation hole (F2).** The
+   gzip ISIZE backstop was never extended to deflate/zlib, which now ride rapidgzip by
+   default (AUTO, seekable, ≥1 MB). Those two codecs have no length trailer to check, so a
+   truncated or corrupt body returns nothing (or a partial prefix) with no error — the
+   opposite of the "damaged input is a first-class citizen" promise.
+
+The vendored LZW (F3) is a faithful port of `uncompresspy` — including its *absence* of a
+16-bit `maxbits` cap — dropped into the trusted zero-dep core, where the eager-decode
+buffering of the base stream turns LZW's unbounded amplification into a real OOM lever.
+
+## Where I disagree / what is actually fine
+
+Precise negatives, since the brief asked for them:
+
+- **The composition refactor is correct.** The base carries no format knowledge; the
+  before/after asymmetry is entirely inside the decoders (`lzip.py:275` before-advance vs
+  `unix_compress.py:374` after-advance). `add_seek_points`' origin-refinement path
+  (`decompressor_stream.py:212`) correctly commits the unix-compress `SeekPoint(0, 3)`
+  header shift even with indexing off.
+- **XZ progressive-enrichment `inner` save/restore is airtight** under the sync contract:
+  `xz.py:575` saves `tell()`, the scan uses absolute seeks, and `finally: seek(saved_pos)`
+  (`xz.py:603`) restores unconditionally. The base *also* defensively restores in
+  `_ensure_index_built` (`decompressor_stream.py:335`). The "concurrent reader observes the
+  moved position" worry does not apply: v1 is sync-only and member streams are not shared
+  across threads without an external lock.
+- **Forward-only decoders carry no state across `recreate`** — each returns a freshly
+  constructed backend object (`decompress.py:30/58/100/136/165`); and they are only ever
+  recreated at the origin anyway (no seek points).
+- **The `_AcceleratorStream` finalizer is correct and at the birth site** — `weakref.finalize`
+  on a `staticmethod` that takes the raw inner (no `self` capture), holding a strong ref so
+  `close()` runs before the object is freed (`codecs.py:139`). Valid accelerated output is
+  **byte-identical** to stdlib (verified for gzip/deflate/zlib), so there is no
+  correctness cliff at the AUTO threshold for *valid* input — only the truncation asymmetry
+  of F2.
+- **lzip empty-member collisions are safe** (`state=None` → last-wins); a 3-member lzip
+  with two empty members seeks to the right size with no assert.
+- **LZW code-table bounds are correct**: `dictionary[code]` only ever `IndexError`s into the
+  `code == next_code` KwKwK branch, which requires a prior entry; no negative or
+  past-the-end index reaches output (`unix_compress.py:244`).
+- **Vendoring is complete**: no runtime `import uncompresspy` anywhere in `src/`; the BSD-3
+  notice is intact in-file (`unix_compress.py:412`).
+- **The rapidgzip error tables still match on the 0.16.0 floor** for the cases that *do*
+  raise (corrupt gzip via ISIZE backstop; header/format errors) — the F2 gap is that
+  deflate/zlib truncation/corruption doesn't raise *at all*, not that a raised error is
+  mistranslated.
+
+See `seek-index.md`, `vendored-lzw.md`, `accelerators.md` for the detail and reproducers,
+and `QUESTIONS.md` for the four maintainer decisions these surface.

--- a/review/next/03-stream-decoder-layer/accelerators.md
+++ b/review/next/03-stream-decoder-layer/accelerators.md
@@ -1,0 +1,90 @@
+# accelerators.md — `codecs.py` rapidgzip hot-path review
+
+Context: #105 put rapidgzip on **deflate/zlib** (the commonest codecs) behind the AUTO
+size gate, where it was previously gzip/bzip2 only.
+
+## F2 (High) — accelerated deflate/zlib silently swallow truncation *and* corruption
+
+`DeflateCodec.open` (`codecs.py:953`) and `ZlibCodec.open` (`codecs.py:987`) route through
+`_open_rapidgzip(source)` — a bare `_AcceleratorStream` with **no truncation backstop**.
+The only backstop, `_GzipTruncationCheckStream`, is applied by `GzipCodec.open`
+(`codecs.py:606`) and *only* for a seekable **path** source. deflate and zlib get nothing,
+and they have no length trailer for a backstop to check even in principle.
+
+### Measured (`repro/accel_valid.py`, `repro/accel_trunc.py`, `repro/accel_corrupt.py`)
+
+Valid input decodes correctly through rapidgzip (byte-identical to the payload), so there
+is **no correctness cliff for valid data** at the AUTO threshold. The problem is damaged
+input:
+
+| Codec | Input | stdlib (`use_rapidgzip=OFF`) | rapidgzip (`ON`) |
+|-------|-------|------------------------------|------------------|
+| raw-deflate | truncated to 66%/90% | `TruncatedError` | **0 bytes, no error** |
+| zlib | truncated to 66%/90% | `TruncatedError` | **0 bytes, no error** |
+| raw-deflate | mid-stream corruption | (stdlib raises) | **96776/105000 bytes, no error** |
+| zlib | mid-stream corruption | (stdlib raises) | **96776/105000 bytes, no error** |
+| gzip | truncated, **path** source | `TruncatedError` | `TruncatedError` (ISIZE backstop ✓) |
+| gzip | truncated, **BytesIO** source | `TruncatedError` | **0 bytes, no error** (backstop skipped) |
+
+So through the accelerator, a truncated deflate/zlib stream yields **zero** bytes and no
+exception; a *corrupt* one yields a truncated prefix and no exception. The stdlib
+`DecompressorStream` path raises `TruncatedError` (its `_read_decompressed_chunk` checks
+`if not self._decoder.finished`, `decompressor_stream.py:279`) and delivers the recoverable
+prefix on a bounded read.
+
+### Activation surface
+
+`_rapidgzip_enabled` (`codecs.py:232`) → `AcceleratorMode.enabled_for`
+(`config.py:36`): the accelerator engages when `use_rapidgzip=ON`, **or** `AUTO` +
+`config.seekable` + known `compressed_input_size ≥ 1 MiB`
+(`RAPIDGZIP_AUTO_MIN_COMPRESSED_SIZE`, `config.py:73`). Public `open_stream` defaults to
+`seekable=False`, so the *default* single-stream open stays on stdlib — but any caller that
+requests seekable/random-access streams over a ≥1 MB deflate/zlib member (e.g. seekable ZIP
+member access, or `use_rapidgzip=ON`) lands on the silent path.
+
+For ZIP deflate members, container-level CRC verification (`verify.py`) may catch the
+mismatch downstream *when enabled* — but that turns the bug into an all-or-nothing error and
+still **loses the recoverable prefix** that VISION #3 promises. For standalone `.zlib`
+single-file streams, and any path where digest verification is off, the truncation/corruption
+is simply invisible.
+
+### Why it matters (VISION #3)
+
+"Damaged input is a first-class citizen — truncation → recoverable members + honest error."
+The accelerated deflate/zlib path delivers neither: no honest error, and (for truncation)
+not even the recoverable prefix. It is strictly worse than the stdlib path it silently
+replaces once a member crosses 1 MB in seekable mode.
+
+### Fix direction (QUESTIONS.md)
+
+deflate/zlib can't grow a length trailer, but the decode *completeness* is knowable: after
+a full sequential read, rapidgzip's own end-of-stream state (or a stdlib re-check of the
+tail) could distinguish "clean EOS" from "ran out". At minimum, a rapidgzip stream that
+returns 0 bytes for a non-empty compressed input, or stops before EOS, should raise rather
+than report clean EOF. Alternatively, gate deflate/zlib acceleration behind the same
+"seekable path with a verifiable structure" condition the gzip backstop already requires.
+
+## Lifecycle, free-threading, error tables (checked, no new finding)
+
+- **Finalizer** (`_AcceleratorStream`, `codecs.py:113-155`): correct and at the birth site.
+  `weakref.finalize(self, self._close_inner, self._inner)` uses a `staticmethod` that closes
+  the raw inner (no `self` capture that would pin the wrapper), holding a strong ref so
+  `close()` runs before the object is freed; `close()` just fires the guard early. A
+  million-member sweep that never explicitly closes still relies on GC to run the finalizer
+  (threads/FDs live until collection), but that is the documented design, not a regression,
+  and it is the same for gzip/bzip2 as before #105.
+- **Free-threading:** the accelerators remain single-object, GIL-serialized here (one live
+  rapidgzip object per stream, `parallelization=0`). #105 did not add cross-stream sharing,
+  so the "GIL-only, don't promise otherwise" boundary is unchanged. Not independently
+  stress-tested under `3.13t` in this pass — flagged only as "unchanged", not "verified
+  safe".
+- **Error-message tables vs the pinned floor:** on the installed `rapidgzip 0.16.0`
+  (`[all-lowest]` floor), the cases that *do* raise are still matched — corrupt gzip surfaces
+  via the ISIZE backstop, and `_translate_rapidgzip` (`codecs.py:259`) maps the
+  header/format/`std::exception` cases. The F2 gap is orthogonal: deflate/zlib
+  truncation/corruption produces **no exception for the table to translate**, so the tables
+  being correct doesn't help.
+- **bzip2** (`_rapidgzip_bzip2` / `IndexedBzip2File`, `codecs.py:110`): out of the deflate/zlib
+  scope of #105; its `_translate_accelerator` table (`codecs.py:727`) is unchanged and its
+  CRC-per-block checks mean truncation/corruption there *does* raise (bzip2 has block CRCs;
+  deflate/zlib do not). Not a finding.

--- a/review/next/03-stream-decoder-layer/repro/README.md
+++ b/review/next/03-stream-decoder-layer/repro/README.md
@@ -1,0 +1,16 @@
+# Reproducers for Brief 3 findings
+
+Run from this directory with the repo env active (`uv run python <script>`).
+Backends used: rapidgzip 0.16.0 (accel_*), stdlib lzma/zlib (xz_*, lzw_*).
+
+- `xz_craft.py`   — builds `evil_zero_blocks.xz` (F1 fixture) + prints the backward-scan blocks
+- `xz_crash.py`   — F1: `seek(0, SEEK_END)` → AssertionError (run xz_craft.py first)
+- `xz_size.py`    — F1: `try_get_size()` → AssertionError
+- `xz_trunc.py`   — F4 contrast: xz raises TruncatedError on the first `read(-1)`
+- `lzw_enc2.py`   — F3: LZW amplification + `read(1)` buffer blowup (52 KB → 450 MB)
+- `lzw_trunc.py`  — F3b: `maxbits` 17/24/31 accepted; `read(-1)` swallow probe
+- `lzw_trunc2.py` — F4: `.Z` truncation not raised on first `read(-1)`
+- `accel_valid.py`   — F2: valid vs truncated deflate/zlib through rapidgzip
+- `accel_trunc.py`   — F2: stdlib raises vs rapidgzip swallows (truncation)
+- `accel_corrupt.py` — F2: mid-stream corruption swallowed by accelerated deflate/zlib
+- `accel_gzip.py`    — F2: gzip ISIZE backstop works on path, skipped on BytesIO

--- a/review/next/03-stream-decoder-layer/repro/accel_corrupt.py
+++ b/review/next/03-stream-decoder-layer/repro/accel_corrupt.py
@@ -1,0 +1,29 @@
+import zlib, gzip, tempfile, os
+from dataclasses import replace
+from archivey.internal.config import DEFAULT_STREAM_CONFIG
+from archivey.config import AcceleratorMode
+from archivey.internal.streams.codecs import open_codec_stream, Codec
+
+payload = b"The quick brown fox. "*5000
+def corrupt_mid(data):
+    b = bytearray(data); 
+    for i in range(len(b)//2, len(b)//2+20): b[i] ^= 0xFF
+    return bytes(b)
+
+cfg = replace(DEFAULT_STREAM_CONFIG, seekable=True, use_rapidgzip=AcceleratorMode.ON)
+for codec, data, label in [
+    (Codec.GZIP, gzip.compress(payload,9), "gzip"),
+    (Codec.DEFLATE, (lambda: (lambda c: c.compress(payload)+c.flush())(zlib.compressobj(9,zlib.DEFLATED,-15)))(), "deflate"),
+    (Codec.ZLIB, zlib.compress(payload,9), "zlib"),
+]:
+    cd = corrupt_mid(data)
+    with tempfile.NamedTemporaryFile(suffix=".bin", delete=False) as f:
+        f.write(cd); path=f.name
+    try:
+        with open_codec_stream(codec, path, config=cfg) as s:
+            out = s.read()
+        print(f"{label} corrupt [rapidgzip]: read {len(out)}B NO error")
+    except Exception as e:
+        print(f"{label} corrupt [rapidgzip]: {type(e).__name__}: {str(e)[:70]}")
+    finally:
+        os.unlink(path)

--- a/review/next/03-stream-decoder-layer/repro/accel_gzip.py
+++ b/review/next/03-stream-decoder-layer/repro/accel_gzip.py
@@ -1,0 +1,30 @@
+import gzip, io, tempfile, os
+from dataclasses import replace
+from archivey.internal.config import DEFAULT_STREAM_CONFIG
+from archivey.config import AcceleratorMode
+from archivey.internal.streams.codecs import open_codec_stream, Codec
+
+payload = b"The quick brown fox. "*5000
+gz = gzip.compress(payload, 9)
+trunc = gz[:len(gz)*2//3]
+cfg = replace(DEFAULT_STREAM_CONFIG, seekable=True, use_rapidgzip=AcceleratorMode.ON)
+
+# path source (backstop should be active)
+with tempfile.NamedTemporaryFile(suffix=".gz", delete=False) as f:
+    f.write(trunc); path=f.name
+try:
+    with open_codec_stream(Codec.GZIP, path, config=cfg) as s:
+        out = s.read()
+    print(f"gzip trunc [path, backstop]: read {len(out)}B NO error")
+except Exception as e:
+    print(f"gzip trunc [path, backstop]: raised {type(e).__name__}")
+finally:
+    os.unlink(path)
+
+# non-path (BytesIO) source: backstop is skipped
+try:
+    with open_codec_stream(Codec.GZIP, io.BytesIO(trunc), config=cfg) as s:
+        out = s.read()
+    print(f"gzip trunc [BytesIO, no backstop]: read {len(out)}B NO error")
+except Exception as e:
+    print(f"gzip trunc [BytesIO, no backstop]: raised {type(e).__name__}: {str(e)[:50]}")

--- a/review/next/03-stream-decoder-layer/repro/accel_trunc.py
+++ b/review/next/03-stream-decoder-layer/repro/accel_trunc.py
@@ -1,0 +1,31 @@
+import io, zlib, tempfile, os
+from dataclasses import replace
+from archivey.internal.config import DEFAULT_STREAM_CONFIG
+from archivey.config import AcceleratorMode
+from archivey.internal.streams.codecs import open_codec_stream, Codec
+
+payload = b"The quick brown fox. "*5000   # ~105KB
+# raw deflate
+co = zlib.compressobj(9, zlib.DEFLATED, -15)
+raw_deflate = co.compress(payload) + co.flush()
+# zlib-wrapped
+zlib_data = zlib.compress(payload, 9)
+
+def run(codec, data, label):
+    trunc = data[:len(data)*2//3]   # cut off the end
+    for mode,name in [(AcceleratorMode.OFF,"stdlib"), (AcceleratorMode.ON,"rapidgzip")]:
+        cfg = replace(DEFAULT_STREAM_CONFIG, seekable=True, use_rapidgzip=mode)
+        # write to a temp path (rapidgzip prefers a real file)
+        with tempfile.NamedTemporaryFile(suffix=".bin", delete=False) as f:
+            f.write(trunc); path=f.name
+        try:
+            with open_codec_stream(codec, path, config=cfg) as s:
+                out = s.read()
+            print(f"{label} [{name}]: read {len(out)} bytes, NO error (truncation swallowed)")
+        except Exception as e:
+            print(f"{label} [{name}]: raised {type(e).__name__}: {str(e)[:60]}")
+        finally:
+            os.unlink(path)
+
+run(Codec.DEFLATE, raw_deflate, "raw-deflate")
+run(Codec.ZLIB, zlib_data, "zlib")

--- a/review/next/03-stream-decoder-layer/repro/accel_valid.py
+++ b/review/next/03-stream-decoder-layer/repro/accel_valid.py
@@ -1,0 +1,29 @@
+import zlib, tempfile, os
+from dataclasses import replace
+from archivey.internal.config import DEFAULT_STREAM_CONFIG
+from archivey.config import AcceleratorMode
+from archivey.internal.streams.codecs import open_codec_stream, Codec
+
+payload = b"The quick brown fox. "*5000
+co = zlib.compressobj(9, zlib.DEFLATED, -15)
+raw_deflate = co.compress(payload) + co.flush()
+zlib_data = zlib.compress(payload, 9)
+
+def run(codec, data, label, trunc_frac):
+    data2 = data if trunc_frac==1.0 else data[:int(len(data)*trunc_frac)]
+    cfg = replace(DEFAULT_STREAM_CONFIG, seekable=True, use_rapidgzip=AcceleratorMode.ON)
+    with tempfile.NamedTemporaryFile(suffix=".bin", delete=False) as f:
+        f.write(data2); path=f.name
+    try:
+        with open_codec_stream(codec, path, config=cfg) as s:
+            out = s.read()
+        print(f"{label} frac={trunc_frac}: rapidgzip read {len(out)}B (expected {len(payload)}), match_prefix={payload.startswith(out) if out else 'n/a'}")
+    except Exception as e:
+        print(f"{label} frac={trunc_frac}: raised {type(e).__name__}: {str(e)[:50]}")
+    finally:
+        os.unlink(path)
+
+for frac in (1.0, 0.9, 0.66):
+    run(Codec.DEFLATE, raw_deflate, "raw-deflate", frac)
+for frac in (1.0, 0.9, 0.66):
+    run(Codec.ZLIB, zlib_data, "zlib", frac)

--- a/review/next/03-stream-decoder-layer/repro/lzw_enc2.py
+++ b/review/next/03-stream-decoder-layer/repro/lzw_enc2.py
@@ -1,0 +1,75 @@
+from archivey.internal.streams.unix_compress import LzwState
+
+def encode_growth(byte_val, n_codes, max_width):
+    flag = 0x80 | (max_width & 0x1F)
+    out = bytearray([0x1F, 0x9D, flag])
+    bit_buffer = 0; bits_in = 0
+    code_width = 9
+    codes_in_era = 0
+    codes_per_era = 1 << (code_width - 1)
+    starting_code = 257
+    next_code = starting_code
+    prev_none = True
+
+    def put(code):
+        nonlocal bit_buffer, bits_in
+        bit_buffer |= code << bits_in
+        bits_in += code_width
+        while bits_in >= 8:
+            out.append(bit_buffer & 0xFF)
+            bit_buffer >>= 8; bits_in -= 8
+
+    def after_code():
+        nonlocal codes_in_era, codes_per_era, code_width, bit_buffer, bits_in, next_code, prev_none
+        codes_in_era += 1
+        if not prev_none and next_code <= (1 << code_width) - 1:
+            next_code += 1
+        prev_none = False
+        if codes_in_era >= codes_per_era and code_width < max_width:
+            code_width += 1
+            codes_in_era = 0
+            codes_per_era = 1 << (code_width - 1)
+            bit_buffer = 0; bits_in = 0
+
+    # literal first
+    put(byte_val); after_code()
+    emitted = 0
+    while emitted < n_codes:
+        c = next_code  # KwKwK: reference the entry being created
+        put(c); after_code()
+        emitted += 1
+    if bits_in > 0:
+        out.append(bit_buffer & 0xFF)
+    return bytes(out)
+
+for mw, nc in [(16, 4000), (16, 20000), (31, 20000), (31, 60000)]:
+    data = encode_growth(0x41, nc, mw)
+    st = LzwState()
+    try:
+        o1, _ = st.feed(data)
+        o2, _ = st.flush()
+        out_len = len(o1) + len(o2)
+        dict_mem = sum(len(e) for e in st._dictionary)
+        ratio = out_len / len(data)
+        print(f"mw={mw} codes={nc}: input={len(data)}B decoded={out_len}B (x{ratio:.0f}) "
+              f"dict_entries={len(st._dictionary)} dict_mem={dict_mem/1e6:.1f}MB")
+    except Exception as e:
+        print(f"mw={mw} codes={nc}: {type(e).__name__}: {str(e)[:70]}")
+
+print("\n--- validity + stream buffer check ---")
+import io, tracemalloc
+from archivey.internal.streams.unix_compress import UnixCompressDecompressorStream
+
+data = encode_growth(0x41, 30000, 16)
+# validity: output is all 'A'
+st = LzwState(); o1,_ = st.feed(data); o2,_=st.flush()
+full = o1+o2
+print(f"input={len(data)}B decoded={len(full)}B  all-'A'={set(full)=={0x41}}")
+
+# stream-level: does a single read(1) balloon the internal buffer?
+tracemalloc.start()
+s = UnixCompressDecompressorStream(io.BytesIO(data), seekable=False)
+one = s.read(1)
+cur, peak = tracemalloc.get_traced_memory()
+tracemalloc.stop()
+print(f"read(1) returned {len(one)} byte; internal buffer now {len(s._buffer)/1e6:.0f}MB; peak alloc {peak/1e6:.0f}MB")

--- a/review/next/03-stream-decoder-layer/repro/lzw_trunc.py
+++ b/review/next/03-stream-decoder-layer/repro/lzw_trunc.py
@@ -1,0 +1,38 @@
+import io
+from archivey.internal.streams.unix_compress import UnixCompressDecompressorStream, LzwState
+
+# Build a small valid .Z then truncate mid-code so leftover bits are nonzero.
+def encode_simple(payload, max_width=16):
+    # trivial: literals only (no dict refs) -> valid .Z of the payload
+    flag = 0x80 | max_width
+    out = bytearray([0x1F,0x9D,flag]); bb=0; bits=0; cw=9
+    for b in payload:
+        bb |= b << bits; bits += cw
+        while bits>=8:
+            out.append(bb&0xFF); bb>>=8; bits-=8
+    if bits>0: out.append(bb&0xFF)
+    return bytes(out)
+
+data = encode_simple(b"HELLO WORLD"*4)
+# corrupt: append a byte with nonzero high bits after a truncation point
+truncated = data + b"\x01"  # stray nonzero leftover bits -> should be TruncatedError
+
+print("=== read(-1) on truncated .Z ===")
+s = UnixCompressDecompressorStream(io.BytesIO(truncated), seekable=False)
+try:
+    d = s.read(-1)   # readall path
+    print(f"read(-1) returned {len(d)} bytes, NO error raised (truncation swallowed on this call?)")
+    d2 = s.read()    # subsequent read
+    print(f"second read() returned {len(d2)} bytes")
+except Exception as e:
+    print("raised:", type(e).__name__, str(e)[:80])
+
+print("\n=== maxbits>16 acceptance ===")
+from archivey.internal.streams.unix_compress import _parse_header
+for mw in (16, 17, 24, 31):
+    hdr = bytes([0x1F,0x9D, 0x80 | mw])
+    try:
+        w, bm = _parse_header(hdr)
+        print(f"maxbits={mw}: ACCEPTED (max_width={w})")
+    except Exception as e:
+        print(f"maxbits={mw}: rejected {type(e).__name__}")

--- a/review/next/03-stream-decoder-layer/repro/lzw_trunc2.py
+++ b/review/next/03-stream-decoder-layer/repro/lzw_trunc2.py
@@ -1,0 +1,48 @@
+import io
+from archivey.internal.streams.unix_compress import UnixCompressDecompressorStream, LzwState
+
+def encode_literals(payload, max_width=16):
+    flag = 0x80 | max_width
+    out = bytearray([0x1F,0x9D,flag]); bb=0; bits=0; cw=9
+    for b in payload:
+        bb |= b << bits; bits += cw
+        while bits>=8:
+            out.append(bb&0xFF); bb>>=8; bits-=8
+    if bits>0: out.append(bb&0xFF)
+    return bytes(out)
+
+base = encode_literals(b"HELLO")
+# find an appended byte that trips the truncated flag (nonzero leftover < 1 code)
+truncated_data = None
+for extra in range(1,256):
+    cand = base + bytes([extra])
+    st = LzwState()
+    try:
+        st.feed(cand); st.flush()
+    except Exception:
+        continue
+    if st.truncated:
+        truncated_data = cand; break
+print("found truncated input:", truncated_data is not None, "state.truncated flag set")
+
+if truncated_data:
+    print("\n=== read(-1) (readall) path ===")
+    s = UnixCompressDecompressorStream(io.BytesIO(truncated_data), seekable=False)
+    err=None
+    try:
+        d = s.read(-1)
+        print(f"read(-1) -> {len(d)} bytes, no raise")
+        d2 = s.read()
+        print(f"next read() -> {len(d2)} bytes, no raise  => TRUNCATION SWALLOWED" )
+    except Exception as e:
+        print("raised:", type(e).__name__)
+
+    print("\n=== bounded read(n) path (loop to EOF) ===")
+    s2 = UnixCompressDecompressorStream(io.BytesIO(truncated_data), seekable=False)
+    try:
+        while True:
+            d = s2.read(4)
+            if not d: break
+        print("loop ended with NO TruncatedError => swallowed")
+    except Exception as e:
+        print("raised:", type(e).__name__, "=> truncation surfaced")

--- a/review/next/03-stream-decoder-layer/repro/xz_craft.py
+++ b/review/next/03-stream-decoder-layer/repro/xz_craft.py
@@ -1,0 +1,43 @@
+import io, struct, zlib
+from archivey.internal.streams.xz import (
+    _encode_mbi, _round_up_4, _XZ_STREAM_MAGIC, _XZ_FOOTER_MAGIC,
+    _read_xz_index_backwards,
+)
+
+CHECK = 0x00  # check "None": no per-block check field
+
+def stream_header(check):
+    flags = bytes([0x00, check])
+    crc = zlib.crc32(flags) & 0xFFFFFFFF
+    return _XZ_STREAM_MAGIC + flags + struct.pack("<I", crc)
+
+def build_index(records):
+    body = b"\x00" + _encode_mbi(len(records))
+    for unpadded, uncomp in records:
+        body += _encode_mbi(unpadded) + _encode_mbi(uncomp)
+    body += b"\x00" * (_round_up_4(len(body)) - len(body))
+    crc = zlib.crc32(body) & 0xFFFFFFFF
+    return body + struct.pack("<I", crc)
+
+def footer(index_bytes, check):
+    backward_raw = (len(index_bytes)//4) - 1
+    flags = bytes([0x00, check])
+    fbody = struct.pack("<I", backward_raw) + flags
+    fcrc = zlib.crc32(fbody) & 0xFFFFFFFF
+    return struct.pack("<I", fcrc) + fbody + _XZ_FOOTER_MAGIC
+
+# Three "blocks": first has uncompressed_size 100, next two are zero-size.
+records = [(10, 100), (10, 0), (10, 0)]
+blocks_total = sum(_round_up_4(u) for u, _ in records)   # 12*3 = 36
+block_payload = b"\x00" * blocks_total                    # never decoded by the scan
+
+idx = build_index(records)
+ft = footer(idx, CHECK)
+data = stream_header(CHECK) + block_payload + idx + ft
+
+print("file size", len(data))
+bounds = _read_xz_index_backwards(io.BytesIO(data), len(data))
+for b in bounds:
+    print("block: decompressed_start", b.decompressed_start, "compressed_start", b.compressed_start, "uncomp", b.uncompressed_size)
+
+open("evil_zero_blocks.xz","wb").write(data)

--- a/review/next/03-stream-decoder-layer/repro/xz_crash.py
+++ b/review/next/03-stream-decoder-layer/repro/xz_crash.py
@@ -1,0 +1,13 @@
+import io
+from archivey.internal.streams.xz import XzDecompressorStream
+
+data = open("evil_zero_blocks.xz","rb").read()
+
+s = XzDecompressorStream(io.BytesIO(data), seekable=True)
+try:
+    s.seek(0, io.SEEK_END)   # triggers _ensure_index_built -> build_index -> add_seek_points
+    print("no crash, size=", s.tell())
+except AssertionError as e:
+    print("ASSERTIONERROR (crash on hostile input):", repr(e)[:200])
+except Exception as e:
+    print("other:", type(e).__name__, str(e)[:200])

--- a/review/next/03-stream-decoder-layer/repro/xz_size.py
+++ b/review/next/03-stream-decoder-layer/repro/xz_size.py
@@ -1,0 +1,8 @@
+import io
+from archivey.internal.streams.xz import XzDecompressorStream
+data = open("evil_zero_blocks.xz","rb").read()
+s = XzDecompressorStream(io.BytesIO(data), seekable=True)
+try:
+    print("size via try_get_size:", s.try_get_size())
+except AssertionError as e:
+    print("ASSERTIONERROR via try_get_size:", repr(e)[:120])

--- a/review/next/03-stream-decoder-layer/repro/xz_trunc.py
+++ b/review/next/03-stream-decoder-layer/repro/xz_trunc.py
@@ -1,0 +1,13 @@
+import io, lzma
+from archivey.internal.streams.xz import XzDecompressorStream
+from archivey.internal.streams.lzip import LzipDecompressorStream
+
+# valid xz then truncate mid-stream
+raw = lzma.compress(b"HELLO WORLD"*100, format=lzma.FORMAT_XZ)
+trunc = raw[:len(raw)//2]
+s = XzDecompressorStream(io.BytesIO(trunc), seekable=False)
+try:
+    d = s.read(-1)
+    print(f"xz read(-1) -> {len(d)} bytes NO raise")
+except Exception as e:
+    print("xz read(-1) raised on FIRST call:", type(e).__name__)

--- a/review/next/03-stream-decoder-layer/seek-index.md
+++ b/review/next/03-stream-decoder-layer/seek-index.md
@@ -1,0 +1,113 @@
+# seek-index.md — seek-point correctness across the discovery paths
+
+## F1 (High) — XZ zero-`uncompressed_size` blocks crash the seek-index build
+
+**Claim:** a crafted `.xz` whose index declares two or more blocks with
+`uncompressed_size == 0` (after at least one non-zero block) makes the seek-index build
+emit two `SeekPoint`s at the *same* `decompressed_offset` carrying *different* `state`
+objects, which trips `assert False` in `_resolve_same_offset_collision` →
+**`AssertionError`** (an uncaught crash, outside the `ArchiveyError` tree, and silently
+stripped under `python -O`).
+
+### The mechanism
+
+`SeekPoint` orders by `decompressed_offset` only (`decompressor_stream.py:33`). When two
+points share an offset, `add_seek_points` routes to `_resolve_same_offset_collision`
+(`decompressor_stream.py:237`):
+
+```python
+def _resolve_same_offset_collision(self, index, point):
+    existing = self._seek_points[index]
+    if existing.compressed_offset == point.compressed_offset and existing.state is point.state:
+        return                                   # exact dup
+    if point.compressed_offset >= existing.compressed_offset and existing.state is point.state:
+        self._seek_points[index] = point         # forward refinement, last-wins
+        return
+    assert False, (...)                          # <-- decompressor_stream.py:251
+```
+
+Both "safe" branches require `existing.state is point.state`. XZ is the only decoder that
+puts a **non-`None`** `state` on its points — the `_XzBlockBounds` object for that block
+(`xz.py:583`, `xz.py:615`). Two different blocks are two different objects, so `is` is
+`False` and control reaches `assert False`.
+
+Two blocks share a `decompressed_offset` **iff** the block(s) between them have
+`uncompressed_size == 0`, because `decompressed_start` accumulates `uncompressed_size`
+(`xz.py:269-273`). `_parse_xz_index` rejects `unpadded_size == 0` but **not**
+`uncompressed_size == 0` (`xz.py:158`), so zero-decompressed blocks pass index validation.
+
+### Two reachable triggers, neither requires decoding the block bodies
+
+- **One-shot backward scan** (`build_index`, `xz.py:608`): fired by `seek(0, SEEK_END)`,
+  a forward seek past the known frontier, or `try_get_size()`. `build_index_backwards`
+  (`decompressor_stream.py:139`) maps every block with `decompressed_start > last_known`
+  to a point and calls `add_seek_points`. The two zero-size blocks both map to the same
+  offset → assert. **The block bodies are never decompressed on this path**, so the garbage
+  in the block payload is irrelevant — only the (attacker-controlled, CRC-valid) index and
+  footer are read.
+- **Progressive enrichment** (`_progressive_stream_points`, `xz.py:582`): same emission,
+  but gated behind the stream actually decoding to `eof`, so it additionally needs the
+  bodies to be valid LZMA2. The one-shot path is the clean trigger.
+
+### Reproducer
+
+`repro/xz_craft.py` builds the file from the module's own `_encode_mbi`/`_round_up_4`
+helpers (records `[(10,100),(10,0),(10,0)]`, correct CRCs); `repro/xz_crash.py` and
+`repro/xz_size.py` trigger it:
+
+```
+$ python repro/xz_crash.py
+ASSERTIONERROR (crash on hostile input): AssertionError('seek-point collision at the
+same decompressed_offset with differing resume data: existing=SeekPoint(
+decompressed_offset=100, compressed_offset=24, state=_XzBlockBounds(...
+$ python repro/xz_size.py
+ASSERTIONERROR via try_get_size: AssertionError('seek-point collision ...
+```
+
+The crafted file is only 72 bytes.
+
+### Why it matters (VISION #2)
+
+"Parse untrusted archives without native-code parser attack surface / memory-safe
+hostile-input parsing" — a hostile `.xz` should surface a `CorruptionError`, not an
+`AssertionError`. Under `-O` the assert vanishes and the divergent-state point silently
+**last-wins**, so the same input then produces a *wrong* resume state for that offset
+(a silently-wrong seek) instead of a crash. Both outcomes are wrong.
+
+### Fix sketch (for the maintainer to rule on — see QUESTIONS.md)
+
+The genuinely-divergent case (`point.state is not existing.state`,
+`point.compressed_offset >= existing.compressed_offset`) on a **zero-length decompressed
+span** is not corruption in the "reject the file" sense — it is a legal-but-degenerate
+index. Options: (a) translate the divergent collision to `CorruptionError` instead of
+asserting; (b) drop `uncompressed_size == 0` blocks (or coalesce equal-offset points)
+before they reach `add_seek_points`, since a zero-length block is never a useful seek
+target; (c) reject `uncompressed_size == 0` in `_parse_xz_index` (strictest; check whether
+any real encoder emits empty blocks first — standard `xz` does not).
+
+## What is fine on the other three discovery paths
+
+- **Progressive boundary (lzip, xz stream-start):** before-placement points at member/stream
+  start; lzip's `state` is always `None` so same-offset collisions (empty members)
+  resolve last-wins correctly — verified with a 3-member lzip containing two empty members
+  (`repro/` lzip check: seeks to size 4, no assert).
+- **Progressive enrichment `inner` save/restore:** airtight (`xz.py:575`/`:603` save +
+  `finally`-restore; base re-restores at `decompressor_stream.py:335`). Not a concurrency
+  hazard under the sync-only v1 contract.
+- **`stream_cell` late-bound closures** (`xz.py:638-667`): a faithful port of the old
+  subclass coupling. `get_seek_points`/`index_built` only *read* `stream._seek_points`/
+  `_index_built`; `build_index` and `feed` are never interleaved under the single-threaded
+  contract, so there is no read-vs-mutate race. Correct as-is (the design already flags it
+  as the thing to replace with an explicit handle when BGZF needs it).
+
+## F5 (Low, test-coverage) — no seek-math property test
+
+The brief's old finding #6 is still open. `tests/test_seekable_streams.py` exercises seek
+with fixed offsets (`10000`, `12345`, a couple of block-boundary crossings) and no
+`hypothesis`/randomized generator appears anywhere in the stream tests. The seek arithmetic
+in `DecompressorStream.seek` (`decompressor_stream.py:347-417`) — buffer-relative vs
+seek-point-relative branches, `SEEK_END` size discovery, the `new_pos >= size` short-circuit
+— is the highest-risk arithmetic in the layer and has no property test asserting
+`seek(k); read(n) == plaintext[k:k+n]` for random `k, n` across single-stream, multi-stream,
+multi-block, and empty-member fixtures. Worth adding; it would also have caught F1 with a
+zero-block fixture in the generator.

--- a/review/next/03-stream-decoder-layer/vendored-lzw.md
+++ b/review/next/03-stream-decoder-layer/vendored-lzw.md
@@ -1,0 +1,133 @@
+# vendored-lzw.md — `unix_compress.py` hostile-input review
+
+Hand-written LZW decode of untrusted `.Z` bytes in the **zero-dep trusted core**, with no
+`[extra]` gate to hide behind, so VISION #2 applies at full strength.
+
+## F3 (Med) — decompression bomb: eager per-`feed` decode + no `maxbits` ceiling
+
+### 3a. `feed()` has no output budget; the base buffers the whole thing
+
+`LzwState._process` (`unix_compress.py:143`) decodes **all** currently-buffered compressed
+input into a single `output` bytearray and returns it. The base stream reads a 64 KB
+compressed chunk and appends the *entire* decoded result to `self._buffer`:
+
+```python
+# decompressor_stream.py:302
+if len(self._buffer) < n and not self._eof:
+    self._buffer.extend(self._read_decompressed_chunk())   # extends by a full feed()'s output
+```
+
+So there is no back-pressure between "bytes the caller asked for" and "bytes produced". A
+single `read(1)` forces one `_read_decompressed_chunk`, which for LZW can be arbitrarily
+large because LZW's amplification is **unbounded** and *grows with stream position* (later
+codes reference ever-longer dictionary entries) — unlike deflate (~1032:1 hard cap) or the
+LZMA family, which archivey trusts to be roughly bounded per input chunk.
+
+**Measured** (`repro/lzw_enc2.py`, a valid run-of-`'A'` stream the real `compress` would
+also emit):
+
+```
+mw=16 codes=20000: input=33665B decoded=200030001B (x5942)
+mw=31 codes=60000: input=112101B decoded=1800090001B (x16058)   # 112 KB -> 1.8 GB
+read(1) on a 52 KB .Z: internal buffer now 450MB; peak alloc 1402MB
+```
+
+`read(1)` returning **one byte** leaves a **450 MB** buffer resident. The output is verified
+to be a legitimate all-`'A'` run (correct roundtrip, not an encoder artifact).
+
+### 3b. `maxbits` is bounded to 31, not 16
+
+`_parse_header` (`unix_compress.py:51`):
+
+```python
+max_width = flag_byte & _CODE_WIDTH_FLAG      # _CODE_WIDTH_FLAG = 0x1F  -> up to 31
+if max_width < _INITIAL_CODE_WIDTH:           # only the lower bound (9) is checked
+    raise CorruptionError(...)
+```
+
+`repro/lzw_trunc.py` confirms `maxbits ∈ {17,24,31}` are all **accepted**. Real `compress`
+/ `gzip -d` cap `maxbits` at 16 (`BITS`); anything above is rejected. The dictionary is
+bounded only by `2**maxbits` entries (`next_code <= current_mask` guard,
+`unix_compress.py:264`), so allowing 31 raises the ceiling from 2¹⁶ to 2³¹ and removes the
+natural per-entry-length bound that 16 bits imposes — directly worsening 3a.
+
+**This is inherited, not introduced:** upstream `uncompresspy` has the identical
+`self._max_width = flag_byte & _CODE_WIDTH_FLAG` with only a `< 9` check
+(`uncompresspy.py:117`). The port is faithful — but the missing cap is now in *archivey's*
+trusted core, and the brief explicitly asks "is that field itself bounded?" The honest
+answer is "to 31, not to the format's 16."
+
+### Existing mitigations and their gaps
+
+- `ArchiveyConfig` has a decompression-ratio guard (`config.py:84`, `max_ratio=1000`,
+  `ratio_activation_threshold=5 MB`), but it only applies to `extract`/`extract_all`, and it
+  counts bytes **after** each 1 MB copy chunk is already produced — the eager `feed()` in 3a
+  balloons memory *inside* a single `read()` before the guard's counter advances. So the
+  guard bounds total *extracted* bytes, not *peak* memory per read.
+- `stream_members` / forward-only iteration enforce **no** caps at all (documented at
+  `config.py:104`), so a caller streaming a `.Z` member has no protection whatsoever.
+
+### Why it matters (VISION #2 / #4)
+
+A ~50 KB attacker file forcing hundreds of MB of resident buffer on the first byte read is
+a memory-safety problem in the trusted core, and it undercuts the "honest cost signals"
+claim (the cost of `read(1)` is wildly non-local). Suggested direction in QUESTIONS.md:
+cap `maxbits` at 16, and/or give the decoder an output budget (decode at most ~N bytes per
+`feed`, retaining un-consumed compressed input) so the base's existing chunking actually
+bounds peak memory.
+
+## F4 (Med) — `.Z` truncation not raised on a single-shot `read(-1)`
+
+`UnixCompressDecoder` reports truncation via the deferred `pending_error` mechanism: at EOF
+`flush()` sets `self._pending_error = TruncatedError(...)` when leftover bits are nonzero
+(`unix_compress.py:347`). The base only consults `pending_error` on a `read` that returns
+**no** bytes (`decompressor_stream.py:307`):
+
+```python
+def read(self, n=-1):
+    if n is None or n < 0:
+        data = self.readall()      # returns ALL remaining bytes in one shot
+    ...
+    if not data:                   # <-- pending_error only checked here
+        err = self._decoder.pending_error
+        ...
+```
+
+`readall()` (`decompressor_stream.py:286`) never checks `pending_error` itself. So on a
+truncated-but-partially-decodable `.Z`:
+
+```
+# repro/lzw_trunc2.py
+read(-1) -> 6 bytes, no raise          # truncation NOT surfaced on this call
+next read() -> raises TruncatedError    # only on the subsequent empty read
+```
+
+Contrast xz/lzip, whose `flush()` raises `TruncatedError` **directly** inside
+`_read_decompressed_chunk`, so `read(-1)` raises on the *first* call
+(`repro/xz_trunc.py`: `xz read(-1) raised on FIRST call: TruncatedError`).
+
+A consumer that does one `stream.read()` and discards the handle — a very common idiom for
+"read the whole member" — gets truncated data from a `.Z` with **no error**, while getting
+a clean `TruncatedError` from every other codec. The `_copy_to_fileobj` extraction path
+reads in a bounded loop to empty, so it *does* surface the error; the gap is single-shot
+`read()`/`readall()`. This is a VISION #3 consistency bug (truncation is a first-class
+citizen — but only for some codecs on some read shapes).
+
+Fix sketch: have `readall()` check `pending_error` after the loop, or have unix-compress
+raise from `flush()` directly like the other seekable decoders (the deferred mechanism buys
+nothing here — the leftover-bits signal is already known at `flush` time).
+
+## What is fine
+
+- **KwKwK / index-past-table is bounded** (`unix_compress.py:244-259`): `dictionary[code]`
+  only `IndexError`s into the `code == next_code` branch, which requires `prev_entry is not
+  None` (raising `CorruptionError` otherwise); `code > next_code` is a clean
+  `CorruptionError`. `len(dictionary) == next_code` is invariant, so no code indexes past
+  the live table and no unbounded index growth beyond the `2**maxbits` cap.
+- **CLEAR realignment / `pending_skip`** across feed boundaries (`unix_compress.py:234`) and
+  **after-placement CLEAR seek points** (`unix_compress.py:371`) match the design.
+- **Origin header commit** (`_commit_header_points` → `SeekPoint(0, 3)`,
+  `unix_compress.py:358`) and its `recreate` reset (`unix_compress.py:320`, fresh
+  `LzwState`, `pending_error` cleared by the base on reset) are correct.
+- **Vendoring complete**: no runtime `import uncompresspy` in `src/`; BSD-3 notice intact
+  (`unix_compress.py:412-443`).


### PR DESCRIPTION
Completes the deep review commissioned in `review/next/03-stream-decoder-layer.md`: a correctness + hostile-input pass over the post-#96 seekable decoder layer, the rapidgzip deflate/zlib hot path (#105), and the vendored LZW core (#89). Deliverable lives under `review/next/03-stream-decoder-layer/` (SUMMARY + three theme files + QUESTIONS + runnable `repro/`). No source changes — this is a review, and every finding ships with a reproducer, not a patch.

**Baseline:** `pytest [all]` green — 1555 passed, 120 skipped. rapidgzip 0.16.0 (the pinned floor).

## Findings

| # | Sev | Finding | Where |
|---|-----|---------|-------|
| F1 | **High** | Crafted `.xz` with ≥2 zero-`uncompressed_size` blocks trips `assert False` → **AssertionError crash** when the seek index is built (`seek(0, SEEK_END)` / `try_get_size`). XZ is the only decoder that stores a non-`None` `state` on its points, so same-offset collisions carry distinct objects and skip both safe branches. Under `-O` it degrades to a silently-wrong seek. | `decompressor_stream.py:251`, reached via `xz.py:608`/`582` |
| F2 | **High** | Accelerated **deflate/zlib** silently swallow **truncation *and* mid-stream corruption** (0/partial bytes, no error) where stdlib raises `TruncatedError`. Only gzip+path has the ISIZE backstop; deflate/zlib have none. Now the default for ≥1 MB members in seekable mode after #105. | `codecs.py:953`, `codecs.py:987` |
| F3 | **Med** | LZW decodes a whole `feed()` eagerly with no output budget → a **52 KB `.Z` buffers 450 MB** on `read(1)` (peak 1.4 GB). `maxbits` accepted up to 31 (real `compress` caps at 16), so the dictionary ceiling is 2³¹. Inherited from `uncompresspy`; no bomb guard on `stream_members`. | `unix_compress.py:143`/`51`, `decompressor_stream.py:302` |
| F4 | **Med** | `.Z` truncation is deferred via `pending_error` and **not raised on a single-shot `read(-1)`/`readall()`** — partial bytes returned, error only on the next read. xz/lzip raise on the first `read(-1)`. | `decompressor_stream.py:286`, `unix_compress.py:347` |
| F5 | Low | No property-based seek-math test (old finding #6 still open); seek tests are example-based. | `tests/test_seekable_streams.py` |

## What is actually fine

The composition refactor itself is clean: the base is format-agnostic, the before/after placement policy lives entirely in the decoders, XZ enrichment `inner` save/restore is airtight under the sync contract, forward-only decoders carry no state across `recreate`, the `_AcceleratorStream` finalizer is correct and at the birth site, valid accelerated output is byte-identical to stdlib, and the vendoring is complete (no runtime `uncompresspy` import, BSD-3 notice intact). Full negatives in `SUMMARY.md`.

## Maintainer decisions

`QUESTIONS.md` raises four: how to fix the F1 collision (reject vs coalesce vs assert→CorruptionError), whether accelerated deflate/zlib must raise on damaged input (F2), the LZW `maxbits` cap + output budget (F3), and `.Z` single-shot truncation (F4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QJ49Wi8LKYpJ4UdGd8UjzX

---
_Generated by [Claude Code](https://claude.ai/code/session_01QJ49Wi8LKYpJ4UdGd8UjzX)_