### PR TITLE
review: archive CLI (PR #120) findings under review/archive/

### DIFF
--- a/review/README.md
+++ b/review/README.md
@@ -42,7 +42,7 @@ deferred to a lighter follow-on pass.
 | `archive/2026-07-16-rar-reader/` | Native RAR hostile-input & correctness (PR #113) | F1–F6 fixed with tests. |
 | `archive/2026-07-16-crypto/` | Native decryption/KDF/verification correctness (PR #115) | F1–F5 fixed in #127. |
 | `archive/2026-07-16-stream-decoder/` | Post-#96 decoder layer, accelerators, vendored LZW (PR #122) | F1–F6 fixed in #128. |
-| `archive/2026-07-17-cli/` | CLI design + implementation (PR #131 → #120) | F1–F12 + D1–D8 addressed in #120; R1–R4 follow-ups fixed before merge. |
+| `archive/2026-07-17-cli/` | CLI design + implementation (PR #131 → #120) | F1–F12 + D1–D8 addressed in #120; R1–R4 and hoist H1–H3 / D4 logging follow-ups fixed before merge. |
 
 ## Conventions every brief inherits
 

--- a/review/README.md
+++ b/review/README.md
@@ -42,6 +42,7 @@ deferred to a lighter follow-on pass.
 | `archive/2026-07-16-rar-reader/` | Native RAR hostile-input & correctness (PR #113) | F1–F6 fixed with tests. |
 | `archive/2026-07-16-crypto/` | Native decryption/KDF/verification correctness (PR #115) | F1–F5 fixed in #127. |
 | `archive/2026-07-16-stream-decoder/` | Post-#96 decoder layer, accelerators, vendored LZW (PR #122) | F1–F6 fixed in #128. |
+| `archive/2026-07-17-cli/` | CLI design + implementation (PR #131 → #120) | F1–F12 + D1–D8 addressed in #120; R1–R4 follow-ups fixed before merge. |
 
 ## Conventions every brief inherits
 

--- a/review/archive/2026-07-17-cli/QUESTIONS.md
+++ b/review/archive/2026-07-17-cli/QUESTIONS.md
@@ -1,0 +1,102 @@
+# Maintainer decisions — Brief 4 (CLI, PR #120)
+
+Design calls the review surfaced that are *not* plain bugs. Each has a
+recommendation; none blocks merging the bug fixes (F1–F2 especially), but D2 and
+D3 shape user-visible behavior enough that deciding them before the first
+release is worth it.
+
+## D1 — Should the smart default dest consider the member filters?
+
+Today `smart_dest` computes top-level entries from **all** members, so
+`archivey x a.zip 'b/*'` extracts into `./a/b/…` even though everything being
+extracted shares the single root `b/`. Applying the include/exclude predicate
+before counting tops would give `./b/…` — consistent with the "single top-level
+dir needs no wrapper" rule as experienced by the user.
+
+**Recommend:** compute tops on the filtered set (the predicate is already in
+hand; one-line change). Counter-argument to weigh: with filters the wrapper dir
+name (`./a/`) advertises which archive the files came from, which partial
+extractions arguably benefit from more, and `unar` has no equivalent feature to
+copy. Either answer is fine — but pick one and add a scenario, since the spec's
+smart-dest rows don't mention filters.
+
+## D2 — Default verbosity of extraction outcomes (renames, skips, counts)
+
+The CLI default `--overwrite rename` means data lands under names the user
+didn't ask for. `extract_all` already returns per-member results with rename
+markers (`requested_path != path`) — the CLI just doesn't read them.
+
+**Recommend:** stderr always gets one closing summary line
+(`12 extracted, 2 renamed, 0 skipped → ./photos/`), renames are listed
+individually even without `-v` (they change where data lives; cf. `unar`'s
+"(1)" reporting), and `-v` adds the full per-member `unzip`-style trace. This
+also gives `extract -v` a meaning (today it's `del`'d — F3).
+
+## D3 — `test` semantics when a member stream fails to *open*
+
+Digest mismatches mid-read are counted as FAIL and the run continues (good —
+verified). But an open-time failure (encrypted member without a usable
+password, corrupt header) raises out of the iterator and aborts the whole run
+with no summary. For the verb whose job is "tell me which members are bad",
+partial reporting beats aborting.
+
+**Recommend:** catch per-member open failures inside the loop, count FAIL,
+continue; abort only on failures that genuinely poison the iterator (e.g. solid
+stream desync — the library can't skip past those anyway). Needs a small
+library-side answer too: can `stream_members` surface per-member open errors
+without terminating iteration (e.g. yield `(member, error)` or a documented
+"skip damaged unit" mode)? If not, the CLI can pre-check `member.is_encrypted`
+and no-password to at least fail those members individually.
+
+## D4 — Who configures logging/diagnostics display?
+
+The CLI sets up no logging. Library diagnostics that log at WARNING (e.g.
+`Member name normalized: 'sub' -> 'sub/'`) reach the terminal through Python's
+bare last-resort handler — unformatted, unsuppressable, mid-listing.
+
+**Recommend:** `main()` installs a stderr handler (WARNING default), `-v` (or a
+separate `--debug`) lowers to INFO/DEBUG, and a future `-q` raises to ERROR.
+Also decide whether member-level diagnostics belong in `list -v` output (the
+spec says `-v` "SHALL surface diagnostics" — currently only `member.diagnostics`
+attached to members are shown, while archive-level diagnostics are not).
+
+## D5 — Progress on `test` (and `list` for streaming formats)?
+
+Progress is extract-only. A `test` of a multi-GB archive is silent until the
+end. The tqdm plumbing and stderr discipline already exist.
+
+**Recommend:** yes for `test` (bytes read vs. total when sizes are known) in a
+small follow-up; skip `list` (fast except degenerate cases).
+
+## D6 — Reserve more future verbs now?
+
+Known-verb-wins means each *future* verb changes the meaning of
+`archivey <word>` for a file named `<word>` — a compat wrinkle every time.
+`hash`/`create`/`convert` are pre-reserved; other plausible verbs (`cat`,
+`ls`?) are not.
+
+**Recommend:** reserve `cat` now (it's in the design's own non-goals list as a
+likely future), and add a sentence to the spec stating the policy: new verbs
+may be added and take precedence over same-named files, `archivey list <path>`
+is the permanent escape hatch.
+
+## D7 — Exit-code flavor for the reserved surface
+
+Reserved verbs (`create`, …) exit **2**; reserved `--salvage` and the `-` token
+exit **1** (`CliError`'s default). All are "not available yet".
+
+**Recommend:** 2 for all three (they're grammar-level "you can't ask for that
+yet"), keeping 1 for operational failures on real archives. Cheap now; a
+behavior change later.
+
+## D8 — Wrong-password message (library, CLI-visible)
+
+`archivey t enc.7z --password wrong` prints
+`Password required to decrypt this 7z member` — the same message as supplying
+no password at all. Users who *did* pass one will read this as "the flag was
+ignored" (especially plausible while F1 exists…). Library-side message split
+(`no password supplied` vs `password(s) rejected`), or CLI-side rephrasing from
+`EncryptionError` context.
+
+**Recommend:** library-side; the distinction exists internally (candidates were
+consulted and exhausted vs. never present).

--- a/review/archive/2026-07-17-cli/SUMMARY.md
+++ b/review/archive/2026-07-17-cli/SUMMARY.md
@@ -1,0 +1,155 @@
+# Brief 4 — CLI (PR #120, `cli-v1`): design + implementation review
+
+Review of the `archivey` command as proposed in `openspec/changes/cli-v1/` (merged
+in #110) and implemented in **PR #120** (`cursor/cli-v1-cdb2` @ `42c688d`). Covers
+both the *decisions* (grammar, defaults, safety posture) and the *code*
+(correctness, clarity, UX). Docs-only — no source is modified. All findings were
+reproduced by running the CLI from the PR branch; line references are against
+`42c688d`.
+
+## Headline
+
+**The design is strong and the implementation is close.** The grammar decisions
+(known-verb-wins default-to-list, `-d`-only destination, anti-tarbomb smart dest,
+positional includes + long-only `--exclude`, argparse-aligned exit codes, reserved
+`-` / `--salvage` / write verbs, TTY password prompt, stdout/stderr hygiene) are
+individually well-reasoned, consistent with each other, and correctly leave room
+for `hash`/`create`/`convert`/salvage. The verb implementations are small, mostly
+correct, and the behavior-matrix tests cover every scenario in the delta spec —
+all 29 pass, and `openspec validate --strict cli-v1` is clean.
+
+The gap is between the spec's floor and the PR's own ambitions. Two bugs are
+user-facing today: **every global flag placed before the verb is silently
+discarded** (F1 — `archivey --password secret t enc.7z` fails to decrypt,
+`archivey --track-io a.zip` reports nothing, and the `--help` usage line
+explicitly advertises this placement), and **piping `list` into `head` exits 1
+with `[Errno 32] Broken pipe` noise** (F2 — the `except BrokenPipeError` handler
+is dead code behind `except OSError`). Beyond those, the friendliness goals are
+undercut by silence in exactly the places this CLI's defaults make surprising:
+the default `--overwrite rename` renames collided files **without telling the
+user** (F3), and `extract -v` does nothing at all (its `verbose` is `del`'d).
+
+Baseline for this review: `uv sync --group dev --extra all` on the PR worktree,
+Python 3.11.15; `pytest tests/test_cli.py` → 29 passed.
+
+## Design review
+
+### Endorsed as-is (no change requested)
+
+- **Known-verb-wins + default-to-list** (Decision 1). The escape hatch
+  (`archivey list ./x`) is tested, the default verb is read-only, and reserved
+  write verbs are reachable only by explicit name. Right call, correctly argued.
+- **`-d`/`--dest` only, no positional dest** (3b) and **smart enclosing dir**
+  (3c). The `unar`-style rule with the single-root exception and `-d .` opt-out
+  is the best available shape for the "safer unzip" story. Implementation
+  correctly avoids `foo/foo/` double-nesting (verified).
+- **Positional includes + long-only `--exclude`** (11); **one archive per
+  invocation** (13); **quiet `test` + `-v`** (14); **exit codes 0/1/2 with ≥3
+  reserved** (12); **`-` reserved** (15); **argparse over Click** (9) given the
+  zero-dep + always-installed constraints; **`--track-io` via
+  `enable_measurement()`** with no builtins patch (10) — implemented exactly as
+  specified, counters read via a first-party `isinstance(BaseArchiveReader)`.
+- **CLI `rename` vs library `ERROR` overwrite split** (3). The split itself is
+  right — but see F3: a *silent* rename default is only defensible if renames
+  are reported.
+- The **`has_static_candidates` relaxation** in `core.py:218` (provider-only
+  passwords no longer rejected on non-encrypted formats) is correct, narrowly
+  scoped, tested at both the library (`test_tar.py`) and CLI level, and does not
+  contradict any spec requirement (the old guard was implementation-level, not
+  spec'd).
+- The **ZIP ASCII-sniff diagnostic fix** (`zip_reader.py:503-533`) riding along
+  in this PR is correct (all paths in the `except` return; no unbound-variable
+  fallthrough) and well tested.
+
+### Design-level gaps (decisions to make, not bugs) — see QUESTIONS.md
+
+- **D1. Smart dest ignores the member filters.** `smart_dest` computes top-level
+  entries from *all* members, so `archivey x a.zip 'b/*'` lands in `./a/b/…`
+  even though the filtered set has the single root `b/`. Computing tops on the
+  filtered set gives `./b/…`, matching the single-root rule's spirit.
+- **D2. Extraction outcome reporting.** `extract_all` returns an
+  `ExtractionReport` (per-member status incl. `requested_path != path` rename
+  markers); the CLI drops it on the floor. Decide the default verbosity:
+  recommended — one summary line to stderr always (`N extracted, M renamed, K
+  skipped`), per-member lines + rename details under `-v`.
+- **D3. `test` abort-vs-continue on member-open failure** (see F4) — spec says
+  "reports failures", but an open-time failure aborts with no summary.
+- **D4. Logging/diagnostics ownership.** The CLI configures no logging; library
+  warnings (e.g. `Member name normalized: 'sub' -> 'sub/'`) reach the terminal
+  via Python's bare last-resort handler on every `list`/`test`. Decide the
+  CLI's logging posture (default WARNING to stderr with a real formatter; `-v`
+  or `--debug` raises verbosity; maybe `-q`).
+- **D5. Progress is extract-only.** `test` on a multi-GB archive shows nothing
+  until the summary. tqdm plumbing exists; a byte-progress bar on `test` is
+  cheap and matches DEV behavior.
+- **D6. Future-verb hazard of known-verb-wins.** Every verb added later (e.g.
+  `cat`, `ls`) silently changes the meaning of `archivey <that-word>` for files
+  with that name. Consider reserving the plausible set now (as `hash`/`create`/
+  `convert` already are) and noting the policy in the spec.
+- **D7. Exit-code flavor consistency for reserved surface.** Reserved *verbs*
+  exit 2 (usage) but reserved `--salvage` and the `-` token exit 1 (via
+  `CliError` default). All three are "you asked for a thing that doesn't exist
+  yet"; pick one flavor (2 feels right for all).
+
+## Findings
+
+| # | Sev | Where | One-liner |
+|---|-----|-------|-----------|
+| F1 | **High** | `cli/main.py:130-227` | Global flags before the verb are parsed by the main parser, then **silently clobbered by the subparser's defaults** (shared-`parents` argparse pitfall). `--password`/`--track-io`/`-v`/`--hide-progress` all affected; hits the flagship default-list form (`archivey --track-io a.zip`) and the placement shown in `--help`'s own usage line. |
+| F2 | **High** | `cli/main.py:318-325` | `except BrokenPipeError: return EXIT_OK` is dead code — `BrokenPipeError ⊂ OSError` and the `except OSError` clause precedes it. `archivey l big.zip \| head -1` exits **1** and prints `[Errno 32] Broken pipe` to stderr (reproduced). |
+| F3 | **Medium** | `cli/extract_cmd.py:91,116-133` | Default `--overwrite rename` renames collided files (`a.txt` → `a (1).txt`) with **zero output**; the returned `ExtractionReport` (which records every rename/skip) is discarded, and `extract`'s `verbose` is `del`'d — `-v` is a no-op on the verb where it matters most. |
+| F4 | **Medium** | `cli/test_cmd.py:36-55` | The per-member `try` wraps only `stream.read()`; a member whose stream fails to **open** (encrypted member + wrong/absent password, corrupt local header) raises during iterator advance, aborting `test` with no `N OK, M failed` summary (reproduced with an AES 7z). Mid-read digest failures correctly count-and-continue; open failures should too where the format allows. |
+| F5 | **Low+** | `cli/main.py:131-227` | `allow_abbrev` is left on, and abbreviations interact badly with `_inject_default_list`: `archivey --pass secret a.zip` becomes `--pass list secret a.zip` → argparse sets `password="list"` then fails with `invalid choice: 'secret'` (reproduced — baffling message, wrong-password near-miss). `allow_abbrev=False` on all parsers also keeps the `_VALUE_OPTIONS` table honest. |
+| F6 | **Low** | `cli/main.py:50-73` | `_inject_default_list` treats bare `-` as an option (`startswith("-")`), so `archivey -` exits 2 with `invalid choice: '-'` instead of the friendly reserved-stdin message that `archivey list -` gives. Special-case `-` as a positional in the scan. |
+| F7 | **Low** | `cli/main.py:285-325` | No `KeyboardInterrupt` handling: Ctrl-C mid-extract spews a raw traceback. Catch → return 130 (and consider a partial-output note on extract). |
+| F8 | **Low** | `cli/extract_cmd.py:20-36,49-72` | `_archive_stem` edge cases: a file named exactly `.tar.gz` yields stem `""` → `Path("")` == cwd → splatter despite multiple tops; the hardcoded suffix list misses `.tar.Z`/`.tar.lzma`/`.taz`/`.tzst`/… Simpler and complete: strip the last suffix, then a remaining `.tar`; or use `reader.format.file_extension()` (already available at the call site). |
+| F9 | **Low** | `tests/test_cli.py:259-268` | `test_no_tqdm_progress_still_extracts` monkeypatches `progress_mod.make_progress_callback`, but `extract_cmd` imported the function by name at module import — the patch never takes effect; the test passes vacuously (non-TTY already yields `None`). Patch `archivey.cli.extract_cmd.make_progress_callback` instead. |
+| F10 | **Low** | `cli/extract_cmd.py:124-132`; `cli/main.py:321` | An `OSError` during extraction (disk full, perms) bypasses the `ArchiveyError` handler and its "extraction stopped; remaining members were not extracted" explanation — the user gets a bare errno line with no stop notice. Catch `OSError` in the same clause. |
+| F11 | **Low** | `cli/progress.py:49-83` | Bar lifecycle: never closed when `members_total is None` (streaming formats) or when extraction aborts (no `try/finally`), relying on GC at process exit; fine today, fragile if `main()` is embedded. Also `_display_stream`'s fallback writes to `sys.__stderr__` even when the *process* stderr was deliberately redirected by a wrapper that replaced `sys.stderr` — intended for test runners, but surprising as library-ish behavior. |
+| F12 | **Nits** | various | (a) `info` output alignment is ragged (`confidence:certain`, `multivolume:False` vs padded keys) and prints enum reprs (`ArchiveFormat.ZIP`) instead of human names; (b) `track-io` prints `compressed_bytes_consumed=None` — print `-`; (c) container rename uses `stem-1` while the library's file rename yields `name (1).txt` — two styles in one tool; (d) `test` counts directories/links in `N OK` (inflates vs `unzip -t` expectations); (e) `fnmatch.fnmatch` is case-insensitive on Windows — `fnmatch.fnmatchcase` gives deterministic cross-platform filter semantics; (f) `main(out=…)`'s `out` is `del`'d and verbs ignore `main`'s `err` — the params suggest an injection seam that doesn't exist; wire them or drop them; (g) `--track-io` on `info` is silently `del`'d — either report (open does decode work for some formats) or say "n/a". |
+
+## F1 detail + verified fix shape
+
+`build_parser()` passes the *same* `_common_parent()` instance to the main parser
+and to every subparser. On 3.11/3.12 (and current 3.13), `_SubParsersAction`
+re-applies the subparser's defaults to the shared namespace, so values the main
+parser already parsed are overwritten:
+
+```text
+archivey --password secret test enc.7z   → password=None   (prompt/fail; silent)
+archivey --track-io a.zip                → track_io=False   (flag no-ops; silent)
+archivey -v test a.zip                   → verbose=False
+```
+
+Verified fix (ran against this branch): build **two** parent instances —
+the top-level one with real defaults, the subparser one with
+`default=argparse.SUPPRESS` on every option — so an absent post-verb flag sets no
+attribute and cannot clobber. Note the trap that makes the obvious one-parent
+`set_defaults` variant fail: `parents=` copies **action references**, so
+`main.set_defaults(...)` mutates the shared actions' defaults back. With the
+two-instance shape, post-verb still overrides pre-verb (`--password early test
+--password late` → `late`), which is the right precedence. Add pre-verb placement
+tests for all four globals.
+
+## Spec compliance
+
+Every scenario row in `openspec/changes/cli-v1/specs/cli/spec.md` was exercised
+(via `tests/test_cli.py` plus manual runs): default-list dispatch, verb-named
+file, reserved verbs, aliases, `--digests`, smart dest (multi-top, single-root,
+`-d .`), include/exclude precedence, `--include` rejected, exit codes, `-`
+reserved on named verbs, no-tqdm degradation, `--track-io` accounting. No spec
+violations found; F1 lives in territory the spec doesn't pin (it never says
+globals work pre-verb) but the implementation's own help advertises it, so it is
+judged against the PR, not the spec. `openspec validate --strict cli-v1` passes;
+`tasks.md`-only delta vs #110 confirmed (`proposal.md`/`design.md`/`specs/*`
+byte-identical to main).
+
+## Suggested fix order
+
+1. F1 (two-instance parents + SUPPRESS; pre-verb tests) — silent wrong behavior.
+2. F2 (reorder handlers; suppress the late stderr flush noise) — every pipeline.
+3. F3 + D2 (consume `ExtractionReport`; summary line; wire `-v`) — the safety
+   story depends on renames being visible.
+4. F4/D3 (count open-failures as FAIL and continue where the iterator allows).
+5. F5–F12 as cleanup in one pass; D1/D4–D7 after maintainer calls in
+   QUESTIONS.md.

--- a/review/archive/2026-07-17-cli/VERIFICATION.md
+++ b/review/archive/2026-07-17-cli/VERIFICATION.md
@@ -1,0 +1,133 @@
+> **Archive note (2026-07-17):** R1–R4 below were fixed on PR #120 before merge;
+> this file is the mid-pass verification snapshot. See `review/README.md` archive
+> table for the final outcome.
+
+# Brief 4 — verification of the fix pass (PR #120 @ `b75aacc`)
+
+Re-review of the follow-up commits `3453e5c` (F1–F12) and `660f7ed` (D1–D8) plus
+`b75aacc` (IDEAS.md parking), commissioned after the implementor's status
+comment on PR #131. Everything below was re-verified by running the CLI and the
+full test suite from the updated branch (Python 3.11.15, `--extra all`).
+
+## Verdict
+
+**The findings pass is genuinely good — F1–F12 and D2–D8 are all correctly
+implemented and tested — but the branch is not mergeable yet.** One fix (D8)
+regressed a library test that fails in every `[all]` CI job (R1), the F5 fix
+missed the subparsers (R2), the D4 logging fix surfaced a pre-existing
+library-side warning spam on ordinary tars (R3), and the D1 "no-index →
+always-wrap" catch is a spec-level behavior change vs. the merged #110 proposal
+that needs an explicit maintainer sign-off (R4).
+
+## Confirmed fixed (re-tested end-to-end)
+
+| Item | Evidence |
+| --- | --- |
+| F1 pre-verb globals | `archivey --track-io a.zip` reports; `archivey --password secret t enc.7z` decrypts (`1 OK, 0 failed`); post-verb still overrides pre-verb. Two-instance `SUPPRESS` parents exactly as recommended; regression tests added, incl. the namespace-capture test. |
+| F2 broken pipe | `archivey l big.zip \| head -1` → exit 0, empty stderr; handler reordered above `OSError` + `_silence_broken_pipe()` flush guard. |
+| F3/D2 extraction reporting | `renamed: out/a.txt -> out/a (1).txt` always printed; closing summary `2 extracted, 1 renamed, 0 skipped → out/` always printed; `-v` adds per-member `extracted:` lines. `ExtractionReport` consumed; `verbose` no longer `del`'d. |
+| F4/D3 test summary on open failure | `archivey t enc.7z` (no password) → `FAIL: …` + `0 OK, 1 failed`, exit 1. Manual `next()` loop catches per-advance errors; generator-death limitation documented in code + IDEAS.md. |
+| F5 abbreviation (pre-verb) | `archivey --pass secret a.zip` → clean `unrecognized arguments: --pass`, exit 2. **But see R2** — subparsers still abbreviate. |
+| F6 bare `-` | `archivey -` → the friendly reserved-stdin message (exit 2, per D7). |
+| F7 Ctrl-C | `except KeyboardInterrupt → "interrupted", 130` correctly wraps `_dispatch` (verified by inspection; disjoint from the other handlers). |
+| F8 stem | `file_extension()`-based strip + generic suffix fallback; `.tar.gz`-named file → `"archive"`, `data.tar.Z` → `data`; unit-tested. |
+| F9 vacuous test | Now patches `archivey.cli.extract_cmd.make_progress_callback` (the consumed binding). |
+| F10 OSError stop notice | `except (ArchiveyError, OSError)` shares the "extraction stopped" message. |
+| F11 bar lifecycle | `ProgressCallback` class with idempotent `close()`, called in `finally` by both extract and test. |
+| F12 nits | info aligned + human format labels (`ZIP`, not `ArchiveFormat.ZIP`); track-io prints `-` for None; container rename now `stem (1)` matching library style; test counts files only (dirs/links → verbose `skip` lines); `fnmatchcase`; `out`/`err` threaded through `_dispatch` into every verb; `--track-io` on info prints an explicit `n/a`. |
+| D1 filtered tops | `archivey x pack.zip 'b/*'` (multi-top zip, single filtered root) → `./b/…`, no wrapper; tested. No-index case → always wrap; tested. **See R4 for the sign-off question.** |
+| D4 logging | `WARNING: Member name normalized: …` properly formatted via the `archivey` logger handler; `-v` → INFO. No caplog/propagate fallout anywhere in the suite. **See R3.** |
+| D5 test progress | Bar driven from synthesized `ExtractionProgress` (cumulative bytes, file-only totals, totals only when all sizes known); closed in `finally`; smoke-checked on a fake TTY. |
+| D6 `cat` reserved | Verb table, help, spec + permanence sentence; tested. |
+| D7 exit 2 | `-` and `--salvage` now exit 2 like reserved verbs; tests updated. |
+| D8 message split | `archivey t enc.7z --password wrong` → `Wrong password or corrupt 7z folder`; no password → `Password required…`; unit test covers required-vs-rejected. **But see R1.** |
+
+Gates on `b75aacc`: `ruff check` + `ruff format --check` clean, `pyrefly` 0
+errors, `ty` all-pass, `openspec validate --strict cli-v1` clean. Full pytest:
+**1686 passed, 1 failed** — the single failure is R1, and it is exactly what CI
+shows (every `[all]` job red with only that test; `core-only` green because the
+test needs py7zr).
+
+## Remaining issues
+
+### R1 — **Blocks merge.** D8 regressed the 7z header-encrypted error message
+
+`sevenzip_reader.py` `_decrypt_header` now re-raises
+`_PasswordCandidatesExhausted.message` verbatim. With no candidates supplied
+that message is the generic `Password required to read this encrypted member`,
+so the header path lost its "7z header" context and
+`test_sevenzip_reader.py::test_header_encrypted_archive_requires_password`
+(`match="header"`) fails — the only red test, in every `[all]` CI job on every
+OS/Python. The old message was also better UX: it tells the user the *listing*
+needs a password, not some member.
+
+**Fix shape:** keep the required-vs-rejected split but restore the surface in
+the header path — e.g. required → `Password required to decrypt the 7z header`,
+rejected → `Password(s) rejected for the 7z header` (rewrite
+`…read this encrypted member` → `…the 7z header`, or pass a
+surface label down to `attempt()`). Leave the member path as-is.
+
+### R2 — F5 incomplete: post-verb abbreviation still enabled
+
+`allow_abbrev=False` was set on the top-level parser and on both parent
+instances, but `sub.add_parser(...)` does **not** inherit it (argparse default
+`True` per parser). Verified: `archivey x a.zip -d out --over error` silently
+abbreviates `--overwrite`. Harmless today, but it un-stabilizes the script
+grammar (any future `--over*` flag turns existing scripts ambiguous — exactly
+what F5 was about). Pass `allow_abbrev=False` in every `sub.add_parser(...)`
+call; add one post-verb abbreviation test.
+
+### R3 — D4 surfaced library warning spam: one WARNING per tar directory
+
+Python's `tarfile` strips the trailing slash from directory member names, so
+`presented_name` (`pkg`) always differs from the normalized name (`pkg/`) and
+`emit_member_name_normalized` fires for **every directory in every ordinary
+tar**:
+
+```
+$ archivey l wt.tar          # tar with 3 dirs, made by GNU tar
+WARNING: Member name normalized: 'pkg' -> 'pkg/'
+WARNING: Member name normalized: 'pkg/sub2' -> 'pkg/sub2/'
+WARNING: Member name normalized: 'pkg/sub1' -> 'pkg/sub1/'
+```
+
+`archivey l linux.tar.gz` would print thousands of these. Pre-existing library
+behavior (previously leaked through the last-resort handler), but D4's proper
+handler makes it prominent, and "the friendliest CLI" cannot warn per-directory
+on well-formed input. Library-side fix, same logic as this PR's own ZIP
+ASCII-sniff fix: adding the canonical trailing slash to a DIRECTORY-typed
+member is *not an observable normalization event* — suppress the diagnostic
+when the only delta is the trailing slash on a directory (in `tar_reader`'s
+presented name, or centrally in `emit_member_name_normalized`).
+
+### R4 — Needs maintainer sign-off: no-index always-wrap changes a merged-spec rule
+
+`660f7ed` rewrites the smart-dest rule for formats without a cheap index (plain
+TAR and all compressed tars; future stdin): **always** extract into
+`./<stem>/`, never scan-then-reuse. Verified consequence: a single-root source
+tarball — the most common real-world archive —
+
+```
+$ archivey x src.tar.gz      # contains only src-1.0/…
+extracting into src/
+→ ./src/src-1.0/f.txt        # was ./src-1.0/… under the #110 rule
+```
+
+The merged #110 spec promised unconditional root-reuse ("single top-level
+directory → extract into `.`"). The change's spec delta and design were amended
+to the new rule, it errs safe, avoids a full decompress-for-metadata pass, is
+tested, and the post-hoc hoist that recovers root-reuse is parked in IDEAS.md —
+all coherent. But it is a **UX regression on the flagship case** and a rewrite
+of an approved spec requirement, decided implementor-side; per the
+pause-and-surface rule this is the maintainer's call: accept (double-wrap until
+hoist lands), schedule the hoist now, or keep the #110 behavior for *seekable*
+no-index archives by paying the metadata pass. Also, if accepted: the scenario
+row "single top-level dir → reuses the archive's root dir" still reads as
+unconditional in the delta spec — qualify it with "indexed" to remove the
+internal contradiction.
+
+## Suggested order
+
+R1 (one-line-ish, unblocks CI) → R2 (mechanical) → R3 (library-side suppress;
+turns D4 from liability to win) → R4 (maintainer decision, then a wording fix
+either way).

--- a/review/archive/2026-07-17-cli/VERIFICATION.md
+++ b/review/archive/2026-07-17-cli/VERIFICATION.md
@@ -1,6 +1,8 @@
-> **Archive note (2026-07-17):** R1–R4 below were fixed on PR #120 before merge;
-> this file is the mid-pass verification snapshot. See `review/README.md` archive
-> table for the final outcome.
+> **Archive note (2026-07-17):** All actionable findings from this review were
+> addressed on PR #120 before merge (including R1–R4 and the hoist H1–H3 / D4
+> logging follow-ups documented in the rounds below). This file is the
+> chronological verification log. See `review/README.md` archive table for the
+> final outcome.
 
 # Brief 4 — verification of the fix pass (PR #120 @ `b75aacc`)
 
@@ -131,3 +133,119 @@ internal contradiction.
 R1 (one-line-ish, unblocks CI) → R2 (mechanical) → R3 (library-side suppress;
 turns D4 from liability to win) → R4 (maintainer decision, then a wording fix
 either way).
+
+---
+
+# Round 2 — verification of R1–R4 (`f201259`)
+
+Re-verified end-to-end on `f201259` (full suite: **1691 passed, 0 failed**;
+ruff/pyrefly/ty/`openspec validate --strict` all clean — R1's red CI test now
+passes locally).
+
+## Confirmed fixed
+
+- **R1** ✓ — no password → `Password required to decrypt the 7z header`; wrong
+  password → `Password(s) rejected for the 7z header` (both verified against a
+  live header-encrypted 7z; the garbage-decrypt→parse-failure path is also
+  mapped to rejected-header, with a new regression test).
+- **R2** ✓ — `allow_abbrev=False` on every subparser incl. reserved verbs;
+  `archivey x a.zip --over error` now exits 2; post-verb test added.
+- **R3** ✓ — trailing-slash-only DIRECTORY normalization suppressed in
+  `emit_member_name_normalized`; `archivey l <ordinary tar>` is warning-free;
+  observable renames (e.g. `./pkg` → `pkg/`) still warn; unit test added.
+- **R4 hoist, main paths** ✓ — single-root tar hoisted to `./root/` (wrapper
+  removed); single-file tar hoisted to `./file`; multi-top tar stays wrapped;
+  filtered streaming extract hoists the filtered root (D1 end-state); genuine
+  pre-existing collision under `rename` → `root (1)/` with a notice; spec/
+  design/IDEAS updated coherently and the indexed scenario row is now
+  qualified.
+
+## New findings — wrapper-identity collision (H1–H3)
+
+`maybe_hoist_single_root` treats "the hoist target name is taken" uniformly via
+`_collision_dest`, but when the sole root's name **equals the wrapper's own
+name** the "collision" is with the wrapper itself — the directory the hoist is
+about to delete. This is the most common tarball convention (`src.tar.gz`
+containing `src/`). All three overwrite behaviors mishandle it (all reproduced):
+
+| # | Sev | Repro (`src.tar` containing `src/f.txt`) | Result |
+|---|-----|------------------------------------------|--------|
+| **H1** | **Critical — data loss** | `archivey x src.tar --overwrite replace` | `_collision_dest` does `shutil.rmtree("src")` — that IS the wrapper holding the just-extracted data. The subsequent move fails (`No such file or directory: 'src/src'`), the run prints `2 extracted` and **exits 0**, and **no extracted files exist on disk**. A success-reporting invocation that destroys its own output. |
+| H2 | Medium | default (`rename`) | Lands at `./src (1)/f.txt` instead of `./src/f.txt` — renamed away from a "collision" with a directory that was about to be removed. |
+| H3 | Low | `--overwrite error` / `skip` | Keeps `./src/src/f.txt` (the exact double-nesting the hoist exists to remove) with a message implying a real conflict. |
+
+**Fix (covers all three):** special-case `child.name == wrapper.name` *before*
+`_collision_dest` — the target is the wrapper, so no collision logic applies:
+rename the wrapper aside to a unique temp sibling (`src.hoist-tmp`), move the
+child into place, rmdir the temp. ~10 lines in `maybe_hoist_single_root`; tests:
+the three rows above.
+
+**Design note (non-blocking, maintainer call):** on a *genuine* collision,
+`--overwrite replace` rmtree's the pre-existing tree before hoisting, which is
+more destructive than the indexed single-root path (extract into `.` merges,
+replacing per-file). Spec's "subject to the overwrite policy" permits it, but
+"replace colliding files" vs "delete whole colliding trees" is a real semantic
+gap for explicit `replace` users — consider keep-wrapper for that case too, or
+an explicit doc note.
+
+---
+
+# Round 3 — H1–H3 resolution + two answers (`741553e` on #120)
+
+**Maintainer directives applied** (2026-07-17): never delete files (replace
+only files being extracted); hoisting must produce the exact same result as
+extracting directly into the destination.
+
+## Q: do encrypted-header RARs have the R1 problem? — No
+
+Verified against the RAR5 and RAR3 encrypted-header fixtures: no password →
+`Password required to decrypt RAR headers`; wrong password → `Wrong password
+for RAR5 header encryption` / `Failed to decrypt RAR3 headers (wrong
+password?)` (RAR3 has no password-check value, hence the hedge — correct). All
+name the header surface and distinguish required from rejected. No change
+needed.
+
+## H1–H3 fix: hoist is now a per-file merge equivalent to direct extraction
+
+Pushed to #120 as `741553e` (per maintainer's "do the hoist fixes"):
+
+- `_collision_dest` (whole-entry resolution incl. the H1 `rmtree`) replaced by
+  `_merge_move`: directories merge into existing directories; file/symlink
+  collisions resolve per file exactly like `extract_all` — `rename` derives the
+  library's `name (N)` spelling (mirrors `_derive_free_name`), `replace` uses
+  `os.replace` on the single colliding file, `skip` keeps the existing file
+  (removing only our own just-extracted copy, which a direct extraction would
+  never have written). **No `rmtree` anywhere; pre-existing files are never
+  deleted.** Symlinks are moved as links and never descended into.
+- A collision the policy cannot resolve without deleting data (`error`, or a
+  dir-vs-file shape under `replace`/`skip`) stops the hoist, leaves the unmoved
+  remainder under the wrapper, and exits 1 — the direct extraction would have
+  failed on the same collision. (Deliberate residual divergence: direct
+  extraction fails with a partial splatter in archive order; the hoist fails
+  with the remainder safe under the wrapper. Layouts on the *failure* path are
+  not bit-identical; success paths are.)
+- The wrapper-identity case (`src.tar.gz` containing `src/`) is flattened in
+  place — the wrapper becomes the root, no collision logic runs. All three
+  H-repros now land at `./src/f.txt`, exit 0, no data touched.
+- Summary counts fold hoist renames/skips in (`extra_renamed`/`extra_skipped`),
+  so `3 extracted, 1 renamed …` matches the direct-extraction output.
+- Spec delta + design updated to state the equivalence contract and the
+  never-delete rule. 8 new tests: identity dir/file, per-policy equivalence
+  battery seeded against the direct-extraction baseline, error-keeps-wrapper,
+  and replace-never-rmtrees (dir-vs-file with a `precious.txt` inside).
+
+## New find while running the CONTRIBUTING three-leg gate: D4 logging leak
+
+The `all-lowest` leg failed **17** caplog-based warning tests across the suite:
+`configure_cli_logging` set `propagate = False` and kept a process-global
+handler on the `archivey` logger, which on pytest 8.3.0 (the declared floor)
+blinds every later `caplog` assertion once any CLI verb test has run. Invisible
+on the current-versions leg (newer pytest captures non-propagating loggers).
+Fixed in the same commit: the handler is now installed via a `cli_logging`
+context manager scoped to one `main()` invocation, `propagate` is untouched
+(a present handler already suppresses the last-resort handler), and level is
+restored on exit. Regression test asserts no handler/propagate/level residue.
+
+**Gates on `741553e`:** `[all]` 1699 passed; `[all-lowest]` 1699 passed (was
+17 failed); `[core-only]` 1386 passed + zero-dep check OK; ruff format/check,
+pyrefly, ty, `openspec validate --strict cli-v1` all clean.


### PR DESCRIPTION
## Summary

Review deliverable for **PR #120** (`cli-v1` implementation, `cursor/cli-v1-cdb2` @ `42c688d`): design-choice assessment + implementation findings, following the `review/next/` brief convention. Docs-only.

- `review/next/04-cli-pr120/SUMMARY.md` — headline, design endorsements/challenges, findings **F1–F12** with `file:line` refs (all reproduced by running the CLI from the PR branch), spec-compliance check, suggested fix order.
- `review/next/04-cli-pr120/QUESTIONS.md` — maintainer decisions **D1–D8** (smart-dest × filters, rename reporting, `test` abort-vs-continue, logging ownership, progress on `test`, future-verb reservations, exit-code flavor, wrong-password message).

## Headline findings

| # | Sev | One-liner |
|---|-----|-----------|
| F1 | High | Global flags before the verb are silently clobbered by subparser defaults (shared-`parents` argparse pitfall): `archivey --password secret t enc.7z` fails to decrypt, `archivey --track-io a.zip` no-ops — the placement `--help` itself advertises. Verified fix shape included (two parent instances, `SUPPRESS` defaults on the subparser copy). |
| F2 | High | `except BrokenPipeError` is dead code behind `except OSError`; `archivey l big.zip \| head` exits 1 with `[Errno 32] Broken pipe` noise. |
| F3 | Med | Default `--overwrite rename` renames collided files with zero output (`ExtractionReport` discarded; `extract -v` is `del`'d). |
| F4 | Med | `test` aborts without its `N OK, M failed` summary when a member stream fails to *open* (wrong/absent password), vs. count-and-continue on digest failures. |

Design verdict: grammar and safety decisions endorsed as-is; no spec violations found (`openspec validate --strict cli-v1` clean; all delta scenarios exercised).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Us4A5Z6aV2nVVZoqkN1pu8

---
_Generated by [Claude Code](https://claude.ai/code/session_01Us4A5Z6aV2nVVZoqkN1pu8)_