### PR TITLE
fix: solid selective decode + cheap perf wins from #134

### DIFF
--- a/review/stream-layering/brief.md
+++ b/review/stream-layering/brief.md
@@ -63,11 +63,11 @@ Composition site: `base_reader._wrap_member_stream` (`base_reader.py:572`) +
 **Concrete double-wrap (fixed on the perf follow-up branch):** the default
 `_lazy_member_stream` used to build an outer `ArchiveStream(lazy=True)` whose
 `open_fn` called `_open_member` → `_wrap_member_stream` (a *second*
-`ArchiveStream`). That nesting is now collapsed via
-`ArchiveStream.release_inner` / `_wrap_member_stream(..., open_fn=...)` — confirm
-the public handle's `_inner` after first read is **not** an `ArchiveStream`, and
-treat any remaining nesting as a regression. Solid sequential paths (7z/RAR)
-build a single wrapper the same way.
+`ArchiveStream`). Nesting is now collapsed inside `ArchiveStream._ensure_open`
+via `_collapse_nested` (steals a still-lazy opener, or an already-opened inner) —
+confirm the public handle's `_inner` after first read is **not** an `ArchiveStream`,
+and treat any remaining nesting as a regression. Solid sequential paths (7z/RAR)
+build a single wrapper directly.
 
 ## Part 1 — Correctness audit (do this first; it defines the invariants a collapse must keep)
 
@@ -94,8 +94,9 @@ overhead. Verify each, with `file:line` and the concrete input/state:
 - **`ArchiveStream`** (`archive_stream.py`): the lazy-open claim/lock and the "open_fn
   claimed then failed" path; `_fail` translation ordering (closed-file before the
   per-library translator); the finalizer/lease release and its interpreter-exit caveat;
-  `size` derivation; `release_inner` (used to flatten a deferred `_open_member` wrap) —
-  confirm close/lease ownership stays on the public handle only.
+  `size` derivation; `_collapse_nested` (flattens a deferred `_open_member` wrap inside
+  `_ensure_open`, stealing a still-lazy opener or an already-opened inner) — confirm
+  close/lease ownership stays on the public handle only.
 - **`SharedSource`/CONCURRENT**: how views are minted per handle and whether the
   single-live-stream / re-seek invariants survive. **This is the main constraint on
   fusion** (see Part 2).

--- a/review/stream-layering/brief.md
+++ b/review/stream-layering/brief.md
@@ -27,6 +27,14 @@ likely dominated by materialization/`zipfile`, not the wrapper stack (streams op
 lazily) — confirm, but the wrapper target is the **read/extract per-chunk and
 per-open** cost.
 
+**Attribution discipline (sharpening from #134):** #134's ZIP read-all profile splits
+the non-zlib time across *several* buckets — `DecompressorStream`'s chunk loop +
+bytearray copy, `VerifyingStream`, nested `ArchiveStream` shims, and CRC itself
+(parity with `zipfile`). This review can only claim wins on the **wrapper** buckets.
+Do **not** project that fusion alone closes the full 2.2× gap. Isolate with a
+**STORED ZIP** microbench (no decode layer) so wrapper overhead is visible without
+zlib/`DecompressorStream` noise; leave decode-engine cost to backlog Topic 6.
+
 ## The current stack (trace and confirm — this is the object of review)
 
 For a ZIP member the handed-out handle is, bottom to top (hot path, measurement off):
@@ -51,6 +59,12 @@ Python `read()` hops, no decompression), and a **deflate member** adds the decod
 Composition site: `base_reader._wrap_member_stream` (`base_reader.py:572`) +
 `zip_reader.py:816` (VerifyingStream) — map the equivalent stack for **every** backend
 (TAR, 7z solid, RAR-via-unrar, ISO, single-file, directory).
+
+**Concrete double-wrap to confirm:** the default `_lazy_member_stream` builds an outer
+`ArchiveStream(lazy=True)` whose `open_fn` calls `_open_member` → `_wrap_member_stream`,
+which builds a *second* `ArchiveStream`. Solid sequential paths (7z/RAR) now use the
+same pattern after the H1 lazy-positioning fix. That nested outer is a first-class
+collapse candidate (construction + per-read dispatch), distinct from fusing verify/slice.
 
 ## Part 1 — Correctness audit (do this first; it defines the invariants a collapse must keep)
 
@@ -77,7 +91,8 @@ overhead. Verify each, with `file:line` and the concrete input/state:
 - **`ArchiveStream`** (`archive_stream.py`): the lazy-open claim/lock and the "open_fn
   claimed then failed" path; `_fail` translation ordering (closed-file before the
   per-library translator); the finalizer/lease release and its interpreter-exit caveat;
-  `size` derivation.
+  `size` derivation; **nested** `ArchiveStream` (lazy outer over already-wrapped inner) —
+  does close/lease/diagnostics watermark behave once or twice, and is that intentional?
 - **`SharedSource`/CONCURRENT**: how views are minted per handle and whether the
   single-live-stream / re-seek invariants survive. **This is the main constraint on
   fusion** (see Part 2).
@@ -95,14 +110,18 @@ The maintainer's hypothesis to evaluate, accept/refute, or refine:
 Evaluate concretely:
 
 - **Per-layer verdict table.** For each layer (member-boundary slice, `fix_stream_start_position`
-  slice, verify, outer, and the decode engine) classify: *fuse into the outer stream* /
-  *keep separate, structural* / *already conditional (skip)*. Justify each against the
-  Part-1 invariants.
+  slice, verify, outer, *and the redundant nested outer from `_lazy_member_stream`*)
+  classify: *fuse into the outer stream* / *keep separate, structural* /
+  *already conditional (skip)* / *construction-only collapse* (same type nested twice).
+  Justify each against the Part-1 invariants. Decode engine stays out of scope
+  (Topic 6) — list it as *keep separate* with a one-line pointer, not a redesign.
 - **What fuses cleanly.** `VerifyingStream` is the strongest candidate: the outer
   `ArchiveStream` already reads through an inner and owns `size`; folding the hasher +
   `expected_size` bound into its `read`/`close` removes a whole layer on *every* member.
   But it's conditional (nested `open_stream`/inner-archive handles and non-FILE members
   don't verify) — show the fused stream stays correct when there's nothing to verify.
+  Separately: collapsing the **double `ArchiveStream`** on the lazy-open path is likely
+  the cheapest win and may not need a full verify/slice fusion — quantify it alone.
 - **What resists fusion, and why.** Member-boundary slicing entangles with
   `SharedSource` (multiple concurrent views over one handle, re-seek under lock) and
   with internal uses (`fix_stream_start_position`, codec body slices) that aren't at
@@ -116,12 +135,20 @@ Evaluate concretely:
   it may matter more than the dispatch count.
 - **Decode stays separate.** The `DecompressorStream`/`Decoder` engine and the
   accelerator/crypto stages are *not* in scope to fold in — they're the settled #96
-  decode layer. The target is the wrapper stack *around* the decoder, not the decoder.
+  decode layer (and Topic 6 for their *speed*). The target is the wrapper stack
+  *around* the decoder, not the decoder. Note #134 already landed a `readall()`
+  join-of-chunks fast path on `DecompressorStream`; don't re-litigate it here.
+- **Irreducible floor.** Before recommending fusion, state what cost *must* remain:
+  at least one Python `read` that updates a hasher + bounds length, plus translate/stamp
+  on errors, plus lease/finalizer on the public handle. If the measured stack is already
+  close to that floor on STORED ZIP, fusion is the wrong lever.
 - **Cost, measured.** Back the recommendation with numbers: per-`read(64K)` dispatch
   cost across the current stack vs a fused stream, and per-`open()` construction cost
   (the `ArchiveStream` lock+finalizer+watermark, the `VerifyingStream` hasher setup, the
   `SlicingStream`) — reuse #134's harness / `--track-io` and add a microbench. Tie the
-  projected win back to the 2.2× / 2.4–3.7× gaps.
+  projected win back to the **wrapper share** of the 2.2× / 2.4–3.7× gaps, not the
+  whole gap. Prefer: STORED vs deflate, and "collapse nested ArchiveStream only" as an
+  incremental measurement before full verify+slice fusion.
 
 ## Non-goals
 - Not re-opening the #96 decoder composition or the accelerator internals — those are
@@ -132,6 +159,8 @@ Evaluate concretely:
   the verify/slice/outer logic is a first-class finding (it also de-risks the fusion).
 - Don't fuse away an invariant to win a benchmark: a smaller stack that verifies less,
   or breaks CONCURRENT, fails VISION #2/#3 and is not an acceptable trade.
+- Not open+list / detection / member-model construction (H3) — out of scope; those are
+  non-stream costs from #134.
 
 ## Deliverable
 Per README. Suggested theme files: `correctness.md` (the per-wrapper audit + the
@@ -141,4 +170,6 @@ invariants it preserves, what stays separate and why, and the measured/estimated
 The headline the maintainer wants: **can a single stream under the `ArchiveStream`
 identity replace slicing+verification without weakening any Part-1 invariant, and how
 much does it buy?** Give a clear yes/no/partial with the design and the numbers, not a
-menu.
+menu. If the answer is "partial," prefer a ranked sequence (e.g. collapse nested
+`ArchiveStream` first; fuse verify next; leave SharedSource slicing) over an options
+list.

--- a/review/stream-layering/brief.md
+++ b/review/stream-layering/brief.md
@@ -64,7 +64,8 @@ Composition site: `base_reader._wrap_member_stream` (`base_reader.py:572`) +
 `_lazy_member_stream` used to build an outer `ArchiveStream(lazy=True)` whose
 `open_fn` called `_open_member` → `_wrap_member_stream` (a *second*
 `ArchiveStream`). Nesting is now collapsed inside `ArchiveStream._ensure_open`
-via `_collapse_nested` (steals a still-lazy opener, or an already-opened inner) —
+via `_collapse_nested` (steals a still-lazy opener, or an already-opened inner, and
+**adopts nested translate/stamp/rewind_warning** so codec errors stay typed) —
 confirm the public handle's `_inner` after first read is **not** an `ArchiveStream`,
 and treat any remaining nesting as a regression. Solid sequential paths (7z/RAR)
 build a single wrapper directly.

--- a/review/stream-layering/brief.md
+++ b/review/stream-layering/brief.md
@@ -60,11 +60,14 @@ Composition site: `base_reader._wrap_member_stream` (`base_reader.py:572`) +
 `zip_reader.py:816` (VerifyingStream) — map the equivalent stack for **every** backend
 (TAR, 7z solid, RAR-via-unrar, ISO, single-file, directory).
 
-**Concrete double-wrap to confirm:** the default `_lazy_member_stream` builds an outer
-`ArchiveStream(lazy=True)` whose `open_fn` calls `_open_member` → `_wrap_member_stream`,
-which builds a *second* `ArchiveStream`. Solid sequential paths (7z/RAR) now use the
-same pattern after the H1 lazy-positioning fix. That nested outer is a first-class
-collapse candidate (construction + per-read dispatch), distinct from fusing verify/slice.
+**Concrete double-wrap (fixed on the perf follow-up branch):** the default
+`_lazy_member_stream` used to build an outer `ArchiveStream(lazy=True)` whose
+`open_fn` called `_open_member` → `_wrap_member_stream` (a *second*
+`ArchiveStream`). That nesting is now collapsed via
+`ArchiveStream.release_inner` / `_wrap_member_stream(..., open_fn=...)` — confirm
+the public handle's `_inner` after first read is **not** an `ArchiveStream`, and
+treat any remaining nesting as a regression. Solid sequential paths (7z/RAR)
+build a single wrapper the same way.
 
 ## Part 1 — Correctness audit (do this first; it defines the invariants a collapse must keep)
 
@@ -91,8 +94,8 @@ overhead. Verify each, with `file:line` and the concrete input/state:
 - **`ArchiveStream`** (`archive_stream.py`): the lazy-open claim/lock and the "open_fn
   claimed then failed" path; `_fail` translation ordering (closed-file before the
   per-library translator); the finalizer/lease release and its interpreter-exit caveat;
-  `size` derivation; **nested** `ArchiveStream` (lazy outer over already-wrapped inner) —
-  does close/lease/diagnostics watermark behave once or twice, and is that intentional?
+  `size` derivation; `release_inner` (used to flatten a deferred `_open_member` wrap) —
+  confirm close/lease ownership stays on the public handle only.
 - **`SharedSource`/CONCURRENT**: how views are minted per handle and whether the
   single-live-stream / re-seek invariants survive. **This is the main constraint on
   fusion** (see Part 2).
@@ -110,18 +113,17 @@ The maintainer's hypothesis to evaluate, accept/refute, or refine:
 Evaluate concretely:
 
 - **Per-layer verdict table.** For each layer (member-boundary slice, `fix_stream_start_position`
-  slice, verify, outer, *and the redundant nested outer from `_lazy_member_stream`*)
-  classify: *fuse into the outer stream* / *keep separate, structural* /
-  *already conditional (skip)* / *construction-only collapse* (same type nested twice).
-  Justify each against the Part-1 invariants. Decode engine stays out of scope
-  (Topic 6) — list it as *keep separate* with a one-line pointer, not a redesign.
-- **What fuses cleanly.** `VerifyingStream` is the strongest candidate: the outer
-  `ArchiveStream` already reads through an inner and owns `size`; folding the hasher +
-  `expected_size` bound into its `read`/`close` removes a whole layer on *every* member.
-  But it's conditional (nested `open_stream`/inner-archive handles and non-FILE members
-  don't verify) — show the fused stream stays correct when there's nothing to verify.
-  Separately: collapsing the **double `ArchiveStream`** on the lazy-open path is likely
-  the cheapest win and may not need a full verify/slice fusion — quantify it alone.
+  slice, verify, outer) classify: *fuse into the outer stream* / *keep separate,
+  structural* / *already conditional (skip)*. The redundant nested outer from
+  `_lazy_member_stream` is **already collapsed** (confirm; do not re-propose). Justify
+  each against the Part-1 invariants. Decode engine stays out of scope (Topic 6) —
+  list it as *keep separate* with a one-line pointer, not a redesign.
+- **What fuses cleanly.** `VerifyingStream` is the strongest remaining candidate: the
+  outer `ArchiveStream` already reads through an inner and owns `size`; folding the
+  hasher + `expected_size` bound into its `read`/`close` removes a whole layer on
+  *every* member. But it's conditional (nested `open_stream`/inner-archive handles and
+  non-FILE members don't verify) — show the fused stream stays correct when there's
+  nothing to verify.
 - **What resists fusion, and why.** Member-boundary slicing entangles with
   `SharedSource` (multiple concurrent views over one handle, re-seek under lock) and
   with internal uses (`fix_stream_start_position`, codec body slices) that aren't at
@@ -147,8 +149,8 @@ Evaluate concretely:
   (the `ArchiveStream` lock+finalizer+watermark, the `VerifyingStream` hasher setup, the
   `SlicingStream`) — reuse #134's harness / `--track-io` and add a microbench. Tie the
   projected win back to the **wrapper share** of the 2.2× / 2.4–3.7× gaps, not the
-  whole gap. Prefer: STORED vs deflate, and "collapse nested ArchiveStream only" as an
-  incremental measurement before full verify+slice fusion.
+  whole gap. Prefer: STORED vs deflate as the isolation axis (nested `ArchiveStream`
+  is already gone).
 
 ## Non-goals
 - Not re-opening the #96 decoder composition or the accelerator internals — those are
@@ -170,6 +172,5 @@ invariants it preserves, what stays separate and why, and the measured/estimated
 The headline the maintainer wants: **can a single stream under the `ArchiveStream`
 identity replace slicing+verification without weakening any Part-1 invariant, and how
 much does it buy?** Give a clear yes/no/partial with the design and the numbers, not a
-menu. If the answer is "partial," prefer a ranked sequence (e.g. collapse nested
-`ArchiveStream` first; fuse verify next; leave SharedSource slicing) over an options
-list.
+menu. If the answer is "partial," prefer a ranked sequence (e.g. fuse verify next;
+leave SharedSource slicing) over an options list.

--- a/src/archivey/internal/backends/rar_reader.py
+++ b/src/archivey/internal/backends/rar_reader.py
@@ -15,6 +15,7 @@ from archivey.config import ArchiveyConfig
 from archivey.cost import AccessCost, CostReceipt, ListingCost, StreamCapability
 from archivey.diagnostics import DiagnosticCode, DigestContext
 from archivey.exceptions import (
+    ArchiveyError,
     CorruptionError,
     EncryptionError,
     StreamNotSeekableError,
@@ -597,23 +598,17 @@ class RarReader(BaseArchiveReader):
                     continue
                 size = _member_stream_size(member)
                 # Capture the pipe offset for this member, then advance the running
-                # cursor. open_member itself is deferred to first read so an
-                # unselected/unread member does not skip-decode its predecessors
-                # (same laziness contract as SevenZipReader._member_stream_from_solid).
+                # cursor. ``lazy=True`` defers skip-decode until first read; verify
+                # wrap stays inside open_fn so VerifyingStream.close cannot probe an
+                # unselected handle into a solid open.
                 member_offset = pipe_offset
                 pipe_offset += size
+                lazy_solid = solid.open_member(member_offset, size, lazy=True)
 
                 def open_fn(
-                    offset: int = member_offset,
-                    member_size: int = size,
+                    inner: BinaryIO = lazy_solid,
                     m: ArchiveMember = member,
                 ) -> BinaryIO:
-                    try:
-                        inner = solid.open_member(offset, member_size)
-                    except EOFError as exc:
-                        raise TruncatedError(
-                            "RAR solid stream ended before the requested member"
-                        ) from exc
                     return self._prepare_payload_stream(inner, m)
 
                 stream = self._wrap_member_stream(
@@ -631,6 +626,11 @@ class RarReader(BaseArchiveReader):
                 previous.close()
             solid.close()
             self._live_unrar = None
+
+    def _translate_exception(self, exc: Exception) -> ArchiveyError | None:
+        if isinstance(exc, EOFError):
+            return TruncatedError("RAR solid stream ended before the requested member")
+        return None
 
     def _tweaked_verify_spec(
         self, info: RarMemberInfo

--- a/src/archivey/internal/backends/rar_reader.py
+++ b/src/archivey/internal/backends/rar_reader.py
@@ -596,14 +596,35 @@ class RarReader(BaseArchiveReader):
                     yield member, None
                     continue
                 size = _member_stream_size(member)
-                try:
-                    inner = solid.open_member(pipe_offset, size)
-                except EOFError as exc:
-                    raise TruncatedError(
-                        "RAR solid stream ended before the requested member"
-                    ) from exc
+                # Capture the pipe offset for this member, then advance the running
+                # cursor. open_member itself is deferred to first read so an
+                # unselected/unread member does not skip-decode its predecessors
+                # (same laziness contract as SevenZipReader._member_stream_from_solid).
+                member_offset = pipe_offset
                 pipe_offset += size
-                stream = self._wrap_payload_stream(inner, member, track_output=False)
+
+                def open_fn(
+                    offset: int = member_offset,
+                    member_size: int = size,
+                    m: ArchiveMember = member,
+                ) -> BinaryIO:
+                    try:
+                        inner = solid.open_member(offset, member_size)
+                    except EOFError as exc:
+                        raise TruncatedError(
+                            "RAR solid stream ended before the requested member"
+                        ) from exc
+                    return self._wrap_payload_stream(inner, m, track_output=False)
+
+                stream = ArchiveStream(
+                    open_fn,
+                    translate=self._translate_exception,
+                    stamp=lambda exc, m=member: self._stamp_error_context(exc, m.name),
+                    lazy=True,
+                    seekable=False,
+                    size=member.size,
+                    collector=self._diagnostics_collector,
+                )
                 previous = stream
                 yield member, stream
         finally:

--- a/src/archivey/internal/backends/rar_reader.py
+++ b/src/archivey/internal/backends/rar_reader.py
@@ -614,16 +614,15 @@ class RarReader(BaseArchiveReader):
                         raise TruncatedError(
                             "RAR solid stream ended before the requested member"
                         ) from exc
-                    return self._wrap_payload_stream(inner, m, track_output=False)
+                    return self._prepare_payload_stream(inner, m)
 
-                stream = ArchiveStream(
-                    open_fn,
-                    translate=self._translate_exception,
-                    stamp=lambda exc, m=member: self._stamp_error_context(exc, m.name),
-                    lazy=True,
-                    seekable=False,
+                stream = self._wrap_member_stream(
+                    None,
+                    member.name,
+                    open_fn=open_fn,
                     size=member.size,
-                    collector=self._diagnostics_collector,
+                    track_output=False,
+                    seekable=False,
                 )
                 previous = stream
                 yield member, stream
@@ -668,13 +667,12 @@ class RarReader(BaseArchiveReader):
             return None
         return expected, transforms
 
-    def _wrap_payload_stream(
+    def _prepare_payload_stream(
         self,
         inner: BinaryIO,
         member: ArchiveMember,
-        *,
-        track_output: bool = True,
-    ) -> ArchiveStream:
+    ) -> BinaryIO:
+        """Verify + size-bound a RAR payload view (no ``ArchiveStream`` yet)."""
         # Verify every member's declared length (and any CRC32/BLAKE2sp) as it is read:
         # an over-long external decode stops at the declared size and errors, a short one
         # raises, and a wrong one fails its digest. Applied to all members (not just
@@ -701,8 +699,20 @@ class RarReader(BaseArchiveReader):
                 archive_name=self._archive_name,
                 digest_transforms=transforms,
             )
+        return inner
+
+    def _wrap_payload_stream(
+        self,
+        inner: BinaryIO,
+        member: ArchiveMember,
+        *,
+        track_output: bool = True,
+    ) -> ArchiveStream:
         return self._wrap_member_stream(
-            inner, member.name, size=member.size, track_output=track_output
+            self._prepare_payload_stream(inner, member),
+            member.name,
+            size=member.size,
+            track_output=track_output,
         )
 
     def _can_direct_read(self, info: RarMemberInfo) -> bool:

--- a/src/archivey/internal/backends/sevenzip_reader.py
+++ b/src/archivey/internal/backends/sevenzip_reader.py
@@ -615,28 +615,18 @@ class SevenZipReader(BaseArchiveReader):
     def _member_stream_from_solid(
         self, solid: SolidBlockReader, member: ArchiveMember
     ) -> ArchiveStream:
-        """Hand out a lazy stream; ``solid.open_member`` runs on first read.
+        """Hand out a stream whose solid positioning runs on first read.
 
-        Positioning at yield time would skip-decode every preceding unread member as
-        the iterator advances — breaking the ``stream_members`` laziness contract
-        (unselected/unread members must not be decompressed) and making selective
-        extraction of one early solid member decode ~the whole folder. ``SolidBlockReader``
-        already skips unread tails lazily when the *next* member is opened; deferring
-        that open to first-read time is what makes skipped members free.
-
-        Single ``ArchiveStream``: ``open_fn`` returns the prepared BinaryIO (verify
-        only), not another wrapper.
+        Uses ``solid.open_member(..., lazy=True)`` so an unselected handle can be
+        closed without skip-decoding. Verification is applied in ``open_fn`` (not at
+        yield time): ``VerifyingStream.close`` probes with ``read(1)``, which would
+        otherwise force the lazy solid open on every skipped member.
         """
         prefix = self._member_prefix(member)
         size = _member_stream_size(member)
+        lazy_solid = solid.open_member(prefix, size, lazy=True)
 
-        def open_fn() -> BinaryIO:
-            try:
-                inner = solid.open_member(prefix, size)
-            except EOFError as exc:
-                raise TruncatedError(
-                    "7z folder ended before the requested member"
-                ) from exc
+        def open_fn(inner: BinaryIO = lazy_solid) -> BinaryIO:
             return self._prepare_folder_member(inner, member)
 
         return self._wrap_member_stream(
@@ -647,6 +637,11 @@ class SevenZipReader(BaseArchiveReader):
             track_output=False,
             seekable=False,
         )
+
+    def _translate_exception(self, exc: Exception) -> ArchiveyError | None:
+        if isinstance(exc, EOFError):
+            return TruncatedError("7z folder ended before the requested member")
+        return None
 
     def _ensure_link_target(self, member: ArchiveMember) -> None:
         if member.type != MemberType.SYMLINK or member.link_target is not None:

--- a/src/archivey/internal/backends/sevenzip_reader.py
+++ b/src/archivey/internal/backends/sevenzip_reader.py
@@ -590,6 +590,17 @@ class SevenZipReader(BaseArchiveReader):
     def _wrap_folder_member(
         self, inner: BinaryIO, member: ArchiveMember
     ) -> ArchiveStream:
+        return self._wrap_member_stream(
+            self._prepare_folder_member(inner, member),
+            member.name,
+            size=member.size,
+            track_output=False,
+        )
+
+    def _prepare_folder_member(
+        self, inner: BinaryIO, member: ArchiveMember
+    ) -> BinaryIO:
+        """Verify + size-bound a solid-folder member view (no ``ArchiveStream`` yet)."""
         if member.size is not None or member.hashes:
             inner = VerifyingStream(
                 inner,
@@ -599,9 +610,7 @@ class SevenZipReader(BaseArchiveReader):
                 member=member,
                 archive_name=self._archive_name,
             )
-        return self._wrap_member_stream(
-            inner, member.name, size=member.size, track_output=False
-        )
+        return inner
 
     def _member_stream_from_solid(
         self, solid: SolidBlockReader, member: ArchiveMember
@@ -614,6 +623,9 @@ class SevenZipReader(BaseArchiveReader):
         extraction of one early solid member decode ~the whole folder. ``SolidBlockReader``
         already skips unread tails lazily when the *next* member is opened; deferring
         that open to first-read time is what makes skipped members free.
+
+        Single ``ArchiveStream``: ``open_fn`` returns the prepared BinaryIO (verify
+        only), not another wrapper.
         """
         prefix = self._member_prefix(member)
         size = _member_stream_size(member)
@@ -625,16 +637,15 @@ class SevenZipReader(BaseArchiveReader):
                 raise TruncatedError(
                     "7z folder ended before the requested member"
                 ) from exc
-            return self._wrap_folder_member(inner, member)
+            return self._prepare_folder_member(inner, member)
 
-        return ArchiveStream(
-            open_fn,
-            translate=self._translate_exception,
-            stamp=lambda exc: self._stamp_error_context(exc, member.name),
-            lazy=True,
-            seekable=False,
+        return self._wrap_member_stream(
+            None,
+            member.name,
+            open_fn=open_fn,
             size=member.size,
-            collector=self._diagnostics_collector,
+            track_output=False,
+            seekable=False,
         )
 
     def _ensure_link_target(self, member: ArchiveMember) -> None:

--- a/src/archivey/internal/backends/sevenzip_reader.py
+++ b/src/archivey/internal/backends/sevenzip_reader.py
@@ -606,13 +606,36 @@ class SevenZipReader(BaseArchiveReader):
     def _member_stream_from_solid(
         self, solid: SolidBlockReader, member: ArchiveMember
     ) -> ArchiveStream:
-        try:
-            inner = solid.open_member(
-                self._member_prefix(member), _member_stream_size(member)
-            )
-        except EOFError as exc:
-            raise TruncatedError("7z folder ended before the requested member") from exc
-        return self._wrap_folder_member(inner, member)
+        """Hand out a lazy stream; ``solid.open_member`` runs on first read.
+
+        Positioning at yield time would skip-decode every preceding unread member as
+        the iterator advances — breaking the ``stream_members`` laziness contract
+        (unselected/unread members must not be decompressed) and making selective
+        extraction of one early solid member decode ~the whole folder. ``SolidBlockReader``
+        already skips unread tails lazily when the *next* member is opened; deferring
+        that open to first-read time is what makes skipped members free.
+        """
+        prefix = self._member_prefix(member)
+        size = _member_stream_size(member)
+
+        def open_fn() -> BinaryIO:
+            try:
+                inner = solid.open_member(prefix, size)
+            except EOFError as exc:
+                raise TruncatedError(
+                    "7z folder ended before the requested member"
+                ) from exc
+            return self._wrap_folder_member(inner, member)
+
+        return ArchiveStream(
+            open_fn,
+            translate=self._translate_exception,
+            stamp=lambda exc: self._stamp_error_context(exc, member.name),
+            lazy=True,
+            seekable=False,
+            size=member.size,
+            collector=self._diagnostics_collector,
+        )
 
     def _ensure_link_target(self, member: ArchiveMember) -> None:
         if member.type != MemberType.SYMLINK or member.link_target is not None:

--- a/src/archivey/internal/base_reader.py
+++ b/src/archivey/internal/base_reader.py
@@ -462,20 +462,22 @@ class BaseArchiveReader(ArchiveReader):
         """A stream over ``member``'s data that defers ``_open_member`` to the first read.
 
         Closing it before any read never opens the member at all. ``_open_member``
-        already translates and stamps its own errors, and ``ArchiveStream`` passes an
-        ``ArchiveyError`` through (re-stamping is a no-op), so deferral does not change
-        what a failed open raises — only when.
+        already returns an ``ArchiveStream``; we flatten it via
+        :meth:`ArchiveStream.release_inner` so the public handle is a **single**
+        wrapper (not ``ArchiveStream`` over ``ArchiveStream``). Deferral does not
+        change what a failed open raises — only when.
         """
-        stream = ArchiveStream(
-            lambda: self._open_member(member),
-            translate=self._translate_exception,
-            stamp=lambda exc: self._stamp_error_context(exc, member.name),
-            lazy=True,
-            seekable=self._seek_declared(),
-            size=member.size,
-            collector=self._diagnostics_collector,
+        return self._register_public_stream(
+            self._wrap_member_stream(
+                None,
+                member.name,
+                open_fn=lambda: self._open_member(member),
+                size=member.size,
+                # ``_open_member`` already applied output tracking inside its wrap.
+                track_output=False,
+                seekable=self._seek_declared(),
+            )
         )
-        return self._register_public_stream(stream)
 
     @abstractmethod
     def _open_member(self, member: ArchiveMember) -> ArchiveStream:
@@ -571,12 +573,14 @@ class BaseArchiveReader(ArchiveReader):
 
     def _wrap_member_stream(
         self,
-        inner: BinaryIO,
+        inner: BinaryIO | None,
         member_name: str | None,
         *,
+        open_fn: Callable[[], BinaryIO] | None = None,
         lazy: bool = False,
         size: int | None = None,
         track_output: bool = True,
+        seekable: bool | None = None,
     ) -> ArchiveStream:
         """Wrap a raw member stream so read/seek errors route through the backend's
         translator and are stamped with format/archive/member context.
@@ -586,14 +590,48 @@ class BaseArchiveReader(ArchiveReader):
         than a raw codec exception, and so the handle advertises its decompressed length
         (the fsspec-style ``size``) for cheap nested-archive source sizing.
 
+        Pass ``open_fn`` (and ``inner=None``) for a lazy open — one ``ArchiveStream``,
+        opened on first read. If ``open_fn`` returns an ``ArchiveStream`` (e.g. from
+        ``_open_member``), it is flattened via :meth:`ArchiveStream.release_inner` so
+        callers never see a nested wrapper.
+
         Seekability is gated by ``MemberStreams.SEEKABLE``: without it the wrapper reports
-        non-seekable even when ``inner`` could seek.
+        non-seekable even when ``inner`` could seek. Pass ``seekable=`` to override the
+        default (eager: declared ∧ ``is_seekable(inner)``; lazy: declared).
 
         When measurement is on and ``track_output`` is true (the default), decoded bytes
         delivered through this handle are added to :attr:`bytes_decompressed`. Solid
         backends that already count at the folder/block decode layer pass
         ``track_output=False`` to avoid double-counting.
         """
+        if (inner is None) == (open_fn is None):
+            raise TypeError("exactly one of inner or open_fn is required")
+
+        if open_fn is not None:
+
+            def tracked_open(
+                raw_open: Callable[[], BinaryIO] = open_fn,
+            ) -> BinaryIO:
+                raw = raw_open()
+                if isinstance(raw, ArchiveStream):
+                    # Collapse ArchiveStream-over-ArchiveStream from deferred
+                    # ``_open_member`` (and any similar nested wrap).
+                    raw = raw.release_inner()
+                if track_output:
+                    raw = self._track_decompressed(raw)
+                return raw
+
+            return ArchiveStream(
+                tracked_open,
+                translate=self._translate_exception,
+                stamp=lambda exc: self._stamp_error_context(exc, member_name),
+                lazy=True,
+                seekable=(self._seek_declared() if seekable is None else seekable),
+                size=size,
+                collector=self._diagnostics_collector,
+            )
+
+        assert inner is not None
         if track_output:
             inner = self._track_decompressed(inner)
         return ArchiveStream(
@@ -601,7 +639,11 @@ class BaseArchiveReader(ArchiveReader):
             translate=self._translate_exception,
             stamp=lambda exc: self._stamp_error_context(exc, member_name),
             lazy=lazy,
-            seekable=self._seek_declared() and is_seekable(inner),
+            seekable=(
+                self._seek_declared() and is_seekable(inner)
+                if seekable is None
+                else seekable
+            ),
             size=size,
             collector=self._diagnostics_collector,
         )

--- a/src/archivey/internal/base_reader.py
+++ b/src/archivey/internal/base_reader.py
@@ -462,10 +462,9 @@ class BaseArchiveReader(ArchiveReader):
         """A stream over ``member``'s data that defers ``_open_member`` to the first read.
 
         Closing it before any read never opens the member at all. ``_open_member``
-        already returns an ``ArchiveStream``; we flatten it via
-        :meth:`ArchiveStream.release_inner` so the public handle is a **single**
-        wrapper (not ``ArchiveStream`` over ``ArchiveStream``). Deferral does not
-        change what a failed open raises — only when.
+        already returns an ``ArchiveStream``; nesting is collapsed inside
+        :meth:`ArchiveStream._ensure_open` so the public handle is a **single**
+        wrapper. Deferral does not change what a failed open raises — only when.
         """
         return self._register_public_stream(
             self._wrap_member_stream(
@@ -592,8 +591,8 @@ class BaseArchiveReader(ArchiveReader):
 
         Pass ``open_fn`` (and ``inner=None``) for a lazy open — one ``ArchiveStream``,
         opened on first read. If ``open_fn`` returns an ``ArchiveStream`` (e.g. from
-        ``_open_member``), it is flattened via :meth:`ArchiveStream.release_inner` so
-        callers never see a nested wrapper.
+        ``_open_member``), :meth:`ArchiveStream._ensure_open` collapses the nesting
+        automatically so callers never see a double wrapper.
 
         Seekability is gated by ``MemberStreams.SEEKABLE``: without it the wrapper reports
         non-seekable even when ``inner`` could seek. Pass ``seekable=`` to override the
@@ -602,27 +601,30 @@ class BaseArchiveReader(ArchiveReader):
         When measurement is on and ``track_output`` is true (the default), decoded bytes
         delivered through this handle are added to :attr:`bytes_decompressed`. Solid
         backends that already count at the folder/block decode layer pass
-        ``track_output=False`` to avoid double-counting.
+        ``track_output=False`` to avoid double-counting. When ``open_fn`` may return an
+        ``ArchiveStream``, pass ``track_output=False`` (counting belongs on that inner
+        wrap); collapse happens in ``_ensure_open``.
         """
         if (inner is None) == (open_fn is None):
             raise TypeError("exactly one of inner or open_fn is required")
 
         if open_fn is not None:
+            if track_output:
 
-            def tracked_open(
-                raw_open: Callable[[], BinaryIO] = open_fn,
-            ) -> BinaryIO:
-                raw = raw_open()
-                if isinstance(raw, ArchiveStream):
-                    # Collapse ArchiveStream-over-ArchiveStream from deferred
-                    # ``_open_member`` (and any similar nested wrap).
-                    raw = raw.release_inner()
-                if track_output:
-                    raw = self._track_decompressed(raw)
-                return raw
+                def tracked_open(
+                    raw_open: Callable[[], BinaryIO] = open_fn,
+                ) -> BinaryIO:
+                    # open_fn should return a bytes stream when tracking here; nested
+                    # ArchiveStream collapse is handled in ArchiveStream._ensure_open
+                    # (use track_output=False when open_fn returns ArchiveStream).
+                    return self._track_decompressed(raw_open())
+
+                use_open: Callable[[], BinaryIO] = tracked_open
+            else:
+                use_open = open_fn
 
             return ArchiveStream(
-                tracked_open,
+                use_open,
                 translate=self._translate_exception,
                 stamp=lambda exc: self._stamp_error_context(exc, member_name),
                 lazy=True,

--- a/src/archivey/internal/extraction.py
+++ b/src/archivey/internal/extraction.py
@@ -336,6 +336,16 @@ class ExtractionCoordinator:
         collision_map: dict[str, Path] = {}
         orphans: list[_Orphan] = []
         members_done = 0
+        # Explicit selection with a free member list: once every selected member has
+        # been seen, stop the forward pass. Solid backends otherwise keep walking the
+        # rest of the archive (and would skip-decode unread tails if positioning were
+        # eager). Predicate selectors and streaming backends have no finite remaining
+        # count, so they still drain.
+        selected_total = (
+            members_total
+            if selector is not None and members_total is not None
+            else None
+        )
 
         for original, stream in reader.stream_members(stream_selector):
             member_started = False
@@ -478,6 +488,8 @@ class ExtractionCoordinator:
                 members_total,
                 member_bytes_written=(tracker.member_bytes if member_started else 0),
             )
+            if selected_total is not None and members_done >= selected_total:
+                break
 
         # Core second pass: resolve orphaned hardlinks whose (re-readable) source was
         # excluded. Only populated for a seekable source; forward-only orphans already

--- a/src/archivey/internal/registry.py
+++ b/src/archivey/internal/registry.py
@@ -108,12 +108,14 @@ class BackendRegistry:
         self._writers: dict[ArchiveFormat, type[WriteBackend]] = {}
         # Unique reader classes in registration order (a class may serve several formats).
         self._reader_classes: list[type[ReadBackend]] = []
+        self._extension_map_cache: dict[str, ArchiveFormat] | None = None
 
     def register_reader(self, backend_cls: type[ReadBackend]) -> None:
         if backend_cls not in self._reader_classes:
             self._reader_classes.append(backend_cls)
         for fmt in backend_cls.FORMATS:
             self._readers[fmt] = backend_cls
+        self._extension_map_cache = None
 
     def register_writer(self, backend_cls: type[WriteBackend]) -> None:
         for fmt in backend_cls.FORMATS:
@@ -150,7 +152,14 @@ class BackendRegistry:
         return probes
 
     def extension_map(self) -> dict[str, ArchiveFormat]:
-        """The merged ``extension -> format`` map across backends and the stream codecs."""
+        """The merged ``extension -> format`` map across backends and the stream codecs.
+
+        Cached after first build: registration is import-time (and rare in tests), while
+        ``open_archive`` looks the map up on every call. Invalidated on ``register_reader``.
+        """
+        cached = self._extension_map_cache
+        if cached is not None:
+            return cached
         merged: dict[str, ArchiveFormat] = {}
         for cls in self._reader_classes:
             merged.update(cls.EXTENSIONS)
@@ -158,6 +167,7 @@ class BackendRegistry:
             if codec.single_file_format is not None:
                 for ext in codec.extensions:
                     merged[ext] = codec.single_file_format
+        self._extension_map_cache = merged
         return merged
 
     # --- availability --------------------------------------------------------------------

--- a/src/archivey/internal/streams/archive_stream.py
+++ b/src/archivey/internal/streams/archive_stream.py
@@ -214,7 +214,12 @@ class ArchiveStream(ReadOnlyIOStream):
             open_fn = self._open_fn
             self._open_fn = None  # claim: only one caller proceeds to open_fn
         try:
-            opened = open_fn()
+            opened: BinaryIO = open_fn()
+            # Lazy ``stream_members`` open_fn often returns another ``ArchiveStream``
+            # (from ``_open_member`` → ``_wrap_member_stream``). Collapse here so the
+            # public handle is a single wrapper; callers need not know about nesting.
+            while isinstance(opened, ArchiveStream):
+                opened = ArchiveStream._collapse_nested(opened)
         except Exception as e:  # noqa: BLE001 - re-raised via the translator
             # _open_fn stays None (claimed above) so a retry raises rather than
             # re-entering a half-open backend.
@@ -229,25 +234,37 @@ class ArchiveStream(ReadOnlyIOStream):
             self._inner = opened
             return self._inner
 
-    def release_inner(self) -> BinaryIO:
-        """Hand off the opened inner stream and neutralize this wrapper.
+    @staticmethod
+    def _collapse_nested(nested: ArchiveStream) -> BinaryIO:
+        """Reduce a nested ``ArchiveStream`` to a bytes stream for the outer handle.
 
-        Used to collapse nested ``ArchiveStream`` wrapping (a lazy outer whose
-        ``open_fn`` calls a path that already returns ``ArchiveStream``): the caller
-        takes ownership of the bytes stream; closing this wrapper will not close it.
-        Translate/stamp on the outer handle remain the public contract.
+        If ``nested`` is still lazy, its opener is taken and invoked (the outer is
+        opening *now*, so deferral transfers rather than being forced early by a
+        separate ``release_inner`` call). If it is already open, its inner is stolen.
+        Either way the nested wrapper is neutralized and will not close the result.
         """
-        if self.closed:
+        if nested.closed:
             raise ValueError("I/O operation on closed file.")
-        inner = self._ensure_open()
-        with self._open_lock:
-            self._inner = None
-            self._open_fn = None
-        self._detach_finalizer()
-        self._on_close = None
-        # Mark closed without touching ``inner`` (``close`` would otherwise close it).
-        super().close()
-        return inner
+        with nested._open_lock:
+            open_fn = nested._open_fn
+            inner = nested._inner
+            nested._open_fn = None
+            nested._inner = None
+        nested._detach_finalizer()
+        nested._on_close = None
+        # Mark closed without touching stolen opener/inner.
+        super(ArchiveStream, nested).close()
+
+        if inner is not None:
+            return inner
+        if open_fn is not None:
+            opened = open_fn()
+            while isinstance(opened, ArchiveStream):
+                opened = ArchiveStream._collapse_nested(opened)
+            return opened
+        raise ArchiveyUsageError(
+            "Cannot collapse nested ArchiveStream: it has no opener and no inner stream."
+        )
 
     def _fail(self, e: Exception) -> NoReturn:
         """Translate + stamp ``e`` and raise, or re-raise it unchanged."""

--- a/src/archivey/internal/streams/archive_stream.py
+++ b/src/archivey/internal/streams/archive_stream.py
@@ -216,10 +216,11 @@ class ArchiveStream(ReadOnlyIOStream):
         try:
             opened: BinaryIO = open_fn()
             # Lazy ``stream_members`` open_fn often returns another ``ArchiveStream``
-            # (from ``_open_member`` → ``_wrap_member_stream``). Collapse here so the
-            # public handle is a single wrapper; callers need not know about nesting.
+            # (from ``_open_member`` → ``_wrap_member_stream``, or a codec stream under
+            # that). Collapse here so the public handle is a single wrapper — but adopt
+            # the nested translator/stamp/rewind_warning so codec errors stay typed.
             while isinstance(opened, ArchiveStream):
-                opened = ArchiveStream._collapse_nested(opened)
+                opened = self._collapse_nested(opened)
         except Exception as e:  # noqa: BLE001 - re-raised via the translator
             # _open_fn stays None (claimed above) so a retry raises rather than
             # re-entering a half-open backend.
@@ -234,17 +235,42 @@ class ArchiveStream(ReadOnlyIOStream):
             self._inner = opened
             return self._inner
 
-    @staticmethod
-    def _collapse_nested(nested: ArchiveStream) -> BinaryIO:
-        """Reduce a nested ``ArchiveStream`` to a bytes stream for the outer handle.
+    def _collapse_nested(self, nested: ArchiveStream) -> BinaryIO:
+        """Reduce a nested ``ArchiveStream`` to a bytes stream for this handle.
 
-        If ``nested`` is still lazy, its opener is taken and invoked (the outer is
-        opening *now*, so deferral transfers rather than being forced early by a
-        separate ``release_inner`` call). If it is already open, its inner is stolen.
-        Either way the nested wrapper is neutralized and will not close the result.
+        If ``nested`` is still lazy, its opener is taken and invoked (this handle is
+        opening *now*, so deferral transfers rather than being forced early). If it is
+        already open, its inner is stolen. Either way the nested wrapper is neutralized
+        and will not close the result.
+
+        Codec streams (``open_codec_stream``) carry a library-specific translator;
+        member wrappers often wrap those again. Adopting nested ``translate`` /
+        ``stamp`` / ``rewind_warning`` keeps BadGzipFile / zlib.error / etc. typed
+        after the collapse.
         """
         if nested.closed:
             raise ValueError("I/O operation on closed file.")
+
+        nested_translate = nested._translate
+        nested_stamp = nested._stamp
+        outer_translate = self._translate
+        outer_stamp = self._stamp
+
+        def composed_translate(exc: Exception) -> ArchiveyError | None:
+            translated = nested_translate(exc)
+            if translated is not None:
+                return translated
+            return outer_translate(exc)
+
+        def composed_stamp(err: ArchiveyError) -> None:
+            nested_stamp(err)
+            outer_stamp(err)
+
+        self._translate = composed_translate
+        self._stamp = composed_stamp
+        if self._rewind_warning is None and nested._rewind_warning is not None:
+            self._rewind_warning = nested._rewind_warning
+
         with nested._open_lock:
             open_fn = nested._open_fn
             inner = nested._inner
@@ -260,7 +286,7 @@ class ArchiveStream(ReadOnlyIOStream):
         if open_fn is not None:
             opened = open_fn()
             while isinstance(opened, ArchiveStream):
-                opened = ArchiveStream._collapse_nested(opened)
+                opened = self._collapse_nested(opened)
             return opened
         raise ArchiveyUsageError(
             "Cannot collapse nested ArchiveStream: it has no opener and no inner stream."

--- a/src/archivey/internal/streams/archive_stream.py
+++ b/src/archivey/internal/streams/archive_stream.py
@@ -229,6 +229,26 @@ class ArchiveStream(ReadOnlyIOStream):
             self._inner = opened
             return self._inner
 
+    def release_inner(self) -> BinaryIO:
+        """Hand off the opened inner stream and neutralize this wrapper.
+
+        Used to collapse nested ``ArchiveStream`` wrapping (a lazy outer whose
+        ``open_fn`` calls a path that already returns ``ArchiveStream``): the caller
+        takes ownership of the bytes stream; closing this wrapper will not close it.
+        Translate/stamp on the outer handle remain the public contract.
+        """
+        if self.closed:
+            raise ValueError("I/O operation on closed file.")
+        inner = self._ensure_open()
+        with self._open_lock:
+            self._inner = None
+            self._open_fn = None
+        self._detach_finalizer()
+        self._on_close = None
+        # Mark closed without touching ``inner`` (``close`` would otherwise close it).
+        super().close()
+        return inner
+
     def _fail(self, e: Exception) -> NoReturn:
         """Translate + stamp ``e`` and raise, or re-raise it unchanged."""
         if isinstance(e, ArchiveyError):

--- a/src/archivey/internal/streams/decompressor_stream.py
+++ b/src/archivey/internal/streams/decompressor_stream.py
@@ -339,10 +339,18 @@ class DecompressorStream(ReadOnlyIOStream):
         return self._ingest_decode(self._decoder.feed(chunk, max_length))
 
     def readall(self) -> bytes:
+        # Prefer join-of-chunks over staging through the shared bytearray: a whole-stream
+        # read never needs the partial-read buffer, and the extend + bytes(buffer) copy
+        # was a measurable share of ZIP read-all overhead (perf review H2).
+        chunks: list[bytes] = []
+        if self._buffer:
+            chunks.append(bytes(self._buffer))
+            self._buffer.clear()
         while not self._eof:
-            self._buffer.extend(self._read_decompressed_chunk())
-        data = bytes(self._buffer)
-        self._buffer.clear()
+            chunk = self._read_decompressed_chunk()
+            if chunk:
+                chunks.append(chunk)
+        data = b"".join(chunks)
         if self._size is None or self._pos <= self._size:
             self._pos += len(data)
             self._size = self._pos

--- a/src/archivey/internal/streams/streamtools/solid.py
+++ b/src/archivey/internal/streams/streamtools/solid.py
@@ -8,11 +8,11 @@ member's unread tail, or an inter-member gap) is consumed only when the *next* m
 opened, so closing a member the caller never advances past costs nothing. Closing the
 reader closes the block without draining.
 
-``open_member(..., lazy=True)`` defers that open (and its skip-decode) until the first
-read on the returned handle — so an iterator that yields then closes an unselected
-member pays nothing. This is the sequential/iteration primitive. Random access into a
-solid block is served differently (a seekable slice over a seekable decode), so this
-class is deliberately forward-only and does not seek.
+``open_member(..., lazy=True)`` returns the same :class:`_MemberSlice` type but defers
+that open (and its skip-decode) until the first read — so an iterator that yields then
+closes an unselected member pays nothing. This is the sequential/iteration primitive.
+Random access into a solid block is served differently (a seekable slice over a
+seekable decode), so this class is deliberately forward-only and does not seek.
 
 Like the rest of ``streamtools`` this module knows nothing about archivey's error
 hierarchy: a truncated block surfaces as a plain :class:`EOFError` for the caller to
@@ -46,15 +46,49 @@ class _MemberSlice(ReadOnlyIOStream):
     Non-owning: closing a member slice never closes the shared block — the
     :class:`SolidBlockReader` owns that. Reads are bounded to the member's declared size
     and flow through the reader so it always knows the block's position.
+
+    When constructed with ``pending=True`` (``open_member(..., lazy=True)``), the
+    skip-to-``offset`` runs on first read rather than at construction; closing without
+    reading never touches the block.
     """
 
-    def __init__(self, reader: SolidBlockReader, size: int) -> None:
+    def __init__(
+        self,
+        reader: SolidBlockReader,
+        offset: int,
+        size: int,
+        *,
+        pending: bool = False,
+    ) -> None:
         super().__init__()
         self._reader = reader
+        self._offset = offset
         self._size = size
         self._remaining = size
+        self._pending = pending
+
+    def _ensure_positioned(self) -> None:
+        if not self._pending:
+            return
+        if self.closed:
+            raise ValueError("I/O operation on closed file.")
+        reader = self._reader
+        if reader._closed:
+            raise ValueError("SolidBlockReader is closed")
+        if self._offset < reader._pos:
+            raise ValueError(
+                f"solid members must be opened in order: offset {self._offset} < "
+                f"position {reader._pos}"
+            )
+        # Finalize any prior active member and jump the gap (same as eager open_member).
+        reader._current = None
+        skip_forward(reader._block, self._offset - reader._pos)
+        reader._pos = self._offset
+        reader._current = self
+        self._pending = False
 
     def read(self, n: int = -1, /) -> bytes:
+        self._ensure_positioned()
         if self._remaining <= 0:
             return b""
         if n < 0 or n > self._remaining:
@@ -64,47 +98,16 @@ class _MemberSlice(ReadOnlyIOStream):
         return data
 
     def tell(self) -> int:
-        return self._size - self._remaining
-
-
-class _LazyMember(ReadOnlyIOStream):
-    """Deferred ``open_member``: skip-decode runs on first read, not at construction.
-
-    Closing without reading never touches the block. Useful when a sequential pass
-    yields every member but only some are selected — the unselected handles close
-    free.
-    """
-
-    def __init__(self, reader: SolidBlockReader, offset: int, size: int) -> None:
-        super().__init__()
-        self._reader = reader
-        self._offset = offset
-        self._size = size
-        self._inner: BinaryIO | None = None
-
-    def _ensure(self) -> BinaryIO:
         if self.closed:
             raise ValueError("I/O operation on closed file.")
-        if self._inner is None:
-            self._inner = self._reader.open_member(self._offset, self._size, lazy=False)
-        return self._inner
-
-    def read(self, n: int = -1, /) -> bytes:
-        return self._ensure().read(n)
-
-    def tell(self) -> int:
-        if self.closed:
-            raise ValueError("I/O operation on closed file.")
-        if self._inner is None:
+        if self._pending:
             return 0
-        return self._inner.tell()
+        return self._size - self._remaining
 
     def close(self) -> None:
         if self.closed:
             return
-        if self._inner is not None:
-            self._inner.close()
-            self._inner = None
+        # Unopened pending slices must not touch the block.
         super().close()
 
 
@@ -119,7 +122,8 @@ class SolidBlockReader:
 
     Pass ``lazy=True`` to defer that open until the first read on the returned handle
     (claim-time still rejects ``offset`` behind the current position). Closing a lazy
-    handle without reading never skip-decodes.
+    handle without reading never skip-decodes. Eager and lazy both return the same
+    :class:`_MemberSlice` type — no extra wrapper layer.
     """
 
     def __init__(self, block: BinaryIO, *, close_block: bool = True) -> None:
@@ -138,13 +142,13 @@ class SolidBlockReader:
                 f"{self._pos}"
             )
         if lazy:
-            return _LazyMember(self, offset, size)
+            return _MemberSlice(self, offset, size, pending=True)
         # Finalize the previous member and jump the gap in one forward skip. This is where
         # a prior member's unread tail is actually consumed (lazy drain).
         self._current = None
         skip_forward(self._block, offset - self._pos)
         self._pos = offset
-        slice_ = _MemberSlice(self, size)
+        slice_ = _MemberSlice(self, offset, size, pending=False)
         self._current = slice_
         return slice_
 

--- a/src/archivey/internal/streams/streamtools/solid.py
+++ b/src/archivey/internal/streams/streamtools/solid.py
@@ -8,9 +8,11 @@ member's unread tail, or an inter-member gap) is consumed only when the *next* m
 opened, so closing a member the caller never advances past costs nothing. Closing the
 reader closes the block without draining.
 
-This is the sequential/iteration primitive. Random access into a solid block is served
-differently (a seekable slice over a seekable decode), so this class is deliberately
-forward-only and does not seek.
+``open_member(..., lazy=True)`` defers that open (and its skip-decode) until the first
+read on the returned handle — so an iterator that yields then closes an unselected
+member pays nothing. This is the sequential/iteration primitive. Random access into a
+solid block is served differently (a seekable slice over a seekable decode), so this
+class is deliberately forward-only and does not seek.
 
 Like the rest of ``streamtools`` this module knows nothing about archivey's error
 hierarchy: a truncated block surfaces as a plain :class:`EOFError` for the caller to
@@ -65,6 +67,47 @@ class _MemberSlice(ReadOnlyIOStream):
         return self._size - self._remaining
 
 
+class _LazyMember(ReadOnlyIOStream):
+    """Deferred ``open_member``: skip-decode runs on first read, not at construction.
+
+    Closing without reading never touches the block. Useful when a sequential pass
+    yields every member but only some are selected — the unselected handles close
+    free.
+    """
+
+    def __init__(self, reader: SolidBlockReader, offset: int, size: int) -> None:
+        super().__init__()
+        self._reader = reader
+        self._offset = offset
+        self._size = size
+        self._inner: BinaryIO | None = None
+
+    def _ensure(self) -> BinaryIO:
+        if self.closed:
+            raise ValueError("I/O operation on closed file.")
+        if self._inner is None:
+            self._inner = self._reader.open_member(self._offset, self._size, lazy=False)
+        return self._inner
+
+    def read(self, n: int = -1, /) -> bytes:
+        return self._ensure().read(n)
+
+    def tell(self) -> int:
+        if self.closed:
+            raise ValueError("I/O operation on closed file.")
+        if self._inner is None:
+            return 0
+        return self._inner.tell()
+
+    def close(self) -> None:
+        if self.closed:
+            return
+        if self._inner is not None:
+            self._inner.close()
+            self._inner = None
+        super().close()
+
+
 class SolidBlockReader:
     """Vend consecutive member sub-streams over one forward-only decoded block.
 
@@ -73,6 +116,10 @@ class SolidBlockReader:
     non-decreasing ``offset`` order; the reader skips forward from its current position to
     ``offset`` lazily, at open time, so a partially-read (or unread) member costs nothing
     until the next one is requested. Only one member is active at a time.
+
+    Pass ``lazy=True`` to defer that open until the first read on the returned handle
+    (claim-time still rejects ``offset`` behind the current position). Closing a lazy
+    handle without reading never skip-decodes.
     """
 
     def __init__(self, block: BinaryIO, *, close_block: bool = True) -> None:
@@ -82,7 +129,7 @@ class SolidBlockReader:
         self._current: _MemberSlice | None = None
         self._closed = False
 
-    def open_member(self, offset: int, size: int) -> BinaryIO:
+    def open_member(self, offset: int, size: int, *, lazy: bool = False) -> BinaryIO:
         if self._closed:
             raise ValueError("SolidBlockReader is closed")
         if offset < self._pos:
@@ -90,6 +137,8 @@ class SolidBlockReader:
                 f"solid members must be opened in order: offset {offset} < position "
                 f"{self._pos}"
             )
+        if lazy:
+            return _LazyMember(self, offset, size)
         # Finalize the previous member and jump the gap in one forward skip. This is where
         # a prior member's unread tail is actually consumed (lazy drain).
         self._current = None

--- a/tests/test_measurement.py
+++ b/tests/test_measurement.py
@@ -16,7 +16,7 @@ from archivey.internal.streams.counting import (
     OutputCountingStream,
     SeekCountingStream,
 )
-from tests.conftest import requires_binary
+from tests.conftest import requires, requires_binary
 
 _RAR_FIXTURES = Path(__file__).parent / "fixtures" / "rar"
 _RAR_BASIC_CONTENTS = {
@@ -176,3 +176,47 @@ def test_solid_sequential_decodes_once(
             mid = reader.bytes_decompressed
             reader.read(target)
             assert reader.bytes_decompressed > mid
+
+
+@requires("py7zr")
+def test_solid_selective_stream_decodes_only_needed(tmp_path: Path) -> None:
+    """Unselected solid members must not be decompressed (archive-reading laziness).
+
+    Regression for the perf-review H1 trap: eager solid positioning at yield time
+    made ``stream_members`` / selective extract of one early member decode ~the
+    whole folder. Bound is prefix+member with a tiny EOF-probe slack.
+    """
+    files = {f"m{i:03d}.bin": bytes([i]) * 4096 for i in range(8)}
+    source = tmp_path / "src"
+    source.mkdir()
+    for name, data in files.items():
+        (source / name).write_bytes(data)
+    archive = tmp_path / "solid.7z"
+    py7zr = pytest.importorskip("py7zr")
+    with py7zr.SevenZipFile(archive, "w", filters=[{"id": py7zr.FILTER_LZMA2}]) as zf:
+        for name in sorted(files):
+            zf.write(source / name, arcname=name)
+
+    first = "m000.bin"
+    needed = len(files[first])
+    with enable_measurement(), open_archive(archive) as reader:
+        assert isinstance(reader, BaseArchiveReader)
+        assert reader.info.is_solid is True
+        pairs = [
+            (member, stream.read() if stream is not None else None)
+            for member, stream in reader.stream_members(members=[first])
+        ]
+        assert len(pairs) == 1
+        member, data = pairs[0]
+        assert member.name == first
+        assert data == files[first]
+        # Whole folder is 32 KiB; a regression that positions every member lands ~28–32 KiB.
+        assert reader.bytes_decompressed <= needed + 64
+
+    with enable_measurement(), open_archive(archive) as reader:
+        assert isinstance(reader, BaseArchiveReader)
+        dest = tmp_path / "out"
+        report = reader.extract_all(dest, members=[first])
+        assert len(report.results) == 1
+        assert (dest / first).read_bytes() == files[first]
+        assert reader.bytes_decompressed <= needed + 64

--- a/tests/test_member_stream_contract.py
+++ b/tests/test_member_stream_contract.py
@@ -237,6 +237,32 @@ def test_member_streams_are_archive_streams(member: tuple[Path, str]) -> None:
                 stream.close()
 
 
+def test_stream_members_do_not_nest_archive_streams(tmp_path: Path) -> None:
+    """``stream_members`` must hand out a single ArchiveStream, not wrap-over-wrap.
+
+    Regression for the lazy-open double wrap (``_lazy_member_stream`` over
+    ``_wrap_member_stream``): after first read, the public handle's inner must not
+    itself be an ``ArchiveStream``.
+    """
+    from archivey.internal.streams.archive_stream import ArchiveStream
+
+    path = tmp_path / "a.zip"
+    with zipfile.ZipFile(path, "w") as zf:
+        zf.writestr("a.txt", b"payload")
+    with open_archive(path) as ar:
+        for member, stream in ar.stream_members():
+            if not member.is_file or stream is None:
+                continue
+            assert isinstance(stream, ArchiveStream)
+            assert stream.read() == b"payload"
+            inner = stream._inner
+            assert inner is not None
+            assert not isinstance(inner, ArchiveStream)
+            break
+        else:
+            pytest.fail("expected a file member")
+
+
 def test_member_stream_advertises_size(member: tuple[Path, str]) -> None:
     # The fsspec-style `size` attribute carries the decompressed length when the
     # archive metadata knows it (feeds nested-archive sizing and the bomb tracker).

--- a/tests/test_solid.py
+++ b/tests/test_solid.py
@@ -90,6 +90,28 @@ def test_close_block_false_leaves_block_open() -> None:
     assert block.was_closed is False
 
 
+def test_lazy_open_member_defers_skip_until_read() -> None:
+    block = _CountingBlock(b"AAAABBBBCCCC")
+    reader = SolidBlockReader(block)
+    first = reader.open_member(0, 4, lazy=True)
+    second = reader.open_member(4, 4, lazy=True)
+    # Claiming lazy handles must not touch the block.
+    assert block.bytes_read == 0
+    first.close()  # unread — free
+    assert block.bytes_read == 0
+    assert second.read() == b"BBBB"
+    # Skipped the first member's range only when the second was actually read.
+    assert block.bytes_read == 8
+
+
+def test_lazy_open_member_out_of_order_still_rejected_at_claim() -> None:
+    block = _CountingBlock(b"AAAABBBB")
+    reader = SolidBlockReader(block)
+    reader.open_member(4, 4).read()
+    with pytest.raises(ValueError, match="in order"):
+        reader.open_member(0, 4, lazy=True)
+
+
 def test_skip_forward_helper_raises_on_short_stream() -> None:
     stream = io.BytesIO(b"1234")
     skip_forward(stream, 4)

--- a/tests/test_solid.py
+++ b/tests/test_solid.py
@@ -91,10 +91,15 @@ def test_close_block_false_leaves_block_open() -> None:
 
 
 def test_lazy_open_member_defers_skip_until_read() -> None:
+    from archivey.internal.streams.streamtools.solid import _MemberSlice
+
     block = _CountingBlock(b"AAAABBBBCCCC")
     reader = SolidBlockReader(block)
     first = reader.open_member(0, 4, lazy=True)
     second = reader.open_member(4, 4, lazy=True)
+    # Same type as eager; no extra wrapper layer.
+    assert isinstance(first, _MemberSlice)
+    assert isinstance(second, _MemberSlice)
     # Claiming lazy handles must not touch the block.
     assert block.bytes_read == 0
     first.close()  # unread — free
@@ -110,6 +115,16 @@ def test_lazy_open_member_out_of_order_still_rejected_at_claim() -> None:
     reader.open_member(4, 4).read()
     with pytest.raises(ValueError, match="in order"):
         reader.open_member(0, 4, lazy=True)
+
+
+def test_lazy_then_read_after_later_member_raises() -> None:
+    """A pending slice whose offset was passed by another open cannot be read later."""
+    block = _CountingBlock(b"AAAABBBB")
+    reader = SolidBlockReader(block)
+    early = reader.open_member(0, 4, lazy=True)
+    assert reader.open_member(4, 4).read() == b"BBBB"
+    with pytest.raises(ValueError, match="in order"):
+        early.read()
 
 
 def test_skip_forward_helper_raises_on_short_stream() -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to the performance deep review ([#134](https://github.com/davitf/archivey-2/pull/134)): land decision-free fixes, sharpen the stream-layering brief, and collapse nested `ArchiveStream` / solid lazy open.

### Code

- **H1: solid selective decode** — `SolidBlockReader.open_member(..., lazy=True)` defers skip-decode into `_MemberSlice` (pending until first read). 7z/RAR use it; verify wrap stays in `ArchiveStream` `open_fn` so `VerifyingStream.close` cannot probe unselected members. `extract_all` early-exits when a finite pre-filtered selection is exhausted. EOF → `TruncatedError` via `_translate_exception`.
- **Collapse nested `ArchiveStream`** — `_ensure_open` collapses via `_collapse_nested` (steals still-lazy opener or opened inner; composes nested `translate`/`stamp`, adopts `rewind_warning`).
- **H3 micro-win:** cache `BackendRegistry.extension_map`.
- **H2 partial:** `DecompressorStream.readall()` joins chunks instead of `bytearray` staging.
- Tests pin selective solid decode, non-nested stream handles, and solid `lazy=`.

### Docs

`review/stream-layering/brief.md` sharpened (STORED isolation, collapse already fixed, irreducible floor).

### Not in this PR

Wall-budget enforcement (Q2), VISION open/list scope (Q1), `SOLID_DECODE_FACTOR` (Q3), verify-skip knob (Q4), random-solid baseline gate (Q6), full verify+slice fusion (stream-layering review).

## Before/after benchmarks (this PR vs `main`)

Same host, shared fixtures, `--mode full --scale realistic` (warmup on). Harness: median of 3 rounds. ZIP microbench: 31 tight rounds. Artifact: full writeup in the agent run.

### Headline: selective solid 7z (H1)

| | bytes_decompressed | × needed (64 KiB) | wall (median) |
|---|---:|---:|---:|
| **main** | 2,031,617 | **31.0×** | ~5.0 ms |
| **this PR** | 65,536 | **1.0×** | ~1.7 ms |

Exact VISION trap fixed end-to-end (`extract` / `stream_members` of one early member).

### ZIP `stream_members` read-all microbench

| | median | p10 | p90 |
|---|---:|---:|---:|
| main | 26.52 ms | 26.43 | 26.71 |
| this PR | 26.42 ms | 26.33 | 26.51 |
| Δ | **−0.4%** | | |

Nested `ArchiveStream` collapse + `readall` join: within noise on this host.

### Harness medians (3 rounds)

| Case | main | this PR | Δ wall | main ratio | PR ratio |
|---|---:|---:|---:|---:|---:|
| `zip_open_list` | 0.76 ms | 0.73 ms | −3.4% | — | — |
| `zip_read_all` | 26.70 ms | 26.78 ms | +0.3% | 2.01× | 2.00× |
| `zip_extract` | 52.33 ms | 52.54 ms | +0.4% | — | — |
| `tar_open_list` | 1.63 ms | 1.54 ms | −5.5% | — | — |
| `tar_read_all` | 3.77 ms | 3.86 ms | +2.3% | 1.68× | 1.72× |
| `gzip_read_all` | 31.77 ms | 31.63 ms | −0.5% | 1.02× | 1.02× |
| `targz_read_all_accel_off` | 21.20 ms | 21.45 ms | +1.2% | 1.19× | 1.20× |
| `targz_read_all_accel_on` | 8.35 ms | 8.46 ms | +1.3% | 0.46× | 0.47× |
| `sevenzip_solid_sequential` | 8.69 ms | 8.64 ms | −0.5% | — | — |
| `sevenzip_solid_random` | 151.46 ms | 148.63 ms | −1.9% | — | — |

**Takeaway:** H1 is the unambiguous win. Wrapper/`readall` work has not closed the ≤1.3× ZIP gap here (~2.0× still); that remains for the stream-layering review. Treat harness Δ within ~±5% as flat.

## Test plan

- [x] solid / measurement / extraction / member-stream contract / rar / error translation
- [x] ruff / pyrefly / ty clean on touched modules
- [x] before/after realistic harness + selective solid microbench

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7ceb525a-91f9-4358-b461-1b171383ab65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7ceb525a-91f9-4358-b461-1b171383ab65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

