### PR TITLE
docs: #139 verification record, Q1 listing-ratio direction, 7z wrong-password gap (O8)

### DIFF
--- a/docs/internal/threat-model.md
+++ b/docs/internal/threat-model.md
@@ -218,6 +218,51 @@ still rejecting only names that cannot be `os.fsencode`d at all; `TRUSTED` attem
 faithful bytes and lets the local OS decide (today's behavior). Awaiting implementation of
 that `safe-extraction` delta.
 
+### O8. 7z wrong header-decryption password can silently yield an *empty* archive
+
+The 7z format has **no password check value** (unlike RAR5's `pswcheck` or WinZip
+AES's verifier bytes), so wrong-password detection on a header-encrypted archive
+(`-mhe=on`) is heuristic: decrypt with the derived key, LZMA-decode the garbage,
+and rely on the decode or the header parse failing. There are two lines of
+defense today:
+
+1. **Decoded-folder CRC** — `decode_folder_to_bytes` verifies the encoded-header
+   folder's `kCRC` digest when the writer stored one
+   (`sevenzip_pipeline.py`). Reference 7-Zip writes it → detection is
+   deterministic (2⁻³²) for those archives. **py7zr does not**
+   (`digest_defined: False` on the encoded-header folder), and our own `[7z-write]`
+   output goes through py7zr, so archives *we* write share the gap.
+2. **Structural parse failure** of the garbage — which usually works, but not
+   always.
+
+Measured (2026-07-18, loop of fresh py7zr header-encrypted archives, wrong
+password): **~0.3% of salts slip through both checks** (2/300, 3/1,110 across
+runs — the AES IV/salt is random per write, so the rate is per-archive, not
+per-attempt). Every observed slip-through decodes to a degenerate header that
+parses as **an archive with zero members**: `open_archive(...,
+password="wrong")` returns member_count=0 with no error. Hazard: not traversal
+or corruption, but *silent data invisibility* — a backup-verification or sweep
+tool concludes "empty archive" instead of "wrong password" and reports success.
+This is also the root cause of the flaky
+`test_header_encrypted_wrong_password_mentions_header` (seen on Windows
+py3.14 CI for PR #139; the flake predates that PR — same rate measured on
+`main`).
+
+*Direction (proposed, not yet implemented):* after decoding a `kEncodedHeader`,
+**treat a parsed result with zero file records as a rejected password**
+(`EncryptionError`). Legitimate writers never emit an encrypted header for an
+empty archive — header encryption exists to hide member names, and an empty
+py7zr/7-Zip archive is written with `next_header_size == 0` or a plain header —
+so the check costs nothing on real archives and deterministically closes the
+*observed* slip-through mode (and deflakes the test). Residual: garbage that
+parses into a *non-empty* plausible header survives in principle, but must then
+present coherent member counts/sizes/digests against the real packed streams —
+astronomically unlikely, and inherent to the format absent a check value. Two
+cheap hardenings beyond that: validate decoded-header property ordering/bounds
+strictly (the parser already rejects most nonsense), and suggest upstream that
+py7zr write `kCRC` for the encoded-header folder (fixes detection for archives
+we and py7zr produce, the common fixture case).
+
 ## OPEN gaps — compatibility
 
 ### C1. The RAR decompressor matrix (and unrar licensing) — won’t-do / closed

--- a/review/performance/QUESTIONS.md
+++ b/review/performance/QUESTIONS.md
@@ -24,6 +24,31 @@ TAR 1.4–1.8×. Is the intended reading:
 
 The answer decides whether P2 is "fix H2/H3 until green" or "fix + re-word".
 
+**Maintainer direction (2026-07-18) — metadata ops get *ratio* budgets vs the
+relevant peer, not absolute numbers:**
+
+- **ZIP/TAR listing** (we wrap stdlib internally): at most **2–3× per member**
+  vs `zipfile`/`tarfile`.
+- **7z/RAR listing** (our own native parsers): **on par with `py7zr`/`rarfile`**
+  — the peers are already test oracles, so benchmark-only optional deps.
+
+Consequences to implement:
+
+1. Harness: add `open_list` ratio cases with those peers and bands —
+   `zipfile`/`tarfile` peers exist (ZIP wired in #139); `py7zr`/`rarfile`
+   listing peers are new. Bands per backend, asserted the same way the wall
+   budget ends up asserted (Q2).
+2. This makes ZIP open+list a *live* budget miss again: measured **5–8×**
+   `zipfile` (ci and realistic scales, `budget-table.md`), vs the chosen 2–3×
+   band — so the per-member model-build cost (~45 µs/member `_to_member` etc.,
+   Track 3's deferred "dedicated change") is now in-budget work, needing
+   roughly a 2–3× reduction. 7z/RAR vs `py7zr`/`rarfile` is unmeasured — the
+   native parsers may already be at/under parity; measure before optimizing.
+3. Read/extract regimes stay as previously framed: decompression-dominated
+   ≤1.3× (met for large-member ZIP after #139), extract inside the ~2× safety
+   band (met at realistic scale), many-small read_all follows the listing
+   story (its cost *is* per-member machinery).
+
 ## Q2 — Where should the wall budget be *enforced*?
 
 Today: nowhere (`gate-efficacy.md` G1) — deliberate, because shared-runner ratios

--- a/review/performance/SUMMARY.md
+++ b/review/performance/SUMMARY.md
@@ -43,11 +43,11 @@ bounded.
 | # | Severity | Finding | Where | Status |
 |---|----------|---------|-------|--------|
 | P1 | **blocker** | ≤1.3× wall budget enforced nowhere; nightly hard-fails only at 10×, VISION band informational | `benchmarks/harness.py:55,826-834`, `benchmark-wall.yml` | open — decision needed (Q2) |
-| P2 | **blocker** | Budget not met: ZIP read-all 2.2–2.3×, extract-all 2.4–3.7×, open+list 5–8×; TAR read 1.8× | `budget-table.md` | open |
+| P2 | **blocker** | Budget not met: ZIP read-all 2.2–2.3×, extract-all 2.4–3.7×, open+list 5–8×; TAR read 1.8× | `budget-table.md` | **partial** — #136/#137/#139 put large-member ZIP read ≤1.25× and realistic extract ~1.9×; open+list vs the Q1 ratio bands and many-small remain |
 | P3 | **blocker** | Selective solid-7z extraction decodes ~whole folder for one early member (31× needed bytes); CLI `extract archive.7z <name>` hits it | `sevenzip_reader.py:283-323`, `extraction.py:340` | **fixed by #136** — verified 31.0× → 1.00× |
-| P4 | high | Non-solid re-decompression is invisible to the gate: decode-twice-deliver-once ZIP regression passes (byte axis counts delivered output; seek slack ×2+8 absorbs churn; wall ungated) | `gate-efficacy.md` G4, `repro.py` probe 3 | open |
-| P5 | high | A full 2× solid re-decode passes the gate (`SOLID_DECODE_FACTOR = 2.0`, non-strict bound) — VISION says a re-read must fail | `harness.py:51,526-532`, `repro.py` probe 2 | open — tighten (Q3) |
-| P6 | med | Harness has no stdlib peer for open/list/extract (why P2's extract miss went unnoticed); no RAR case in committed baseline; ZIP-AES / native-codec / in-ZIP-accelerated paths unbenchmarked | `gate-efficacy.md` G6/G7 | open |
+| P4 | high | Non-solid re-decompression is invisible to the gate: decode-twice-deliver-once ZIP regression passes (byte axis counts delivered output; seek slack ×2+8 absorbs churn; wall ungated) | `gate-efficacy.md` G4, `repro.py` probe 3 | **fixed by #139** — over-decode ×1.1 bound + seek slack baseline+8; probe CAUGHT |
+| P5 | high | A full 2× solid re-decode passes the gate (`SOLID_DECODE_FACTOR = 2.0`, non-strict bound) — VISION says a re-read must fail | `harness.py:51,526-532`, `repro.py` probe 2 | **fixed by #139** — factor 1.25; probe CAUGHT |
+| P6 | med | Harness has no stdlib peer for open/list/extract (why P2's extract miss went unnoticed); no RAR case in committed baseline; ZIP-AES / native-codec / in-ZIP-accelerated paths unbenchmarked | `gate-efficacy.md` G6/G7 | partial — #139 adds ZIP open_list/extract peers; RAR/encrypted/accel cases + Q1 listing peers still missing |
 | P7 | med | Per-`open()` 5–8× zipfile (detection + member-model build ~0.3 ms/archive) — the founding million-archive sweep pays minutes | `hotspots.md` H3 | partial — #136 caches the extension map; rest open |
 | P8 | low | rapidgzip AUTO threshold (1 MiB) conservative: seek workloads win ~1.5× well below it; provenance script never measured compressed sizes near 1 MiB | `hotspots.md` H5 | follow-up |
 | P9 | low | Measurement blind spots: 7z password-confirm folder decode uncounted; RAR byte axis (unrar pipe output) cannot see solid rewind | `gate-efficacy.md` G6 | follow-up |
@@ -77,6 +77,31 @@ selective-solid probe re-run against main, #136, #137 trees):
   plan: `residual-gap.md`.
 - **Still open:** P1 (enforcement), P2 (budget — now with a concrete lever),
   P4/P5 (gate bounds), P6 (stdlib peers), Q1–Q4/Q6.
+
+## Second follow-up (#139, `main` @ `93dc28e`) — verified
+
+#139 implemented the `residual-gap.md` plan; I verified it independently (full
+suite green, gate green, probes re-run, before/after probe on shared fixtures):
+
+- **Decode-feed fix confirmed.** ZIP read-all **1.41× → 1.20×** on the review
+  host; OS-level `read()` census 1220 → **196** (zipfile = 195). H1 stays 1.00×.
+- **P4 and P5 fixed.** All three `repro.py` adversarial probes now CAUGHT
+  (`SOLID_DECODE_FACTOR` 1.25, non-solid over-decode ×1.1, seek slack
+  baseline+8); `sevenzip_solid_random` gated vs baseline×1.5 (Q6).
+- **The regime split is the story now** (#139 Track 2): 4 KiB members ≈ 4×
+  (pure per-member machinery, feed-size-insensitive), 256 KiB ≈ 1.38×,
+  1 MiB ≈ 1.30×. Q1 has a maintainer direction as of 2026-07-18 — metadata
+  ops budgeted as *ratios vs the relevant peer* (2–3×/member vs
+  `zipfile`/`tarfile`; parity vs `py7zr`/`rarfile` for the native parsers) —
+  see `QUESTIONS.md` Q1 for the consequences (listing peers in the harness;
+  ZIP open+list becomes in-budget work again).
+- **Side-finding (security register O8):** while triaging #139's Windows CI
+  failure — a pre-existing flake, not the PR — measured that **~0.3% of
+  py7zr-written header-encrypted 7z archives open as an *empty* archive under
+  a wrong password** (no error; py7zr stores no encoded-header CRC, and the
+  garbage occasionally parses as a zero-member header). Hazard + proposed
+  deterministic tightening (reject file-less encoded headers) written up in
+  `docs/internal/threat-model.md` O8.
 
 ## What is actually fine
 

--- a/review/performance/gate-efficacy.md
+++ b/review/performance/gate-efficacy.md
@@ -11,6 +11,15 @@ sequential solid path collapsing to per-member re-decode. Everything else VISION
 names is either unasserted (wall ratios), structurally invisible (non-solid
 re-decompression), or inside the slack (a clean 2× solid re-decode).**
 
+> **Status update (#139 merged, verified):** G3, G4, and G5 are closed —
+> `SOLID_DECODE_FACTOR` 2.0 → 1.25, a non-solid over-decode bound (×1.1) on
+> `read_all`, seek slack `baseline×2+8` → `baseline+8`, and
+> `sevenzip_solid_random` bounded vs its committed baseline ×1.5 (ci scale).
+> All three `repro.py` probes now report CAUGHT. G1 (wall enforcement) remains
+> the open blocker; G6/G7 are partial — #139 added ZIP `open_list`/`extract`
+> stdlib peers, and the Q1 direction (2026-07-18) adds listing-ratio peers
+> (`zipfile`/`tarfile` bands, `py7zr`/`rarfile` parity) to the missing list.
+
 ## G1 — The wall budget is enforced nowhere (blocker)
 
 - PR gate: `--mode structural` computes wall ratios but never checks them


### PR DESCRIPTION
Docs-only follow-up now that #134 and #139 are merged. Three things:

## 1. #139 verification recorded

`review/performance/SUMMARY.md` + `gate-efficacy.md` statuses updated with independently verified results: P4 and P5 **fixed** (all three `repro.py` adversarial probes now CAUGHT; `SOLID_DECODE_FACTOR` 1.25, non-solid over-decode ×1.1, seek slack baseline+8, solid-random gated ×1.5), decode-feed fix confirmed (ZIP read-all **1.41× → 1.20×** on the review host; OS-read census 1220 → **196** vs zipfile's 195; H1 stays 1.00×). P2/P6 moved to partial with what remains.

## 2. Q1 maintainer direction recorded (`QUESTIONS.md`)

Metadata ops get **ratio budgets vs the relevant peer**, not absolute numbers: at most **2–3×/member vs `zipfile`/`tarfile`** for ZIP/TAR listing (stdlib is wrapped internally), **parity vs `py7zr`/`rarfile`** for the native 7z/RAR parsers (already test oracles). Consequences spelled out: listing-peer harness cases to add, ZIP open+list (measured 5–8×) becomes in-budget work again (~2–3× reduction needed in per-member model build), 7z/RAR listing vs peers is unmeasured — measure before optimizing.

## 3. New threat-model gap: O8 (`docs/internal/threat-model.md`)

While triaging #139's Windows CI failure (a pre-existing flake, not the PR): **~0.3% of py7zr-written header-encrypted 7z archives open as an *empty* archive under a wrong password** — no error, member_count=0. Root cause: 7z has no password check value; the decoded-folder CRC check only fires when the writer stored one (7-Zip does, **py7zr does not**, including our own `[7z-write]` output), and wrong-key garbage occasionally LZMA-decodes into a header that parses with zero file records. Measured 2/300 and 3/1,110 across runs (salt-dependent, per-archive). Hazard: silent data invisibility for verification/sweep tooling; also the root cause of the flaky `test_header_encrypted_wrong_password_mentions_header`.

Proposed deterministic tightening (written up in O8, not implemented here): treat a `kEncodedHeader` that decodes to a **file-less** header as a rejected password — legitimate writers never encrypt an empty header, so the check is free on real archives, closes the entire observed slip-through mode, and deflakes the test. Plus an upstream suggestion: py7zr writing `kCRC` for the encoded-header folder would make detection deterministic for the archives it (and we) produce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KUVVDfbfxWdmLugeyRz4JF

---
_Generated by [Claude Code](https://claude.ai/code/session_01KUVVDfbfxWdmLugeyRz4JF)_