### PR TITLE
feat: fuse member verify into ArchiveStream (stream-layering review)

### DIFF
--- a/review/stream-layering/BENCH.md
+++ b/review/stream-layering/BENCH.md
@@ -1,0 +1,56 @@
+# Before/after benchmarks — verify fusion (#137)
+
+Host: shared x86_64 runner, CPython 3.11, `[all]` extras.
+Compared trees via `PYTHONPATH=<tree>/src` against a shared fixture dir.
+
+- **main** `@ 38f7b99`
+- **#136** `@ 2a6b91b` (immediate before — nested AS collapse, no verify fusion)
+- **fusion** (this PR) `@ fba9f69`
+
+## Stack (STORED ZIP, after first read)
+
+| Tree | Stack |
+|------|-------|
+| main / #136 | `ArchiveStream → VerifyingStream → ArchiveStream → SlicingStream` |
+| fusion | `ArchiveStream → SlicingStream` (verifier fused; codec AS collapsed) |
+
+## STORED / DEFLATE microbench (64 × 256 KiB, 41 warm rounds)
+
+`stream_members` read-all medians (ms); ratio vs stdlib `zipfile`.
+
+| | main | #136 | fusion | fusion vs #136 |
+|--|-----:|-----:|-------:|---------------:|
+| STORED archivey | 7.76 | 7.53 | 7.67 | **+1.8%** |
+| STORED zipfile | 4.45 | 4.43 | 4.46 | — |
+| STORED ratio | 1.74× | 1.70× | 1.72× | — |
+| STORED `open()`+read | 7.61 | 7.53 | 7.62 | +1.2% |
+| DEFLATE archivey | 30.4 | 30.7 | 31.6 | **+2.7%** |
+| DEFLATE ratio | 1.92× | 1.96× | 2.00× | — |
+
+## Harness `--mode full --scale realistic --warmup` (#136 → fusion)
+
+Shared fixtures. Wall medians (ms); Δ% = fusion vs #136.
+
+| Case | #136 | fusion | Δ | #136× | fusion× |
+|------|-----:|-------:|--:|------:|--------:|
+| `zip_open_list` | 0.78 | 0.76 | −2.3% | — | — |
+| `zip_read_all` | 27.22 | 27.21 | −0.0% | 2.00 | 2.03 |
+| `zip_extract` | 53.47 | 55.47 | +3.7% | — | — |
+| `tar_open_list` | 1.54 | 1.69 | +9.5% | — | — |
+| `tar_read_all` | 3.94 | 4.03 | +2.4% | 1.76 | 1.77 |
+| `gzip_read_all` | 36.47 | 36.27 | −0.6% | 1.02 | 1.04 |
+| `targz_read_all_accel_off` | 23.21 | 22.10 | −4.8% | 1.24 | 1.22 |
+| `targz_read_all_accel_on` | 10.89 | 9.19 | −15.7%* | 0.43 | 0.51 |
+| `tarbz2_read_all_accel_off` | 381.87 | 381.66 | −0.1% | 1.03 | 1.03 |
+| `tarbz2_read_all_accel_on` | 129.31 | 129.23 | −0.1% | 0.35 | 0.35 |
+| `sevenzip_solid_sequential` | 8.90 | 8.65 | −2.8% | — | — |
+| `sevenzip_solid_random` | 155.18 | 150.55 | −3.0% | — | — |
+
+\*accel-on rows are noisier (accelerator startup); treat as flat.
+
+## Takeaway
+
+Wall times are **within noise (~±5%)** of #136. Fusion is a **structural** win
+(one fewer wrapper; codec `ArchiveStream` collapse finishes) and fixes F1/F2; it
+does **not** close the ZIP ≤1.3× gap (still ~2.0× on `zip_read_all`). Matches the
+review's measured ~5% upper bound on the wrapper share.

--- a/review/stream-layering/QUESTIONS.md
+++ b/review/stream-layering/QUESTIONS.md
@@ -1,0 +1,34 @@
+# Questions for the maintainer
+
+## Q1 — Accept the partial-collapse verdict?
+
+**Implemented in this PR** (on top of #136): `MemberVerifier` fused into
+`ArchiveStream`; ZIP/7z/RAR backends pass `expected_hashes` /
+`expected_size`; codec `ArchiveStream` collapses through; F1/F2 fixed.
+`SlicingStream` / `SharedSource` / decode engine left alone.
+
+Alternatives considered and rejected:
+
+- **Fuse slice+verify into one stream** — breaks or duplicates CONCURRENT /
+  `SharedSource` view minting for a sub-percent read-path win past the floor.
+- **Do nothing on layering; only fix F1/F2** — leaves the codec `ArchiveStream`
+  stranded under verify forever; #136's collapse cannot finish.
+- **Sell fusion as closing the ≤1.3× gap** — numbers say ~5% STORED end-to-end;
+  deflate remains Topic 6.
+
+## Q2 — F1 severity / fix venue
+
+**Done in this PR** with the fusion (`MemberVerifier.read` treats `n == 0` as
+a no-op).
+
+## Q3 — Keep `VerifyingStream` as a helper type?
+
+**Chose (b):** `MemberVerifier` holds the logic; `VerifyingStream` remains a
+thin wrapper for `codecs.py`'s length-only backstop and unit tests. Member
+backends no longer construct it. Deleting the class later is optional cleanup.
+
+## Q4 — `SlicingStream.readinto` follow-up?
+
+The brief hoped a fused `readinto` would matter more than dispatch count. On
+this host it does not, until the slice layer also stops allocating. Worth a
+follow-up task, or park until an extract path is shown `readinto`-bound?

--- a/review/stream-layering/SUMMARY.md
+++ b/review/stream-layering/SUMMARY.md
@@ -1,0 +1,80 @@
+# Stream wrapper layering — SUMMARY
+
+**Brief:** `brief.md` (correctness of slice/verify/outer wrappers + whether
+slicing+verification can collapse into one stream under `ArchiveStream`).
+
+**Reviewed at:** PR #136 @ `2a6b91b` (solid selective decode + nested
+`ArchiveStream` collapse), on top of `main` @ `38f7b99`. The brief's sharpening
+(STORED isolation, collapse already fixed, irreducible floor) lives on that PR;
+this review evaluates the **post-#136** stack. On plain `main` before #136,
+`stream_members` still double-wraps (`ArchiveStream → ArchiveStream →
+VerifyingStream → …`); after #136 the public handle's `_inner` is
+`VerifyingStream` directly — confirm with `measurements.py stack`.
+**Baseline:** `[all]` on #136 — **1748 passed / 87 skipped**, `ruff` / `pyrefly` /
+`ty` clean.
+**Host:** shared x86_64 runner, CPython 3.11. Numbers from `measurements.py`;
+ratios directional but stable across ≥2 runs.
+
+## Headline
+
+**Partial yes — fuse verification into `ArchiveStream`; leave slicing structural.**
+
+A single public `ArchiveStream` **can** absorb `VerifyingStream` without weakening
+the Part-1 invariants that matter (sequential-EOF verify, size cap + trailing
+probe, seek-disables-verify, typed-error precedence, `readinto` hashing). Doing so
+also **unblocks collapsing the codec `ArchiveStream`** that today sits *under*
+`VerifyingStream` and survives #136's `_collapse_nested` (which only flattens
+direct nesting). Member-boundary / `SharedSource` `SlicingStream` must stay —
+CONCURRENT re-seek-under-lock and internal codec slices are not 1:1 with the
+public handle.
+
+**How much it buys:** on STORED ZIP (no decode noise) the live stack is
+`ArchiveStream → VerifyingStream → ArchiveStream(codec) → SlicingStream`. A true
+fused `ArchiveStream → SlicingStream` removes ~8% of the *synthetic stack* time
+and ~5% of end-to-end archivey read-all; archivey stays ~1.75× zipfile because
+most of the residual is per-member open machinery (local-header parse, codec
+resolve, lease/finalizer) plus CRC work that zipfile also does. Fusion does
+**not** close the #134 deflate 2.0–2.3× gap — that remains Topic 6
+(`DecompressorStream`). The stack is already near the irreducible floor on the
+per-`read(64K)` path; the ranked move is still worth doing (correctness
+simplification + unblocks codec-AS collapse + small measurable win), not as the
+budget closer.
+
+## Top findings
+
+| # | Sev | Finding | Where | Status |
+|---|-----|---------|-------|--------|
+| F1 | **Medium** | `VerifyingStream.read(0)` (and mid-stream `read(0)`) is treated as EOF — false `CorruptionError` / `TruncatedError`. `_GzipTruncationCheckStream` already pins the opposite contract. | `verify.py` (`MemberVerifier.read`) | **fixed** (this PR) |
+| F2 | Low | `VerifyingStream.close()` can leave wrapper+inner unclosed when the EOF probe raises a non-`CorruptionError`/`TruncatedError` `ArchiveyError` (e.g. `EncryptionError`). | `verify.py` (`finish_on_close`) | **fixed** (this PR) |
+| D1 | design | **Fuse verify into `ArchiveStream`** (conditional when hashes/size present); leave `SlicingStream`/`SharedSource`/`LockedStream` and the decode engine separate. Ranked sequence in `collapse-design.md`. | `archive_stream.py`, backends | **implemented** (this PR) |
+| D2 | design | Nested codec `ArchiveStream` under `VerifyingStream` remains after #136; verify-fusion is what lets `_collapse_nested` finish the job. | live STORED stack: `AS → SlicingStream` | **fixed** by D1 |
+
+## What is actually fine
+
+- **`readinto` side-effect contract** holds today: `VerifyingStream` is a
+  `ReadOnlyIOStream` (readinto→read); counting streams override `readinto`;
+  `_GzipTruncationCheckStream` sets `readinto_passthrough=False`; no
+  side-effecting `DelegatingStream` subclass was found that forgets the flag.
+- **`SlicingStream` dual mode** (eager single-consumer vs locked re-seek),
+  BytesIO-matching negative-seek clamp, `own_source` close, and
+  construction-without-unlocked-`tell` are correct and well tested.
+- **`SharedSource` / CONCURRENT** view minting and the “never unlocked
+  tell/seek on a shared `BufferedReader`” rule hold; this is the real reason
+  member-boundary slicing cannot fully fuse into the public handle.
+- **`ArchiveStream` lazy-open claim**, `_fail` ordering (closed-file before
+  translator), finalizer/lease, and #136 `_collapse_nested` (including
+  translate/stamp/rewind adoption) are sound; public `_inner` after first read
+  is not an `ArchiveStream` (pinned).
+- **Stream-decoder F6** (over-long hashed members) is closed via
+  `expected_size` on ZIP/7z/RAR verify wraps.
+- **#136 nested-outer collapse** confirmed: `stream_members` no longer double-wraps;
+  solid lazy `open_member` keeps verify inside `open_fn` so close cannot probe
+  unselected members.
+
+## Files
+
+- `correctness.md` — per-wrapper audit + invariant list a fusion must keep.
+- `layer-map.md` — per-backend stacks (post-#136), composition sites.
+- `collapse-design.md` — verdict table, fused design, measured win, floor.
+- `QUESTIONS.md` — maintainer decisions.
+- `measurements.py` — runnable STORED isolation + stack dump + synthetic fusion.

--- a/review/stream-layering/brief.md
+++ b/review/stream-layering/brief.md
@@ -27,14 +27,6 @@ likely dominated by materialization/`zipfile`, not the wrapper stack (streams op
 lazily) — confirm, but the wrapper target is the **read/extract per-chunk and
 per-open** cost.
 
-**Attribution discipline (sharpening from #134):** #134's ZIP read-all profile splits
-the non-zlib time across *several* buckets — `DecompressorStream`'s chunk loop +
-bytearray copy, `VerifyingStream`, nested `ArchiveStream` shims, and CRC itself
-(parity with `zipfile`). This review can only claim wins on the **wrapper** buckets.
-Do **not** project that fusion alone closes the full 2.2× gap. Isolate with a
-**STORED ZIP** microbench (no decode layer) so wrapper overhead is visible without
-zlib/`DecompressorStream` noise; leave decode-engine cost to backlog Topic 6.
-
 ## The current stack (trace and confirm — this is the object of review)
 
 For a ZIP member the handed-out handle is, bottom to top (hot path, measurement off):
@@ -59,16 +51,6 @@ Python `read()` hops, no decompression), and a **deflate member** adds the decod
 Composition site: `base_reader._wrap_member_stream` (`base_reader.py:572`) +
 `zip_reader.py:816` (VerifyingStream) — map the equivalent stack for **every** backend
 (TAR, 7z solid, RAR-via-unrar, ISO, single-file, directory).
-
-**Concrete double-wrap (fixed on the perf follow-up branch):** the default
-`_lazy_member_stream` used to build an outer `ArchiveStream(lazy=True)` whose
-`open_fn` called `_open_member` → `_wrap_member_stream` (a *second*
-`ArchiveStream`). Nesting is now collapsed inside `ArchiveStream._ensure_open`
-via `_collapse_nested` (steals a still-lazy opener, or an already-opened inner, and
-**adopts nested translate/stamp/rewind_warning** so codec errors stay typed) —
-confirm the public handle's `_inner` after first read is **not** an `ArchiveStream`,
-and treat any remaining nesting as a regression. Solid sequential paths (7z/RAR)
-build a single wrapper directly.
 
 ## Part 1 — Correctness audit (do this first; it defines the invariants a collapse must keep)
 
@@ -95,9 +77,7 @@ overhead. Verify each, with `file:line` and the concrete input/state:
 - **`ArchiveStream`** (`archive_stream.py`): the lazy-open claim/lock and the "open_fn
   claimed then failed" path; `_fail` translation ordering (closed-file before the
   per-library translator); the finalizer/lease release and its interpreter-exit caveat;
-  `size` derivation; `_collapse_nested` (flattens a deferred `_open_member` wrap inside
-  `_ensure_open`, stealing a still-lazy opener or an already-opened inner) — confirm
-  close/lease ownership stays on the public handle only.
+  `size` derivation.
 - **`SharedSource`/CONCURRENT**: how views are minted per handle and whether the
   single-live-stream / re-seek invariants survive. **This is the main constraint on
   fusion** (see Part 2).
@@ -115,17 +95,14 @@ The maintainer's hypothesis to evaluate, accept/refute, or refine:
 Evaluate concretely:
 
 - **Per-layer verdict table.** For each layer (member-boundary slice, `fix_stream_start_position`
-  slice, verify, outer) classify: *fuse into the outer stream* / *keep separate,
-  structural* / *already conditional (skip)*. The redundant nested outer from
-  `_lazy_member_stream` is **already collapsed** (confirm; do not re-propose). Justify
-  each against the Part-1 invariants. Decode engine stays out of scope (Topic 6) —
-  list it as *keep separate* with a one-line pointer, not a redesign.
-- **What fuses cleanly.** `VerifyingStream` is the strongest remaining candidate: the
-  outer `ArchiveStream` already reads through an inner and owns `size`; folding the
-  hasher + `expected_size` bound into its `read`/`close` removes a whole layer on
-  *every* member. But it's conditional (nested `open_stream`/inner-archive handles and
-  non-FILE members don't verify) — show the fused stream stays correct when there's
-  nothing to verify.
+  slice, verify, outer, and the decode engine) classify: *fuse into the outer stream* /
+  *keep separate, structural* / *already conditional (skip)*. Justify each against the
+  Part-1 invariants.
+- **What fuses cleanly.** `VerifyingStream` is the strongest candidate: the outer
+  `ArchiveStream` already reads through an inner and owns `size`; folding the hasher +
+  `expected_size` bound into its `read`/`close` removes a whole layer on *every* member.
+  But it's conditional (nested `open_stream`/inner-archive handles and non-FILE members
+  don't verify) — show the fused stream stays correct when there's nothing to verify.
 - **What resists fusion, and why.** Member-boundary slicing entangles with
   `SharedSource` (multiple concurrent views over one handle, re-seek under lock) and
   with internal uses (`fix_stream_start_position`, codec body slices) that aren't at
@@ -139,20 +116,12 @@ Evaluate concretely:
   it may matter more than the dispatch count.
 - **Decode stays separate.** The `DecompressorStream`/`Decoder` engine and the
   accelerator/crypto stages are *not* in scope to fold in — they're the settled #96
-  decode layer (and Topic 6 for their *speed*). The target is the wrapper stack
-  *around* the decoder, not the decoder. Note #134 already landed a `readall()`
-  join-of-chunks fast path on `DecompressorStream`; don't re-litigate it here.
-- **Irreducible floor.** Before recommending fusion, state what cost *must* remain:
-  at least one Python `read` that updates a hasher + bounds length, plus translate/stamp
-  on errors, plus lease/finalizer on the public handle. If the measured stack is already
-  close to that floor on STORED ZIP, fusion is the wrong lever.
+  decode layer. The target is the wrapper stack *around* the decoder, not the decoder.
 - **Cost, measured.** Back the recommendation with numbers: per-`read(64K)` dispatch
   cost across the current stack vs a fused stream, and per-`open()` construction cost
   (the `ArchiveStream` lock+finalizer+watermark, the `VerifyingStream` hasher setup, the
   `SlicingStream`) — reuse #134's harness / `--track-io` and add a microbench. Tie the
-  projected win back to the **wrapper share** of the 2.2× / 2.4–3.7× gaps, not the
-  whole gap. Prefer: STORED vs deflate as the isolation axis (nested `ArchiveStream`
-  is already gone).
+  projected win back to the 2.2× / 2.4–3.7× gaps.
 
 ## Non-goals
 - Not re-opening the #96 decoder composition or the accelerator internals — those are
@@ -163,8 +132,6 @@ Evaluate concretely:
   the verify/slice/outer logic is a first-class finding (it also de-risks the fusion).
 - Don't fuse away an invariant to win a benchmark: a smaller stack that verifies less,
   or breaks CONCURRENT, fails VISION #2/#3 and is not an acceptable trade.
-- Not open+list / detection / member-model construction (H3) — out of scope; those are
-  non-stream costs from #134.
 
 ## Deliverable
 Per README. Suggested theme files: `correctness.md` (the per-wrapper audit + the
@@ -174,5 +141,4 @@ invariants it preserves, what stays separate and why, and the measured/estimated
 The headline the maintainer wants: **can a single stream under the `ArchiveStream`
 identity replace slicing+verification without weakening any Part-1 invariant, and how
 much does it buy?** Give a clear yes/no/partial with the design and the numbers, not a
-menu. If the answer is "partial," prefer a ranked sequence (e.g. fuse verify next;
-leave SharedSource slicing) over an options list.
+menu.

--- a/review/stream-layering/collapse-design.md
+++ b/review/stream-layering/collapse-design.md
@@ -1,0 +1,245 @@
+# Collapse design — verdict, fused stream, measured win
+
+## Headline answer
+
+**Partial yes.** Fuse **verification** into the outer `ArchiveStream`. Keep
+**slicing** (`SlicingStream` / `SharedSource` / `LockedStream`) and the
+**decode engine** as separate layers. Do not re-propose the nested-outer
+collapse — #136 already did that.
+
+Ranked sequence:
+
+1. **Fix F1** (`read(0)` must not verify) — correctness; also a fusion prerequisite.
+2. **Fuse `VerifyingStream` into `ArchiveStream`** (optional hasher +
+   `expected_size` on the outer). Backends that today wrap
+   `VerifyingStream(...)` pass verify knobs into `_wrap_member_stream` /
+   `ArchiveStream` instead. When there is nothing to verify, the fused path is
+   a no-op (same as skipping the wrap today).
+3. **Let `_collapse_nested` finish** — once verify is no longer an opaque layer
+   between two `ArchiveStream`s, the codec `ArchiveStream` collapses into the
+   public handle (translators compose). STORED ZIP becomes
+   `ArchiveStream → SlicingStream`.
+4. **Optional follow-up:** real `SlicingStream.readinto` (seek+`readinto` under
+   lock) so a fused hasher can hash a `memoryview` without a bytes copy. Small
+   on this host; larger if callers move to `readinto`-heavy extract paths.
+5. **Do not fuse** member-boundary / shared slicing, TAR/ISO `LockedStream`, or
+   the decode engine.
+
+---
+
+## Per-layer verdict table
+
+| Layer | Verdict | Why |
+|-------|---------|-----|
+| Public `ArchiveStream` (translate, stamp, size, lease, rewind, lazy open) | **keep** — identity | The brief's outer carrier; leases/finalizers/diagnostics watermark live here. |
+| Nested outer from `_lazy_member_stream` | **already collapsed** (#136) | Confirm only; do not re-propose. |
+| `VerifyingStream` | **fuse into outer** | Strongest candidate: outer already reads through an inner and owns `size`. Conditional (no hashes/size → no-op). Unblocks codec-AS collapse. |
+| Codec `ArchiveStream` under verify | **collapse after fuse** | Structural leftover: `_collapse_nested` cannot see through `VerifyingStream`. After fuse it becomes a direct nested AS and flattens. |
+| Member-boundary `SlicingStream` (ZIP raw, 7z member, RAR direct) | **keep separate, structural** | 1:N views over a shared handle; locked re-seek; CONCURRENT. Not the same object as the public lease. |
+| `SharedSource.view` / `fix_stream_start_position` / 7z LZMA cap slices | **keep separate, structural** | Internal/shared uses, not member-boundary identity. |
+| `LockedStream` / `CloseLockedStream` | **keep separate, structural** | Library-owned seek-then-read serialization (TAR/ISO/ZIP close). |
+| `_MemberSlice` (solid) | **keep separate** | Forward-only block cursor; #136 already avoided an extra lazy wrapper type. |
+| Decode engine (`DecompressorStream` / accelerator / crypto) | **keep separate** | Settled #96; Topic 6 for speed. #134 `readall` join already landed. |
+| Measurement wrappers | **already conditional (skip)** | Identity when measurement off. |
+
+---
+
+## What fuses cleanly
+
+### Design sketch — verify knobs on `ArchiveStream`
+
+```text
+ArchiveStream(
+    open_fn,
+    translate=..., stamp=..., size=member.size,
+    expected_hashes=member.hashes or None,   # new, optional
+    expected_size=member.size,               # already have size; reuse for cap
+    digest_transforms=..., collector=...,
+)
+```
+
+`read` / `close` gain the current `VerifyingStream` state machine (with F1/F2
+fixed). When `expected_hashes` is empty/None **and** no length check is
+requested, skip hasher setup entirely — nested `open_stream` / non-FILE /
+directory / TAR / ISO paths stay as cheap as today.
+
+`readinto`: either (a) route through fused `read` (safe, keeps today's copy), or
+(b) call `inner.readinto` into the caller's buffer and `hasher.update(mv[:n])`
+(fast path). (b) only wins if the inner also has a real `readinto` — today
+`SlicingStream` does not (it inherits `ReadOnlyIOStream.readinto` → `read` →
+bytes). So ship (a) with the fuse; treat (b)+`SlicingStream.readinto` as step 4.
+
+### Invariants preserved (map from `correctness.md`)
+
+| Invariant | How the fused stream keeps it |
+|-----------|-------------------------------|
+| 1 `read(0)` no-op | Explicit guard before EOF logic (fixes F1) |
+| 2 readinto hashes | Implement fused `readinto` or force through `read` |
+| 3 sequential-EOF only; seek disables | Same frontier/`_verify_enabled` logic on the outer |
+| 4 size cap + trailing probe + deferred short | Same `_finish` / close ordering |
+| 5 typed-error precedence + always close | `try`/`finally` around probe (fixes F2) |
+| 9 one public AS; compose translators | Collapse now sees codec AS directly |
+| 10 lease once | Verify no longer a separate close layer; outer `on_close` unchanged |
+| 11 cheap size | Unchanged |
+
+Nothing in the fuse touches invariants 6–8 (those are why slicing stays).
+
+### When there is nothing to verify
+
+TAR / ISO / directory / ZipCrypto / single-file reader / empty 7z records never
+install verify today. Fused outer with knobs unset = current `ArchiveStream`
+with zero hasher fields — no extra per-read work. Conditional verify stays
+conditional.
+
+---
+
+## What resists fusion
+
+**Member-boundary slicing + `SharedSource`.** Multiple concurrent views over one
+handle need a per-view position and locked re-seek. That is a different object
+model from the public member lease. Even for ZIP's single-consumer sequential
+pass (where re-seek is redundant with only one live stream), the same
+`SlicingStream` type is what CONCURRENT fan-out and 7z/RAR views use — splitting
+"member slice inside AS" vs "shared view" would duplicate the bound/seek logic
+the module docstring already unified (`slice.py:1-15`).
+
+Quantitatively, after verify-fuse+codec-collapse the STORED stack is already
+`ArchiveStream → SlicingStream` — one hop above the irreducible floor (a single
+Python `read` that hashes+bounds over a file handle). Further fusing the slice
+into AS buys almost nothing on the read path (see numbers) and costs the
+shared-view story.
+
+---
+
+## Irreducible floor
+
+On a STORED member the library **must** still:
+
+1. Present a bounded view of the member's bytes (slice or equivalent),
+2. Update at least one hasher and enforce `expected_size` on sequential EOF,
+3. Translate/stamp errors,
+4. Hold a lease/finalizer on the public handle.
+
+Floor ≈ **one** `ArchiveStream` (hash+bound+translate+lease) over a
+`SlicingStream` (or, for backends without archivey slicing, over the library
+handle). Today's post-#136 STORED stack is **two** extra Python objects above
+that floor (`VerifyingStream` + codec `ArchiveStream`). Fusion reaches the floor
+for ZIP STORED; it cannot go below it without dropping verify or CONCURRENT
+safety (VISION #2/#3 — not acceptable).
+
+---
+
+## Cost, measured
+
+Host: shared x86_64, CPython 3.11, `[all]`. Script: `measurements.py`.
+Corpus: 64 × 256 KiB **STORED** ZIP (no zlib). Medians, warmup discarded.
+
+### End-to-end (wrapper isolation)
+
+| Path | median | vs zipfile |
+|------|-------:|-----------|
+| archivey `stream_members` read-all (live, #136) | 7.37 ms | **1.75×** |
+| zipfile read-all | 4.18 ms | 1.00× |
+| DEFLATE same corpus (context only) | 31.1 / 15.4 ms | **2.00×** |
+
+Open+list on the same STORED corpus remains ~5× zipfile — detection + member
+model (H3 from #134), **not** the wrapper stack (streams open lazily). Out of
+scope here.
+
+### Synthetic stacks over the same `ZipFile.fp` (read-all)
+
+| Stack | median | Δ vs current-like |
+|-------|-------:|------------------:|
+| current-like `AS → VS → AS → Slice` | 4.59 ms | — |
+| after verify-fuse (codec AS gone) `AS → VS → Slice` | 4.42 ms | −3.7% |
+| true fused `AS → Slice` (hash in AS) | 4.21 ms | **−8.3%** |
+| raw seek+read+crc32 (no wrappers) | ~4.0 ms | floor reference |
+
+Live archivey (7.37 ms) is ~2.8 ms above the current-like synthetic stack: that
+delta is per-member open machinery (`_local_data_region`, `open_codec_stream` /
+`resolve_codec`, lease, `ArchiveStream.__init__` ×2, watermark) — **not** fixed
+by layer fusion.
+
+### Per-`read(64K)` dispatch (4 MiB buffer, 64 reads)
+
+| Stack | median |
+|-------|-------:|
+| bare `BytesIO` | 0.140 ms |
+| `SlicingStream` | 0.195 ms |
+| `VerifyingStream` (CRC) | 0.861 ms |
+| floor `AS → VS → BytesIO` | 0.879 ms |
+| fused-verify `AS → VS → Slice` | 0.933 ms |
+| current `AS → VS → AS → Slice` | 0.943 ms |
+
+CRC + Python verify loop dominates; the extra codec `ArchiveStream` hop is
+~1% of this microbench. Matches the "near floor on the read path" claim.
+
+### Construction ×1000 (build + close, no read)
+
+| Stack | ms / 1000 |
+|-------|----------:|
+| `SlicingStream` | 1.6 |
+| `VerifyingStream` | 1.8 |
+| floor `AS → VS` | 4.5 |
+| fused-verify `AS → VS → Slice` | 7.5 |
+| current `AS → VS → AS → Slice` | 9.9 |
+
+Removing the nested codec AS saves ~2.4 ms / 1000 opens (~25% of wrapper
+construction). Visible on many-small-member workloads; modest on 64×256 KiB.
+
+### `readinto`
+
+On this host, chunked `readinto` through today's `AS → VS` is only ~6% slower
+than chunked `read` — VS already goes `readinto`→`read`→bytes, and
+`SlicingStream` does the same, so the fused "hash the memoryview" path cannot
+avoid the slice-layer copy until `SlicingStream.readinto` is real. Peak traced
+allocs were within noise (~138 KiB). **Do not sell readinto as the headline
+win** of verify-fusion alone; sell codec-AS collapse + one fewer object +
+correctness consolidation.
+
+### Tie-back to #134's 2.2× / 2.4–3.7× gaps
+
+| Gap | Wrapper share addressable by this review |
+|-----|------------------------------------------|
+| ZIP STORED read-all ~1.75× | Fusion recovers ~5% end-to-end (~0.4 ms of 7.4); residual is open machinery + CRC parity |
+| ZIP DEFLATE read-all ~2.0–2.3× | Wrapper slice of the non-zlib bucket shrinks slightly; **decode engine still dominates** (Topic 6) |
+| ZIP extract-all 2.4–3.7× | Same stream win as read-all on the stream half; FS safety half is #134 H4 |
+| ZIP open+list 5–8× | **Out of scope** (not stream wrappers) |
+
+Fusion is the right structural cleanup and a real but **small** performance
+lever. It is not the budget closer.
+
+---
+
+## Concrete fused-stream shape (for an implementer)
+
+```text
+# ZIP STORED after fuse + collapse
+ArchiveStream(                    # public: translate∘codec_translate, stamp,
+                                  #          size, lease, hasher, expected_size
+  inner = SlicingStream(fp, start, length, lock=ZipFile._lock)
+)
+
+# ZIP DEFLATE after fuse + collapse
+ArchiveStream(                    # same knobs
+  inner = DecompressorStream(SlicingStream(...))   # or accelerator
+)
+
+# TAR (unchanged — nothing to verify)
+ArchiveStream(inner = [LockedStream(] ExFileObject [)])
+```
+
+Backend change pattern: replace
+
+```python
+decoded = VerifyingStream(decoded, hashes, expected_size=size, ...)
+return self._wrap_member_stream(decoded, name, size=size)
+```
+
+with verify kwargs on `_wrap_member_stream` / `ArchiveStream`. Keep
+`VerifyingStream` as a thin helper **or** delete it once all call sites move —
+either is fine; the type is not part of the public API.
+
+Solid 7z/RAR: keep verify **inside** the lazy `open_fn` (or equivalent fused
+kwargs applied only when the pending slice actually opens) so close on an
+unread handle cannot force solid positioning — the #136 constraint stays.

--- a/review/stream-layering/correctness.md
+++ b/review/stream-layering/correctness.md
@@ -1,0 +1,194 @@
+# Correctness audit — slice / verify / outer / SharedSource
+
+Part 1 of the brief. Every claim below was traced on PR #136 @ `2a6b91b` and,
+where a bug is alleged, reproduced with a concrete input.
+
+## Invariant list a fused stream MUST keep
+
+These are the non-negotiables extracted from the audit. `collapse-design.md`
+maps each onto the proposed fused `ArchiveStream`.
+
+1. **`read(0)` / zero-length `readinto` is a no-op** — never triggers EOF
+   verification (F1 today violates this).
+2. **Read side effects cover every read path** — `readinto` must hash/bound
+   identically to `read` (either route through `read`, or implement an
+   equivalent `readinto`).
+3. **Verify only on clean sequential EOF** (terminal empty read, or
+   close-at-clean-EOF). Partial reads never verify. Seek off the sequential
+   frontier disables digest/length checks for the rest of the handle's life.
+4. **`expected_size` caps delivered bytes**, detects over-long output with a
+   bounded one-byte trailing probe (also drains WinZip AES HMAC), and defers
+   hashless short errors until **after** inner close so a more specific inner
+   error wins. Digest mismatch still beats synthetic short.
+5. **Typed inner errors keep precedence** over synthetic truncation/verify
+   errors, but close must still close the inner and mark the wrapper closed
+   (F2 today can skip teardown).
+6. **Locked slice / SharedSource mode** never performs unlocked
+   seek/tell/read on the shared handle; every seek+read pair is atomic under
+   the shared lock.
+7. **Single-consumer slice mode** may use the underlying position directly —
+   do not silently switch it to re-seek semantics.
+8. **Archivey-owned concurrent byte-range access** goes through
+   `SharedSource` / locked views; no backend-local unsynchronized cursor
+   scratch (`base_reader.py:488-505`).
+9. **One public `ArchiveStream`** after first read; nested translators/stamps/
+   rewind warnings compose on collapse. Failed lazy open is single-claim (no
+   retry of a half-open backend).
+10. **Leases/finalizers release exactly once**; collapsing an unregistered
+    nested wrapper must not steal or drop a public lease.
+11. **`.size` stays cheap** — explicit metadata first; never open a lazy stream
+    solely to answer size.
+
+---
+
+## 1. `readinto` side-effect safety
+
+| Layer | Base | `readinto` behaviour | Verdict |
+|-------|------|----------------------|---------|
+| `VerifyingStream` | `ReadOnlyIOStream` | → `read()` (`base.py:51-56`) | **OK** — hashes |
+| `CountingReader` / `OutputCountingStream` | `DelegatingStream` | override counts filled bytes (`counting.py:54-62`, `:82-88`) | **OK** |
+| `LockedStream` | `DelegatingStream` | override holds lock (`locked.py:36-44`) | **OK** |
+| `_GzipTruncationCheckStream` | `DelegatingStream` | `readinto_passthrough=False` (`codecs.py:400-402`) | **OK** |
+| `_AcceleratorStream`, `_UnrarOwnedStream`, `_PyCdlibStream`, `CloseLockedStream`, `SeekCountingStream` | `DelegatingStream` | no read side effect; passthrough fine | **OK** |
+| `ArchiveStream` | `ReadOnlyIOStream` | own `readinto` → `inner.readinto` with translate (`archive_stream.py:329-340`) | **OK** — duplicates lazy-open + `_fail`; no read-side hash of its own today |
+| `SlicingStream` / `_MemberSlice` | `ReadOnlyIOStream` | → `read()` | **OK** (but allocates; see collapse-design readinto note) |
+
+No `DelegatingStream` subclass that overrides `read` with a side effect was
+found missing `readinto_passthrough=False` or an explicit `readinto`.
+
+**Fusion implication:** a fused `ArchiveStream` that hashes **must not** keep
+today's `readinto`→`inner.readinto` bypass unless the fused `readinto` itself
+updates the hasher (preferably by hashing a `memoryview` of the caller's
+buffer).
+
+---
+
+## 2. `VerifyingStream` EOF / close (`verify.py`)
+
+### State machine (sequential, verify enabled)
+
+```
+                 read(n>0) data
+    [armed] ─────────────────────► [armed, pos+=n, hash]
+       │                                │
+       │ read → b"" or pos≥expected       │ seek off frontier
+       ▼                                ▼
+    [_finish]                      [disarmed]  (no verify ever)
+       │
+       ├─ trailing probe if pos≥expected_size
+       ├─ verify digests
+       └─ note short if pos<expected_size → raise at close
+```
+
+Confirmed behaviours (with tests in `tests/test_codecs.py`):
+
+- Size cap before inner read (`:219-239`); over-long via trailing `read(1)`
+  (`:198-211`).
+- Digest before short verdict (`:212-217`); hashless short deferred until after
+  inner close (`:319-330`).
+- Partial read then close skips verification.
+- Accel-raises-instead-of-EOF on close probe → `TruncatedError` when still short
+  (`:301-311`); typed `ArchiveyError` that is already
+  `CorruptionError`/`TruncatedError` is kept as `finish_exc`.
+- WinZip AES HMAC drained by the same trailing probe (`zip_aes.py:163-174`;
+  `tests/test_zip_aes.py`).
+- **F6 closed:** over-long hashed content whose CRC matches the *bloated*
+  payload still raises via `expected_size`
+  (`tests/test_codecs.py:619-635`). ZIP/7z/RAR pass `expected_size`.
+
+### F1 — `read(0)` treated as EOF (Medium)
+
+`verify.py:246-254`: any empty `data` with verify still armed runs `_finish`.
+There is no `if n == 0: return b""` guard. Concrete triggers:
+
+```python
+# hashed: false CorruptionError (empty digest ≠ stored CRC)
+VerifyingStream(io.BytesIO(b"abc"), {"crc32": crc32(b"abc")}).read(0)
+
+# hashless + expected_size: false TruncatedError on close
+s = VerifyingStream(io.BytesIO(b"abc"), {}, expected_size=3)
+s.read(0); s.close()
+
+# mid-stream after partial read — also fires (digest covers only prefix)
+s = VerifyingStream(io.BytesIO(b"abc"), {"crc32": crc32(b"abc")})
+s.read(1); s.read(0)  # CorruptionError
+```
+
+Contrast: `_GzipTruncationCheckStream` explicitly treats `read(0)` as non-EOF
+(`tests/test_codecs.py:706-718`). Stdlib `BytesIO.read(0) == b""` without
+end-of-stream side effects. Repro: `measurements.py f1`.
+
+### F2 — close can skip teardown on some typed probe errors (Low)
+
+`verify.py:292-300`: on the close-time `read(1)` probe, a non-`CorruptionError`/
+`TruncatedError` `ArchiveyError` is re-raised **before** `self._inner.close()` /
+`super().close()`. Repro with a custom inner raising `EncryptionError` on the
+probe: after `close()`, both `VerifyingStream.closed` and `inner.closed` are
+`False`. Shipped paths mostly raise `CorruptionError`/`TruncatedError` here
+(AES HMAC, size overrun), so blast radius is limited — but a fused close path
+should `try`/`finally` close regardless. Repro: `measurements.py f2`.
+
+---
+
+## 3. `SlicingStream` dual mode (`slice.py`)
+
+| Rule | Where | Verdict |
+|------|-------|---------|
+| Locked mode: no unlocked `tell`/`seek` at construction when `start` given | `:99-109` | **OK** (tests `test_slice.py:273-304`) |
+| Locked `read`: re-seek + read under same guard | `:148-160` | **OK** |
+| `SEEK_END` unknown length probes under guard | `:178-185` | **OK** |
+| Single-consumer: eager seek at construction; keep underlying in sync | `:110-116`, `:201-205` | **OK** |
+| Negative `SEEK_CUR`/`SEEK_END` clamps; negative `SEEK_SET` raises | `:191-198` | **OK** (BytesIO match) |
+| `own_source` controls close only; default non-owning | `:211-217` | **OK** |
+| `read(0)` returns `b""` without side effects | `:146-147` | **OK** |
+
+`fix_stream_start_position` (`:237-250`) adds a second slice only when a
+seekable source is mid-stream — internal/codec use, not the member-boundary
+layer.
+
+---
+
+## 4. `ArchiveStream` (`archive_stream.py`)
+
+| Rule | Where | Verdict |
+|------|-------|---------|
+| Lazy open claimed once under lock; `open_fn` runs outside | `:193-216` | **OK** |
+| Failed open leaves `_open_fn is None` (no retry) | `:224-227` | **OK** |
+| `_fail`: `ArchiveyError` stamp → closed-file `ValueError` → translator | `:295-317` | **OK** |
+| `#136` `_collapse_nested` steals lazy opener or opened inner; composes translate/stamp/rewind; neuters nested finalizer/`on_close` | `:238-293` | **OK** |
+| Public `_inner` after first read is not an `ArchiveStream` | pinned `test_member_stream_contract.py` | **OK** |
+| Finalizer/lease: attach after `_on_close`; close detaches + releases once | `archive_stream.py:104-156`, `:401-439`; `base_reader.py` register path | **OK** (interpreter-exit caveat documented `:109-115`) |
+| `size`: explicit → opened `try_get_size` / `.size`; lazy unopened → `None` | `:167-191` | **OK** |
+
+**Seam that #136 did not close:** collapse only runs when `open_fn()` **returns**
+an `ArchiveStream`. The ZIP/7z/RAR hot path returns
+`ArchiveStream(VerifyingStream(ArchiveStream(codec)))` from `_open_member`, so
+collapse steals `VerifyingStream` and the **codec** `ArchiveStream` remains
+underneath. Live dump (STORED `open` / `stream_members`):
+
+```
+ArchiveStream                  ← public
+  VerifyingStream
+    ArchiveStream              ← codec shim (STORED: identity over slice)
+      SlicingStream
+        BufferedReader
+```
+
+---
+
+## 5. `SharedSource` / CONCURRENT — the fusion constraint
+
+`SharedSource.view` (`shared.py:97-137`) mints locked non-owning
+`SlicingStream`s; clamps past-EOF views; never closes a caller-owned handle.
+ZIP uses an equivalent pattern (`SlicingStream(..., lock=ZipFile._lock)` in
+`zip_reader.py:922-928`) without the `SharedSource` type. TAR/ISO use
+`LockedStream` around library-owned seek-then-read handles.
+
+**Why this blocks fusing member-boundary slicing into the public handle as a
+general rule:** the slice is a *view object* that must be mintable N ways over
+one source, with per-view `_pos` and atomic re-seek. The public `ArchiveStream`
+is 1:1 with a member lease. Folding the view into the outer stream would either
+(a) break multi-view fan-out, or (b) re-implement `SlicingStream` inside
+`ArchiveStream` and still need the view type for `SharedSource` /
+`fix_stream_start_position` / 7z LZMA caps. Keep the primitive; only the
+per-member verify layer is a clean fold into the outer identity.

--- a/review/stream-layering/layer-map.md
+++ b/review/stream-layering/layer-map.md
@@ -1,0 +1,232 @@
+# Layer map — per-backend member-stream stacks (post-#136)
+
+Measurement OFF. Stacks are **bottom → public**. Line refs are on PR #136
+(`2a6b91b`). `#136` collapses direct nested `ArchiveStream`s inside
+`_ensure_open`; it does **not** look through `VerifyingStream`, so a codec
+`ArchiveStream` under verify remains (see ZIP/STORED).
+
+Shared rules:
+
+- Public wrap: `BaseArchiveReader._wrap_member_stream` —
+  `base_reader.py:573-650`
+- Lazy `stream_members`: `_lazy_member_stream` — `base_reader.py:461-479`;
+  collapse — `archive_stream.py:217-223`, `:238-293`
+- `_track_decompressed` / seek wrappers are identity when measurement is off —
+  `base_reader.py:526-543`
+- `open_codec_stream` may apply `fix_stream_start_position` then returns a
+  codec `ArchiveStream` — `codecs.py:1441-1471`
+
+---
+
+## ZIP
+
+### Unencrypted STORED
+
+Composition: `_raw_member_stream` `zip_reader.py:911-928` →
+`open_codec_stream(STORED)` `:1012-1024` → `VerifyingStream` `:1030-1040` →
+`_wrap_member_stream` `:1041`.
+
+```
+ZipFile.fp
+  SlicingStream(start=data_start, length=compress_size, lock=ZipFile._lock)
+    ArchiveStream(codec)          # StoredCodec returns the slice as-is
+      VerifyingStream(hashes, expected_size)
+        ArchiveStream(member)     # public; stream_members collapses only this outer
+```
+
+Verify: **yes**. Slice: member-boundary, locked re-seek.
+
+### Unencrypted deflate (and other codecs)
+
+Same skeleton; codec layer is `DecompressorStream` / accelerator instead of
+identity:
+
+```
+ZipFile.fp
+  SlicingStream(locked member payload)
+    DecompressorStream | _AcceleratorStream | …
+      ArchiveStream(codec)
+        VerifyingStream
+          ArchiveStream(member)
+```
+
+### ZipCrypto (stdlib path)
+
+`_open_member` encrypted branch `zip_reader.py:1319-1322` →
+`ZipFile.open` `:1069-1074` → optional `CloseLockedStream` under CONCURRENT
+`:1051-1055` → `_wrap_member_stream`.
+
+```
+ZipExtFile (zipfile owns decrypt/decompress/CRC)
+  [CloseLockedStream]             # CONCURRENT only
+    ArchiveStream(member)
+```
+
+Verify: **skipped** (stdlib CRC). No archivey `SlicingStream` on the returned
+handle.
+
+### WinZip AES (method 99)
+
+`_open_aes_member` `zip_reader.py:752-825`:
+
+```
+ZipFile.fp
+  SlicingStream(locked full AES payload)
+    WinZipAesDecryptStream
+      codec stream + ArchiveStream(codec)
+        VerifyingStream            # trailing probe drains HMAC
+          ArchiveStream(member)
+```
+
+---
+
+## TAR
+
+### Plain / random open
+
+`tar_reader.py:492-511`:
+
+```
+tarfile.ExFileObject
+  [LockedStream]                  # CONCURRENT or streaming handle lock
+    ArchiveStream(member)
+```
+
+Verify: **no**. Slice: **no**.
+
+### Compressed `.tar.gz` / `.tar.xz` / …
+
+Outer codec once at archive open (`tar_reader.py:198-223`), then same member
+stack. Streaming `_iter_with_data` (`:317-337`) always locks.
+
+---
+
+## ISO
+
+`iso_reader.py:468-485`:
+
+```
+pycdlib.PyCdlibIO
+  _PyCdlibStream
+    [LockedStream]                # CONCURRENT
+      ArchiveStream(member)
+```
+
+Verify: **no**. Slice: **no**. `SharedSource`: **no**.
+
+---
+
+## 7z
+
+### Folder pipeline (solid and non-solid)
+
+`SharedSource` at open (`sevenzip_reader.py:189`) → pack
+`SharedSource.view` (`:465-477`) → pipeline stages
+(`sevenzip_pipeline.py:305-368`: AES / codec+`ArchiveStream` / optional LZMA
+cap `SlicingStream` / BCJ).
+
+### Random `open(member)`
+
+`sevenzip_reader.py:657-691` + verify wrap `:600-613`:
+
+```
+decoded folder stream
+  SlicingStream(prefix, length=size, own_source=True)   # or forward skip + length slice
+    VerifyingStream                 # if size or hashes
+      ArchiveStream(member)
+```
+
+### `stream_members` solid lazy (#136)
+
+`sevenzip_reader.py:615-639` + `solid.py:136-145`:
+
+```
+decoded folder stream
+  SolidBlockReader
+    _MemberSlice(pending)           # positions on first read
+      VerifyingStream               # inside ArchiveStream open_fn
+        ArchiveStream(member, seekable=False)
+```
+
+Verify inside `open_fn` so `VerifyingStream.close` cannot probe an unselected
+member into a solid open.
+
+---
+
+## RAR
+
+### Direct stored
+
+`SharedSource.view` → verify → wrap (`rar_reader.py:718-730`, `:670-716`):
+
+```
+archive source
+  SlicingStream via SharedSource.view(data_offset, file_size)
+    VerifyingStream
+      ArchiveStream(member)
+```
+
+### `unrar p` (random / non-solid)
+
+```
+unrar stdout
+  _UnrarOwnedStream
+    VerifyingStream                 # usual case
+      ArchiveStream(member)
+```
+
+### Solid lazy `stream_members` (#136)
+
+`rar_reader.py:564-623`:
+
+```
+unrar ALL-pipe
+  _UnrarOwnedStream
+    SolidBlockReader
+      _MemberSlice(pending)
+        VerifyingStream             # inside open_fn
+          ArchiveStream(member, seekable=False)
+```
+
+---
+
+## Single-file compressed
+
+`single_file_reader.py:304-359`:
+
+| Source | Stack |
+|--------|--------|
+| Path (seekable) | codec stream → `ArchiveStream(codec)` → public `ArchiveStream` (**collapsed** on open) |
+| Seekable `BinaryIO` | `SharedSource.view(0)` → codec → codec AS → public AS (collapsed) |
+| Non-seekable | `[CountingReader?]` → codec → codec AS → public AS (collapsed) |
+
+Verify: **skipped** at reader (codec-internal checks remain).
+`fix_stream_start_position` may add a slice inside `open_codec_stream`.
+
+---
+
+## Directory
+
+`directory_reader.py:269-276`:
+
+```
+open(path, "rb")
+  ArchiveStream(member)
+```
+
+Verify / slice / locks: **none**.
+
+---
+
+## Cross-cutting
+
+| Mechanism | Where used on hot path |
+|-----------|------------------------|
+| `VerifyingStream` | ZIP unencrypted + AES; 7z members; RAR payloads |
+| Member-boundary `SlicingStream` | ZIP raw payload; 7z member over folder; RAR direct stored |
+| `SharedSource` views | 7z, RAR, single-file seekable streams |
+| `LockedStream` | TAR, ISO (CONCURRENT / streaming) |
+| `CloseLockedStream` | ZIP ZipCrypto CONCURRENT close |
+| `fix_stream_start_position` | `open_codec_stream`, nested `open_archive` |
+| Nested codec `ArchiveStream` under verify | ZIP unencrypted/AES; remains after #136 |
+| Decode engine | out of scope (Topic 6) |

--- a/review/stream-layering/measurements.py
+++ b/review/stream-layering/measurements.py
@@ -1,0 +1,376 @@
+#!/usr/bin/env python3
+"""Runnable evidence for the stream-layering review.
+
+Designed against the post-#136 stack (nested outer ``ArchiveStream`` collapsed;
+codec ``ArchiveStream`` may still sit under ``VerifyingStream``). On plain
+``main`` before #136 lands, ``measurements.py stack`` shows an extra outer nest
+on ``stream_members`` only; ``open()`` already looks like the post-collapse
+shape. Synthetic fusion sections are valid either way.
+
+Run::
+
+    uv run --no-sync python review/stream-layering/measurements.py
+    uv run --no-sync python review/stream-layering/measurements.py f1 f2 stack stored
+
+Sections:
+
+    f1       VerifyingStream.read(0) false-EOF (F1)
+    f2       close-leak on typed probe error (F2)
+    stack    live STORED / DEFLATE handle dump after first read
+    stored   STORED ZIP isolation + synthetic fusion stacks
+    all      everything (default)
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import os
+import statistics
+import struct
+import sys
+import tempfile
+import time
+import zipfile
+import zlib
+from pathlib import Path
+
+# Prefer the checkout's src/ over an editable install of another revision so
+# `python review/stream-layering/measurements.py` reflects the tree you are in
+# (important when comparing main vs the #136 collapse).
+_SRC = Path(__file__).resolve().parents[2] / "src"
+if _SRC.is_dir():
+    sys.path.insert(0, str(_SRC))
+
+from archivey import open_archive  # noqa: E402
+from archivey.exceptions import (  # noqa: E402
+    CorruptionError,
+    EncryptionError,
+    TruncatedError,
+)
+from archivey.internal.streams.archive_stream import ArchiveStream  # noqa: E402
+from archivey.internal.streams.streamtools.slice import SlicingStream  # noqa: E402
+from archivey.internal.streams.verify import VerifyingStream  # noqa: E402
+
+CHUNK = 64 * 1024
+
+
+def med(fn, n: int = 15) -> float:
+    xs: list[float] = []
+    for _ in range(n):
+        t0 = time.perf_counter()
+        fn()
+        xs.append((time.perf_counter() - t0) * 1000)
+    return statistics.median(xs[1:])
+
+
+def section_f1() -> None:
+    print("=== F1: VerifyingStream.read(0) treated as EOF ===")
+    payload = b"abc"
+    crc = zlib.crc32(payload) & 0xFFFFFFFF
+
+    try:
+        VerifyingStream(io.BytesIO(payload), {"crc32": crc}).read(0)
+        print("  hashed read(0): OK (unexpected — bug fixed?)")
+    except CorruptionError as e:
+        print(f"  hashed read(0): CorruptionError ({e})")
+
+    s = VerifyingStream(io.BytesIO(payload), {}, expected_size=3)
+    assert s.read(0) == b""
+    try:
+        s.close()
+        print("  hashless read(0)+close: OK (unexpected — bug fixed?)")
+    except TruncatedError as e:
+        print(f"  hashless read(0)+close: TruncatedError ({e})")
+
+    s = VerifyingStream(io.BytesIO(payload), {"crc32": crc})
+    assert s.read(1) == b"a"
+    try:
+        s.read(0)
+        print("  mid-stream read(0): OK (unexpected — bug fixed?)")
+    except CorruptionError as e:
+        print(f"  mid-stream read(0): CorruptionError ({e})")
+
+    print(f"  BytesIO.read(0) reference: {io.BytesIO(payload).read(0)!r}")
+
+
+def section_f2() -> None:
+    print("=== F2: close leak on non-Corruption/Truncated ArchiveyError probe ===")
+
+    class Boom(io.BytesIO):
+        def __init__(self) -> None:
+            super().__init__(b"ab")
+            self.close_called = False
+
+        def read(self, n: int = -1) -> bytes:
+            data = super().read(n)
+            if not data:
+                raise EncryptionError("boom")
+            return data
+
+        def close(self) -> None:
+            self.close_called = True
+            super().close()
+
+    inner = Boom()
+    s = VerifyingStream(inner, {}, expected_size=3)
+    assert s.read(2) == b"ab"
+    try:
+        s.close()
+        print("  close: OK (unexpected)")
+    except EncryptionError as e:
+        print(f"  close raised {type(e).__name__}: {e}")
+    print(
+        f"  wrapper.closed={s.closed} inner.closed={inner.closed} "
+        f"close_called={inner.close_called}"
+    )
+
+
+def _dump(obj: object, depth: int = 0, seen: set[int] | None = None) -> None:
+    if seen is None:
+        seen = set()
+    if id(obj) in seen:
+        return
+    seen.add(id(obj))
+    name = type(obj).__name__
+    extra = ""
+    if isinstance(obj, VerifyingStream):
+        extra = f" verify={obj._verify_enabled} pos={obj._pos}"
+    if isinstance(obj, ArchiveStream):
+        extra = f" size={obj._size} open_fn={'set' if obj._open_fn else None}"
+    print("  " * depth + f"{name}{extra}")
+    for attr in ("_inner", "_stream"):
+        child = getattr(obj, attr, None)
+        if child is not None and child is not obj:
+            _dump(child, depth + 1, seen)
+
+
+def section_stack() -> None:
+    print("=== Live stack dump (after first read) ===")
+    import archivey as _ay
+
+    print(f"(archivey imported from {_ay.__file__})")
+    with tempfile.TemporaryDirectory() as td:
+        stored = Path(td) / "stored.zip"
+        deflate = Path(td) / "deflate.zip"
+        payload = b"x" * 65536
+        with zipfile.ZipFile(stored, "w", compression=zipfile.ZIP_STORED) as zf:
+            zf.writestr("a.bin", payload)
+        with zipfile.ZipFile(deflate, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+            zf.writestr("a.bin", payload)
+
+        with open_archive(stored) as r:
+            print("STORED open():")
+            with r.open("a.bin") as f:
+                f.read(1)
+                _dump(f)
+            print("STORED stream_members():")
+            for _m, s in r.stream_members():
+                if s is None:
+                    continue
+                s.read(1)
+                _dump(s)
+                break
+
+        with open_archive(deflate) as r:
+            print("DEFLATE open():")
+            with r.open("a.bin") as f:
+                f.read(1)
+                _dump(f)
+
+
+def _build_stored_zip(path: Path, members: int, size: int) -> list[int]:
+    payloads = [os.urandom(size) for _ in range(members)]
+    crcs = [zlib.crc32(p) & 0xFFFFFFFF for p in payloads]
+    with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_STORED) as zf:
+        for i, p in enumerate(payloads):
+            zf.writestr(f"m{i:03d}.bin", p)
+    return crcs
+
+
+def _regions(z: zipfile.ZipFile):
+    fp = z.fp
+    assert fp is not None
+    for info in z.infolist():
+        fp.seek(info.header_offset)
+        hdr = fp.read(30)
+        nlen, elen = struct.unpack_from("<HH", hdr, 26)
+        yield info, info.header_offset + 30 + nlen + elen
+
+
+class _Fused(ArchiveStream):
+    """Minimal fused AS→Slice hasher for the synthetic comparison."""
+
+    def __init__(self, inner: object, crc: int, size: int) -> None:
+        self._exp_crc = crc
+        self._exp = size
+        self._pos = 0
+        self._crc = 0
+        self._done = False
+        super().__init__(
+            lambda: inner,  # type: ignore[arg-type,return-value]
+            translate=lambda _e: None,
+            lazy=False,
+            size=size,
+        )
+
+    def read(self, n: int = -1) -> bytes:
+        if self._done:
+            return b""
+        rem = self._exp - self._pos
+        if rem <= 0:
+            trailing = super().read(1)
+            if trailing:
+                raise ValueError("overlong")
+            if (self._crc & 0xFFFFFFFF) != self._exp_crc:
+                raise ValueError("crc")
+            self._done = True
+            return b""
+        want = rem if n < 0 else min(n, rem)
+        data = super().read(want)
+        if data:
+            self._crc = zlib.crc32(data, self._crc)
+            self._pos += len(data)
+            return data
+        if (self._crc & 0xFFFFFFFF) != self._exp_crc:
+            raise ValueError("crc")
+        self._done = True
+        return data
+
+
+def section_stored() -> None:
+    print("=== STORED ZIP isolation (64 × 256 KiB) ===")
+    members, size = 64, 256 * 1024
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / "stored.zip"
+        crcs = _build_stored_zip(path, members, size)
+
+        def ay() -> None:
+            with open_archive(path) as r:
+                for _m, s in r.stream_members():
+                    if s is None:
+                        continue
+                    with s:
+                        s.read()
+
+        def zf() -> None:
+            with zipfile.ZipFile(path) as z:
+                for info in z.infolist():
+                    with z.open(info) as f:
+                        f.read()
+
+        def current_like() -> None:
+            with zipfile.ZipFile(path) as z:
+                fp = z.fp
+                assert fp is not None
+                for i, (info, start) in enumerate(_regions(z)):
+                    sl = SlicingStream(
+                        fp, start=start, length=info.file_size, lock=z._lock
+                    )
+                    codec = ArchiveStream(
+                        lambda sl=sl: sl, translate=lambda _e: None, lazy=False
+                    )
+                    vs = VerifyingStream(
+                        codec, {"crc32": crcs[i]}, expected_size=info.file_size
+                    )
+                    outer = ArchiveStream(
+                        lambda vs=vs: vs,
+                        translate=lambda _e: None,
+                        lazy=False,
+                        size=info.file_size,
+                    )
+                    outer.read()
+                    outer.close()
+
+        def after_fuse() -> None:
+            with zipfile.ZipFile(path) as z:
+                fp = z.fp
+                assert fp is not None
+                for i, (info, start) in enumerate(_regions(z)):
+                    sl = SlicingStream(
+                        fp, start=start, length=info.file_size, lock=z._lock
+                    )
+                    vs = VerifyingStream(
+                        sl, {"crc32": crcs[i]}, expected_size=info.file_size
+                    )
+                    outer = ArchiveStream(
+                        lambda vs=vs: vs,
+                        translate=lambda _e: None,
+                        lazy=False,
+                        size=info.file_size,
+                    )
+                    outer.read()
+                    outer.close()
+
+        def true_fused() -> None:
+            with zipfile.ZipFile(path) as z:
+                fp = z.fp
+                assert fp is not None
+                for i, (info, start) in enumerate(_regions(z)):
+                    sl = SlicingStream(
+                        fp, start=start, length=info.file_size, lock=z._lock
+                    )
+                    outer = _Fused(sl, crcs[i], info.file_size)
+                    outer.read()
+                    outer.close()
+
+        rows = [
+            ("archivey live", ay),
+            ("zipfile", zf),
+            ("current-like AS>VS>AS>Slice", current_like),
+            ("after verify-fuse AS>VS>Slice", after_fuse),
+            ("true fused AS>Slice", true_fused),
+        ]
+        results: dict[str, float] = {}
+        for label, fn in rows:
+            ms = med(fn)
+            results[label] = ms
+            print(f"  {label:<34} {ms:6.2f} ms")
+        print(
+            f"  STORED ratio archivey/zipfile: "
+            f"{results['archivey live'] / results['zipfile']:.2f}x"
+        )
+        cur, fused = (
+            results["current-like AS>VS>AS>Slice"],
+            results["true fused AS>Slice"],
+        )
+        print(
+            f"  synthetic fusion win vs current-like: "
+            f"{(cur - fused) / cur * 100:.1f}% ({cur:.2f} → {fused:.2f} ms)"
+        )
+        print(
+            f"  end-to-end win estimate if stack alone: "
+            f"~{cur - fused:.2f} ms of {results['archivey live']:.2f} ms "
+            f"({(cur - fused) / results['archivey live'] * 100:.1f}%)"
+        )
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "sections",
+        nargs="*",
+        default=["all"],
+        help="f1 f2 stack stored all",
+    )
+    args = p.parse_args(argv)
+    wanted = set(args.sections)
+    if "all" in wanted:
+        wanted = {"f1", "f2", "stack", "stored"}
+    if "f1" in wanted:
+        section_f1()
+        print()
+    if "f2" in wanted:
+        section_f2()
+        print()
+    if "stack" in wanted:
+        section_stack()
+        print()
+    if "stored" in wanted:
+        section_stored()
+        print()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/archivey/internal/backends/rar_reader.py
+++ b/src/archivey/internal/backends/rar_reader.py
@@ -56,7 +56,6 @@ from archivey.internal.streams.streamtools import (
     is_seekable,
     is_stream,
 )
-from archivey.internal.streams.verify import VerifyingStream
 from archivey.internal.volumes import ConcatenatedFile, discover_volume_siblings
 from archivey.types import (
     EXTRA_IS_JUNCTION,
@@ -125,7 +124,7 @@ def _crc_is_tweaked(info: RarMemberInfo) -> bool:
 
 
 def _member_hashes(info: RarMemberInfo) -> dict[str, int | bytes]:
-    """Plaintext digests safe for :class:`VerifyingStream` without a HashKey.
+    """Plaintext digests safe for member verification without a HashKey.
 
     When ``RAR5_XENC_TWEAKED`` / ``HASHMAC`` (0x02) is set, the stored CRC32 and
     BLAKE2sp are key-tweaked (``ConvertHashToMAC``) and must not be compared to the
@@ -577,9 +576,9 @@ class RarReader(BaseArchiveReader):
         )
         self._live_unrar = proc
         # Each payload member in the pipe is verified individually (CRC/BLAKE2sp and
-        # declared length via VerifyingStream), so the pipe-level unrar exit code is
-        # redundant for corruption and is suppressed here to avoid legacy-format false
-        # positives; wrong-password (11) still maps.
+        # declared length via fused ArchiveStream verify), so the pipe-level unrar
+        # exit code is redundant for corruption and is suppressed here to avoid
+        # legacy-format false positives; wrong-password (11) still maps.
         owned: BinaryIO = self._track_decompressed(
             _UnrarOwnedStream(stdout, proc, has_verifiable_hash=True)
         )
@@ -599,25 +598,26 @@ class RarReader(BaseArchiveReader):
                 size = _member_stream_size(member)
                 # Capture the pipe offset for this member, then advance the running
                 # cursor. ``lazy=True`` defers skip-decode until first read; verify
-                # wrap stays inside open_fn so VerifyingStream.close cannot probe an
-                # unselected handle into a solid open.
+                # is fused into the outer ArchiveStream so a never-opened handle
+                # skips verify on close (no solid positioning for unread members).
                 member_offset = pipe_offset
                 pipe_offset += size
                 lazy_solid = solid.open_member(member_offset, size, lazy=True)
 
-                def open_fn(
-                    inner: BinaryIO = lazy_solid,
-                    m: ArchiveMember = member,
-                ) -> BinaryIO:
-                    return self._prepare_payload_stream(inner, m)
-
+                hashes, vsize, transforms, verify_member = self._payload_verify_args(
+                    member
+                )
                 stream = self._wrap_member_stream(
                     None,
                     member.name,
-                    open_fn=open_fn,
+                    open_fn=lambda inner=lazy_solid: inner,
                     size=member.size,
                     track_output=False,
                     seekable=False,
+                    expected_hashes=hashes,
+                    expected_size=vsize,
+                    digest_transforms=transforms,
+                    verify_member=verify_member,
                 )
                 previous = stream
                 yield member, stream
@@ -667,21 +667,20 @@ class RarReader(BaseArchiveReader):
             return None
         return expected, transforms
 
-    def _prepare_payload_stream(
-        self,
-        inner: BinaryIO,
-        member: ArchiveMember,
-    ) -> BinaryIO:
-        """Verify + size-bound a RAR payload view (no ``ArchiveStream`` yet)."""
-        # Verify every member's declared length (and any CRC32/BLAKE2sp) as it is read:
-        # an over-long external decode stops at the declared size and errors, a short one
-        # raises, and a wrong one fails its digest. Applied to all members (not just
-        # hashed ones), so a hash-less member still can't be silently truncated. A seek
-        # off the sequential frontier disables the checks (VerifyingStream), preserving
-        # random access on seekable direct reads.
-        #
-        # Tweaked RAR5 digests (HASHMAC) are not in ``member.hashes``; when a password
-        # is available they are verified via ConvertHashToMAC transforms instead.
+    def _payload_verify_args(
+        self, member: ArchiveMember
+    ) -> tuple[
+        Mapping[str, int | bytes] | None,
+        int | None,
+        Mapping[str, Callable[[bytes], bytes]] | None,
+        ArchiveMember | None,
+    ]:
+        """Return ``(hashes, size, transforms, member)`` for fused verify, or Nones.
+
+        Verify every member's declared length (and any CRC32/BLAKE2sp) as it is
+        read. Tweaked RAR5 digests (HASHMAC) use ConvertHashToMAC transforms when
+        a password is available.
+        """
         expected: Mapping[str, int | bytes] = member.hashes
         transforms: Mapping[str, Callable[[bytes], bytes]] | None = None
         raw = member._raw
@@ -689,17 +688,9 @@ class RarReader(BaseArchiveReader):
             tweaked = self._tweaked_verify_spec(raw)
             if tweaked is not None:
                 expected, transforms = tweaked
-        if member.size is not None or expected:
-            inner = VerifyingStream(
-                inner,
-                expected,
-                expected_size=member.size,
-                collector=self._diagnostics_collector,
-                member=member,
-                archive_name=self._archive_name,
-                digest_transforms=transforms,
-            )
-        return inner
+        if member.size is None and not expected:
+            return None, None, None, None
+        return expected, member.size, transforms, member
 
     def _wrap_payload_stream(
         self,
@@ -708,11 +699,16 @@ class RarReader(BaseArchiveReader):
         *,
         track_output: bool = True,
     ) -> ArchiveStream:
+        hashes, size, transforms, verify_member = self._payload_verify_args(member)
         return self._wrap_member_stream(
-            self._prepare_payload_stream(inner, member),
+            inner,
             member.name,
             size=member.size,
             track_output=track_output,
+            expected_hashes=hashes,
+            expected_size=size,
+            digest_transforms=transforms,
+            verify_member=verify_member,
         )
 
     def _can_direct_read(self, info: RarMemberInfo) -> bool:
@@ -774,8 +770,8 @@ class RarReader(BaseArchiveReader):
             version_control=raw.is_file_version_history(),
         )
         self._live_unrar = proc
-        # Prefer our VerifyingStream (including tweaked ConvertHashToMAC) over unrar's
-        # exit code for corruption; wrong-password (11) still maps.
+        # Prefer our fused digest check (including tweaked ConvertHashToMAC) over
+        # unrar's exit code for corruption; wrong-password (11) still maps.
         has_hash = bool(member.hashes) or (
             isinstance(raw, RarMemberInfo)
             and self._tweaked_verify_spec(raw) is not None
@@ -790,8 +786,7 @@ class RarReader(BaseArchiveReader):
         )
         try:
             # Folder/pipe output already counted; avoid double-counting at the member wrap.
-            # VerifyingStream (in _wrap_payload_stream) bounds and checks the pipe against
-            # the member's declared size (and any CRC32/BLAKE2sp).
+            # Fused verify in _wrap_payload_stream bounds/checks declared size + digests.
             return self._wrap_payload_stream(owned, member, track_output=False)
         except BaseException:
             owned.close()

--- a/src/archivey/internal/backends/sevenzip_reader.py
+++ b/src/archivey/internal/backends/sevenzip_reader.py
@@ -73,7 +73,6 @@ from archivey.internal.streams.streamtools import (
     read_exact,
     skip_forward,
 )
-from archivey.internal.streams.verify import VerifyingStream
 from archivey.internal.timestamps import TimestampIssue, filetime_to_datetime
 from archivey.types import (
     ArchiveFormat,
@@ -590,27 +589,16 @@ class SevenZipReader(BaseArchiveReader):
     def _wrap_folder_member(
         self, inner: BinaryIO, member: ArchiveMember
     ) -> ArchiveStream:
+        verify = member.size is not None or bool(member.hashes)
         return self._wrap_member_stream(
-            self._prepare_folder_member(inner, member),
+            inner,
             member.name,
             size=member.size,
             track_output=False,
+            expected_hashes=member.hashes if verify else None,
+            expected_size=member.size if verify else None,
+            verify_member=member if verify else None,
         )
-
-    def _prepare_folder_member(
-        self, inner: BinaryIO, member: ArchiveMember
-    ) -> BinaryIO:
-        """Verify + size-bound a solid-folder member view (no ``ArchiveStream`` yet)."""
-        if member.size is not None or member.hashes:
-            inner = VerifyingStream(
-                inner,
-                member.hashes,
-                expected_size=member.size,
-                collector=self._diagnostics_collector,
-                member=member,
-                archive_name=self._archive_name,
-            )
-        return inner
 
     def _member_stream_from_solid(
         self, solid: SolidBlockReader, member: ArchiveMember
@@ -618,24 +606,25 @@ class SevenZipReader(BaseArchiveReader):
         """Hand out a stream whose solid positioning runs on first read.
 
         Uses ``solid.open_member(..., lazy=True)`` so an unselected handle can be
-        closed without skip-decoding. Verification is applied in ``open_fn`` (not at
-        yield time): ``VerifyingStream.close`` probes with ``read(1)``, which would
-        otherwise force the lazy solid open on every skipped member.
+        closed without skip-decoding. Verification is fused into the outer
+        ``ArchiveStream``: a never-opened lazy handle skips verify on close, so
+        unread members do not force solid positioning.
         """
         prefix = self._member_prefix(member)
         size = _member_stream_size(member)
         lazy_solid = solid.open_member(prefix, size, lazy=True)
-
-        def open_fn(inner: BinaryIO = lazy_solid) -> BinaryIO:
-            return self._prepare_folder_member(inner, member)
+        verify = member.size is not None or bool(member.hashes)
 
         return self._wrap_member_stream(
             None,
             member.name,
-            open_fn=open_fn,
+            open_fn=lambda: lazy_solid,
             size=member.size,
             track_output=False,
             seekable=False,
+            expected_hashes=member.hashes if verify else None,
+            expected_size=member.size if verify else None,
+            verify_member=member if verify else None,
         )
 
     def _translate_exception(self, exc: Exception) -> ArchiveyError | None:

--- a/src/archivey/internal/backends/zip_reader.py
+++ b/src/archivey/internal/backends/zip_reader.py
@@ -74,7 +74,6 @@ from archivey.internal.streams.streamtools import (
     is_stream,
     read_exact,
 )
-from archivey.internal.streams.verify import VerifyingStream
 from archivey.internal.timestamps import TimestampIssue, filetime_to_datetime
 from archivey.internal.zip_aes import (
     open_winzip_aes_member,
@@ -814,13 +813,13 @@ class ZipReader(BaseArchiveReader):
         hashes = member.hashes if member is not None else {}
         size = member.size if member is not None else info.file_size
         if hashes or size is not None:
-            decoded = VerifyingStream(
+            return self._wrap_member_stream(
                 decoded,
-                hashes,
+                member_name,
+                size=size,
+                expected_hashes=hashes,
                 expected_size=size,
-                collector=self._diagnostics_collector,
-                member=member,
-                archive_name=self._archive_name,
+                verify_member=member,
             )
         return self._wrap_member_stream(decoded, member_name, size=size)
 
@@ -1030,13 +1029,13 @@ class ZipReader(BaseArchiveReader):
         hashes = member.hashes if member is not None else {}
         size = member.size if member is not None else info.file_size
         if hashes or size is not None:
-            decoded = VerifyingStream(
+            return self._wrap_member_stream(
                 decoded,
-                hashes,
+                member_name,
+                size=size,
+                expected_hashes=hashes,
                 expected_size=size,
-                collector=self._diagnostics_collector,
-                member=member,
-                archive_name=self._archive_name,
+                verify_member=member,
             )
         return self._wrap_member_stream(decoded, member_name, size=size)
 
@@ -1320,7 +1319,7 @@ class ZipReader(BaseArchiveReader):
             # Traditional ZipCrypto stays on the stdlib zipfile decryption path.
             raw = self._open_zip_entry(info, member, member_name=member.name)
             return self._wrap_member_stream(raw, member.name, size=member.size)
-        # Unencrypted: codec layer already wrapped (+ VerifyingStream) in _open_codec_member.
+        # Unencrypted: codec layer + fused verify in _open_codec_member.
         return self._open_codec_member(info, member, member_name=member.name)
 
     def _get_archive_info(self) -> ArchiveInfo:

--- a/src/archivey/internal/base_reader.py
+++ b/src/archivey/internal/base_reader.py
@@ -580,6 +580,10 @@ class BaseArchiveReader(ArchiveReader):
         size: int | None = None,
         track_output: bool = True,
         seekable: bool | None = None,
+        expected_hashes: Mapping[str, int | bytes] | None = None,
+        expected_size: int | None = None,
+        digest_transforms: Mapping[str, Callable[[bytes], bytes]] | None = None,
+        verify_member: ArchiveMember | None = None,
     ) -> ArchiveStream:
         """Wrap a raw member stream so read/seek errors route through the backend's
         translator and are stamped with format/archive/member context.
@@ -604,6 +608,11 @@ class BaseArchiveReader(ArchiveReader):
         ``track_output=False`` to avoid double-counting. When ``open_fn`` may return an
         ``ArchiveStream``, pass ``track_output=False`` (counting belongs on that inner
         wrap); collapse happens in ``_ensure_open``.
+
+        Pass ``expected_hashes`` / ``expected_size`` to fuse container digest and
+        length verification into the returned ``ArchiveStream`` (no separate
+        ``VerifyingStream`` layer). A never-opened lazy handle skips verify on
+        close, so solid unread members stay cheap.
         """
         if (inner is None) == (open_fn is None):
             raise TypeError("exactly one of inner or open_fn is required")
@@ -631,6 +640,11 @@ class BaseArchiveReader(ArchiveReader):
                 seekable=(self._seek_declared() if seekable is None else seekable),
                 size=size,
                 collector=self._diagnostics_collector,
+                expected_hashes=expected_hashes,
+                expected_size=expected_size,
+                digest_transforms=digest_transforms,
+                verify_member=verify_member,
+                archive_name=self._archive_name,
             )
 
         assert inner is not None
@@ -648,6 +662,11 @@ class BaseArchiveReader(ArchiveReader):
             ),
             size=size,
             collector=self._diagnostics_collector,
+            expected_hashes=expected_hashes,
+            expected_size=expected_size,
+            digest_transforms=digest_transforms,
+            verify_member=verify_member,
+            archive_name=self._archive_name,
         )
 
     @abstractmethod

--- a/src/archivey/internal/streams/archive_stream.py
+++ b/src/archivey/internal/streams/archive_stream.py
@@ -4,6 +4,11 @@ This is the carrier for the exception-translation contract (see ``error-handling
 CONTRIBUTING). Any exception raised while opening or reading the wrapped stream is routed
 through a per-library *translator* (raw third-party exception → ``ArchiveyError`` subclass
 or ``None`` to let it propagate), then *stamped* with format/archive/member context.
+
+Member digest/length verification (formerly a separate ``VerifyingStream`` layer) is
+optional state on this handle — see ``expected_hashes`` / ``expected_size`` — so a
+member is served by one public stream that collapses nested codec ``ArchiveStream``s
+and hashes/bounds in the same ``read()``.
 """
 
 from __future__ import annotations
@@ -13,7 +18,7 @@ import sys
 import threading
 import weakref
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, BinaryIO, Callable, NoReturn
+from typing import TYPE_CHECKING, BinaryIO, Callable, Mapping, NoReturn
 
 from archivey.diagnostics import (
     DiagnosticCode,
@@ -24,11 +29,13 @@ from archivey.exceptions import ArchiveyError, ArchiveyUsageError
 from archivey.internal.diagnostics_collector import resolve_collector
 from archivey.internal.logs import streams as logger
 from archivey.internal.streams.streamtools import ReadOnlyIOStream, is_seekable
+from archivey.internal.streams.verify import MemberVerifier, build_member_verifier
 
 if TYPE_CHECKING:
     from _typeshed import WriteableBuffer
 
     from archivey.internal.diagnostics_collector import DiagnosticCollector
+    from archivey.types import ArchiveMember
 
 # A translator maps a raw exception to an ArchiveyError, or returns None to signal "not
 # mine — let it propagate unchanged" (the catch-all-free rule in CONTRIBUTING).
@@ -78,6 +85,12 @@ class ArchiveStream(ReadOnlyIOStream):
         size: int | None = None,
         collector: DiagnosticCollector | None = None,
         on_close: CloseHook | None = None,
+        expected_hashes: Mapping[str, int | bytes] | None = None,
+        expected_size: int | None = None,
+        digest_transforms: Mapping[str, Callable[[bytes], bytes]] | None = None,
+        verify_member: ArchiveMember | None = None,
+        archive_name: str | None = None,
+        verifier: MemberVerifier | None = None,
     ) -> None:
         super().__init__()
         self._open_fn: Callable[[], BinaryIO] | None = open_fn
@@ -97,6 +110,21 @@ class ArchiveStream(ReadOnlyIOStream):
         self._diagnostics_watermark = (
             collector.watermark() if collector is not None else None
         )
+        # Fused member verification (None when there is nothing to check). Prefer an
+        # already-built ``verifier`` (collapse adoption); otherwise build from knobs.
+        # ``expected_size`` here is the verify bound only — bare ``size=`` (fsspec
+        # attribute) must not enable length checks on TAR/ISO/directory handles.
+        if verifier is not None:
+            self._verifier: MemberVerifier | None = verifier
+        else:
+            self._verifier = build_member_verifier(
+                expected_hashes,
+                expected_size=expected_size,
+                collector=collector,
+                member=verify_member,
+                archive_name=archive_name,
+                digest_transforms=digest_transforms,
+            )
         self._finalizer: weakref.finalize | None = None
         if not lazy:
             self._ensure_open()
@@ -270,6 +298,11 @@ class ArchiveStream(ReadOnlyIOStream):
         self._stamp = composed_stamp
         if self._rewind_warning is None and nested._rewind_warning is not None:
             self._rewind_warning = nested._rewind_warning
+        # Adopt fused verification from the nested member wrap (lazy stream_members
+        # outer has none; the inner ``_open_member`` wrap carries the knobs).
+        if self._verifier is None and nested._verifier is not None:
+            self._verifier = nested._verifier
+            nested._verifier = None
 
         with nested._open_lock:
             open_fn = nested._open_fn
@@ -321,12 +354,22 @@ class ArchiveStream(ReadOnlyIOStream):
         # wrapper's own (plain file semantics, not translated), and a lazy open failure
         # is already routed through _fail inside it.
         inner = self._ensure_open()
+        verifier = self._verifier
         try:
+            if verifier is not None:
+                return verifier.read(inner, n)
             return inner.read(n)
         except Exception as e:  # noqa: BLE001 - re-raised via the translator
             self._fail(e)
 
     def readinto(self, b: "WriteableBuffer", /) -> int:
+        # When verifying, route through read() so digest/bounds stay consistent
+        # (same contract as VerifyingStream / ReadOnlyIOStream.readinto).
+        if self._verifier is not None:
+            mv = memoryview(b).cast("B")
+            data = self.read(len(mv))
+            mv[: len(data)] = data
+            return len(data)
         inner = self._ensure_open()
         readinto = getattr(inner, "readinto", None)
         if readinto is None:
@@ -348,6 +391,9 @@ class ArchiveStream(ReadOnlyIOStream):
             result = inner.seek(offset, whence)
         except Exception as e:  # noqa: BLE001 - re-raised via the translator
             self._fail(e)
+        verifier = self._verifier
+        if verifier is not None:
+            verifier.note_seek(result)
         self._maybe_warn_rewind(before, result)
         return result
 
@@ -409,14 +455,22 @@ class ArchiveStream(ReadOnlyIOStream):
         # still propagate; dual-failure grouping is for ordinary close/teardown errors.
         close_exc: Exception | None = None
         try:
-            if self._inner is not None:
+            inner = self._inner
+            verifier = self._verifier
+            if inner is not None:
                 try:
-                    self._inner.close()
+                    if verifier is not None:
+                        # finish_on_close closes the inner (and runs deferred verify).
+                        verifier.finish_on_close(inner)
+                    else:
+                        inner.close()
                 except Exception as e:  # noqa: BLE001 - re-raised via the translator
                     try:
                         self._fail(e)
                     except Exception as translated:  # noqa: BLE001 - may be ArchiveyError
                         close_exc = translated
+            # Never-opened lazy handle: skip verify (solid unread members must not
+            # probe / force positioning).
         finally:
             super().close()
             self._detach_finalizer()

--- a/src/archivey/internal/streams/verify.py
+++ b/src/archivey/internal/streams/verify.py
@@ -1,36 +1,22 @@
-"""Decompressed-output digest (and length) verification stage.
+"""Decompressed-output digest (and length) verification.
 
-Wraps a *sequential* decompressed stream and checks the member's container-supplied
-digests (``ArchiveMember.hashes``) — and, when ``expected_size`` is supplied, its
-declared decompressed length — against the bytes actually read. The length check bounds
-reads to the declared size (so an over-long decode stops there and raises instead of
-running unbounded), raises on a short stream, and runs alongside the digest check so a
-member with no stored hash still cannot be silently truncated. Per the
-``compressed-streams`` spec:
+Container digests (``ArchiveMember.hashes``) and optional declared decompressed
+length are checked on a clean sequential read to EOF. The logic lives in
+:class:`MemberVerifier` so it can run either as a standalone
+:class:`VerifyingStream` wrapper (codec length backstops) or **fused into**
+:class:`~archivey.internal.streams.archive_stream.ArchiveStream` (the member
+hot path — one fewer Python layer, and nested codec ``ArchiveStream``s can
+collapse through).
 
-- Verification runs **only on a full sequential read to clean EOF**. A partial read is
-  never verified (the digest of partial content is undefined), so this stage applies to
-  the sequential read path, not to random-access reads.
-- The stage is transparent to seeking: it delegates ``seek``/``seekable`` to the inner
-  stream, but a seek that moves off the sequential frontier disables verification for the
-  rest of the stream's life (the running digest is then incomplete). So a member opened
-  ``MemberStreams.SEEKABLE`` is still verified if the caller only reads forward, and simply
-  skips the check once it seeks — mirroring the gzip truncation backstop in ``codecs.py``.
-- The mismatch is raised from the terminal read — the call that would return ``b""`` —
-  *after* every data chunk (including the last) has already been delivered. A
-  ``while chunk := f.read(n)`` consumer thus receives all bytes, then gets
-  ``CorruptionError`` instead of the final empty read.
-- An algorithm whose backend is missing (or that is unknown) is **skipped with a
-  ``DIGEST_UNVERIFIABLE`` diagnostic** rather than failing the read; algorithms that can
-  be computed (always including CRC32 via stdlib, and BLAKE2sp via the internal hasher)
-  are still verified.
-- ``close()`` also verifies when the inner stream is already at clean EOF, so a single
-  ``read()`` that consumed the whole member (as ``ArchiveReader.read`` does) still
-  checks digests.
+Per the ``compressed-streams`` spec:
 
-This is distinct from a codec's own internal integrity check (gzip trailer CRC, xz stream
-check) — those are surfaced by the codec backend; this verifies the *container's* digest
-over the decompressed bytes.
+- Verification runs **only on a full sequential read to clean EOF**. A partial
+  read is never verified. ``read(0)`` is a no-op (not EOF).
+- A seek off the sequential frontier disables verification for the rest of the
+  handle's life.
+- The mismatch is raised from the terminal empty read *after* every data chunk
+  has been delivered; ``close()`` also verifies when already at clean EOF.
+- Missing/unknown digest algorithms emit ``DIGEST_UNVERIFIABLE`` and are skipped.
 """
 
 from __future__ import annotations
@@ -111,28 +97,17 @@ def _expected_as_bytes(value: int | bytes, hasher: _IncrementalHasher) -> bytes:
     return value
 
 
-class VerifyingStream(ReadOnlyIOStream):
-    """Wrap ``inner`` and verify the member's ``expected`` digests (and, optionally, its
-    declared decompressed length) on a clean sequential read to end-of-stream.
+class MemberVerifier:
+    """Incremental digest/length checker over bytes read from an inner stream.
 
-    ``read`` hashes the bytes it returns (``readinto``/``readall`` come from
-    :class:`ReadOnlyIOStream`, built on this ``read``, so they hash too) and checks the
-    digests once the stream reaches clean EOF. ``seek``/``seekable`` delegate to ``inner``;
-    a seek off the sequential frontier disables verification for the rest of the stream's
-    life, since the running digest can no longer cover the whole member.
-
-    When ``expected_size`` is given, reads are bounded to that many bytes so an
-    over-long decode (a decompressor/pipe emitting more than the member's declared size)
-    stops at the declared size and raises :class:`CorruptionError` immediately rather than
-    running unbounded; a stream that ends short of it raises :class:`TruncatedError`. The
-    length check runs after the digest check (so a hashed short read still surfaces as a
-    digest mismatch) and the short verdict is applied at close, after the inner stream is
-    closed, so a more specific inner error (e.g. a wrong-password subprocess exit) wins.
+    Not a ``BinaryIO`` itself — :class:`VerifyingStream` and
+    :class:`~archivey.internal.streams.archive_stream.ArchiveStream` own one and
+    call :meth:`read` / :meth:`note_seek` / :meth:`finish_on_close` against their
+    inner handle.
     """
 
     def __init__(
         self,
-        inner: BinaryIO,
         expected: Mapping[str, int | bytes],
         *,
         expected_size: int | None = None,
@@ -141,8 +116,6 @@ class VerifyingStream(ReadOnlyIOStream):
         archive_name: str | None = None,
         digest_transforms: Mapping[str, Callable[[bytes], bytes]] | None = None,
     ) -> None:
-        super().__init__()
-        self._inner = inner
         self._expected_size = expected_size
         self._short = False
         self._expected: dict[str, bytes] = {}
@@ -179,6 +152,14 @@ class VerifyingStream(ReadOnlyIOStream):
         self._pos = 0  # bytes read so far — the sequential verification frontier
         self._verify_enabled = True  # cleared by a seek off the frontier
 
+    @property
+    def enabled(self) -> bool:
+        return self._verify_enabled
+
+    @property
+    def pos(self) -> int:
+        return self._pos
+
     def _verify_digests(self) -> None:
         """Check every computable digest; raise on the first mismatch."""
         for algorithm, expected in self._expected.items():
@@ -192,14 +173,14 @@ class VerifyingStream(ReadOnlyIOStream):
                     f"decompressed content."
                 )
 
-    def _finish(self) -> None:
+    def _finish(self, inner: BinaryIO) -> None:
         """Run end-of-stream checks once: over-length, then digests, then note short."""
         self._verified = True
         if self._expected_size is not None and self._pos >= self._expected_size:
             # Delivered the declared size; the underlying must have nothing more.
             # This probe also drains post-payload authenticators (e.g. WinZip AES HMAC).
             try:
-                trailing = self._inner.read(1)
+                trailing = inner.read(1)
             except ArchiveyError:
                 raise
             except Exception:  # noqa: BLE001 - opaque accel errors ≈ no trailing data
@@ -216,7 +197,11 @@ class VerifyingStream(ReadOnlyIOStream):
             # a digest mismatch above.
             self._short = True
 
-    def read(self, n: int = -1, /) -> bytes:
+    def read(self, inner: BinaryIO, n: int = -1) -> bytes:
+        """Read from ``inner``, update digests/bounds, and verify on clean EOF."""
+        # read(0) is a no-op — never treat it as EOF (stdlib file / BytesIO contract).
+        if n == 0:
+            return b""
         if (
             self._verify_enabled
             and self._expected_size is not None
@@ -230,16 +215,16 @@ class VerifyingStream(ReadOnlyIOStream):
             else:
                 want = remaining if n < 0 else min(n, remaining)
                 try:
-                    data = self._inner.read(want)
+                    data = inner.read(want)
                 except Exception:  # noqa: BLE001 - abandon verify; re-raise decoder error
                     # Abandon length/digest checks: close must not raise a second fault
                     # after the caller already saw this decode error (macOS rapidgzip
-                    # mid-cut often raises here, then again on VerifyingStream.close).
+                    # mid-cut often raises here, then again on finish_on_close).
                     self._verify_enabled = False
                     raise
         else:
             try:
-                data = self._inner.read(n)
+                data = inner.read(n)
             except Exception:  # noqa: BLE001 - abandon verify; re-raise decoder error
                 self._verify_enabled = False
                 raise
@@ -250,31 +235,22 @@ class VerifyingStream(ReadOnlyIOStream):
                     hasher.update(data)
             return data
         if self._verify_enabled and not self._verified:
-            self._finish()
+            self._finish(inner)
         return data
 
-    def seekable(self) -> bool:
-        return is_seekable(self._inner)
-
-    def seek(self, offset: int, whence: int = 0, /) -> int:
-        result = self._inner.seek(offset, whence)
-        # A seek off the sequential frontier makes the running digest incomplete; give up
-        # on verification (a no-op seek to the current position keeps it armed).
+    def note_seek(self, result: int) -> None:
+        """Update the frontier after a successful inner seek; disable if off-frontier."""
         if result != self._pos:
             self._verify_enabled = False
         self._pos = result
-        return result
 
-    def tell(self) -> int:
-        return self._inner.tell()
+    def finish_on_close(self, inner: BinaryIO) -> None:
+        """Run deferred EOF verification around an inner that is still open.
 
-    def close(self) -> None:
-        if self.closed:
-            return
-        # ``archive.read()`` often does a single ``read()`` that returns all bytes without
-        # a follow-up empty read, so verify here when the inner stream is already at clean
-        # EOF (partial reads still skip verification).
-        finish_exc: CorruptionError | TruncatedError | None = None
+        Always closes ``inner`` (and surfaces probe/finish errors after that close).
+        Callers that have not opened an inner yet should not call this.
+        """
+        finish_exc: ArchiveyError | None = None
         if self._verify_enabled and not self._verified:
             reached_declared = (
                 self._expected_size is not None and self._pos >= self._expected_size
@@ -283,20 +259,17 @@ class VerifyingStream(ReadOnlyIOStream):
             # macOS) may raise on truncated input instead of returning b""; treat that
             # as EOF when we are still short of the declared size so silent short-reads
             # still become TruncatedError, without double-faulting after read() raised.
-            # Typed library errors (HMAC mismatch, etc.) must still propagate.
+            # Typed library errors (HMAC mismatch, etc.) must still propagate — but the
+            # inner must still be closed (F2).
             more = False
             probe_raised = False
             if not reached_declared:
                 try:
-                    more = bool(self._inner.read(1))
+                    more = bool(inner.read(1))
                 except ArchiveyError as exc:
-                    finish_exc = (
-                        exc
-                        if isinstance(exc, (CorruptionError, TruncatedError))
-                        else None
-                    )
-                    if finish_exc is None:
-                        raise
+                    # Close the inner first, then re-raise (F2: never leave the
+                    # wrapper/inner unclosed on a typed probe error).
+                    finish_exc = exc
                     more = True  # skip _finish; surface finish_exc after close
                 except Exception:  # noqa: BLE001 - accel truncate may raise any error
                     probe_raised = True
@@ -311,16 +284,19 @@ class VerifyingStream(ReadOnlyIOStream):
                     )
                 else:
                     try:
-                        self._finish()
+                        self._finish(inner)
                     except CorruptionError as exc:
                         finish_exc = (
                             exc  # still close the inner below before re-raising
                         )
         short = self._short
+        # Close first. An inner teardown error (e.g. unrar wrong-password exit)
+        # must win over a deferred short/truncation verdict — same precedence as
+        # the pre-fusion VerifyingStream.close.
         try:
-            self._inner.close()
-        finally:
-            super().close()
+            inner.close()
+        except Exception:
+            raise
         if finish_exc is not None:
             raise finish_exc
         if short:
@@ -328,3 +304,106 @@ class VerifyingStream(ReadOnlyIOStream):
                 f"Decompressed content ended after {self._pos} of "
                 f"{self._expected_size} expected bytes."
             )
+
+
+def build_member_verifier(
+    expected: Mapping[str, int | bytes] | None,
+    *,
+    expected_size: int | None = None,
+    collector: DiagnosticCollector | None = None,
+    member: ArchiveMember | None = None,
+    archive_name: str | None = None,
+    digest_transforms: Mapping[str, Callable[[bytes], bytes]] | None = None,
+) -> MemberVerifier | None:
+    """Return a :class:`MemberVerifier` when there is something to check, else ``None``."""
+    hashes = expected if expected is not None else {}
+    if not hashes and expected_size is None:
+        return None
+    return MemberVerifier(
+        hashes,
+        expected_size=expected_size,
+        collector=collector,
+        member=member,
+        archive_name=archive_name,
+        digest_transforms=digest_transforms,
+    )
+
+
+class VerifyingStream(ReadOnlyIOStream):
+    """Wrap ``inner`` and verify digests/length via a :class:`MemberVerifier`.
+
+    Kept for codec length backstops and tests. Member backends fuse the same
+    verifier into :class:`~archivey.internal.streams.archive_stream.ArchiveStream`.
+    """
+
+    def __init__(
+        self,
+        inner: BinaryIO,
+        expected: Mapping[str, int | bytes],
+        *,
+        expected_size: int | None = None,
+        collector: DiagnosticCollector | None = None,
+        member: ArchiveMember | None = None,
+        archive_name: str | None = None,
+        digest_transforms: Mapping[str, Callable[[bytes], bytes]] | None = None,
+    ) -> None:
+        super().__init__()
+        self._inner = inner
+        verifier = build_member_verifier(
+            expected,
+            expected_size=expected_size,
+            collector=collector,
+            member=member,
+            archive_name=archive_name,
+            digest_transforms=digest_transforms,
+        )
+        # Always construct a verifier when this wrapper is used explicitly (even if
+        # both hashes and size are empty — length-only call sites pass expected_size).
+        if verifier is None:
+            verifier = MemberVerifier(
+                {},
+                expected_size=expected_size,
+                collector=collector,
+                member=member,
+                archive_name=archive_name,
+                digest_transforms=digest_transforms,
+            )
+        self._verifier = verifier
+
+    # Compat for tests / diagnostics that inspect frontier state.
+    @property
+    def _verify_enabled(self) -> bool:
+        return self._verifier.enabled
+
+    @property
+    def _pos(self) -> int:
+        return self._verifier.pos
+
+    @property
+    def _expected_size(self) -> int | None:
+        return self._verifier._expected_size
+
+    def read(self, n: int = -1, /) -> bytes:
+        return self._verifier.read(self._inner, n)
+
+    def seekable(self) -> bool:
+        return is_seekable(self._inner)
+
+    def seek(self, offset: int, whence: int = 0, /) -> int:
+        result = self._inner.seek(offset, whence)
+        self._verifier.note_seek(result)
+        return result
+
+    def tell(self) -> int:
+        return self._inner.tell()
+
+    def close(self) -> None:
+        if self.closed:
+            return
+        try:
+            self._verifier.finish_on_close(self._inner)
+        finally:
+            # finish_on_close closes the inner; always mark the wrapper closed even
+            # when a typed probe error propagates (F2).
+            if not self.closed:
+                super().close()

--- a/src/archivey/internal/streams/verify.py
+++ b/src/archivey/internal/streams/verify.py
@@ -292,11 +292,9 @@ class MemberVerifier:
         short = self._short
         # Close first. An inner teardown error (e.g. unrar wrong-password exit)
         # must win over a deferred short/truncation verdict — same precedence as
-        # the pre-fusion VerifyingStream.close.
-        try:
-            inner.close()
-        except Exception:
-            raise
+        # the pre-fusion VerifyingStream.close, so let a close error propagate over
+        # ``finish_exc`` / ``short`` below rather than swallowing it.
+        inner.close()
         if finish_exc is not None:
             raise finish_exc
         if short:
@@ -349,7 +347,10 @@ class VerifyingStream(ReadOnlyIOStream):
     ) -> None:
         super().__init__()
         self._inner = inner
-        verifier = build_member_verifier(
+        # This wrapper is used explicitly (codec length backstops, tests), so it always
+        # owns a verifier even when there is nothing to check — unlike the fused path,
+        # which uses ``build_member_verifier`` to skip the wrapper entirely in that case.
+        self._verifier = MemberVerifier(
             expected,
             expected_size=expected_size,
             collector=collector,
@@ -357,18 +358,6 @@ class VerifyingStream(ReadOnlyIOStream):
             archive_name=archive_name,
             digest_transforms=digest_transforms,
         )
-        # Always construct a verifier when this wrapper is used explicitly (even if
-        # both hashes and size are empty — length-only call sites pass expected_size).
-        if verifier is None:
-            verifier = MemberVerifier(
-                {},
-                expected_size=expected_size,
-                collector=collector,
-                member=member,
-                archive_name=archive_name,
-                digest_transforms=digest_transforms,
-            )
-        self._verifier = verifier
 
     # Compat for tests / diagnostics that inspect frontier state.
     @property

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -654,6 +654,51 @@ def test_verify_expected_size_partial_read_then_close_is_ok() -> None:
     stream.close()  # must not raise
 
 
+def test_verify_read0_is_not_eof() -> None:
+    """F1: read(0) must not run end-of-stream verification (BytesIO / file contract)."""
+    stream = VerifyingStream(io.BytesIO(CONTENT), {"crc32": _crc32(CONTENT)})
+    assert stream.read(0) == b""
+    assert stream.read(5) == CONTENT[:5]
+    assert stream.read(0) == b""  # mid-stream
+    assert stream.read() == CONTENT[5:]
+    assert stream.read() == b""
+
+
+def test_verify_read0_hashless_does_not_truncate_on_close() -> None:
+    stream = VerifyingStream(io.BytesIO(CONTENT), {}, expected_size=len(CONTENT))
+    assert stream.read(0) == b""
+    stream.close()  # must not raise TruncatedError
+
+
+def test_verify_close_closes_inner_on_typed_probe_error() -> None:
+    """F2: a typed probe error must still close the wrapper and inner."""
+    from archivey.exceptions import EncryptionError
+
+    class Boom(io.BytesIO):
+        def __init__(self) -> None:
+            super().__init__(b"ab")
+            self.close_called = False
+
+        def read(self, n: int = -1) -> bytes:
+            data = super().read(n)
+            if not data:
+                raise EncryptionError("boom")
+            return data
+
+        def close(self) -> None:
+            self.close_called = True
+            super().close()
+
+    inner = Boom()
+    stream = VerifyingStream(inner, {}, expected_size=3)
+    assert stream.read(2) == b"ab"
+    with pytest.raises(EncryptionError, match="boom"):
+        stream.close()
+    assert stream.closed
+    assert inner.closed
+    assert inner.close_called
+
+
 def test_verify_unverifiable_algorithm_skipped_with_warning(
     caplog: pytest.LogCaptureFixture,
 ) -> None:

--- a/tests/test_member_stream_contract.py
+++ b/tests/test_member_stream_contract.py
@@ -263,6 +263,28 @@ def test_stream_members_do_not_nest_archive_streams(tmp_path: Path) -> None:
             pytest.fail("expected a file member")
 
 
+def test_zip_member_fuses_verify_no_verifying_stream_layer(tmp_path: Path) -> None:
+    """STORED ZIP: public ArchiveStream verifies directly over SlicingStream.
+
+    After verify-fusion, the codec ArchiveStream collapses through and there is
+    no VerifyingStream in the chain (review/stream-layering collapse design).
+    """
+    from archivey.internal.streams.archive_stream import ArchiveStream
+    from archivey.internal.streams.streamtools.slice import SlicingStream
+    from archivey.internal.streams.verify import VerifyingStream
+
+    path = tmp_path / "stored.zip"
+    with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_STORED) as zf:
+        zf.writestr("a.bin", b"hello-verify-fuse")
+    with open_archive(path) as ar, ar.open("a.bin") as f:
+        assert isinstance(f, ArchiveStream)
+        assert f._verifier is not None
+        assert not isinstance(f._inner, ArchiveStream)
+        assert not isinstance(f._inner, VerifyingStream)
+        assert isinstance(f._inner, SlicingStream)
+        assert f.read() == b"hello-verify-fuse"
+
+
 def test_member_stream_advertises_size(member: tuple[Path, str]) -> None:
     # The fsspec-style `size` attribute carries the decompressed length when the
     # archive metadata knows it (feeds nested-archive sizing and the bomb tracker).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements the `review/stream-layering` deep-review recommendation on top of merged #136 (nested `ArchiveStream` collapse + solid lazy open). Includes the review deliverables and the code change.

Rebased onto `main` after #136 landed.

## Headline

**Partial fusion, implemented:** container digest/length verification moves into `ArchiveStream` via a shared `MemberVerifier`. ZIP/7z/RAR stop wrapping a separate `VerifyingStream` layer, so `_collapse_nested` can finish collapsing the codec `ArchiveStream`. Live STORED ZIP stack is now:

```
ArchiveStream (verify + translate + lease)
  → SlicingStream
    → BufferedReader
```

`SlicingStream` / `SharedSource` / decode engine stay separate (CONCURRENT + Topic 6).

## Before / after benchmarks

Same host, CPython 3.11, `[all]` extras. Trees compared via `PYTHONPATH=<tree>/src` against shared fixtures. Full writeup: `review/stream-layering/BENCH.md`.

### Stack (STORED ZIP, after first read)

| Tree | Stack |
|------|-------|
| main / #136 | `ArchiveStream → VerifyingStream → ArchiveStream → SlicingStream` |
| **this PR** | `ArchiveStream → SlicingStream` |

### STORED / DEFLATE microbench (64 × 256 KiB, 41 warm rounds)

`stream_members` read-all medians (ms):

| | main | #136 | this PR | vs #136 |
|--|-----:|-----:|--------:|--------:|
| STORED archivey | 7.76 | 7.53 | 7.67 | **+1.8%** |
| STORED zipfile | 4.45 | 4.43 | 4.46 | — |
| STORED ratio | 1.74× | 1.70× | 1.72× | — |
| DEFLATE archivey | 30.4 | 30.7 | 31.6 | **+2.7%** |
| DEFLATE ratio | 1.92× | 1.96× | 2.00× | — |

### Harness `--mode full --scale realistic --warmup` (#136 → this PR)

| Case | #136 | this PR | Δ | #136× | this PR× |
|------|-----:|--------:|--:|------:|---------:|
| `zip_open_list` | 0.78 ms | 0.76 ms | −2.3% | — | — |
| `zip_read_all` | 27.22 ms | 27.21 ms | −0.0% | 2.00 | 2.03 |
| `zip_extract` | 53.47 ms | 55.47 ms | +3.7% | — | — |
| `tar_read_all` | 3.94 ms | 4.03 ms | +2.4% | 1.76 | 1.77 |
| `gzip_read_all` | 36.47 ms | 36.27 ms | −0.6% | 1.02 | 1.04 |
| `targz_read_all_accel_off` | 23.21 ms | 22.10 ms | −4.8% | 1.24 | 1.22 |
| `sevenzip_solid_sequential` | 8.90 ms | 8.65 ms | −2.8% | — | — |
| `sevenzip_solid_random` | 155.18 ms | 150.55 ms | −3.0% | — | — |

**Takeaway:** wall times are within noise (~±5%) of #136. Fusion is a **structural** win (one fewer wrapper; codec AS collapse finishes) plus F1/F2 fixes — it does **not** close the ZIP ≤1.3× gap (`zip_read_all` still ~2.0×). Matches the review's measured wrapper-share bound.

## Code

- `MemberVerifier` extracted; `VerifyingStream` kept as a thin wrapper for `codecs.py` length backstops + unit tests
- `ArchiveStream` / `_wrap_member_stream` take `expected_hashes` / `expected_size`; verify runs in `read`/`close`; never-opened lazy handles skip verify (solid unread members stay cheap)
- ZIP / 7z / RAR backends wired to the fused knobs
- **F1:** `read(0)` is a no-op (no false EOF verify)
- **F2:** typed probe errors still close the inner before re-raising; inner teardown (e.g. unrar wrong-password) still beats deferred `TruncatedError`

## Review docs

`review/stream-layering/{SUMMARY,correctness,layer-map,collapse-design,QUESTIONS,BENCH}.md` + `measurements.py`

## Test plan

- [x] 1752 passed / 87 skipped (`[all]`)
- [x] ruff / pyrefly / ty clean
- [x] New pins: `test_verify_read0_*`, F2 close leak, `test_zip_member_fuses_verify_no_verifying_stream_layer`
- [x] Before/after microbench + realistic harness recorded in `BENCH.md`
- [x] Rebased onto `main` after #136 merge
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b0840290-6e5d-4bd2-9a0b-101fe04297dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b0840290-6e5d-4bd2-9a0b-101fe04297dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

