### PR TITLE
Fix Cursor Cloud install: bootstrap uv when missing

### DIFF
--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -3,10 +3,18 @@
 # Must stay idempotent — runs on every agent boot after the workspace is checked out.
 set -euo pipefail
 
+# Official uv installer lands here; keep it first for non-login shells.
+export PATH="${HOME}/.local/bin:${PATH}"
+
 sudo apt-get update
 sudo apt-get install -y unrar
 
 npm install -g --prefix "${HOME}/.local" @fission-ai/openspec
+
+# JIT / snapshot-less Cloud images may not ship uv; bootstrap if missing.
+if ! command -v uv >/dev/null 2>&1; then
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
 
 uv sync --group dev --extra all
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,7 +53,8 @@ benchmarks/`). **Do not commit without formatting.**
 Non-obvious gotchas:
 
 - The startup update script is committed at `.cursor/install.sh` (wired via
-  `.cursor/environment.json`). It installs `unrar`, the `openspec` CLI, runs
+  `.cursor/environment.json`). It bootstraps `uv` if missing (JIT Cloud images may
+  not ship it), installs `unrar`, the `openspec` CLI, runs
   `uv sync --group dev --extra all`, and `./scripts/install-git-hooks.sh`, so the
   format-on-commit hook is present without a manual step.
 - **`unrar`** (system binary, from the `multiverse` apt component) backs RAR *data*


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Cloud agent update script (`.cursor/install.sh`) was failing with exit code **127** on JIT / snapshot-less environments because `uv` is not preinstalled.

Failure point from the setup log:

```text
./.cursor/install.sh: line 11: uv: command not found
```

`apt` (`unrar`) and `npm` (`openspec`) succeeded, but the script never reached `uv sync` or the git-hook installer.

## Fix

- Ensure `~/.local/bin` is on `PATH`
- Bootstrap `uv` via the official Astral installer when `uv` is missing
- Document the bootstrap in `AGENTS.md`

## Verification

Re-ran `./.cursor/install.sh` successfully on this environment:
- installed `uv 0.11.29`
- synced the Python 3.11 venv (`uv sync --group dev --extra all`)
- installed the pre-commit hook
- second run is idempotent (skips uv bootstrap when already present)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e4ec31c6-e018-4cc5-8a09-cffa347dde40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e4ec31c6-e018-4cc5-8a09-cffa347dde40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

