### PR TITLE
review: stream-layering brief + two backlog review ideas

### DIFF
--- a/review/README.md
+++ b/review/README.md
@@ -25,11 +25,16 @@ Round commissioned 2026-07-17 — the **non-security** pass toward the first pub
 | `api-coherence/` | Public API & member-model coherence / ergonomics (incl. cross-backend parity) |
 | `cli-product/` | The CLI as a **product** — UX, grammar, exit codes, output (not code correctness; #131 did that) |
 | `performance/` | The ≤1.3× stdlib perf budget — benchmark-gate efficacy + the real traps |
+| `stream-layering/` | Stream wrapper stack — are the checks correct, and can slicing+verification collapse into one stream under `ArchiveStream`? |
 
-**All three run against `main` with the CLI (PR #120) merged in.** The CLI is the
+The first three run against `main` with the CLI (PR #120) merged in — the CLI is the
 library's first real second consumer, so it sharpens all three: `api-coherence` reads
 the CLI's use of the public surface as evidence of gaps, `performance` benchmarks the
 CLI's `list`/`test`/`extract` as real workloads, and `cli-product` reviews it directly.
+
+`stream-layering/` was commissioned after the performance review (PR #134) attributed
+part of the missed budget to the per-member wrapper stack; it pairs a correctness audit
+of the slice/verify/outer wrappers with a collapse-for-performance design question.
 
 `backlog.md` holds two more (test-strategy; structural-cleanliness / zero-tech-debt)
 deferred to a lighter follow-on pass.

--- a/review/backlog.md
+++ b/review/backlog.md
@@ -1,11 +1,20 @@
-# Review backlog — deferred to a lighter follow-on pass
+# Review backlog — deferred review ideas
 
-Two more non-security topics are worth a review, but *after* the in-flight three
-(`api-coherence`, `cli-product`, `performance`). They overlap heavily, both feed the
-same pre-`0.2.0` polish, and neither is a deep hostile-input or design-freeze
-question — so they're better run together as one lighter "quality & debt" pass than
-as two separate frontier deep dives. When commissioned, each gets its own top-level
-directory with a `brief.md` and archives when addressed (see `README.md`).
+Non-security review topics worth doing, but *after* the in-flight round
+(`api-coherence`, `cli-product`, `performance`, `stream-layering`). They differ in
+character and timing:
+
+- **Topics 4 + 5** (test-strategy, structural-cleanliness) — a single lighter
+  "quality & debt" pass; they overlap heavily and both feed the same pre-`0.2.0`
+  polish, so run them together rather than as two frontier deep dives.
+- **Topic 6** (decode-engine performance) — a later *performance* round, once the
+  `stream-layering` wrapper work has landed; mostly independent of it.
+- **Topic 7** (outside-in adoption / confidence) — a **capstone**, meaningful only
+  *after everything else is fully addressed*; it judges the finished library, not a
+  work in progress.
+
+When commissioned, each gets its own top-level directory with a `brief.md` and
+archives when addressed (see `README.md`).
 
 ## The framing: zero tech debt
 
@@ -64,6 +73,59 @@ Plus the mechanical debt a zero-debt pass should sweep:
   (The old review found docstring/spec mismatches; the surface has churned a lot since.)
 - Any remaining `TODO`/`FIXME`/"deferred"/"follow-up" markers in `src/` — each is a
   debt-ledger line by definition.
+
+## Topic 6 — Decode-engine performance (`DecompressorStream` / `Decoder`)
+
+**Why:** the archived stream-decoder review (PR #122) and the #96 composition refactor
+looked at the decode engine for **correctness and clarity**, not performance — and the
+in-flight `stream-layering/` review deliberately scopes the decode engine *out*, owning
+only the wrapper stack (slice/verify/outer) around it. So the per-chunk cost of the
+decode engine itself is unreviewed. Mostly independent of `stream-layering`, so it's a
+separate later performance round (after that one lands, so the two don't churn the same
+code at once).
+
+Concrete surfaces to measure:
+- Per-`read()` dispatch through `DecompressorStream` → `Decoder` and the base's
+  `_read_decompressed_chunk` buffering (the archived F3 memory-bound fix touched this —
+  is the *steady-state* read cost tight now?).
+- `fix_stream_start_position` adding a **second** `SlicingStream` in front of a codec that
+  assumes `tell()==0` — is that slice avoidable on the common path?
+- The accelerator wrappers (`_AcceleratorStream` / `_GzipTruncationCheckStream`) per-chunk
+  overhead vs the raw rapidgzip handle, and whether the AUTO gate's crossover is where the
+  fused cost actually breaks even (coordinate with `performance/`'s gate findings).
+- `readinto` zero-copy through the decode stack (same lens as `stream-layering`, one layer
+  down): does decoded output get copied more than necessary?
+
+Not a re-litigation of the #96 design — a pure "is the decode read path as cheap as it can
+be" pass, with numbers.
+
+## Topic 7 — Outside-in: adoption & confidence (capstone)
+
+**Why:** every other review looks *inward* (is this code correct / clean / fast). This one
+looks *from the outside*: would someone actually adopt archivey, and what's missing to make
+them confident? Run it **last** — it judges the finished library against its competitors and
+its own VISION promises, so it's only meaningful once the correctness/API/perf/CLI work is
+fully addressed. Two framings, usable together:
+
+- **The adopting engineer / company (primary).** Put the reviewer in the shoes of an
+  external engineer evaluating archivey against the alternatives (`zipfile`/`tarfile` +
+  ad-hoc glue, `libarchive` bindings, `py7zr`/`rarfile`, `patool`, shelling out to
+  `7z`/`unrar`). What's missing for **confidence and peace of mind** to depend on it: API
+  stability guarantees and semver, the security/CVE-surface story made legible, a
+  trustworthy changelog/release cadence, benchmarks a skeptic can rerun, documentation that
+  answers "how do I do X safely," licensing/provenance of vendored code, supported-platform
+  and free-threading matrices, "what happens on damaged/hostile input" stated plainly,
+  responsiveness signals. Deliverable: the concrete gaps between "technically excellent" and
+  "a stranger bets a production pipeline on it," ranked.
+- **The CPython maintainers (a high bar, not a goal).** As an explicit stretch lens — *not*
+  an actual objective — assess it as if stdlib inclusion were on the table: API taste and
+  minimalism, zero-surprise cross-platform behaviour, test rigor, security posture,
+  maintenance burden, backwards-compat discipline, the "does this belong in the standard
+  library" bar. Useful precisely because it's a harsher standard than any real adopter would
+  apply, so it surfaces polish gaps the primary framing might accept.
+
+This is judgement + gap analysis, not a bug hunt — closer to a product/positioning audit
+grounded in the code and docs. It likely produces roadmap items, not fixes.
 
 ## Not a review — a feature gap to track separately
 

--- a/review/stream-layering/brief.md
+++ b/review/stream-layering/brief.md
@@ -1,0 +1,144 @@
+# Brief — Stream wrapper layering: correctness + collapse-for-performance
+
+Read `review/README.md` (conventions, VISION tie-breakers, deliverable shape). This
+review has **two coupled questions**, and the second is the point:
+
+1. **Correctness** — are the per-member stream wrappers and the checks they perform
+   (slicing bounds, digest/length verification, seek-disables-verify, EOF handling,
+   concurrency re-seek, close/teardown) actually right?
+2. **Necessity** — are the several stacked layers each *required*, or can most of the
+   extra wrapping (slicing, verification) collapse into **one** stream that does
+   everything, keeping the outer `ArchiveStream` identity? This is a performance
+   question with a concrete design hypothesis (below).
+
+## Why now
+
+The performance review (#134) found the ≤1.3× budget missed on the common paths —
+ZIP read-all **2.2–2.3×**, extract-all **2.4–3.7×**, open+list **5–8×** stdlib — and
+attributed part of it to the stream layering. Each member handle the library returns
+is a stack of `ReadOnlyIOStream`/`DelegatingStream` wrappers, and **every `read()`
+chunk pays a Python-level method dispatch (and often a bytes copy) at each layer**.
+Collapsing layers is one of the few structural levers left before `0.2.0`.
+
+Note the division of labour with #134: that review owns *measuring* the budget and
+the open/list/extract hotspots; **this** review owns the *wrapper architecture* —
+whether the layers are correct and whether they can be fused. The open+list 5–8× is
+likely dominated by materialization/`zipfile`, not the wrapper stack (streams open
+lazily) — confirm, but the wrapper target is the **read/extract per-chunk and
+per-open** cost.
+
+## The current stack (trace and confirm — this is the object of review)
+
+For a ZIP member the handed-out handle is, bottom to top (hot path, measurement off):
+
+1. **Source view** — `SlicingStream` (`streamtools/slice.py`) presents the member's
+   byte range; in `SharedSource` mode it re-seeks-under-lock per read for CONCURRENT
+   fan-out. `fix_stream_start_position` may add a *second* `SlicingStream` to give a
+   codec a clean `tell()==0`. TAR/ISO add `LockedStream` (`streamtools/locked.py`)
+   over the shared handle.
+2. **Decode** — the codec stream: `DecompressorStream` + `Decoder` (post-#96),
+   `_AcceleratorStream`/`_GzipTruncationCheckStream` (`codecs.py`), or
+   `AesDecryptStream` (`crypto.py`). STORED members have **no** decode layer.
+3. **Verify** — `VerifyingStream` (`verify.py`): hashes forward reads, checks
+   `member.hashes` + `expected_size` at clean EOF, bounds over-long decodes, drains
+   post-payload authenticators (WinZip AES HMAC), disables on seek off the frontier.
+4. **Outer** — `ArchiveStream` (`archive_stream.py`): lazy open under a lock, exception
+   translate+stamp, `size`, `RewindWarning`, `on_close` lease release, `weakref.finalize`,
+   diagnostics watermark.
+
+So a **STORED ZIP member** = `SlicingStream → VerifyingStream → ArchiveStream` (three
+Python `read()` hops, no decompression), and a **deflate member** adds the decoder.
+Composition site: `base_reader._wrap_member_stream` (`base_reader.py:572`) +
+`zip_reader.py:816` (VerifyingStream) — map the equivalent stack for **every** backend
+(TAR, 7z solid, RAR-via-unrar, ISO, single-file, directory).
+
+## Part 1 — Correctness audit (do this first; it defines the invariants a collapse must keep)
+
+Each wrapper is subtle; a fusion that silently drops one of these is worse than the
+overhead. Verify each, with `file:line` and the concrete input/state:
+
+- **`readinto` side-effect safety.** `DelegatingStream.readinto` zero-copies straight
+  to `inner.readinto`, *bypassing* an overridden `read` unless `readinto_passthrough=
+  False` (`base.py:99-125`). Any layer with a read side effect (hashing, counting)
+  must not be bypassed. Confirm `VerifyingStream` (a `ReadOnlyIOStream`, so `readinto`
+  routes through `read` — good) and `CountingReader`/`OutputCountingStream` (override
+  `readinto` explicitly) are all correct, and that a fused stream preserves this — a
+  `readinto` that skips the hasher is a silent verification hole.
+- **`VerifyingStream` EOF/close logic** (`verify.py:195-331`) is the riskiest: verify
+  only on a clean *sequential* read to EOF; the deferred-short verdict; `reached_declared`
+  vs the `read(1)` probe; the accel-raises-instead-of-EOF path; typed-error precedence;
+  the `expected_size` bound *draining the WinZip AES HMAC*. Enumerate the states and
+  confirm each holds — this is the archived stream-decoder F6/F4 territory, so cross-check
+  those fixes didn't leave a seam.
+- **`SlicingStream` dual mode** (`slice.py`): single-consumer (eager seek) vs
+  re-seek-under-lock (`_seek_before_read`); the "never call unlocked `tell`/`seek` on a
+  shared handle" rule (`BufferedReader.tell` is not thread-safe); `SEEK_END` probing;
+  `own_source` close vs non-owning default; the BytesIO-matching negative-seek clamp.
+- **`ArchiveStream`** (`archive_stream.py`): the lazy-open claim/lock and the "open_fn
+  claimed then failed" path; `_fail` translation ordering (closed-file before the
+  per-library translator); the finalizer/lease release and its interpreter-exit caveat;
+  `size` derivation.
+- **`SharedSource`/CONCURRENT**: how views are minted per handle and whether the
+  single-live-stream / re-seek invariants survive. **This is the main constraint on
+  fusion** (see Part 2).
+
+## Part 2 — Necessity & the collapse hypothesis (the deliverable)
+
+The maintainer's hypothesis to evaluate, accept/refute, or refine:
+
+> Keep an **outer `ArchiveStream`** that carries the extra properties above a plain
+> `BinaryIO` (`size`, cost/rewind, translation, lease). Move **most of the extra
+> wrapping — slicing and verification — into it**, so a member is served by a **single
+> stream** that reads its byte range, decodes, hashes/length-checks, and translates in
+> one `read()`, instead of a 3–4 deep stack.
+
+Evaluate concretely:
+
+- **Per-layer verdict table.** For each layer (member-boundary slice, `fix_stream_start_position`
+  slice, verify, outer, and the decode engine) classify: *fuse into the outer stream* /
+  *keep separate, structural* / *already conditional (skip)*. Justify each against the
+  Part-1 invariants.
+- **What fuses cleanly.** `VerifyingStream` is the strongest candidate: the outer
+  `ArchiveStream` already reads through an inner and owns `size`; folding the hasher +
+  `expected_size` bound into its `read`/`close` removes a whole layer on *every* member.
+  But it's conditional (nested `open_stream`/inner-archive handles and non-FILE members
+  don't verify) — show the fused stream stays correct when there's nothing to verify.
+- **What resists fusion, and why.** Member-boundary slicing entangles with
+  `SharedSource` (multiple concurrent views over one handle, re-seek under lock) and
+  with internal uses (`fix_stream_start_position`, codec body slices) that aren't at
+  the member boundary. Distinguish *member-boundary slicing* (foldable into the
+  per-member outer stream, since that handle is 1:1 with a member) from *shared/internal
+  slicing* (structural — leave it). If CONCURRENT fan-out makes even member-boundary
+  slicing need a separate view, say so and quantify what's left to fuse.
+- **The `readinto` fast path.** A fused single stream can implement one real `readinto`
+  (zero-copy into the caller's buffer) that also hashes/bounds — versus today's
+  `ReadOnlyIOStream.readinto`→`read`→bytes-copy at the verify layer. Estimate that win;
+  it may matter more than the dispatch count.
+- **Decode stays separate.** The `DecompressorStream`/`Decoder` engine and the
+  accelerator/crypto stages are *not* in scope to fold in — they're the settled #96
+  decode layer. The target is the wrapper stack *around* the decoder, not the decoder.
+- **Cost, measured.** Back the recommendation with numbers: per-`read(64K)` dispatch
+  cost across the current stack vs a fused stream, and per-`open()` construction cost
+  (the `ArchiveStream` lock+finalizer+watermark, the `VerifyingStream` hasher setup, the
+  `SlicingStream`) — reuse #134's harness / `--track-io` and add a microbench. Tie the
+  projected win back to the 2.2× / 2.4–3.7× gaps.
+
+## Non-goals
+- Not re-opening the #96 decoder composition or the accelerator internals — those are
+  settled and separately reviewed.
+- Measurement wrappers (`counting.py`) are already identity when measurement is off
+  (`base_reader.py:533`) — not a hot-path cost; don't propose removing them.
+- Not a correctness *bug hunt* beyond the wrappers in scope — but a real bug found in
+  the verify/slice/outer logic is a first-class finding (it also de-risks the fusion).
+- Don't fuse away an invariant to win a benchmark: a smaller stack that verifies less,
+  or breaks CONCURRENT, fails VISION #2/#3 and is not an acceptable trade.
+
+## Deliverable
+Per README. Suggested theme files: `correctness.md` (the per-wrapper audit + the
+invariant list), `layer-map.md` (the full per-backend stack, traced), and
+`collapse-design.md` (the verdict table + a concrete fused-stream design with the
+invariants it preserves, what stays separate and why, and the measured/estimated win).
+The headline the maintainer wants: **can a single stream under the `ArchiveStream`
+identity replace slicing+verification without weakening any Part-1 invariant, and how
+much does it buy?** Give a clear yes/no/partial with the design and the numbers, not a
+menu.


### PR DESCRIPTION
## What this is

Two docs-only review-planning changes on the same branch.

### 1. New in-flight brief — `review/stream-layering/brief.md`

Commissioned after the performance review (**PR #134**) attributed part of the missed ≤1.3× budget (ZIP read-all 2.2×, extract 2.4–3.7×) to the per-member stream wrapper stack. Two coupled questions:

1. **Correctness** — are the slice / verify / outer wrappers and their checks right? (`readinto` side-effect safety, `VerifyingStream`'s clean-EOF / deferred-short / HMAC-drain logic, `SlicingStream`'s single-consumer vs re-seek-under-lock mode, `ArchiveStream`'s lazy-open + finalizer/lease.)
2. **Necessity** — can slicing + verification collapse into a **single stream under the `ArchiveStream` identity** (keeping `size`/cost/translation above a plain `BinaryIO`), cutting the per-`read()` dispatch chain?

Traces the current `SlicingStream → [decode] → VerifyingStream → ArchiveStream` hot path, lists the invariants a fusion must preserve, and separates *member-boundary slicing* (foldable) from *shared/internal slicing* entangled with `SharedSource`/CONCURRENT (structural). Decode engine (#96) + accelerators out of scope. Asks for a verdict + measured win.

### 2. Two more `backlog.md` review ideas

- **Topic 6 — decode-engine performance** (`DecompressorStream`/`Decoder`): the #96/#122 work covered correctness/clarity, not speed; a later perf round, kept separate from the stream-layering wrapper review since they're mostly independent.
- **Topic 7 — outside-in adoption / confidence** (capstone): assess the finished library as an external engineer/company deciding whether to adopt it — what's missing for confidence and peace of mind — with a CPython-stdlib-inclusion high-bar lens. Run only after all other reviews are fully addressed.

The backlog intro is generalized since the deferred set now differs in character and timing.

## Notes

- Docs only — no source or test changes.
- Follow-up to the merged #132; the designated branch was restarted from `main` (force-with-lease) per the fresh-change workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0127YCr1wMVDdGCzsMhNi3pR