### PR TITLE
fix(7z): reject empty decoded header as wrong password (O8)

### DIFF
--- a/docs/internal/threat-model.md
+++ b/docs/internal/threat-model.md
@@ -218,7 +218,7 @@ still rejecting only names that cannot be `os.fsencode`d at all; `TRUSTED` attem
 faithful bytes and lets the local OS decide (today's behavior). Awaiting implementation of
 that `safe-extraction` delta.
 
-### O8. 7z wrong header-decryption password can silently yield an *empty* archive
+### O8. 7z wrong header-decryption password can silently yield an *empty* archive — mitigated
 
 The 7z format has **no password check value** (unlike RAR5's `pswcheck` or WinZip
 AES's verifier bytes), so wrong-password detection on a header-encrypted archive
@@ -248,20 +248,31 @@ This is also the root cause of the flaky
 py3.14 CI for PR #139; the flake predates that PR — same rate measured on
 `main`).
 
-*Direction (proposed, not yet implemented):* after decoding a `kEncodedHeader`,
-**treat a parsed result with zero file records as a rejected password**
-(`EncryptionError`). Legitimate writers never emit an encrypted header for an
-empty archive — header encryption exists to hide member names, and an empty
-py7zr/7-Zip archive is written with `next_header_size == 0` or a plain header —
-so the check costs nothing on real archives and deterministically closes the
-*observed* slip-through mode (and deflakes the test). Residual: garbage that
-parses into a *non-empty* plausible header survives in principle, but must then
-present coherent member counts/sizes/digests against the real packed streams —
-astronomically unlikely, and inherent to the format absent a check value. Two
-cheap hardenings beyond that: validate decoded-header property ordering/bounds
-strictly (the parser already rejects most nonsense), and suggest upstream that
-py7zr write `kCRC` for the encoded-header folder (fixes detection for archives
-we and py7zr produce, the common fixture case).
+*Mechanism (not a `num_files == 0` field):* wrong-key AES still feeds LZMA, which
+often emits the full claimed unpack size (e.g. 105 bytes) of garbage.
+`parse_header_block` only inspects the **leading property id** and stops:
+
+- `0x00` (`END`) → empty `PlainHeader` immediately; the remaining ~104 bytes are
+  **never read**.
+- `0x01 0x00` (`HEADER` + `END`) → `_parse_plain_header` exits on the next `END`
+  with empty streams/files; trailing garbage likewise ignored.
+
+Empirically (8 slips in ~2k py7zr writes): 7/8 were leading `END`, 1/8 was
+`HEADER`+`END`. Rate ≈ 1/256 matches “first garbage byte is `0x00`”. A real
+decoded header for the same fixture is a full 105-byte structure
+(`HEADER` → `MAIN_STREAMS_INFO` → `FILES_INFO` → `END`) with **no** trailing
+unread bytes — so the slip is an early terminator in random output, not a
+zeroed `FILES_INFO` count.
+
+*Mitigation:* after decoding a `kEncodedHeader`, a parsed result with **zero file
+records** is treated as a rejected password (`EncryptionError`). Legitimate writers
+never encrypt an empty header (empty archives use `nextHeaderSize == 0` or a plain
+header). Residual: garbage that parses into a *non-empty* plausible header survives
+in principle (inherent to the format absent a check value); requiring the parser to
+consume the entire decoded buffer (reject trailing bytes), stricter property
+bounds, and upstream py7zr writing `kCRC` for the encoded-header folder remain
+optional hardenings. See `format-7z` ("never a silent empty listing") and
+`test_header_encrypted_empty_decoded_header_rejected`.
 
 ## OPEN gaps — compatibility
 

--- a/openspec/specs/format-7z/spec.md
+++ b/openspec/specs/format-7z/spec.md
@@ -228,7 +228,7 @@ passwords as `EncryptionError`/`CorruptionError`, never silent bytes.
 | Header-encrypted archive, no password/provider result | `EncryptionError` before listing |
 | Header-encrypted archive, valid password + crypto | Header is decrypted natively; members list; `is_encrypted` true |
 | Encrypted folders with different passwords | Each folder uses its matching candidate in random access or one streaming pass |
-| Sole wrong password | `EncryptionError`/`CorruptionError`; no incorrect data |
+| Sole wrong password | `EncryptionError`/`CorruptionError`; no incorrect data (including never a silent empty listing from a header-encrypted archive) |
 | Repeated salt/cycles/password | Derived key cache avoids repeated key derivation |
 
 ### Requirement: Stream solid folders with bounded memory

--- a/src/archivey/internal/backends/sevenzip_pipeline.py
+++ b/src/archivey/internal/backends/sevenzip_pipeline.py
@@ -485,4 +485,8 @@ def parse_sevenzip_archive(
         )
         block = parse_header_block(decoded)
     assert isinstance(block, PlainHeader)
+    # O8: encrypted headers never legitimately decode to zero file records.
+    # Without this, ~0.3% of wrong-password py7zr salts slip through as empty.
+    if header_encrypted and not block.files:
+        raise EncryptionError("Password(s) rejected for the 7z header")
     return materialize_archive(signature, block, is_header_encrypted=header_encrypted)

--- a/src/archivey/internal/backends/sevenzip_reader.py
+++ b/src/archivey/internal/backends/sevenzip_reader.py
@@ -215,6 +215,12 @@ class SevenZipReader(BaseArchiveReader):
                     ) from exc
                 raise
         assert isinstance(block, PlainHeader)
+        # O8: 7zAES has no password check value. Wrong-key garbage occasionally
+        # LZMA-decodes into a header that parses with zero file records (py7zr
+        # omits the encoded-header folder CRC). Legitimate writers never encrypt
+        # an empty header — treat that as a rejected password.
+        if header_encrypted and not block.files:
+            raise EncryptionError("Password(s) rejected for the 7z header")
         return materialize_archive(
             signature, block, is_header_encrypted=header_encrypted
         )

--- a/tests/test_sevenzip_reader.py
+++ b/tests/test_sevenzip_reader.py
@@ -408,6 +408,41 @@ def test_header_encrypted_wrong_password_mentions_header(tmp_path: Path) -> None
     assert "Password required" not in caught.value.message
 
 
+@requires("cryptography")
+def test_header_encrypted_empty_decoded_header_rejected(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """O8: EncodedHeader that decrypts to a file-less plain header is a rejected password.
+
+    7zAES has no check value; py7zr omits the encoded-header folder CRC, so wrong-key
+    garbage occasionally LZMA-decodes into a zero-member header (~0.3% of salts). Force
+    that slip-through mode and require EncryptionError instead of a silent empty listing.
+    """
+    archive = tmp_path / "header-encrypted-o8.7z"
+    _write_py7zr_archive(archive, _FILES, password="secret", header_encryption=True)
+
+    # HEADER + END → PlainHeader with zero file records (legitimate empty archives use
+    # nextHeaderSize == 0 instead, never an encrypted empty header).
+    monkeypatch.setattr(
+        "archivey.internal.backends.sevenzip_reader.decode_encoded_header",
+        lambda *args, **kwargs: b"\x01\x00",
+    )
+
+    with pytest.raises(EncryptionError, match="(?i)rejected.*header") as caught:
+        open_archive(archive, password="secret").close()
+    assert "Password required" not in caught.value.message
+
+    # Same check on the fuzz/helper parse path.
+    from archivey.internal.backends.sevenzip_pipeline import parse_sevenzip_archive
+
+    monkeypatch.setattr(
+        "archivey.internal.backends.sevenzip_pipeline.decode_encoded_header",
+        lambda *args, **kwargs: b"\x01\x00",
+    )
+    with pytest.raises(EncryptionError, match="(?i)rejected.*header"):
+        parse_sevenzip_archive(archive.open("rb"), password=b"secret")
+
+
 @requires("bcj")
 def test_lzma1_bcj_fixture_roundtrip(tmp_path: Path) -> None:
     """py7zr LZMA1+BCJ archives decode via staged pybcj (not combined liblzma)."""


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes the 7z wrong-password gap (threat-model **O8**) surfaced while triaging the Windows flake on #139 / documented in #140.

## Problem

7zAES has no password check value. Reference 7-Zip writes a decoded-folder CRC for header-encrypted archives; **py7zr does not** (and our `[7z-write]` path goes through py7zr). Wrong-key garbage usually fails LZMA/header parse, but ~0.3% of salts decode into a header that parses with **zero file records** — `open_archive(..., password="wrong")` returned `member_count=0` with no error (silent data invisibility; root cause of flaky `test_header_encrypted_wrong_password_mentions_header`).

## Fix

After decoding a `kEncodedHeader`, treat a parsed result with zero file records as `EncryptionError` ("Password(s) rejected for the 7z header"). Legitimate writers never encrypt an empty header (`nextHeaderSize == 0` or a plain header instead).

Applied in both `SevenZipReader._load_archive` and `parse_sevenzip_archive`.

## Tests / docs

- Deterministic regression: force decode → `HEADER+END` (empty plain header) and assert rejection on reader + pipeline paths
- Stress: 200 fresh py7zr header-encrypted archives × wrong password → 200 `EncryptionError`, 0 silent empties
- Genuine empty archives (`nextHeaderSize == 0`) still open with `member_count=0`
- Threat-model O8 recorded as mitigated; `format-7z` scenario clarifies "never a silent empty listing"

## Out of scope

Other #140 items (Q1 listing-ratio direction, #139 verification docs) — ignored per request.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-41ce3d09-7ec3-4df2-94fa-c9e717a8b6ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-41ce3d09-7ec3-4df2-94fa-c9e717a8b6ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

