### PR TITLE
perf: decode-feed fix + structural gate tighten (post-#134 investigation)

### DIFF
--- a/benchmarks/baselines/structural.json
+++ b/benchmarks/baselines/structural.json
@@ -1,5 +1,8 @@
 {
-  "solid_decode_factor": 2.0,
+  "solid_decode_factor": 1.25,
+  "nonsolid_decode_factor": 1.1,
+  "solid_random_bytes_factor": 1.5,
+  "seek_baseline_slack": 8,
   "cases": {
     "zip_open_list": {
       "bytes_decompressed": 0,
@@ -71,7 +74,7 @@
       "bytes_decompressed": 34603008,
       "source_seek_count": 35,
       "unpacked_bytes": 2097152,
-      "notes": "re-decode recorded; not gated"
+      "notes": "re-decode recorded; gated vs baseline×SOLID_RANDOM_BYTES_FACTOR"
     }
   }
 }

--- a/benchmarks/harness.py
+++ b/benchmarks/harness.py
@@ -9,10 +9,10 @@ Run::
 
 Modes:
 
-- ``structural`` (default for CI/PR): **the automated gate** — seek-count baselines
-  and solid decode-once bounds only. Common-path ``bytes_decompressed == unpacked``
-  is tautological (counted at member output); the seek axis is what catches
-  silent re-open churn.
+- ``structural`` (default for CI/PR): **the automated gate** — seek-count baselines,
+  solid decode-once bounds, and a non-solid over-decode bound on ``read_all``.
+  Under-decode remains an integrity check; over-decode catches silent re-open churn
+  that the old seek slack (baseline×2+8) used to absorb.
 - ``full``: also report wall-time ratios vs stdlib peers. Ratios are noisy on
   shared runners, so full mode is a **manual / nightly drift tool**, not the PR
   gate. Sanity ceiling only (no committed wall-time baseline).
@@ -28,6 +28,7 @@ from __future__ import annotations
 import argparse
 import gzip
 import json
+import shutil
 import sys
 import tarfile
 import time
@@ -48,7 +49,20 @@ STRUCTURAL_BASELINE = BASELINES_DIR / "structural.json"
 
 # Sequential solid read may decode a little padding / skip; keep a small slack factor.
 # (Unit tests use a tighter bound on controlled fixtures — see test_measurement.py.)
-SOLID_DECODE_FACTOR = 2.0
+# Was 2.0: that let a clean "decode every solid folder exactly twice" regression
+# pass (perf review G3 / VISION "re-reads a solid block fails the benchmark").
+SOLID_DECODE_FACTOR = 1.25
+# Non-solid read_all over-decode guard. Output-counting makes under-decode the
+# only previous check; without an upper bound, a decode-twice-deliver-once ZIP
+# regression doubles bytes_decompressed and still passes (perf review G4).
+NONSOLID_DECODE_FACTOR = 1.1
+# Random-access solid cost is inherent, but bound it against the committed
+# baseline so a folder-cache regression cannot silently double the work (G5).
+SOLID_RANDOM_BYTES_FACTOR = 1.5
+# Seek-count slack against the committed ci baseline. Was baseline×2+8, which
+# absorbed a full ZIP decode-twice seek doubling (28→52). Fixtures are
+# deterministic; baseline+8 still covers observed host jitter (e.g. gzip 1→3).
+SEEK_BASELINE_SLACK = 8
 # Wall-time sanity ceiling for --mode full. No committed wall_time.json: cold-pass
 # ci ratios were misleading, and shared-runner noise makes ratio regression gates
 # flake. VISION ≤1.3× / ~2× is informational on realistic full runs / nightly.
@@ -201,6 +215,18 @@ def _interleaved_pair_times(
     return ay_samples[mid], last_ay, std_samples[mid]
 
 
+def _stdlib_zip_open_list(path: Path) -> None:
+    with zipfile.ZipFile(path) as zf:
+        zf.namelist()
+        zf.infolist()
+
+
+def _stdlib_zip_extract(path: Path, dest: Path) -> None:
+    dest.mkdir(parents=True, exist_ok=True)
+    with zipfile.ZipFile(path) as zf:
+        zf.extractall(dest)
+
+
 def _stdlib_zip_read_all(path: Path) -> None:
     with zipfile.ZipFile(path) as zf:
         for name in zf.namelist():
@@ -293,10 +319,39 @@ def run_cases(
         return wall, std_wall
 
     # --- ZIP ---
-    wall, (bdec, seeks) = timed_with_optional_warmup(
+    # open_list wall vs zipfile (structural bytes from the measured pass).
+    _m_wall, (bdec, seeks) = timed_with_optional_warmup(
         lambda: _op_open_list(fixtures.zip_path)
     )
-    results.append(CaseResult("zip_open_list", "zip", "open_list", wall, bdec, seeks))
+
+    def _ay_open_list() -> None:
+        with open_archive(fixtures.zip_path) as reader:
+            _ = reader.info
+            list(reader.members())
+
+    if warmup:
+        wall, _ignored, std_wall = _interleaved_pair_times(
+            _ay_open_list,
+            lambda: _stdlib_zip_open_list(fixtures.zip_path),
+            rounds=7,
+        )
+    else:
+        wall, _ = timed_with_optional_warmup(_ay_open_list)
+        std_wall, _ = timed_with_optional_warmup(
+            lambda: _stdlib_zip_open_list(fixtures.zip_path)
+        )
+    results.append(
+        CaseResult(
+            "zip_open_list",
+            "zip",
+            "open_list",
+            wall,
+            bdec,
+            seeks,
+            stdlib_wall_s=std_wall,
+            wall_ratio=(wall / std_wall) if std_wall > 0 else None,
+        )
+    )
     # Structural bytes from a measured pass; wall ratio from an unmeasured peer race.
     _m_wall, (bdec, seeks, unpacked) = timed_with_optional_warmup(
         lambda: _op_read_all(fixtures.zip_path)
@@ -318,10 +373,49 @@ def run_cases(
             wall_ratio=(wall / std_wall) if std_wall > 0 else None,
         )
     )
-    wall, (bdec, seeks) = timed_with_optional_warmup(
+    _m_wall, (bdec, seeks) = timed_with_optional_warmup(
         lambda: _op_extract(fixtures.zip_path, work / "extract-zip")
     )
-    results.append(CaseResult("zip_extract", "zip", "extract", wall, bdec, seeks))
+    _ext_i = 0
+
+    def _ay_extract_clean() -> None:
+        nonlocal _ext_i
+        _ext_i += 1
+        dest = work / "extract-zip-wall" / f"ay-{_ext_i}"
+        if dest.exists():
+            shutil.rmtree(dest)
+        dest.mkdir(parents=True, exist_ok=True)
+        with open_archive(fixtures.zip_path) as reader:
+            reader.extract_all(dest)
+
+    def _std_extract_clean() -> None:
+        nonlocal _ext_i
+        _ext_i += 1
+        dest = work / "extract-zip-wall" / f"std-{_ext_i}"
+        if dest.exists():
+            shutil.rmtree(dest)
+        _stdlib_zip_extract(fixtures.zip_path, dest)
+
+    if warmup:
+        wall, _ignored, std_wall = _interleaved_pair_times(
+            _ay_extract_clean, _std_extract_clean, rounds=7
+        )
+    else:
+        wall, _ = timed_with_optional_warmup(_ay_extract_clean)
+        std_wall, _ = timed_with_optional_warmup(_std_extract_clean)
+    results.append(
+        CaseResult(
+            "zip_extract",
+            "zip",
+            "extract",
+            wall,
+            bdec,
+            seeks,
+            unpacked_bytes=unpacked,  # same fixture as zip_read_all
+            stdlib_wall_s=std_wall,
+            wall_ratio=(wall / std_wall) if std_wall > 0 else None,
+        )
+    )
 
     # --- TAR (plain / uncompressed — harness peer is tarfile r:) ---
     wall, (bdec, seeks) = timed_with_optional_warmup(
@@ -474,7 +568,7 @@ def run_cases(
                 bdec,
                 seeks,
                 unpacked_bytes=fixtures.unpacked_solid_7z,
-                notes="re-decode recorded; not gated",
+                notes="re-decode recorded; gated vs baseline×SOLID_RANDOM_BYTES_FACTOR",
             )
         )
 
@@ -507,7 +601,7 @@ def run_cases(
                 bdec,
                 seeks,
                 unpacked_bytes=fixtures.unpacked_solid_rar,
-                notes="re-decode recorded; not gated",
+                notes="re-decode recorded; gated vs baseline×SOLID_RANDOM_BYTES_FACTOR",
             )
         )
 
@@ -530,25 +624,47 @@ def _structural_checks(
                     f"{r.case}: bytes_decompressed={r.bytes_decompressed} "
                     f"> unpacked×{SOLID_DECODE_FACTOR}={limit} (solid re-decode?)"
                 )
+        if (
+            check_seek_baselines
+            and r.case.endswith("_random")
+            and r.unpacked_bytes
+            and r.format in ("7z", "rar")
+        ):
+            # Absolute re-decode cost is inherent for solid random access; gate
+            # against the committed ci baseline so "got worse" is still visible.
+            # Skipped on non-ci scales (baseline is ci-only), same as seek checks.
+            ref = cases.get(r.case)
+            if ref is not None and ref.get("bytes_decompressed") is not None:
+                limit = int(ref["bytes_decompressed"] * SOLID_RANDOM_BYTES_FACTOR)
+                if r.bytes_decompressed > limit:
+                    failures.append(
+                        f"{r.case}: bytes_decompressed={r.bytes_decompressed} "
+                        f"> baseline×{SOLID_RANDOM_BYTES_FACTOR}={limit}"
+                    )
         if r.operation == "read_all" and r.unpacked_bytes is not None:
-            # Under-decode guard only. For zip/tar/gzip this equals unpacked by
-            # construction (counted at member output) — silent *re*-decode of the
-            # source is caught by the seek-count baseline below, not this axis.
-            # Solid sequential (above) is where the byte axis does real work.
-            if (
-                r.format in ("zip", "tar", "gzip", "tar.gz", "tar.bz2")
-                and r.bytes_decompressed < r.unpacked_bytes
-            ):
-                failures.append(
-                    f"{r.case}: bytes_decompressed={r.bytes_decompressed} "
-                    f"< unpacked={r.unpacked_bytes}"
-                )
-        # Seek counts: ≤ recorded baseline × 2 (host/path variance); missing baseline = skip.
+            # zip/tar/gzip count at member output. Under-decode is a silent short
+            # read; over-decode catches decode-twice-deliver-once (each open still
+            # increments the shared ByteCounter even when only the second handle
+            # is delivered to the caller).
+            if r.format in ("zip", "tar", "gzip", "tar.gz", "tar.bz2"):
+                if r.bytes_decompressed < r.unpacked_bytes:
+                    failures.append(
+                        f"{r.case}: bytes_decompressed={r.bytes_decompressed} "
+                        f"< unpacked={r.unpacked_bytes}"
+                    )
+                over_limit = int(r.unpacked_bytes * NONSOLID_DECODE_FACTOR)
+                if r.bytes_decompressed > over_limit:
+                    failures.append(
+                        f"{r.case}: bytes_decompressed={r.bytes_decompressed} "
+                        f"> unpacked×{NONSOLID_DECODE_FACTOR}={over_limit} "
+                        f"(non-solid re-decode?)"
+                    )
+        # Seek counts: ≤ recorded baseline + slack. Missing baseline = skip.
         # Only meaningful against the same fixture scale as the committed baseline (ci).
         if check_seek_baselines:
             ref = cases.get(r.case)
             if ref is not None and "source_seek_count" in ref:
-                limit = int(ref["source_seek_count"]) * 2 + 8
+                limit = int(ref["source_seek_count"]) + SEEK_BASELINE_SLACK
                 if r.source_seek_count > limit:
                     failures.append(
                         f"{r.case}: source_seek_count={r.source_seek_count} > bound {limit}"
@@ -583,6 +699,9 @@ def write_baselines(results: list[CaseResult]) -> None:
     BASELINES_DIR.mkdir(parents=True, exist_ok=True)
     structural: dict[str, Any] = {
         "solid_decode_factor": SOLID_DECODE_FACTOR,
+        "nonsolid_decode_factor": NONSOLID_DECODE_FACTOR,
+        "solid_random_bytes_factor": SOLID_RANDOM_BYTES_FACTOR,
+        "seek_baseline_slack": SEEK_BASELINE_SLACK,
         "cases": {},
     }
     for r in results:

--- a/review/performance/QUESTIONS.md
+++ b/review/performance/QUESTIONS.md
@@ -39,13 +39,18 @@ flake. Options, not mutually exclusive:
 
 Recommendation: (a)+(c); (b) once ZIP is back inside the band.
 
-## Q3 — Tighten `SOLID_DECODE_FACTOR` from 2.0?
+## Q3 — Tighten `SOLID_DECODE_FACTOR` from 2.0? — RESOLVED
 
 A clean "decode every folder exactly twice" regression passes today (G3), which
 contradicts VISION's own sentence. The harness only runs generated, controlled
 fixtures, and the unit test already holds ×1.1. Any objection to ~1.25 in the
 harness (and making the bound strict `>=`)? If the ×2 slack exists for a known
 future corpus, that corpus isn't in the tree.
+
+**Resolved in the follow-up investigation PR:** `SOLID_DECODE_FACTOR = 1.25`
+(failure when `bytes > unpacked * 1.25`). `repro.py` probe 2 now CAUGHT. Also
+added `NONSOLID_DECODE_FACTOR = 1.1` (G4) and ci-scale solid-random
+baseline×1.5 (Q6/G5).
 
 ## Q4 — Should container-digest verification be skippable?
 
@@ -75,9 +80,13 @@ the stream_members contract? Extraction early-exit is contract-neutral but only
 helps when the selection is exhausted early. I'd do both; flagging because the
 error-timing question touches the `archive-reading` spec's scenarios.
 
-## Q6 — Gating the random-solid case's absolute cost
+## Q6 — Gating the random-solid case's absolute cost — RESOLVED
 
 `sevenzip_solid_random` is recorded, not gated (G5). Bounding it to its committed
 baseline ×1.5 would catch "the O(n²) got worse" (e.g. losing an incidental
 cache) at zero flake risk (byte counts are deterministic). Any reason it was left
 unbounded beyond "the absolute value is inherent"?
+
+**Resolved in the follow-up investigation PR:** gated at baseline×1.5 when
+`check_seek_baselines` is on (ci scale only — the committed baseline is ci-sized;
+applying it to realistic corpora false-fails).

--- a/review/performance/hotspots.md
+++ b/review/performance/hotspots.md
@@ -10,6 +10,10 @@ Repro: `measurements.py <section>`.
 > over-weighted the wrapper stack; the revised attribution (decode-chunk
 > granularity + distributed per-member machinery) is in `residual-gap.md`,
 > which supersedes H2's candidate list.
+>
+> **Follow-up investigation PR:** H2 candidate 3 (larger decode chunks) is
+> implemented (`_COMPRESSED_READ_SIZE = 64 KiB` + scaled bounded feeds). Gate
+> holes G3/G4/G5 closed. Full conclusions: `investigation-report.md`.
 
 ## H1 — Selective extraction from a solid 7z decodes ~the whole folder (blocker) — FIXED (#136)
 

--- a/review/performance/investigation-report.md
+++ b/review/performance/investigation-report.md
@@ -1,0 +1,183 @@
+# Performance investigation — post-#136/#137 tracks
+
+**Branch:** follow-up to PR #134’s residual analysis (`residual-gap.md` / `hotspots.md`).
+**Measured at:** `main` @ `b9cdeac` + this change set.
+**Host:** Cursor Cloud agent VM (x86_64, CPython 3.11). Wall numbers are
+directional; every A/B below is single-process, warmed, median of ≥9 rounds
+unless noted. Repro: `attrib.py`, `repro.py`, `measurements.py`, and the harness.
+
+## Executive conclusions
+
+1. **Decode granularity was real and is fixed.** Raising the compressed feed from
+   8 KiB → 64 KiB (with scale-up to the bounded `read(n)` request, capped at 1 MiB)
+   collapses ZIP member inflate to ~one OS read / one C call. On the review probe
+   fixture (64 × 256 KiB): **OS `read()` calls 1220 → 196** (zipfile = 195);
+   wall **~1.56× → ~1.37×** zipfile. `#128` / F3a `read(1)` buffer + RSS bounds hold.
+2. **Harness “2×” vs probe “1.4×” is a regime split, not a contradiction.** CI
+   fixtures are **8 × 4 KiB** (many-small); the attributed probe is **64 × 256 KiB**.
+   Member-size sweep at fixed 16 MiB total:
+
+   | member size | n | ratio (pre → post feed) |
+   |---:|---:|---:|
+   | 4 KiB | 4096 | **4.05×** (feed: no effect) |
+   | 64 KiB | 256 | 1.74× → **1.59×** |
+   | 256 KiB | 64 | 1.40× → **1.38×** |
+   | 1 MiB | 16 | 1.30× → **1.30×** |
+
+   Realistic harness ZIP read-all lands ~**1.7–1.8×** (under the ~2× safety band;
+   still above 1.3×). CI ZIP read-all stays ~**4×** because it is pure per-member
+   machinery.
+3. **Per-member fixed cost is the next real budget fight — and has no cheap win.**
+   Profile of 2000 × 4 KiB: zlib decompress is ~1% of tottime; top costs are
+   `_to_member`, `dataclasses.replace`, `ArchiveStream` construction (≈3/member),
+   `_local_data_region`, `_wrap_member_stream`. Ablations did not yield a ≥5%
+   move on the many-small fixture without invasive API/shape changes. Left open.
+4. **Extract residual is a deliberate safety floor, not a missed micro-opt.**
+   Fresh 64 × 64 KiB ZIP extract: archivey **~3.7×** zipfile; `strace -c` shows
+   ~523 `lstat` / 64 `rename` / 64 `unlinkat` (mkstemp+replace) vs zipfile’s
+   ~7 `lstat` / 0 `rename`. Realistic harness extract ~**1.9×** (inside ~2×).
+   No code change this pass — product call is Q1 (is ~2× the claim?).
+5. **Gate holes G3/G4/G5 are closed on the PR structural path.**
+
+   | Probe | Before | After |
+   |---|---|---|
+   | solid-collapse O(n²) | CAUGHT | CAUGHT |
+   | solid-double exactly 2× | NOT CAUGHT | **CAUGHT** (`SOLID_DECODE_FACTOR` 2.0 → 1.25) |
+   | zip-double decode-twice | NOT CAUGHT | **CAUGHT** (nonsolid over-decode ×1.1 + seek slack baseline+8) |
+   | solid-random “got worse” | ungated | **gated** vs baseline×1.5 (ci scale only) |
+
+6. **Harness now reports ZIP open_list / extract vs stdlib peers** (G7 partial),
+   so the 4–6× CI-scale metadata/extract ratios are visible in the table instead
+   of silent `ratio=None`.
+
+## What shipped
+
+### Library
+
+- `decompressor_stream.py`: `_COMPRESSED_READ_SIZE = 65536`;
+  `_compressed_feed_size(max_length)` scales large bounded reads up to 1 MiB so
+  fused-verify whole-member `read(declared_size)` is single-shot. Comment
+  documents why 8 KiB was wrong for ZIP parity.
+
+### Benchmark gate
+
+- `SOLID_DECODE_FACTOR = 1.25` (addresses Q3 / G3).
+- `NONSOLID_DECODE_FACTOR = 1.1` over-decode on zip/tar/gzip `read_all` (G4).
+- `SEEK_BASELINE_SLACK = 8` replaces `baseline×2+8` (still absorbs gzip 1→3 jitter;
+  catches zip-double 28→52).
+- `SOLID_RANDOM_BYTES_FACTOR = 1.5` on ci-scale only (G5) — must not use the ci
+  baseline against realistic corpora (caught during this investigation).
+- ZIP `open_list` / `extract` stdlib wall peers wired into `run_cases`.
+- `structural.json` metadata updated to match the new factors.
+
+### Review artifacts
+
+- This report; `repro.py` probe text updated; PR #134 theme files retained for
+  provenance (their “open” status for P3/H2 candidates is historical — see
+  statuses below).
+
+## Track-by-track detail
+
+### Track 1 — Decode granularity (implemented)
+
+**Hypothesis (from `residual-gap.md`):** 8 KiB compressed feeds force ~17 Python
+loop trips per 256 KiB member; zipfile does one C inflate.
+
+**Evidence:**
+
+- Feed sweep (mirrored order, in-process): plateau at ≥64 KiB.
+- Census after change: archivey OS reads ≈ zipfile.
+- `test_decompressor_read_one_bounds_internal_buffer` still green;
+  RSS delta on `read(1)` of a 32 MiB highly-compressible gzip ≈ 0.
+
+**Non-goals preserved:** verification, translation, leases; output still bounded
+by `max_length`.
+
+### Track 2 — Harness vs probe decomposition (investigation only)
+
+Fitted qualitatively as:
+
+```
+ratio ≈ (per_member_overhead × n + per_byte_overhead × bytes) / stdlib
+```
+
+At 4 KiB, per-member term dominates (feed size irrelevant). At ≥256 KiB, per-byte
+/ decode-loop term dominated before this change and is now near the residual
+~190 µs/member floor from `residual-gap.md`.
+
+**Implication for Q1:** claiming ≤1.3× on “ZIP read” without naming the member-size
+regime is misleading. CI harness will keep printing ~4× until many-small cost
+drops; realistic corpora are the fair VISION comparison and are now ~1.7× read /
+~1.9× extract on this host.
+
+### Track 3 — Per-member fixed cost (not shipped)
+
+cProfile (2000 × 4 KiB, 3 rounds) top tottime: `_to_member`, `replace`,
+`ArchiveStream.__init__` (3×/member), `_local_data_region`, wrap/verify setup.
+zlib.decompress ≈ 1% of tottime.
+
+Candidates considered and deferred:
+
+| Idea | Why deferred |
+|---|---|
+| Cache `_local_data_region` by `ZipInfo` id | Fragile under shared `ZipInfo`; CRC failure in naive ablate |
+| Fold remaining `ArchiveStream` constructions | #136 already collapses nested wraps; remaining wraps are load-bearing (lazy + verify + codec) |
+| Lazy `_to_member` field work | Touches archive-data-model / listing contract; needs its own change |
+
+**Accept criterion from residual-gap (≥5% on 1000×4 KiB) was not met** by any
+safe one-liner. Recommend a dedicated change if Q1 treats many-small as in-budget.
+
+### Track 4 — Extract-all residual (investigation only)
+
+`strace -c` on 64 × 64 KiB DEFLATE ZIP, fresh dest:
+
+| syscall | archivey | zipfile |
+|---|---:|---:|
+| `lstat` | 523 | 7 |
+| `openat` | 348 | 148 |
+| `rename` | 64 | 0 |
+| `write` | 64 | 128 |
+| `unlinkat` | 65 | 65 |
+| wall | 33.8 ms | 9.0 ms (**3.74×**) |
+
+Atomic `mkstemp`+`os.replace` and overwrite/lexists policy explain the rename and
+most of the lstat tax. Parent-resolve reuse would only help symlink-heavy trees;
+the default FILE path’s cost is the safety model itself. Realistic harness
+extract ~1.9× already sits in VISION’s ~2× “safety justifies it” band.
+
+### Track 5 — Gate efficacy (implemented)
+
+`repro.py` after this change:
+
+```
+unpatched gate: green
+solid-collapse: CAUGHT
+solid-double (exactly 2×): CAUGHT
+zip-double: CAUGHT  (bytes over-decode + seek slack)
+```
+
+Still **not** enforced: absolute wall ≤1.3× / ≤2× on PR (Q2). Nightly remains
+informational for VISION; sanity ceiling stays 10×. Recommendation from #134
+(Q2 a+c) still stands — this PR did (c)-lite by adding missing ZIP peers.
+
+## Open questions (updated)
+
+| # | Status after this PR |
+|---|---|
+| Q1 budget scope | Still open; new evidence favors (b)/(c): many-small is a different claim |
+| Q2 wall enforcement | Still open; peers added for ZIP open/extract |
+| Q3 `SOLID_DECODE_FACTOR` | **Done here** (1.25) |
+| Q4 verify-skip knob | Unchanged; perf case still ~nil post-#137 |
+| Q5 H1 fix shape | Resolved in #136 |
+| Q6 solid-random bound | **Done here** (ci ×1.5) |
+
+## How to re-verify
+
+```bash
+uv run --no-sync python review/performance/repro.py
+uv run --no-sync python review/performance/attrib.py bench
+uv run --no-sync python review/performance/attrib.py census
+uv run --no-sync python -m benchmarks.harness --mode structural --scale ci
+uv run --no-sync python -m benchmarks.harness --mode full --scale realistic --json-out /tmp/bench.json
+uv run --no-sync pytest tests/test_codecs.py::test_decompressor_read_one_bounds_internal_buffer -q
+```

--- a/review/performance/repro.py
+++ b/review/performance/repro.py
@@ -17,11 +17,12 @@ Probes:
    (which opens each member independently via ``_open_member``).
 2. ``solid-double``    — a subtler regression: every solid folder is decoded
    exactly twice (e.g. an eager verify pass). Checked arithmetically against the
-   gate's ``SOLID_DECODE_FACTOR = 2.0`` bound, and empirically by wrapping
+   gate's ``SOLID_DECODE_FACTOR`` bound, and empirically by wrapping
    ``_iter_with_data`` to drain one full extra folder decode per archive.
 3. ``zip-double``      — a non-solid path decompresses every member twice but
    delivers bytes once (e.g. an internal pre-read). Simulated by patching
    ``ZipReader._open_member`` to open/consume/close the member, then open again.
+   Caught by the non-solid over-decode bound and the tightened seek slack.
 
 Exit code 0 always; output is the evidence table.
 """

--- a/review/performance/residual-gap.md
+++ b/review/performance/residual-gap.md
@@ -8,6 +8,12 @@ runs and on an independent probe here). So the original H2 attribution
 over-weighted the wrapper stack. This file records where the gap *actually*
 is, measured at `main` @ `b9cdeac`, and what to investigate next.
 
+> **Follow-up (this PR):** tracks 1 and 5 from the list below are implemented
+> and verified — see `investigation-report.md`. Decode feed is now 64 KiB
+> (scaled for large bounded reads); gate G3/G4/G5 are closed on the structural
+> path. Tracks 2–4 conclusions are in that report (regime split explained;
+> per-member and extract left open / product).
+
 Fixture for all numbers: 64 × 256 KiB DEFLATE members, ~2:1-compressible
 payload; medians of 21 warm in-process rounds. Repro: `attrib.py <section>`.
 
@@ -25,49 +31,11 @@ sweep (`attrib.py sweep`), per full read-all pass:
 
 Two distinct causes, in order:
 
-### 1. Decode granularity (~8 ms of the gap; the actionable lever)
+### 1. Decode granularity (~8 ms of the gap; the actionable lever) — DONE
 
-`_COMPRESSED_READ_SIZE = 8192` (`decompressor_stream.py:118`) feeds ~8 KiB
-compressed slices into the decoder, so a 256 KiB member takes ~17 trips through
-the 5-frame Python loop (`ArchiveStream.read` → verifier → `DecompressorStream.
-read` → `_read_decompressed_chunk` → `Decoder.feed`), each staging output
-through the shared `bytearray`. `zipfile.read()` reads the member's *entire*
-compressed extent and decompresses it in **one** C call. The call census
-(`attrib.py census`) shows the same story at the OS boundary: 1220 buffered
-`read()` calls per pass vs zipfile's 195.
-
-Sweep (warm, single process, mirrored order):
-
-| compressed feed | wall | ratio vs zipfile |
-|---:|---:|---:|
-| 8192 (today) | 71.6 ms | 1.38× |
-| 65536 | 65.2 ms | 1.25× |
-| 262144 | 64.1 ms | 1.23× |
-| 1 MiB | 64.9 ms | 1.25× |
-
-The curve is flat past 64 KiB because the fixture's compressed members are
-~130 KiB — one or two feeds already reaches single-shot. **A feed of 64 KiB, or
-better a known-size fast path (member's `compress_size` is known for ZIP; read
-exactly that, decompress with `max_length=declared_size`), puts ZIP read-all
-under the 1.3× budget on this host.**
-
-Safety constraints to preserve (why 8 KiB was chosen — see the comment at
-`decompressor_stream.py:114-117`):
-
-- Output amplification stays bounded regardless of feed size as long as
-  `max_length` keeps being passed — the bomb-tracker guarantees live on the
-  *output* side. The feed size only raises peak *compressed* buffer residency
-  (64 KiB–1 MiB is trivially fine; the #128-style `read(1)` bound should be
-  re-checked with the RSS probe in `measurements.py rss` after any change).
-- A single-shot path must not regress `read(small_n)` consumers — gate it on
-  `n < 0 or n >= remaining` with an empty buffer, mirroring the (currently
-  unreachable, see below) `readall` fast path.
-
-Note: the fused verifier turns a caller's `read(-1)` into a *bounded*
-`read(declared_size)` (`verify.py` `MemberVerifier.read`), so
-`DecompressorStream.readall()` — where #136 put the join-of-chunks fast path —
-is **never reached** on the default (verified) path. Any fast path must live on
-the bounded-`read(n)` branch to matter.
+`_COMPRESSED_READ_SIZE` is now 64 KiB with scale-up for large bounded `read(n)`.
+On the follow-up host the review probe measures ~1.37× with OS-read census at
+parity with zipfile (196 vs 195). See `investigation-report.md` Track 1.
 
 ### 2. Distributed per-member machinery (~12 ms; ~190 µs/member; no single hotspot)
 
@@ -77,41 +45,22 @@ At the plateau, decompress and CRC are at parity and the rest is spread thin:
 readinto shims, `_wrap_member_stream` argument plumbing. cProfile shows no
 item above ~2 ms/pass — this is death-by-a-thousand-cuts, and it is why
 per-member cost dominates for *small*-member archives (the many-small regime)
-while barely mattering for large members.
+while barely mattering for large members. **Follow-up:** profiled; no ≥5% safe
+win found — deferred (Track 3).
 
 ## What to investigate next (priority order)
 
-1. **The decode-granularity lever (P2's main remaining lever).** Options, in
-   increasing ambition: raise `_COMPRESSED_READ_SIZE` to 64 KiB; scale the feed
-   to the remaining `max_length` request; single-shot fast path when the
-   compressed extent is known (ZIP always knows `compress_size`). Re-run
-   `attrib.py bench`, the `measurements.py rss` bound, and the many-small
-   penalty case (`measurements.py accel`) as accept criteria. Expected: ZIP
-   read-all ≤ 1.25×, TAR.gz accel-off similarly helped (same stream class).
-2. **Reconcile the harness's 2.0× with this probe's 1.38×.** Same operation,
-   different fixture/loop — the harness `zip_read_all` ratio should be
-   decomposable into (per-member overhead × member count + per-byte overhead ×
-   bytes). Fit those two coefficients by sweeping member size at constant total
-   bytes (4 KiB / 64 KiB / 256 KiB / 1 MiB members); then the harness ratio for
-   any fixture is predictable, and "which regime is the budget about?" (Q1)
-   gets an empirical basis.
-3. **Per-member fixed cost (many-small regime).** Attack only after (2)
-   quantifies its real-world weight. Candidates: fold the codec
-   `ArchiveStream` wrap away when the member wrap immediately collapses it
-   (construct once, not construct-then-steal), find and batch the
-   `dataclasses.replace` call sites, lazy `_to_member` field work. Use paired
-   cProfile diffs per candidate; reject any that doesn't move the
-   1000×4 KiB fixture by ≥5%.
-4. **Extract-all residual (2.4–3.7×, H4).** Untouched by #136/#137. The known
-   costs are filesystem safety (~5 `lstat`s/member, `mkstemp`+rename,
-   `pathlib.resolve`). Measure with `strace -c` / `syscall` census rather than
-   cProfile (the cost is syscalls, not Python), and compare against
-   `shutil.unpack_archive` as the honest peer. Decide deliberately what the
-   safety floor is (VISION's ~2× band exists for exactly this path).
-5. **open+list 5–8× (H3 remainder).** Extension-map cache landed; the rest is
-   detection sniff + member-model build (~45 µs/member). Only worth attacking
-   if the million-archive sweep is a real workload (Q1); the `format=` idiom
-   already bypasses most of it.
+1. ~~**The decode-granularity lever**~~ **Done** (64 KiB feed + scaled bounded read).
+2. ~~**Reconcile the harness's 2.0× with this probe's 1.38×.**~~ **Explained:**
+   CI harness is 8×4 KiB (many-small → ~4×); probe/realistic are 256 KiB members
+   (~1.4–1.8×). See investigation-report Track 2.
+3. **Per-member fixed cost (many-small regime).** Still open — needs a dedicated
+   change if Q1 treats many-small as in-budget.
+4. **Extract-all residual (2.4–3.7×, H4).** Census confirms safety syscalls
+   (mkstemp+rename, lstat tax). Realistic ~1.9× already in the ~2× band; no
+   code change pending Q1.
+5. **open+list 5–8× (H3 remainder).** Still open; ZIP open_list now has a
+   stdlib peer in the harness so the ratio is visible.
 
 ## Methodology notes (hard-won on this host)
 

--- a/src/archivey/internal/streams/decompressor_stream.py
+++ b/src/archivey/internal/streams/decompressor_stream.py
@@ -111,13 +111,35 @@ class BaseDecoder:
         return [], None
 
 
-# Compressed bytes read per fill when the decoder needs more input. Matches CPython
-# gzip / _compression.DecompressReader (io.DEFAULT_BUFFER_SIZE), not a full 64 KiB —
-# keeping the feed small works with max_length to bound peak buffer on read(n).
-_COMPRESSED_READ_SIZE = 8192
+# Compressed bytes read per fill when the decoder needs more input.
+#
+# Historically matched CPython gzip / ``_compression.DecompressReader``
+# (``io.DEFAULT_BUFFER_SIZE`` = 8 KiB). That feed forces ~17 Python trips through
+# the decode loop for a typical 256 KiB ZIP member while ``zipfile`` decompresses
+# each member in one C call — the dominant residual ZIP read-all gap after the
+# stream-layering work in #136/#137 (see ``review/performance/residual-gap.md``).
+# 64 KiB reaches the measured plateau for those members; ``max_length`` still
+# bounds peak *output* buffer on ``read(n)`` (the #128 / F3a contract), and ZIP
+# members are additionally capped by their ``SlicingStream`` compressed extent.
+_COMPRESSED_READ_SIZE = 65536
+# Ceiling when a large bounded ``read(n)`` (whole-member via fused verify) asks
+# for more output than the default feed — one compressed read ≈ one C inflate.
+_COMPRESSED_READ_SIZE_MAX = 1 << 20
 # Output budget when skipping forward during seek (unbounded skip would reintroduce
 # the per-read amplification bomb on highly compressible spans).
 _SEEK_OUTPUT_CHUNK = 65536
+
+
+def _compressed_feed_size(max_length: int) -> int:
+    """How many compressed bytes to pull for one decoder feed.
+
+    Large bounded requests scale up toward ``max_length`` (capped) so a known-size
+    whole-member read collapses to one inflate call. Small / unbounded requests
+    keep the default feed; output amplification remains gated by ``max_length``.
+    """
+    if max_length < 0 or max_length <= _COMPRESSED_READ_SIZE:
+        return _COMPRESSED_READ_SIZE
+    return min(max_length, _COMPRESSED_READ_SIZE_MAX)
 
 
 MakeDecoder = Callable[[SeekPoint, BinaryIO], Decoder]
@@ -327,7 +349,7 @@ class DecompressorStream(ReadOnlyIOStream):
             # Decoder claimed retained input but produced nothing (e.g. a stuck
             # lzma needs_input=False under a budget). Fall through to reading more
             # compressed bytes — or EOF — so the caller cannot spin forever.
-        chunk = self._inner.read(_COMPRESSED_READ_SIZE)
+        chunk = self._inner.read(_compressed_feed_size(max_length))
         if not chunk:
             self._eof = True
             leftover = self._ingest_decode(self._decoder.flush())


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to the #134 performance review (post-#136/#137 residual analysis in `hotspots.md` / `residual-gap.md`). Rebased onto `main` after #134 merged. Full write-up: [`review/performance/investigation-report.md`](./review/performance/investigation-report.md).

## What we ran

The six tracks from the #134 residual plan, on `main` @ `b9cdeac` (re-verified after rebase):

1. **Decode granularity** — ablate + implement
2. **Harness 2× vs probe 1.4×** — member-size sweep at fixed total bytes
3. **Per-member fixed cost** — profile + ablate (≥5% bar)
4. **Extract residual** — `strace -c` census vs `zipfile.extractall`
5. **Gate holes G3/G4/G5** — close with `repro.py` evidence
6. **open+list** — document; add ZIP stdlib peers so ratios are visible

## Conclusions (short)

| Track | Verdict |
|---|---|
| 1 Decode feed | **Real gap; fixed.** 8→64 KiB (+ scale for large bounded reads). OS `read()` census 1220→196 (zipfile=195). Probe ~1.56×→~1.37×. `read(1)` RSS/buffer bounds hold. |
| 2 Regime split | **Explained, not a bug.** CI harness is 8×4 KiB (many-small → ~4×); realistic/probe are 256 KiB members (~1.4–1.8×). |
| 3 Per-member | **No ≥5% safe win.** Profile is death-by-a-thousand-cuts (`_to_member`, wraps, `replace`). Deferred pending Q1. |
| 4 Extract | **Safety floor.** ~3.7× on small ZIP; `lstat`/`rename` tax from mkstemp+replace. Realistic harness extract ~1.9× (inside ~2× band). No code change. |
| 5 Gate | **G3/G4/G5 closed.** `repro.py`: solid-double and zip-double now **CAUGHT**. |

## Code changes

- `decompressor_stream.py`: `_COMPRESSED_READ_SIZE = 65536` + `_compressed_feed_size()`
- `benchmarks/harness.py` + `structural.json`:
  - `SOLID_DECODE_FACTOR` 2.0 → **1.25** (Q3)
  - `NONSOLID_DECODE_FACTOR = 1.1` over-decode on zip/tar/gzip `read_all` (G4)
  - seek slack `baseline+8` (was `×2+8`)
  - solid-random gated vs baseline×1.5 on **ci scale only** (Q6/G5)
  - ZIP `open_list` / `extract` stdlib wall peers (G7 partial)
- Updates to #134 review docs + new `investigation-report.md`

## Verify

```bash
uv run --no-sync python review/performance/repro.py   # all three probes CAUGHT
uv run --no-sync python review/performance/attrib.py census
uv run --no-sync python -m benchmarks.harness --mode structural --scale ci
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-323a5bf7-4b99-454d-912d-6daa054b68d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-323a5bf7-4b99-454d-912d-6daa054b68d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

