### PR TITLE
Auto-format on commit: Cursor-aware ruff pre-commit hook

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,4 @@
+{
+  "name": "archivey-2",
+  "install": "./.cursor/install.sh"
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Cursor Cloud update/install script (see .cursor/environment.json).
+# Must stay idempotent — runs on every agent boot after the workspace is checked out.
+set -euo pipefail
+
+sudo apt-get update
+sudo apt-get install -y unrar
+
+npm install -g --prefix "${HOME}/.local" @fission-ai/openspec
+
+uv sync --group dev --extra all
+
+# Auto ruff fix+format on commit (Cursor remaps core.hooksPath; this install is aware).
+./scripts/install-git-hooks.sh

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Repo pre-commit hook: auto-fix + format staged Python the same way CI checks.
+# Install with: ./scripts/install-git-hooks.sh
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel)"
+cd "$ROOT"
+
+files=()
+while IFS= read -r -d '' f; do
+  case "$f" in
+    src/* | tests/* | scripts/* | benchmarks/*)
+      case "$f" in
+        *.py) files+=("$f") ;;
+      esac
+      ;;
+  esac
+done < <(git diff --cached --name-only -z --diff-filter=ACMR)
+
+if [ "${#files[@]}" -eq 0 ]; then
+  exit 0
+fi
+
+if ! command -v uv >/dev/null 2>&1; then
+  echo "pre-commit: uv not found on PATH; cannot run ruff." >&2
+  exit 1
+fi
+
+uv run --no-sync ruff check --fix -- "${files[@]}"
+uv run --no-sync ruff format -- "${files[@]}"
+git add -- "${files[@]}"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,11 +1,16 @@
-# Install hooks: `uv run pre-commit install`
+# Preferred (works with Cursor Cloud's remapped hooksPath):
+#   ./scripts/install-git-hooks.sh
+# Alternative (framework install; may conflict with remapped hooksPath):
+#   uv run pre-commit install
 # Run on demand: `uv run pre-commit run --all-files`
+#
+# Paths match CI (`.github/workflows/ci.yml` ruff check / format --check).
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.21
     hooks:
       - id: ruff
         args: [--fix]
-        files: ^(src|tests|scripts)/
+        files: ^(src|tests|scripts|benchmarks)/
       - id: ruff-format
-        files: ^(src|tests|scripts)/
+        files: ^(src|tests|scripts|benchmarks)/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,15 +29,15 @@ in place. Run tools with `--no-sync` to avoid a redundant re-resolve, e.g.:
 CI fails on unformatted Python (`ruff format --check` over `src/ tests/ scripts/
 benchmarks/`). **Do not commit without formatting.**
 
-1. **Once per clone / session start**, install the git hook so format+lint-fix runs
-   automatically on every commit:
+1. **Cursor Cloud** installs the git hook via `.cursor/install.sh` on every boot.
+   On a fresh local clone (or if the hook is missing), run:
 
    ```bash
    ./scripts/install-git-hooks.sh
    ```
 
-   (Cursor Cloud remaps `core.hooksPath`; this script installs into the chained
-   original hooks dir so it still runs. Prefer it over bare `pre-commit install`.)
+   (Cursor remaps `core.hooksPath`; this script installs into the chained original
+   hooks dir so it still runs. Prefer it over bare `pre-commit install`.)
 
 2. **Before every commit**, if the hook is not installed (or you used
    `--no-verify`), run formatting yourself:
@@ -52,10 +52,10 @@ benchmarks/`). **Do not commit without formatting.**
 
 Non-obvious gotchas:
 
-- The startup update script also installs the system `unrar` binary and the `openspec`
-  CLI (in addition to `uv sync`), so both are present without manual steps. Prefer
-  adding `./scripts/install-git-hooks.sh` to that update script so every cloud
-  session gets the format-on-commit hook without a manual step.
+- The startup update script is committed at `.cursor/install.sh` (wired via
+  `.cursor/environment.json`). It installs `unrar`, the `openspec` CLI, runs
+  `uv sync --group dev --extra all`, and `./scripts/install-git-hooks.sh`, so the
+  format-on-commit hook is present without a manual step.
 - **`unrar`** (system binary, from the `multiverse` apt component) backs RAR *data*
   tests; without it they skip cleanly rather than fail.
 - **`7z`** (system binary, from `p7zip-full`) is required by tests that build encrypted

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,10 +24,38 @@ in place. Run tools with `--no-sync` to avoid a redundant re-resolve, e.g.:
 - Type-check: `uv run --no-sync pyrefly check` and `uv run --no-sync ty check`
   (both must stay clean; mypy/pyright are intentionally not used)
 
+### Formatting before commit (required)
+
+CI fails on unformatted Python (`ruff format --check` over `src/ tests/ scripts/
+benchmarks/`). **Do not commit without formatting.**
+
+1. **Once per clone / session start**, install the git hook so format+lint-fix runs
+   automatically on every commit:
+
+   ```bash
+   ./scripts/install-git-hooks.sh
+   ```
+
+   (Cursor Cloud remaps `core.hooksPath`; this script installs into the chained
+   original hooks dir so it still runs. Prefer it over bare `pre-commit install`.)
+
+2. **Before every commit**, if the hook is not installed (or you used
+   `--no-verify`), run formatting yourself:
+
+   ```bash
+   uv run --no-sync ruff format src/ tests/ scripts/ benchmarks/
+   uv run --no-sync ruff check --fix src/ tests/ scripts/ benchmarks/
+   ```
+
+   `ruff format --check` only *detects* drift; it does not rewrite files. Always
+   run `ruff format` (no `--check`) to apply.
+
 Non-obvious gotchas:
 
 - The startup update script also installs the system `unrar` binary and the `openspec`
-  CLI (in addition to `uv sync`), so both are present without manual steps.
+  CLI (in addition to `uv sync`), so both are present without manual steps. Prefer
+  adding `./scripts/install-git-hooks.sh` to that update script so every cloud
+  session gets the format-on-commit hook without a manual step.
 - **`unrar`** (system binary, from the `multiverse` apt component) backs RAR *data*
   tests; without it they skip cleanly rather than fail.
 - **`7z`** (system binary, from `p7zip-full`) is required by tests that build encrypted

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,6 +103,9 @@ See `openspec/specs/format-7z/spec.md`, `format-rar/spec.md`,
   `uv run pytest`, `uv run ruff`. Type-checking is **Pyrefly + ty** (the library stays
   clean on both); mypy is not used. The package stays pip-installable (standard PEP 621
   metadata, `hatchling`).
+- **Format before commit** — CI fails on `ruff format --check`. Install the auto-format
+  git hook with `./scripts/install-git-hooks.sh` (see `AGENTS.md` / `CONTRIBUTING.md`);
+  otherwise run `uv run ruff format` yourself before committing.
 - **Before pushing, run the test suite in all three dependency configurations** — current
   versions (`[all]`), minimum versions (`[all-lowest]`), and the zero-dep core
   (`[core-only]`) — since optional libraries change behaviour by both presence and version.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,17 +19,28 @@ Python **3.11+**. Tooling runs through [`uv`](https://docs.astral.sh/uv/):
 
 ```bash
 uv sync                       # create/refresh the dev environment
+./scripts/install-git-hooks.sh  # required: auto ruff fix+format on commit
 uv run pytest                 # run the test suite
 uv run ruff check             # lint
-uv run ruff format            # format
-uv run pre-commit install     # optional: install git hooks (ruff lint + format)
-uv run pre-commit run --all-files  # run hooks on the whole tree
+uv run ruff format            # format (apply; CI uses `ruff format --check`)
+uv run pre-commit run --all-files  # optional: run the framework hooks on the whole tree
 uv run pyrefly check          # type-check (Pyrefly)
 uv run ty check               # type-check (ty)
 ```
 
 Pyrefly and ty are scoped to `src/`, so every command above runs clean with no extra
 path arguments.
+
+**Format before you commit.** CI runs `ruff format --check` (and `ruff check`) over
+`src/ tests/ scripts/ benchmarks/` and will fail on drift. Installing the git hook
+(`./scripts/install-git-hooks.sh`) makes this automatic: staged `*.py` under those
+paths are `ruff check --fix`'d and `ruff format`'d on commit. If you skip the hook,
+run `uv run ruff format` yourself before committing — `ruff format --check` only
+reports problems; it does not rewrite files.
+
+(`uv run pre-commit install` remains an alternative if you prefer the
+`pre-commit` framework's own installer, but on Cursor Cloud it can land in the
+remapped `core.hooksPath`; `./scripts/install-git-hooks.sh` is the supported path.)
 
 RAR *data* tests need the system `unrar` binary (`apt-get install -y unrar`, etc.);
 without it those tests skip cleanly.

--- a/scripts/install-git-hooks.sh
+++ b/scripts/install-git-hooks.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Install the repo's .githooks/pre-commit into the effective git hooks directory.
+#
+# Cursor Cloud remaps core.hooksPath to its own dispatcher; that dispatcher still
+# chains to the original hooks dir recorded in .cursor-original-hooks-path. When
+# that file is present we install there so ruff format runs before every commit
+# without overwriting Cursor's hooks.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SRC="$ROOT/.githooks/pre-commit"
+
+if [ ! -f "$SRC" ]; then
+  echo "install-git-hooks: missing $SRC" >&2
+  exit 1
+fi
+
+cd "$ROOT"
+HOOKS_PATH="$(git rev-parse --git-path hooks)"
+DEST_DIR="$HOOKS_PATH"
+
+if [ -f "$HOOKS_PATH/.cursor-original-hooks-path" ]; then
+  DEST_DIR="$(cat "$HOOKS_PATH/.cursor-original-hooks-path")"
+fi
+
+mkdir -p "$DEST_DIR"
+cp "$SRC" "$DEST_DIR/pre-commit"
+chmod +x "$DEST_DIR/pre-commit"
+echo "Installed pre-commit hook -> $DEST_DIR/pre-commit"
+echo "Staged Python under src/ tests/ scripts/ benchmarks/ will be ruff-fixed + formatted on commit."


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

CI has been failing when agents commit Python without running `ruff format`. The repo already had a `.pre-commit-config.yaml` and CONTRIBUTING mentioned `pre-commit install` as optional, but:

- AGENTS.md only listed `ruff format --check` (detect, not apply)
- hooks were never installed in practice
- Cursor Cloud remaps `core.hooksPath`, so a bare `pre-commit install` does not land in the path that actually runs on commit

The earlier “Set up Cursor Cloud” PR (#34) only committed `AGENTS.md` docs — the update script itself lived only in the personal dashboard environment. This PR puts that script in-repo and wires the format hook into it.

## Changes

- **`.githooks/pre-commit`** — on commit, runs `ruff check --fix` + `ruff format` on staged `*.py` under `src/ tests/ scripts/ benchmarks/` (same paths as CI) and re-stages
- **`scripts/install-git-hooks.sh`** — installs that hook into git’s hooks dir, or into Cursor’s chained “original” hooks dir when `.cursor-original-hooks-path` is present
- **`.cursor/environment.json` + `.cursor/install.sh`** — repo-level Cursor Cloud config (wins over the personal saved env). Same as today’s dashboard update script (`unrar`, `openspec`, `uv sync`), plus `./scripts/install-git-hooks.sh` on every boot
- **Docs** — AGENTS.md / CONTRIBUTING.md / CLAUDE.md require format-before-commit and point at the install script / in-repo update script
- **`.pre-commit-config.yaml`** — include `benchmarks/` to match CI; document the preferred install path

Smoke-tested via Cursor’s hook dispatcher: an intentionally messy staged file was reformatted and re-staged before commit.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-48f5cc28-87b5-40a0-a41f-b4e50be3a2aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-48f5cc28-87b5-40a0-a41f-b4e50be3a2aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

