### PR TITLE
review: api-coherence deep-review findings (incl. members-scope question)

### DIFF
--- a/review/api-coherence/QUESTIONS.md
+++ b/review/api-coherence/QUESTIONS.md
@@ -1,0 +1,72 @@
+# QUESTIONS — maintainer decisions
+
+Per the pause-and-ask rule (`CLAUDE.md`, `CONTRIBUTING.md`): discrepancies and
+judgement calls surfaced, not silently resolved. Ordered by weight.
+
+## Q1 — Duplicate-name members: unify `is_current`, and what do specs mean? (P1)
+
+Two spec artifacts disagree with each other and with the implementation:
+
+- `safe-extraction/spec.md:230`: "Content superseded by later same-name or anti →
+  `SKIPPED` on extract" — **no format qualifier**.
+- `archive-data-model/spec.md:206`: the same statement scoped "(7z)".
+- Implementation: ZIP/TAR never compute `is_current`; a duplicate-name ZIP/TAR fails
+  default extraction with `ExtractionError` (O2 collision under `OverwritePolicy.ERROR`)
+  — repro in `parity.md`.
+
+Decision needed: **(a)** compute last-entry-wins `is_current` in all random-access
+materializations and route exact-same-name duplicates through the non-current skip
+(recommended — makes `tar -rf` output extract by default, restores uniformity;
+detailed plan in `members-scope.md` §"What actually needs fixing"), or **(b)** declare
+`is_current` a 7z/RAR-only concept in `archive-data-model`, fix the `safe-extraction`
+scenario wording, and accept that duplicate-name ZIP/TAR needs a non-default
+`OverwritePolicy` (then also fix `get()`'s docstring parenthetical, `reader.py:114`).
+Either way the conformance sweep should assert the chosen contract instead of
+special-casing duplicates (`test_corpus_sweep.py:203`).
+
+## Q2 — `members()` scope: include non-current by default? (maintainer's added question)
+
+Full analysis in `members-scope.md`. Recommendation: keep "everything" as the only
+listing behavior, no include/exclude argument (streaming-TAR can't honor it, a
+boolean doesn't carve the space — anti items are `is_current=True` — and bookkeeping
+alignment breaks); invest in Q1 + docs + predicate recipes instead. Needs an explicit
+yes/no so the visibility table in `safe-extraction` can be marked settled.
+
+## Q3 — RAR `listing_cost`: `INDEXED` or `REQUIRES_SCANNING`? (P2)
+
+`cost.py:24-27` names "a RAR with no quick-open record" as the canonical
+`REQUIRES_SCANNING` example; `rar_reader.py:773` always reports `INDEXED`; the
+`access-mode-and-cost` spec's example matrix is silent on RAR. Decide which is the
+honest receipt (is the axis "what the format's layout requires" or "what a caller
+pays after open?") and fix the losing artifact + add the RAR row to
+`test_cost_receipt.py`. If the axis is layout-based, distinguishing quick-open RAR5
+from plain requires plumbing a parser fact into the receipt — small but real work,
+which may itself inform the choice.
+
+## Q4 — Approve the surface changes (S1/S3)
+
+Pre-release, all free (`surface.md`): demote the 13 `*Context` classes +
+`RAPIDGZIP_AUTO_MIN_COMPRESSED_SIZE` from `__all__`; export `PasswordInput` (and
+decide `OnDiagnostic`); collapse `MemberSelectorArg` into public `MemberSelector`;
+drop `source_name` from `core.__all__`; fill the `api.md` gaps (`open_stream` at
+minimum). Blanket approval or line-item veto?
+
+## Q5 — A `verify` primitive (E2): now or post-0.2.0?
+
+`archivey test` proves the gap (60 lines, generator-semantics traps, poisoned-stream
+data loss). Adding `reader.verify(...) -> VerifyReport` (or `stream_members`
+error-recovery) is additive — it can land after 0.2.0 without breakage, so this is a
+prioritization question, not a freeze question. Related sub-decision: if it lands,
+`ExtractionProgress` gets a neutral-named alias (`ergonomics.md` nits).
+
+## Q6 — Small freeze-list confirmations
+
+- **`WriteError`**: exported but unraisable until Phase 9. Keep (confident in the
+  name) or demote until writing lands?
+- **`ExtractionStatus.SKIPPED` split (E3)**: add a distinct status or a `reason`
+  field on `ExtractionResult` for non-current skips? Cheap now, negotiation later.
+- **`hashes` value convention**: keep `int` crc32 / `bytes` others (documented), or
+  normalize to `bytes` pre-freeze? Recommendation: keep + document the convention in
+  the field docstring.
+- **`ArchiveFormat` display name** (S2): add `display_name()`/`label` so the CLI
+  stops parsing `repr()`. Name preference?

--- a/review/api-coherence/SUMMARY.md
+++ b/review/api-coherence/SUMMARY.md
@@ -1,0 +1,106 @@
+# API-coherence review — SUMMARY
+
+Reviewed at `main` + CLI (#120) merged (`7139c13`). Baseline (all captured before
+review, `[all]` config): pytest **1699 passed / 131 skipped / 3 deselected**, pyrefly
+**0 errors** (8 warnings), ty clean, `ruff check` clean. `ruff format --check` fails on
+four pre-existing helper scripts under `review/archive/` only — library and tests are
+clean. Findings below reproduce in `[all]`; none depend on optional-library versions
+(they are design findings, not codec behaviour).
+
+## Headline
+
+The surface is in **better shape than the ~90-name count suggests**: the data model is
+carefully specified, the cost receipts are now honest, the docs match the code, and the
+CLI consumed most of the API cleanly. Two things should be settled **before the 0.2.0
+freeze**:
+
+1. **The one real uniform-interface break: duplicate-name members** (`parity.md` P1).
+   The same logical situation — two entries with one name — yields three different
+   outcomes by format: 7z marks the older entry `is_current=False` and default
+   extraction skips it; RAR gives history rows distinct `path;n` names; ZIP/TAR leave
+   both `is_current=True` and **default `extract_all` fails with `ExtractionError`**
+   on an archive as ordinary as an appended-to tarball (`tar -rf`). Runnable repro in
+   `parity.md`. This undercuts VISION claim (1) directly and is also the crux of the
+   maintainer's members-scope question (`members-scope.md`).
+2. **Shed ~20 names from `__all__` and fix the export gaps** (`surface.md`). The 13
+   `Diagnostic*Context` classes and `RAPIDGZIP_AUTO_MIN_COMPRESSED_SIZE` don't belong
+   at top level; meanwhile `PasswordInput` (the type of a public parameter) and
+   `OnDiagnostic` are *not* exported, and `api.md` omits `open_stream` entirely. All
+   free pre-release.
+
+The CLI case study surfaced three genuine library gaps (`ergonomics.md`): the
+`--track-io` counters live only on the internal `BaseArchiveReader` (the CLI
+`isinstance`-checks and imports `enable_measurement` from `internal/`); the "verify
+everything" job has no library primitive (the CLI hand-rolls a 60-line loop with
+subtle generator semantics); and `ArchiveFormat` has no display name (the CLI parses
+`repr()`).
+
+## Top findings
+
+| # | Severity | Finding | Where | Status |
+|---|----------|---------|-------|--------|
+| P1 | **High** | Duplicate-name members: `is_current` computed only by 7z/RAR; ZIP/TAR default extraction *errors* where 7z silently skips — same input, divergent outcome; `safe-extraction` scenario ("superseded by later same-name → SKIPPED") is format-silent and currently false for ZIP/TAR | `sevenzip_parser.py:331`, `extraction.py:351`, repro in `parity.md` | **Maintainer decision** (Q1) |
+| E1 | Medium | No public measurement/IO-stats API: CLI `--track-io` imports `enable_measurement` + `BaseArchiveReader` from `internal/` and reads three counters not on the `ArchiveReader` ABC | `cli/common.py:15-16,56-68`, `base_reader.py:557-1009` | Proposed fix (surface.md §Add) |
+| E2 | Medium | No library "verify" primitive: `archivey test` hand-rolls manual `next()` loop; a mid-pass failure poisons the stream and loses remaining members | `cli/test_cmd.py:56-73` | Proposed direction (Q5) |
+| S1 | Medium | `__all__` = 90 names: 13 `*Context` classes + `RAPIDGZIP_AUTO_MIN_COMPRESSED_SIZE` should demote; `PasswordInput` / `OnDiagnostic` missing; `MemberSelector` vs internal `MemberSelectorArg` duplicate aliases used inconsistently in one class | `__init__.py:113-204`, `reader.py:27,148` | Proposed list (surface.md) |
+| P2 | Low-Med | RAR `listing_cost=INDEXED` always, but `cost.py` docstring names "RAR with no quick-open record" as the canonical `REQUIRES_SCANNING` example — doc/impl conflict on an honest-cost axis | `rar_reader.py:773` vs `cost.py:24-27` | **Maintainer decision** (Q3) |
+| E3 | Low | `ExtractionStatus.SKIPPED` conflates overwrite-skip and non-current-skip; caller must infer reason via `member.is_current` | `extraction_types.py:80-87`, `extraction.py:351` | Proposed fix |
+| S2 | Low | `ArchiveFormat` has no display-name property; CLI string-parses `repr()` | `cli/info_cmd.py:16-23` | Proposed fix |
+| S3 | Low | `archivey.core.__all__` exports internal helper `source_name`; `docs/api.md` omits `open_stream`, `MemberStreams`, selectors, format-support queries | `core.py:78`, `docs/api.md` | Proposed fix |
+| D1 | Low | CLI list line has no mark for `ANTI` (falls to `"?"`, same as `OTHER`) and no non-current indicator — the member model's own distinctions are invisible in the first consumer | `cli/format.py:9-15` | Overlaps cli-product review |
+
+## The maintainer's extra question (members scope)
+
+Analyzed in **`members-scope.md`**. Short version: **keep `members()` / iterators
+returning everything, do not add an include/exclude argument** — a default-exclude is
+unimplementable for streaming TAR (last-entry-wins is unknowable mid-pass), breaks
+`member_count` and `ExtractionReport` alignment, and doesn't even serve the intuitive
+goal (anti entries are `is_current=True`, so "current only" still shows tombstones).
+The real fix is P1: make `is_current` *mean the same thing everywhere*, then the
+one-line caller-side filter (`m.is_current`) — plus the already-predicate-accepting
+`stream_members`/`extract_all` selectors — covers every need. Details and the
+consequence table are in the file.
+
+## What is actually fine (don't churn)
+
+- **`member.hashes`** — the emptiness contract is real *and documented*: the
+  per-format stored-digest matrix in `docs/formats.md` matches the code (ZIP/7z crc32,
+  RAR5 crc32+blake2sp, gz/lz conditional, tar/dir/ISO none). #104's parity landed.
+- **Timestamps** — faithful naive-vs-aware (`ZIP` DOS naive, tar/dir aware UTC, ISO
+  aware with offset, RAR4 wall-clock) with `modified_utc(tz_for_naive=)` as the
+  explicit-assumption escape hatch. This is the right design; don't normalize.
+- **Cost receipts** (except P2) — directory now honestly `REQUIRES_SCANNING` (old
+  finding #4/#9 fixed), compressed tar `REQUIRES_DECOMPRESSION`+`SOLID`, 7z reports
+  `solid_block_count`, single-file reports real source seekability. Per-format
+  receipt test exists (`test_cost_receipt.py`).
+- **The error tree** — granularity is right (wrong-password / truncation / corruption
+  / unsupported are separately catchable), and `ArchiveyUsageError` outside the tree
+  is documented, tested, and defensible (caller bugs must not be swallowed by
+  `except ArchiveyError`).
+- **The extraction cluster** — five-ish names is not the smell the brief feared:
+  inputs (`ExtractionPolicy`/`OverwritePolicy`/`OnError`), per-member outcome
+  (`ExtractionResult`+`Status`), callback (`ExtractionProgress`), aggregate
+  (`ExtractionReport` = results + diagnostics) are distinct concepts, each earning its
+  name. Only the SKIPPED conflation (E3) is worth touching.
+- **Identity rules** — `__contains__` identity-only with a helpful `TypeError`,
+  foreign-member `open()` rejection, `get()` as the single name-lookup — coherent and
+  well-reasoned against streaming-pass consumption.
+- **`MemberStreams` declared capabilities** — uniformly gated across backends
+  including the directory reader (deliberate uniformity), and `streaming` ×
+  `CONCURRENT` rejection is loud.
+- **Safe-by-default config** — limits on by default, `STRICT`+`ERROR` extraction
+  defaults, `ExtractionLimits.UNLIMITED` an explicit opt-out. Knobs are orthogonal.
+- **The one-shot `extract` without `members=`** — deliberate, documented, correct.
+- **Password model** — the CLI's TTY prompt fell out of `PasswordProvider` in 10
+  lines; that's the API working.
+
+## Deliverable map
+
+- `parity.md` — cross-backend audit (P1 headline + the full observable matrix, and
+  where the conformance sweep should assert parity but works around it).
+- `surface.md` — the 90-name audit: demote/add/rename table, naming coherence,
+  smallest-surface proposal.
+- `ergonomics.md` — the three canonical loops + CLI case-study gaps (E1–E3).
+- `members-scope.md` — the maintainer's non-current-members question.
+- `QUESTIONS.md` — decisions that are the maintainer's to make (incl. the two spec
+  discrepancies surfaced per the pause-and-ask rule).

--- a/review/api-coherence/ergonomics.md
+++ b/review/api-coherence/ergonomics.md
@@ -1,0 +1,160 @@
+# Ergonomics — the three canonical loops, judged via the CLI
+
+The merged CLI is the first real second consumer. Method: trace every place it
+reached past the public surface or built machinery the library could have offered.
+Overall: **the CLI validates the API** — `list` is a 40-line module, extraction maps
+flags→enums 1:1, the TTY password prompt fell out of `PasswordProvider` in 10 lines.
+Three real gaps (E1–E3) and some small friction below.
+
+## E1 (Medium) — measurement/IO accounting is public in behavior, internal in API
+
+`--track-io` needs: `enable_measurement()` (context manager) and three counters —
+`bytes_decompressed`, `compressed_bytes_consumed`, `source_seek_count`. All live on
+internal surfaces, so the CLI does this (`cli/common.py:15-16, 56-68`):
+
+```python
+from archivey.internal.base_reader import BaseArchiveReader
+from archivey.internal.measurement import enable_measurement
+...
+if not isinstance(reader, BaseArchiveReader):
+    print("track-io: counters unavailable for this reader", ...)
+```
+
+An `isinstance` check against an internal class, guarding properties that have full
+docstrings (`base_reader.py:557-1009`) — these counters are *designed* as public
+observables (they're the runtime companion to `CostReceipt`, VISION's "honest cost
+signals") but never got a public home. Any downstream tool wanting "how much did that
+cost me?" must copy this pattern.
+
+Recommendation: promote a minimal read side to the ABC — e.g. a single
+`reader.io_stats() -> IoStats | None` (frozen dataclass with the three fields;
+`None` when measurement was off) plus a public `archivey.enable_measurement()`.
+Alternatively fold enablement into `ArchiveyConfig` (a `measure_io: bool`) so no
+context manager is needed. Either is small; pre-release cost: free. Leaving it
+internal is also *defensible* (measurement is a diagnostic tool), but then the CLI —
+shipped in the same wheel — is permanently an internal-API consumer, which normalizes
+the pattern for everyone reading its source as example code.
+
+## E2 (Medium) — the "verify" job has no library primitive
+
+`archivey test` is the third canonical CLI verb, and it required the most delicate
+code in the whole CLI (`cli/test_cmd.py:56-73`): a manual `iter()`/`next()` loop so
+that open-time failures count as FAIL, with this comment:
+
+> Once the generator raises, further next() yields StopIteration — remaining members
+> are lost (library limitation for solid / poisoned streams).
+
+Two library-side observations:
+
+1. **A full-read integrity check is a first-class job** (VISION: damaged input is a
+   first-class citizen; stored digests verify on read). Today it's ~70 lines of
+   caller code with subtle generator semantics. A `reader.verify(members=..., on_progress=...)
+   -> VerifyReport` (or an `on_error=CONTINUE` mode for `stream_members`) would make
+   the CLI verb a formatter — and give library users the same capability, which none
+   of them will hand-roll correctly (the StopIteration-after-raise trap is real).
+2. **`stream_members` has no per-member error recovery.** `extract_all` has
+   `OnError.CONTINUE`; the streaming iterator has nothing, so one bad member header
+   ends the pass even where the backend could skip to the next member (non-solid
+   formats). If a verify primitive lands, it needs exactly this, so the design
+   question is shared. (For solid streams, losing the rest is honest — the report
+   should say so, which is what a `VerifyReport` could carry.)
+
+Not a 0.2.0 blocker (the API *shape* wouldn't change, only grow), but flagged because
+the CLI proves the gap with working code today. → Q5.
+
+## E3 (Low) — `ExtractionStatus.SKIPPED` means two different things
+
+`SKIPPED` is recorded both for "destination existed under `OverwritePolicy.SKIP`"
+(`extraction_types.py:84`) and for "member is non-current" (`extraction.py:351-354`).
+A report consumer (like the CLI's summary, which prints `skipped: <name>` for both)
+can only distinguish by re-deriving `result.member.is_current`. Cheap pre-release fix:
+either a fourth status (`SUPERSEDED`?) or a `reason` field on `ExtractionResult`.
+Post-freeze this becomes a compatibility negotiation. (The third skip-ish concept —
+user-filter skip — produces *no* result row, which is defensible but worth one
+docstring sentence on `extract_all`.)
+
+## The three canonical jobs, walked
+
+### 1. List + hash for dedupe (the founding use case)
+
+```python
+with archivey.open_archive(path) as reader:      # 1 import
+    for member in reader:
+        if member.is_file and "crc32" in member.hashes: ...
+```
+
+Two lines of ceremony; stored-vs-computed fallback documented as a recipe in
+`usage.md` with the per-format matrix one link away. **Discoverability is good** —
+`hashes` is on the dataclass with a docstring naming the key convention. Two notes:
+
+- `hashes` values are `int | bytes` (crc32 int, blake2sp bytes) — every consumer
+  needs a formatting/normalizing branch (the CLI grew `format_hash_value`,
+  `cli/format.py:46-49`). Faithful-but-annoying; a documented convention ("crc32 is
+  an int; everything else bytes") is probably enough, but normalizing to `bytes` was
+  also available pre-freeze. Judgement call, low stakes.
+- The recipe iterates *all* members — including superseded 7z revisions and RAR
+  history rows, silently hashing dead content. After Q1/Q2, add one `is_current`
+  line to the recipe (see `members-scope.md`).
+
+### 2. Safe extract with a policy
+
+`extract(src, dest)` is genuinely one line with safe defaults; the enum cluster maps
+cleanly (CLI: `ExtractionPolicy(policy)` straight from argparse strings — the
+str-valued enums pay off). `ExtractionReport` iterating as its results tuple keeps
+the common loop clean. The five-name cluster is coherent (see SUMMARY "actually
+fine"). Frictions: E3 above, and P1 — under defaults, a duplicate-name tar/zip
+*fails*, which is exactly the sort of surprise the safe-by-default posture is
+supposed to avoid (safety against attack, not against `tar -rf`).
+
+### 3. Open one member and stream it
+
+`open(name_or_member)` → `ArchiveStream`: `KeyError` for unknown names (stdlib-ish),
+`ArchiveyUsageError` for foreign members, usage-error for non-file types,
+`stream.size` and lazy `seekable()` — coherent, spec-backed, and the identity rules
+prevent real bugs. The `try_get_size` story surfaces publicly as `ArchiveStream.size`
+(`archive_stream.py:168`) — fine. The one thing a caller must learn as lore:
+check `member.type`/`is_file` *before* `open()` (non-file raises); the docs say it,
+and `stream_members`' `None`-for-non-file convention covers the loop case.
+
+### Mutability of `ArchiveMember`
+
+"Mutable; callers must treat as read-only" + unhashable-by-design + late-stamped
+fields (streaming link resolution) + `replace()` for filter rewrites. The contract is
+spelled out in `archive-data-model` and the docstrings; `ExtractionResult` even
+documents that `member` stays live-mutable inside a frozen result. This is about as
+honest as a mutable model gets — fine for freeze. One residual: "using a reader after
+`close()` is undefined" (`reader.py:171`) — members outlive the reader as plain data;
+one sentence in `api.md` saying *that* ("fields already stamped remain valid; lazy
+resolution stops") would close the loop.
+
+## Config & error ergonomics (brief §D)
+
+- Defaults are safe (`STRICT`, `ERROR`, limits on, `AUTO` accelerators with silent
+  fallback) and each knob is orthogonal; `ExtractionLimits.UNLIMITED` /
+  `ListingLimits.UNLIMITED` make opt-out explicit and greppable. Good freeze shape.
+- `extract_all(config=..., limits=...)` — `limits` overrides `config.extraction_limits`
+  for one call; slight overlap but documented in the docstring and genuinely useful.
+  Keep.
+- The error tree lets callers catch at the granularity they need; the CLI's whole
+  error policy is two `except` clauses (`ArchiveyError` → 1, `OSError` → 1) plus
+  usage errors propagating as bugs — which is the design working as intended.
+  `ExtractionResult.error: ArchiveyError | OSError | None` honestly reflects that
+  filesystem write errors are not translated (per CONTRIBUTING); documented inline.
+
+## Minor CLI-revealed nits (rounded up)
+
+- `cli/progress.py:9` and `cli/test_cmd.py:14` import `ExtractionProgress` from
+  `archivey.internal.extraction_types` although it's re-exported at top level — the
+  internal path is what IDE auto-import suggests because that's where the class
+  *lives*. Moving public extraction types out of `internal/` (e.g. an
+  `archivey/extraction.py` that internal code imports too) would stop tools from
+  learning the wrong path. Cosmetic but cheap now, annoying later.
+- `ExtractionProgress` reused as the progress payload for `test` (a non-extraction
+  op) — field names like `bytes_written` read oddly for a verify. Not worth a rename
+  alone; if E2's `verify` lands, give it the same dataclass under a neutral name
+  (`MemberProgress`) and alias the old one. Decide with E2, not separately.
+- `_TYPE_MARK` (`cli/format.py:9-15`) has no entry for `MemberType.ANTI` → anti
+  members print `"?"`, indistinguishable from `OTHER`; no listing marker for
+  `is_current=False` either (see `members-scope.md` — the CLI currently renders two
+  identical `a.txt` lines for a versioned 7z). CLI-product territory, but the fix
+  follows Q2's decision.

--- a/review/api-coherence/members-scope.md
+++ b/review/api-coherence/members-scope.md
@@ -1,0 +1,110 @@
+# Should `members()` / iterators include non-current members by default?
+
+The maintainer's added question for this review: today `members()`, `__iter__`,
+`scan_members`, and `stream_members` return **every** entry — superseded same-name
+members (7z), RAR version-history rows (`path;n`), and 7z anti tombstones. Should
+there be an include/exclude argument, and what would each choice cost?
+
+## Recommendation up front
+
+**Keep "everything" as the only behavior of the listing surfaces; do not add an
+include/exclude argument.** Instead: (a) make `is_current` mean the same thing on
+every backend (P1 — that's the actual coherence bug), (b) document the two-level
+model in one place, and (c) let the existing selector/predicate machinery do the
+filtering. The one-line filter is already expressible everywhere it's needed:
+
+```python
+[m for m in reader.members() if m.is_current]          # listing
+reader.stream_members(lambda m: m.is_current)           # streaming
+reader.extract_all(dest)                                # already skips non-current
+```
+
+## Why "everything" is the right default
+
+1. **The reader models the archive, not the extracted tree.** An archive *is* an
+   entry sequence; the final-state view is a derived artifact that `extract_all`
+   already produces (hardwired `is_current` skip, `safe-extraction` spec). Listing
+   faithfully and extracting effectively is a clean two-level model — and it's
+   already the documented, spec'd design (`safe-extraction`'s visibility table:
+   "members() / __iter__ / get → Visible (metadata + is_current=False)").
+2. **Reference tools agree.** `7z l` lists superseded entries and anti items;
+   `unrar l` lists `path;n` rows; `unzip -l`/`tar -t` list duplicates. A
+   current-only default would make Archivey's listing disagree with every tool a
+   user would cross-check against — and with its own `info.member_count`.
+3. **The integrity job needs all entries.** `archivey test` and any digest audit
+   must verify history payloads too (their bytes exist and can be corrupt).
+   Defaulting them out of the iterators would silently weaken verification.
+4. **`get()` already does the "current" thing** for the one case where names
+   collide (returns the last = current for 7z; RAR history rows have distinct
+   names, so `get("path")` is the live one by construction). Point lookup and
+   listing already split along the right line.
+
+## Why an `include_noncurrent=` argument specifically is a bad trade
+
+- **It can't be honored uniformly — which is this review's whole theme.** In
+  `streaming=True` TAR, last-entry-wins is unknowable until the pass ends: a
+  forward-only iterator literally cannot exclude (or even mark) an entry that a
+  later entry will supersede. The flag would be "supported on 7z/RAR/(indexed
+  ZIP/TAR), approximate or erroring on streaming TAR" — a new per-format divergence
+  shipped inside the API surface itself.
+- **A boolean doesn't carve the space users actually mean.** Anti tombstones are
+  `is_current=True` (they *are* the final state of the path — "absent"). So
+  `members(current_only=True)` still yields ANTI entries a naive caller will trip
+  on (`open()` raises), while hiding readable old payloads. The intuitive "just
+  the files I'd get on disk" is really `m.is_current and not m.is_anti` — at which
+  point it's a predicate, and the API already accepts predicates. A flag that
+  needs three values (all / current / extractable-payload) is a smell that it
+  shouldn't be a flag.
+- **Bookkeeping alignment breaks.** `info.member_count`, `ListingLimits.max_members`,
+  `member_id` density, `ExtractionReport` rows (which include `SKIPPED` rows for
+  non-current members), and the CLI's counts all speak "entry space". A default
+  exclusion creates two silently different cardinalities across surfaces that are
+  documented to correspond.
+- **Freeze asymmetry.** Shipping 0.2.0 *without* the flag costs nothing — callers
+  filter with one expression, and a well-named keyword can be added compatibly
+  later if demand shows up. Shipping it and regretting the default (or the shape)
+  is a breaking change. Under freeze pressure, the reversible choice wins.
+
+## What actually needs fixing for this model to hold (ties to P1/Q1)
+
+The two-level model is only defensible if `is_current` is trustworthy — today it
+isn't outside 7z/RAR:
+
+1. **Compute last-entry-wins `is_current` in every random-access materialization**
+   (ZIP central directory, TAR scan, and any future backend). Both see the full
+   entry list before publishing, so it's a dict pass like
+   `compute_is_current` (`sevenzip_parser.py:331`) — hang it on the shared
+   materialization path in `base_reader.py` rather than per-backend.
+2. **Streaming mode gets an honest, documented caveat**: in a forward-only pass
+   `is_current` may be `True` at yield time for an entry later superseded (fields
+   are already documented as late-stamped; the completed-pass cache in
+   `scan_members()` can be back-filled). Extraction in streaming mode then handles
+   same-name entries by overwrite-in-order (bsdtar semantics) — which is what the
+   hardwired skip degrades to when knowledge arrives too late.
+3. **Same-exact-name supersession stops being an O2 collision** (that's what makes
+   ZIP/TAR duplicate extraction error today). O2 keeps its job for *distinct*
+   stored names that collide after normalization (casefold/NFC) — a genuinely
+   different, adversarial situation. Same-byte-name duplicates are the format's
+   own versioning idiom and follow the `is_current` skip like 7z.
+4. **Documentation**: one section ("Duplicates, versions, and tombstones") in
+   `usage.md`/`formats.md` stating the model: *listing is the entry sequence;
+   `is_current` marks the final state; extraction materializes final state;
+   filter with a predicate when you want the current view.* Plus the one-line
+   `is_current` filter added to the dedupe recipe.
+5. **CLI follow-through** (with cli-product review): a listing marker for
+   non-current entries (e.g. lowercase mark or a `;v` column) and a distinct mark
+   for `ANTI`, so the model is visible in the first consumer.
+
+## If the maintainer prefers current-only-by-default anyway
+
+Then the least-bad shape is **not** an argument on `members()` but a distinct
+accessor pair — e.g. `members()` (current view) vs `raw_members()`/`entries()`
+(everything) — so each name has one meaning and `len()` comparisons across calls
+can't silently diverge. Costs to accept, with eyes open: streaming TAR cannot
+implement the current view (raise `UnsupportedOperationError` there?); `info.member_count`
+needs a story (entry count vs current count); `archivey test` must switch to the
+raw surface; anti entries need a decision (they are current); and `7z l` parity is
+lost. This is strictly more surface and more per-format caveats than the
+recommendation — which is why it isn't the recommendation.
+
+→ Decision recorded as **Q2** in `QUESTIONS.md`.

--- a/review/api-coherence/parity.md
+++ b/review/api-coherence/parity.md
@@ -1,0 +1,120 @@
+# Cross-backend parity audit
+
+The load-bearing claim: every observable on `ArchiveMember` / `ArchiveReader` means the
+same thing on every backend. Verdict: **true for almost everything** — the team has
+clearly worked this seam (hashes matrix, timestamp faithfulness, cost-receipt fixes) —
+with **one substantive break (P1)** and a couple of small divergences.
+
+## P1 (High) — duplicate-name members: three formats, three behaviors
+
+`is_current` is defined as "live final state of its path (last-entry-wins)"
+(`types.py:317`, `archive-data-model` spec). Who actually computes it:
+
+| Backend | Same-name duplicates | Result |
+|---|---|---|
+| 7z | `compute_is_current` (`sevenzip_parser.py:331`), incl. anti supersession | earlier entry `is_current=False` → default extract `SKIPPED`, last wins |
+| RAR | history rows get distinct names `path;n` + `is_current=False` (`rar_reader.py:505`) | default extract writes live row only |
+| ZIP | **not computed** — all entries `is_current=True` | second write is an O2 collision → default `OverwritePolicy.ERROR` → **`ExtractionError`, extraction halts** |
+| TAR | **not computed** | same as ZIP |
+| ISO / directory | duplicates impossible (filesystem tree) | n/a |
+
+Runnable repro (committed as scratch during review; trivially recreated):
+
+```python
+import io, tarfile, zipfile
+from archivey import open_archive
+
+with zipfile.ZipFile("d.zip", "w") as z:
+    z.writestr("a.txt", "old"); z.writestr("a.txt", "new")
+with tarfile.open("d.tar", "w") as t:
+    for c in (b"old", b"new"):
+        ti = tarfile.TarInfo("a.txt"); ti.size = len(c)
+        t.addfile(ti, io.BytesIO(c))
+
+with open_archive("d.tar") as r:
+    print([m.is_current for m in r.members()])   # [True, True]
+    r.extract_all("out")   # ExtractionError: Destination already exists: out/a.txt
+```
+
+The same two-entry archive as 7z extracts fine (old entry `SKIPPED`). Observed output
+for zip and tar:
+
+```
+'a.txt' is_current=True size=3
+'a.txt' is_current=True size=3
+extract FAILED (default policy): ExtractionError: Destination already exists: .../a.txt
+```
+
+Why this matters beyond symmetry:
+
+- **An appended-to tarball (`tar -rf archive.tar file`) is a normal artifact**, and GNU
+  tar / bsdtar / unzip all extract it last-entry-wins. Archivey's default refuses it.
+  "Read every format behind one uniform interface" is undercut in both directions:
+  per-format divergence, and divergence from every reference tool.
+- **The specs already disagree with the implementation.** `safe-extraction`'s
+  non-current-skip scenario says "Content superseded by later same-name or anti →
+  `SKIPPED` on extract" with *no format qualifier* (`safe-extraction/spec.md:230`),
+  while `archive-data-model:206` scopes the same statement "(7z)". ZIP/TAR satisfy
+  neither reading cleanly. Per the pause-and-ask rule this is **Q1 in QUESTIONS.md**,
+  not something this review resolves.
+- **The conformance sweep works around it instead of asserting a contract**:
+  `test_corpus_sweep.py:203` passes `overwrite=REPLACE if has_duplicates else ERROR` —
+  the harness itself needed the escape hatch. Whatever Q1 decides, the sweep should
+  assert the *uniform* duplicate contract (same corpus entry, every format, same
+  default outcome) rather than dodging it.
+- Small doc casualty: `ArchiveReader.get()`'s docstring sells "the last (the one a
+  sequential extraction would leave on disk)" (`reader.py:114`) — for ZIP/TAR under
+  default policy, sequential extraction leaves an error, not a file.
+
+Recommended direction (argued in `members-scope.md`): compute last-entry-wins
+`is_current` in every random-access materialization (ZIP central directory and TAR
+scan both see all entries before publishing the list), keep exact-same-name
+supersession out of the O2 collision map (O2 stays for *distinct* stored names that
+collide post-normalization — a genuinely different hazard), and document the one
+honest streaming-mode caveat (a forward-only TAR pass cannot know `is_current`
+mid-pass; in `streaming=True` extraction, same-name entries follow overwrite policy
+— which is what bsdtar does). Migration cost: pre-release, **free** at the API level;
+one spec delta + backend materialization change + sweep assertion.
+
+## P2 (Low-Med) — RAR listing cost: implementation says INDEXED, docstring says otherwise
+
+`ListingCost.REQUIRES_SCANNING`'s docstring names its canonical examples: "an
+uncompressed tar, **or a RAR with no quick-open record**" (`cost.py:24-27`). The RAR
+backend reports `INDEXED` unconditionally (`rar_reader.py:773`). The native parser does
+walk headers file-by-file at open (there is no central index in RAR without the
+quick-open record), so by the receipt's own definition ("describes static open-time
+properties" — `access-mode-and-cost` spec) the honest value for a no-quick-open RAR is
+arguably `REQUIRES_SCANNING`; by the "cost you'll pay *now*" reading it's `INDEXED`
+because open already paid the scan. The two public artifacts disagree — **Q3**.
+(`access-mode-and-cost`'s example matrix lists ZIP/tar/7z but is silent on RAR, so the
+spec doesn't break the tie.)
+
+## The rest of the matrix — checked, uniform
+
+| Observable | Verdict | Evidence |
+|---|---|---|
+| `hashes` | **Uniform & documented.** ZIP crc32 (FILE/SYMLINK), 7z crc32 (FILE, when stored), RAR5 crc32+blake2sp, `.gz` trailer crc32 (single-member, seekable), `.lz` under declared SEEKABLE, none for tar/dir/ISO/bz2/xz — exactly the matrix in `docs/formats.md` §Stored digests. Emptiness contract is explicit ("when the backend documents them"). | `zip_reader.py:627`, `sevenzip_reader.py:349`, `rar_reader.py:138-140`, `codecs.py:768,912` |
+| `CostReceipt` axes | **Honest and orthogonal** (except P2). Directory = `REQUIRES_SCANNING` (old #4/#9 fixed, with the reasoning in a comment); compressed tar = `REQUIRES_DECOMPRESSION`+`SOLID`+`solid_block_count=1`; plain tar = `REQUIRES_SCANNING`+`DIRECT`; 7z = `INDEXED` + `SOLID`/`DIRECT` + real folder count; single-file reports the *actual* source capability rather than assuming seekable. Per-format test: `test_cost_receipt.py::test_cost_receipt_per_format`. | backends' `_get_archive_info` |
+| `stream_capability` | Uniform meaning (source seekability). TAR/single-file compute from the real source; ZIP/7z/RAR/ISO hardcode `SEEKABLE`, defensible because their open fails fast on non-seekable sources (`SUPPORTS_STREAMING_NON_SEEKABLE=False`). | grep of backends |
+| `MemberStreams` gating | Uniform: every backend (including directory, deliberately) honors default forward-only/one-live-stream and unlocks via declared flags; undeclared SEEKABLE forces `seekable() == False` even when the inner handle could seek (`archive_stream.py:328`). | `directory_reader.py:4-6`, backend greps |
+| timestamps | Faithful per format (naive DOS/RAR4 wall-clock vs aware UTC/offset elsewhere), hostile values degrade to `None` + `MEMBER_TIMESTAMP_INVALID` via the shared helper; `modified_utc()` is the explicit conversion. This is divergence *by design and documented on the field*, which is the right kind. | `timestamps.py`, `types.py:372-392` |
+| `mode` | Same meaning everywhere it's set (Unix permission bits): tar `S_IMODE`, dir `S_IMODE(st_mode)`, ZIP from Unix create_system, ISO Rock Ridge, RAR/7z from Unix-host attrs; `None` where the format doesn't carry it. Sweep asserts per-format via `_MODE_FORMATS`. | backends; `test_corpus_sweep.py:45-57` |
+| `MemberType` incl. `ANTI` | `ANTI` is 7z-only by nature; classification, `stream=None`, and usage-error open/read are spec'd and tested (`test_sevenzip_reader.py:703+`). Non-file open/read raises `ArchiveyUsageError` uniformly. | `format-7z` spec, `error-handling` spec |
+| link model | `link_target` (raw stored string) + `link_target_member` (resolved) uniform; resolution rules (latest earlier same-name for tar hardlinks, etc.) centralized in `base_reader.py`, not per-backend. | `base_reader.py:732-830` |
+| `member_count` | Honest: len for ZIP/RAR/7z/single-file, `None` (with a comment saying why) for tar/dir/ISO. | grep above |
+
+## Where the sweep should assert parity but doesn't
+
+1. **Duplicates** — the `REPLACE if has_duplicates` dodge (`test_corpus_sweep.py:198-205`).
+   After Q1: one corpus entry, every format that can express duplicates (zip, tar,
+   7z — extend `sample_archives` builders), assert identical `is_current` pattern and
+   identical default-extract outcome.
+2. **`is_current` is asserted only in per-format tests** (`test_sevenzip_reader`,
+   `test_rar_reader`) — there is no cross-format statement that *every other* backend
+   yields all-`is_current=True` for unique-name corpora. One sweep-level assertion
+   (`all(m.is_current for m in members)` for entries without duplicates) makes the
+   field's meaning a tested invariant instead of a per-backend accident.
+3. **Cost receipts** are tested per-format in `test_cost_receipt.py` (good) but the
+   *docstring examples* in `cost.py` are not tied to it — P2 survived because nothing
+   cross-checks prose against receipts. Cheap fix: when Q3 is decided, encode the
+   RAR row in `test_cost_receipt_per_format` and fix whichever artifact lost.

--- a/review/api-coherence/surface.md
+++ b/review/api-coherence/surface.md
@@ -1,0 +1,94 @@
+# Surface size & public/internal boundary
+
+`archivey.__all__` currently has **90 names**. The headline question — is that the
+right size to freeze? — answer: **no, freeze ~70**: demote 14, add 2–3 that are
+already de-facto public, and fix a handful of coherence nits. All moves are free
+pre-release (0.2.0 is the first public release; nothing external imports these yet).
+
+## Demote (remove from top-level `__all__`, keep importable from their module)
+
+| Names | Why | Migration cost |
+|---|---|---|
+| The 13 `*Context` classes (`ArchiveEofContext` … `SymlinkTargetContext`) | Callers *receive* them on `Diagnostic.context`; nobody constructs or imports them to use the library. They are the payload schema of an extensible subsystem — every future `DiagnosticCode` adds another top-level name forever if they stay. `archivey.diagnostics` already exists as a clean public module with its own `__all__`; point `isinstance` users there. Keep `Diagnostic`, `DiagnosticCode`, `DiagnosticSummary`, `DiagnosticPolicy`, `DiagnosticSeverity`, `DiagnosticDisposition`, `DiagnosticContext` (the union alias) top-level — those are the API. | Free (pre-release). One `docs/api.md` note: "context classes live in `archivey.diagnostics`". |
+| `RAPIDGZIP_AUTO_MIN_COMPRESSED_SIZE` | A benchmark-derived tuning constant (`config.py:75`). Freezing it top-level makes a *threshold value* API. Nobody needs it to *use* AUTO; anyone tuning it is already reading `config.py`. | Free. Keep in `archivey.config` for the curious. |
+
+Result: 90 → 76. (If the maintainer wants to go further, `CreateSystem` and
+`CompressionMethod.properties` are the next-most-esoteric, but they are member-field
+types and cheap to keep — not recommended to cut.)
+
+## Add / fix exports (gaps found via the CLI and signatures)
+
+| Name | Problem | Fix |
+|---|---|---|
+| `PasswordInput` | The declared type of `open_archive(password=)` / `extract(password=)` — the CLI imports it from `archivey.config` (`cli/list_cmd.py:12` etc.) and any typed caller must too, but it is **not in `__all__`**. A public signature's parameter type is public API. | Export it (alias next to `PasswordProvider`/`PasswordRequest`, which already are). |
+| `OnDiagnostic` | Type of the public `ArchiveyConfig.on_diagnostic` field; in `archivey.diagnostics.__all__` but not the package's. | Export or document the `archivey.diagnostics` import path in `api.md`. |
+| `MemberSelector` vs `MemberSelectorArg` | Two names for the same alias: `reader.py:27` defines public `MemberSelector` (used by `stream_members`), while `extract_all`'s signature uses internal `MemberSelectorArg` (`reader.py:148`) — the *same class* shows users two different spellings for the same concept in help()/docs. | Keep one public `MemberSelector`; make `extraction_types.MemberSelectorArg` a private alias of it (or delete). Free. |
+| `archivey.core.__all__` lists `source_name` | An internal streamtools helper published by a public module's `__all__` but absent from the package surface — `from archivey.core import *` pulls it in. | Drop it from `core.__all__` (it's re-exported "for the single implementation", i.e. for internal callers — they can import from `internal.streams.streamtools`). |
+
+## Documentation surface (`docs/api.md`) is missing load-bearing names
+
+`api.md` promises "everything documented here is … listed in `__all__`" but documents
+only ~40 of 90. Fine for exception subclasses (the tree renders under `ArchiveyError`),
+**not** fine for:
+
+- **`open_stream`** — one of the three entry points, absent entirely.
+- `MemberStreams` — the capability-declaration flag shown in `usage.md` examples.
+- `MemberSelector` / `MemberFilter` — parameter types of `stream_members`/`extract_all`.
+- `ExtractionProgress` — the `on_progress` payload.
+- `PasswordProvider` / `PasswordRequest` / `PasswordInput`.
+- `detect_format`'s return types `FormatInfo` / `DetectionConfidence`, and the
+  support-query cluster (`format_availability`, `list_supported_formats`,
+  `list_known_formats`, `FormatSupport`, `FormatAvailability`, `MissingComponent`).
+
+At a freeze, an exported-but-undocumented name is a name you're committing to without
+having decided what it promises. Either document or demote each. Migration: doc-only.
+
+## Naming coherence
+
+- **`Policy` suffix**: `ExtractionPolicy` (trust level), `OverwritePolicy` (collision
+  action), `DiagnosticPolicy` (disposition mapping) — three different shapes share the
+  suffix, but each is genuinely "a policy the caller sets", and the CLI mapped all
+  three onto flags without friction. `OnError` breaks the pattern but mirrors its
+  keyword (`on_error=`) exactly, same as `on_progress`/`on_diagnostic`. Verdict:
+  coherent enough; **do not rename** (churn without an ergonomic win).
+- **Enums-vs-flags convention** is consistent: `Enum` for closed choices, `str`-valued
+  enums where serialization matters (`DiagnosticCode`, formats), `Flag` only where
+  combination is meaningful (`MemberStreams`). Good.
+- **`ArchiveStream`** — public *as a type* (annotation/return), never
+  caller-constructed, but its `__init__` (with `open_fn`, `translate`, `stamp`, …)
+  renders in docs/api.md today. Recommend: keep the name public, hide the constructor
+  from the rendered docs and state "returned by `open()`/`open_stream()`, not
+  constructed". Alternatively re-export a Protocol; not worth it — docstring note
+  suffices.
+- **`ArchiveFormat` display name** — the CLI had to parse `repr()` to print "ZIP"
+  (`cli/info_cmd.py:16-23`). Add a small public property (e.g. `label` or reuse
+  `file_extension()`-style method `display_name()`) returning `"ZIP"`, `"TAR_GZ"`, or
+  the constructed fallback. One property; the CLI helper collapses.
+- **`WriteError`** — exported and documented in the tree, but nothing raises it until
+  Phase 9 writing lands. Freezing an unraisable exception is harmless-but-odd; keep
+  only if you're confident Phase 9 keeps the name (Q6).
+
+## Smallest surface that still serves the three use cases
+
+For calibration, the three canonical jobs need **~32 names**:
+
+- **Entry + reader**: `open_archive`, `open_stream`, `extract`, `ArchiveReader`,
+  `ArchiveStream` (annotation only).
+- **Data model**: `ArchiveMember`, `MemberType`, `ArchiveInfo`, `ArchiveFormat`
+  (+`ContainerFormat`/`StreamFormat` as its fields), `MemberStreams`.
+- **Dedupe/list+hash**: `member.hashes` (no extra names — a field), `CostReceipt`,
+  `ListingCost`, `AccessCost`, `StreamCapability`.
+- **Safe extract**: `ExtractionPolicy`, `OverwritePolicy`, `OnError`,
+  `ExtractionReport`, `ExtractionResult`, `ExtractionStatus`, `ExtractionProgress`,
+  `MemberSelector`, `MemberFilter`, `ExtractionLimits`.
+- **Errors**: `ArchiveyError`, `ArchiveyUsageError` + the subclasses callers branch on
+  (`EncryptionError`, `CorruptionError`, `TruncatedError`, `UnsupportedFormatError`,
+  `ResourceLimitError` at minimum).
+- **Config/password**: `ArchiveyConfig`, `PasswordInput`/`PasswordProvider`/`PasswordRequest`.
+
+Everything else — diagnostics detail, format-support introspection, `ListingLimits`,
+`AcceleratorMode`, `CompressionAlgorithm`/`Method`, `CreateSystem`, the full exception
+tree — is legitimate second-ring API that earns its keep, which is why the
+recommendation is ~70, not ~32. The point of the exercise: nothing in the 90 is
+*mysterious*; the only names that fail the "would a user ever type this?" test are the
+14 demotions above.


### PR DESCRIPTION
Deliverables for the `review/api-coherence` brief (public API & member-model coherence, run against `main` with the CLI merged), plus the maintainer's added question on whether `members()` / iterators should include non-current members by default.

## Contents

- **`SUMMARY.md`** — headline + top-findings table + "what is actually fine". Baseline captured green: 1699 passed / 131 skipped (`[all]`), pyrefly 0 errors, ty clean, ruff clean (4 pre-existing format failures confined to `review/archive/` scripts).
- **`parity.md`** — the cross-backend audit. Headline finding **P1 (High)** with a runnable repro: `is_current` is computed only by 7z/RAR, so a duplicate-name ZIP/TAR (e.g. an appended-to tarball) **fails default extraction** with `ExtractionError` where the same logical 7z silently skips the old entry. The `safe-extraction` and `archive-data-model` specs disagree on scope, so this is surfaced as a decision (Q1), not resolved. Also P2: RAR `listing_cost=INDEXED` vs the `cost.py` docstring's own RAR example.
- **`surface.md`** — audit of the 90-name `__all__`: demote the 13 `Diagnostic*Context` classes + `RAPIDGZIP_AUTO_MIN_COMPRESSED_SIZE`; export `PasswordInput`; collapse the `MemberSelector`/`MemberSelectorArg` duplication; `docs/api.md` gaps (notably `open_stream` is undocumented). Includes the smallest-surface calibration (~32 names) and a ~70-name freeze recommendation.
- **`ergonomics.md`** — the three canonical loops judged via the CLI as first real consumer. Gaps: `--track-io` reaches into `internal/` for measurement counters (E1), no library `verify` primitive behind `archivey test`'s hand-rolled loop (E2), `ExtractionStatus.SKIPPED` conflation (E3).
- **`members-scope.md`** — the added question. Recommendation: keep "everything" as the only listing behavior, no include/exclude argument (streaming-TAR can't honor it, anti items are `is_current=True` so a boolean doesn't carve the space, and counts/reports misalign); fix P1 so `is_current` is trustworthy everywhere and let the existing predicate selectors do the filtering.
- **`QUESTIONS.md`** — Q1–Q6 maintainer decisions, including the two spec discrepancies surfaced per the pause-and-ask rule.

No library code changed — findings only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BqrPV9oQCDK4cfmn5xska1

---
_Generated by [Claude Code](https://claude.ai/code/session_01BqrPV9oQCDK4cfmn5xska1)_