### PR TITLE
refactor: tidy MemberVerifier close + VerifyingStream construction (review of #137)

### DIFF
--- a/src/archivey/internal/streams/verify.py
+++ b/src/archivey/internal/streams/verify.py
@@ -292,11 +292,9 @@ class MemberVerifier:
         short = self._short
         # Close first. An inner teardown error (e.g. unrar wrong-password exit)
         # must win over a deferred short/truncation verdict — same precedence as
-        # the pre-fusion VerifyingStream.close.
-        try:
-            inner.close()
-        except Exception:
-            raise
+        # the pre-fusion VerifyingStream.close, so let a close error propagate over
+        # ``finish_exc`` / ``short`` below rather than swallowing it.
+        inner.close()
         if finish_exc is not None:
             raise finish_exc
         if short:
@@ -349,7 +347,10 @@ class VerifyingStream(ReadOnlyIOStream):
     ) -> None:
         super().__init__()
         self._inner = inner
-        verifier = build_member_verifier(
+        # This wrapper is used explicitly (codec length backstops, tests), so it always
+        # owns a verifier even when there is nothing to check — unlike the fused path,
+        # which uses ``build_member_verifier`` to skip the wrapper entirely in that case.
+        self._verifier = MemberVerifier(
             expected,
             expected_size=expected_size,
             collector=collector,
@@ -357,18 +358,6 @@ class VerifyingStream(ReadOnlyIOStream):
             archive_name=archive_name,
             digest_transforms=digest_transforms,
         )
-        # Always construct a verifier when this wrapper is used explicitly (even if
-        # both hashes and size are empty — length-only call sites pass expected_size).
-        if verifier is None:
-            verifier = MemberVerifier(
-                {},
-                expected_size=expected_size,
-                collector=collector,
-                member=member,
-                archive_name=archive_name,
-                digest_transforms=digest_transforms,
-            )
-        self._verifier = verifier
 
     # Compat for tests / diagnostics that inspect frontier state.
     @property


### PR DESCRIPTION
Code-quality follow-ups from reviewing #136 (merged) and #137. Targets #137's branch so the fixes land in that PR. **No behaviour change** — all three CI dependency legs (`[all]`, `[all-lowest]`, `[core-only]`) stay green, plus ruff/pyrefly/ty clean.

## Review outcome

**#136** (merged) — lazy solid open (`open_member(..., lazy=True)` deferring skip-decode into `_MemberSlice`), nested `ArchiveStream` collapse, `extension_map` cache, and the `readall` join-of-chunks are all clean, well-documented, and each has a focused regression test. No issues found.

**#137** — the `VerifyingStream` → `MemberVerifier` extraction and fusion into `ArchiveStream` is sound; the `read(0)` no-op (F1) and close-before-reraise (F2) fixes are correct and tested; the fused read/readinto/close/seek paths preserve the verify contract, and the end-to-end path is exercised by the format corruption suites and `test_readinto_oversized_buffer_truncates_at_eof`. Two small clarity items, fixed here.

## Changes

- **`MemberVerifier.finish_on_close`** — drop the no-op `try: inner.close() except Exception: raise`. A bare `raise` just re-propagates, so the handler was dead code; plain `inner.close()` keeps the exact same precedence (a close error wins over the deferred `finish_exc` / `short` verdict below).
- **`VerifyingStream.__init__`** — construct `MemberVerifier` directly instead of calling `build_member_verifier` and then reconstructing an empty verifier when it returns `None`. This wrapper always owns a verifier, so the `None` branch never ran; `build_member_verifier` remains the `None`-returning helper for the fused path only.

## Test plan

- [x] `[all]`: 1708 passed / 131 skipped
- [x] `[all-lowest]` (`--resolution lowest-direct`): 1708 passed / 131 skipped
- [x] `[core-only]` (`--no-dev` + zero-dep-core check): 1394 passed / 392 skipped
- [x] ruff format/check, pyrefly, ty clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01BjV2f83sAxXjbjHbUW9s93)_