### PR TITLE
docs(review): triage in-flight findings — what's fixed vs still open

### DIFF
--- a/review/README.md
+++ b/review/README.md
@@ -20,12 +20,15 @@ completed changes out of `changes/`.
 Round commissioned 2026-07-17 — the **non-security** pass toward the first public
 `0.2.0`, after the three security-adjacent reviews archived below. See each `brief.md`:
 
-| Dir | Review |
-|-----|--------|
-| `api-coherence/` | Public API & member-model coherence / ergonomics (incl. cross-backend parity) |
-| `cli-product/` | The CLI as a **product** — UX, grammar, exit codes, output (not code correctness; #131 did that) |
-| `performance/` | The ≤1.3× stdlib perf budget — benchmark-gate efficacy + the real traps |
-| `stream-layering/` | Stream wrapper stack — are the checks correct, and can slicing+verification collapse into one stream under `ArchiveStream`? |
+| Dir | Review | Status (2026-07-18) |
+|-----|--------|---------------------|
+| `api-coherence/` | Public API & member-model coherence / ergonomics (incl. cross-backend parity) | Findings in (#133); **no fixes yet** — Q1–Q6 open |
+| `cli-product/` | The CLI as a **product** — UX, grammar, exit codes, output (not code correctness; #131 did that) | **Brief only** — review not run |
+| `performance/` | The ≤1.3× stdlib perf budget — benchmark-gate efficacy + the real traps | Findings + partial fixes (#134/#136/#137/#139/#140/#141); P1/P2/P6/P7 + Q2/Q4 remain |
+| `stream-layering/` | Stream wrapper stack — are the checks correct, and can slicing+verification collapse into one stream under `ArchiveStream`? | **Essentially done** (#137); park Q4 then archive |
+
+**Live triage of remaining action items / decisions / future copy-targets:**
+[`STATUS.md`](STATUS.md).
 
 The first three run against `main` with the CLI (PR #120) merged in — the CLI is the
 library's first real second consumer, so it sharpens all three: `api-coherence` reads
@@ -37,7 +40,8 @@ part of the missed budget to the per-member wrapper stack; it pairs a correctnes
 of the slice/verify/outer wrappers with a collapse-for-performance design question.
 
 `backlog.md` holds two more (test-strategy; structural-cleanliness / zero-tech-debt)
-deferred to a lighter follow-on pass.
+deferred to a lighter follow-on pass, plus Topics 6–7 (decode-engine perf; outside-in
+adoption capstone).
 
 ## Archive (complete & addressed)
 

--- a/review/STATUS.md
+++ b/review/STATUS.md
@@ -1,0 +1,134 @@
+# In-flight review status (2026-07-18)
+
+Triage of the four top-level reviews after cross-checking findings against
+merged PRs (#120, #133–#141). Update this file when a finding is fixed or a
+question is decided; archive a review directory only when every actionable
+item is fixed or consciously deferred here / in `backlog.md`.
+
+## At a glance
+
+| Review | Findings delivered? | Code/docs follow-ups | Ready to archive? |
+|--------|---------------------|----------------------|-------------------|
+| `stream-layering/` | yes (#137) | **done** (F1/F2/D1/D2); Q4 parked → future | **almost** — park Q4 then archive |
+| `performance/` | yes (#134 + #139/#140) | partial (P3–P5 done; P1/P2/P6/P7 open) | no |
+| `api-coherence/` | yes (#133) | **none yet** — all findings still open | no |
+| `cli-product/` | **no** — brief only | review not run | no |
+
+---
+
+## 1. Actionable right now
+
+Work that does not need a new maintainer decision (direction already recorded,
+or the finding is a clear proposed fix with no spec conflict).
+
+### From `performance/` (Q1 direction recorded 2026-07-18 in #140)
+
+| ID | Action |
+|----|--------|
+| **P7 / H3** | Cut ZIP/TAR open+list toward the **2–3×/member** peer band (measured 5–8×). Dedicated change — Track 3 found no ≥5% micro-win; needs a real model-build pass. |
+| **P6 remainder** | Add `py7zr` / `rarfile` listing peers + bands to the harness; measure 7z/RAR before optimizing. ZIP `open_list`/`extract` peers already in #139. |
+| **P2 remainder** | Many-small `read_all` follows the listing story (same per-member machinery as P7). Large-member ZIP read already ≤1.25× after #139; realistic extract ~1.9× (inside ~2× band) — no further extract code pending Q2. |
+| **VISION/docs** | Re-word the ≤1.3× claim to match Q1 (decompression-dominated ≤1.3×; listing as peer ratios) once enforcement (Q2) is chosen. |
+
+### From `api-coherence/` (no decision blocker once Q4 is a blanket “yes”)
+
+These are pre-release surface/doc fixes the review already proposed; they still
+need an explicit Q4/Q6 nod, but the *implementation* is mechanical:
+
+| ID | Action (after Q4 / Q6 confirm) |
+|----|--------------------------------|
+| **S1 / S3** | Demote `*Context` + `RAPIDGZIP_AUTO_MIN_COMPRESSED_SIZE` from `__all__`; export `PasswordInput` / decide `OnDiagnostic`; drop `core.source_name`; document `open_stream` in `api.md`. |
+| **S2** | `ArchiveFormat.display_name` (or similar) so the CLI stops parsing `repr()`. |
+| **E1** | Public measurement / IO-stats API so CLI `--track-io` leaves `internal/`. |
+| **E3** | Split or reason-tag `ExtractionStatus.SKIPPED` (non-current vs overwrite). |
+
+### Process
+
+| Item | Action |
+|------|--------|
+| **`cli-product/`** | Run the product review (brief is ready; #120 is merged). |
+| **`stream-layering/`** | Mark Q4 deferred → archive the directory (see §3). |
+
+---
+
+## 2. Still needs decisions
+
+Do not implement these until the maintainer answers (pause-and-ask).
+
+### `api-coherence/QUESTIONS.md`
+
+| Q | Finding | Why blocked |
+|---|---------|-------------|
+| **Q1** | **P1** duplicate-name / `is_current` | Spec conflict (`safe-extraction` vs `archive-data-model`) + three format behaviours. Recommended: unify last-entry-wins on random-access formats. |
+| **Q2** | `members()` scope | Recommendation is “keep everything, no include/exclude arg” — needs explicit yes/no. |
+| **Q3** | **P2** RAR `listing_cost` | Doc says `REQUIRES_SCANNING` for no-quick-open; impl always `INDEXED`. |
+| **Q4** | Surface demote/add list | Blanket approval or line-item veto. |
+| **Q5** | **E2** library `verify` primitive | Priority: now vs post-0.2.0 (additive either way). |
+| **Q6** | Freeze nits | `WriteError` keep/demote; SKIPPED split shape; `hashes` int/bytes; display-name spelling. |
+
+### `performance/QUESTIONS.md`
+
+| Q | Finding | Why blocked |
+|---|---------|-------------|
+| **Q2** | **P1** wall-budget enforcement | Nightly drift gate vs 2× band vs informational — flake vs honesty. Recommendation: (a)+(c). |
+| **Q4** | Verify-skip knob | Perf case now ~nil post-#137; still an API-design call (overlaps api-coherence). Leaning: leave as-is. |
+
+### `stream-layering/QUESTIONS.md`
+
+| Q | Status |
+|---|--------|
+| Q1–Q3 | **Decided / implemented** in #137 |
+| **Q4** | Open only as “park vs do now” — see §3 (recommend park) |
+
+---
+
+## 3. Future / archive-copy targets
+
+When archiving a review, copy these into `backlog.md`, `IDEAS.md`, or a
+dedicated follow-up brief — they are not 0.2.0 blockers from the current round.
+
+### From `performance/` (follow-ups)
+
+| ID | Notes |
+|----|-------|
+| **P8** | rapidgzip AUTO threshold (1 MiB) may be conservative for seek workloads. |
+| **P9** | Measurement blind spots (7z password-confirm decode; RAR solid rewind via unrar pipe). |
+| Extract residual | Documented safety floor (`mkstemp`+rename / `lstat`); realistic ~1.9× already in band. |
+| Topic 6 | Decode-engine performance (`DecompressorStream` / accelerators) — already in `backlog.md`. |
+
+### From `stream-layering/`
+
+| ID | Notes |
+|----|-------|
+| **Q4** | Real `SlicingStream.readinto` — park until an extract path is shown `readinto`-bound. Optional cleanup: delete unused `VerifyingStream` later. |
+
+### From `api-coherence/`
+
+| ID | Notes |
+|----|-------|
+| **D1** | CLI list marks for `ANTI` / non-current — belongs to **`cli-product/`** when that review runs. |
+| **E2** (if Q5 = post-0.2.0) | Library `verify` / `VerifyReport` — `IDEAS.md` or a post-freeze change. |
+
+### Already on `backlog.md` (not from this round’s findings)
+
+Topics 4–5 (test strategy + debt ledger), Topic 6 (decode-engine perf), Topic 7
+(outside-in adoption capstone), plus salvage/best-effort mode as a feature gap.
+
+---
+
+## Already addressed (do not re-open)
+
+Cross-check against merged PRs; statuses should also appear in each review’s
+`SUMMARY.md` / `QUESTIONS.md`.
+
+| Review | Item | Where |
+|--------|------|-------|
+| stream-layering | F1, F2, D1, D2; Q1–Q3 | #137 (+ #138 tidy) |
+| performance | P3 (selective solid) | #136 |
+| performance | P4, P5 (gate holes); decode-feed; Q3, Q6 | #139 |
+| performance | Q5 (H1 shape) | #136 |
+| performance | Q1 *direction* (listing = peer ratios) | #140 (implementation still open — §1) |
+| performance | O8 side-finding (empty wrong-password 7z) | #141 (threat-model mitigated) |
+| api-coherence | *(none)* | findings-only #133 |
+| cli-product | *(n/a)* | brief only |
+| archive/ | all five archived reviews | see `README.md` |

--- a/review/api-coherence/QUESTIONS.md
+++ b/review/api-coherence/QUESTIONS.md
@@ -1,5 +1,8 @@
 # QUESTIONS — maintainer decisions
 
+> **Status (2026-07-18):** all six questions still open — no decisions recorded
+> since findings landed in #133. Triage: `../STATUS.md`.
+
 Per the pause-and-ask rule (`CLAUDE.md`, `CONTRIBUTING.md`): discrepancies and
 judgement calls surfaced, not silently resolved. Ordered by weight.
 

--- a/review/api-coherence/SUMMARY.md
+++ b/review/api-coherence/SUMMARY.md
@@ -1,5 +1,10 @@
 # API-coherence review — SUMMARY
 
+> **Status (2026-07-18):** findings delivered in #133; **no code follow-ups have
+> landed yet.** Every row in the table below is still open. Blockers that need
+> a maintainer answer first: **Q1–Q6** (`QUESTIONS.md`). Mechanical surface
+> work (S1/S2/S3/E1/E3) is actionable after Q4/Q6. Triage: `../STATUS.md`.
+
 Reviewed at `main` + CLI (#120) merged (`7139c13`). Baseline (all captured before
 review, `[all]` config): pytest **1699 passed / 131 skipped / 3 deselected**, pyrefly
 **0 errors** (8 warnings), ty clean, `ruff check` clean. `ruff format --check` fails on
@@ -39,15 +44,15 @@ subtle generator semantics); and `ArchiveFormat` has no display name (the CLI pa
 
 | # | Severity | Finding | Where | Status |
 |---|----------|---------|-------|--------|
-| P1 | **High** | Duplicate-name members: `is_current` computed only by 7z/RAR; ZIP/TAR default extraction *errors* where 7z silently skips — same input, divergent outcome; `safe-extraction` scenario ("superseded by later same-name → SKIPPED") is format-silent and currently false for ZIP/TAR | `sevenzip_parser.py:331`, `extraction.py:351`, repro in `parity.md` | **Maintainer decision** (Q1) |
-| E1 | Medium | No public measurement/IO-stats API: CLI `--track-io` imports `enable_measurement` + `BaseArchiveReader` from `internal/` and reads three counters not on the `ArchiveReader` ABC | `cli/common.py:15-16,56-68`, `base_reader.py:557-1009` | Proposed fix (surface.md §Add) |
-| E2 | Medium | No library "verify" primitive: `archivey test` hand-rolls manual `next()` loop; a mid-pass failure poisons the stream and loses remaining members | `cli/test_cmd.py:56-73` | Proposed direction (Q5) |
-| S1 | Medium | `__all__` = 90 names: 13 `*Context` classes + `RAPIDGZIP_AUTO_MIN_COMPRESSED_SIZE` should demote; `PasswordInput` / `OnDiagnostic` missing; `MemberSelector` vs internal `MemberSelectorArg` duplicate aliases used inconsistently in one class | `__init__.py:113-204`, `reader.py:27,148` | Proposed list (surface.md) |
-| P2 | Low-Med | RAR `listing_cost=INDEXED` always, but `cost.py` docstring names "RAR with no quick-open record" as the canonical `REQUIRES_SCANNING` example — doc/impl conflict on an honest-cost axis | `rar_reader.py:773` vs `cost.py:24-27` | **Maintainer decision** (Q3) |
-| E3 | Low | `ExtractionStatus.SKIPPED` conflates overwrite-skip and non-current-skip; caller must infer reason via `member.is_current` | `extraction_types.py:80-87`, `extraction.py:351` | Proposed fix |
-| S2 | Low | `ArchiveFormat` has no display-name property; CLI string-parses `repr()` | `cli/info_cmd.py:16-23` | Proposed fix |
-| S3 | Low | `archivey.core.__all__` exports internal helper `source_name`; `docs/api.md` omits `open_stream`, `MemberStreams`, selectors, format-support queries | `core.py:78`, `docs/api.md` | Proposed fix |
-| D1 | Low | CLI list line has no mark for `ANTI` (falls to `"?"`, same as `OTHER`) and no non-current indicator — the member model's own distinctions are invisible in the first consumer | `cli/format.py:9-15` | Overlaps cli-product review |
+| P1 | **High** | Duplicate-name members: `is_current` computed only by 7z/RAR; ZIP/TAR default extraction *errors* where 7z silently skips — same input, divergent outcome; `safe-extraction` scenario ("superseded by later same-name → SKIPPED") is format-silent and currently false for ZIP/TAR | `sevenzip_parser.py:331`, `extraction.py:351`, repro in `parity.md` | **open — needs Q1** |
+| E1 | Medium | No public measurement/IO-stats API: CLI `--track-io` imports `enable_measurement` + `BaseArchiveReader` from `internal/` and reads three counters not on the `ArchiveReader` ABC | `cli/common.py:15-16,56-68`, `base_reader.py:557-1009` | **open** — proposed fix; actionable after Q4 nod |
+| E2 | Medium | No library "verify" primitive: `archivey test` hand-rolls manual `next()` loop; a mid-pass failure poisons the stream and loses remaining members | `cli/test_cmd.py:56-73` | **open — needs Q5** (now vs post-0.2.0) |
+| S1 | Medium | `__all__` = 90 names: 13 `*Context` classes + `RAPIDGZIP_AUTO_MIN_COMPRESSED_SIZE` should demote; `PasswordInput` / `OnDiagnostic` missing; `MemberSelector` vs internal `MemberSelectorArg` duplicate aliases used inconsistently in one class | `__init__.py:113-204`, `reader.py:27,148` | **open — needs Q4** |
+| P2 | Low-Med | RAR `listing_cost=INDEXED` always, but `cost.py` docstring names "RAR with no quick-open record" as the canonical `REQUIRES_SCANNING` example — doc/impl conflict on an honest-cost axis | `rar_reader.py:773` vs `cost.py:24-27` | **open — needs Q3** |
+| E3 | Low | `ExtractionStatus.SKIPPED` conflates overwrite-skip and non-current-skip; caller must infer reason via `member.is_current` | `extraction_types.py:80-87`, `extraction.py:351` | **open — needs Q6** |
+| S2 | Low | `ArchiveFormat` has no display-name property; CLI string-parses `repr()` | `cli/info_cmd.py:16-23` | **open — needs Q6** |
+| S3 | Low | `archivey.core.__all__` exports internal helper `source_name`; `docs/api.md` omits `open_stream`, `MemberStreams`, selectors, format-support queries | `core.py:78`, `docs/api.md` | **open — needs Q4** |
+| D1 | Low | CLI list line has no mark for `ANTI` (falls to `"?"`, same as `OTHER`) and no non-current indicator — the member model's own distinctions are invisible in the first consumer | `cli/format.py:9-15` | **defer to `cli-product/`** |
 
 ## The maintainer's extra question (members scope)
 

--- a/review/backlog.md
+++ b/review/backlog.md
@@ -9,9 +9,14 @@ character and timing:
   polish, so run them together rather than as two frontier deep dives.
 - **Topic 6** (decode-engine performance) — a later *performance* round, once the
   `stream-layering` wrapper work has landed; mostly independent of it.
+  *(stream-layering fusion landed in #137 — Topic 6 is unblocked on that axis.
+  Also absorb parked stream-layering Q4: real `SlicingStream.readinto`.)*
 - **Topic 7** (outside-in adoption / confidence) — a **capstone**, meaningful only
   *after everything else is fully addressed*; it judges the finished library, not a
   work in progress.
+
+Live triage of the *current* in-flight round's remaining items is in
+[`STATUS.md`](STATUS.md) (actionable / needs-decision / future archive-copy).
 
 When commissioned, each gets its own top-level directory with a `brief.md` and
 archives when addressed (see `README.md`).

--- a/review/cli-product/brief.md
+++ b/review/cli-product/brief.md
@@ -1,5 +1,10 @@
 # Brief — The `archivey` CLI as a product (UX / ergonomics)
 
+> **Status (2026-07-18):** brief only — **product review not yet run.**
+> Start condition (PR #120 merged) is met. Finding D1 from `api-coherence/`
+> (CLI list ANTI / non-current marks) should be folded into this review when
+> it runs. See `../STATUS.md`.
+
 Read `review/README.md` (conventions, VISION tie-breakers, deliverable shape). This
 is a **product** review — the CLI seen through a user's eyes — **not** a code-correctness
 pass. PR #131 already reviewed the implementation for bugs (F1–F12 fixed).

--- a/review/performance/QUESTIONS.md
+++ b/review/performance/QUESTIONS.md
@@ -2,14 +2,13 @@
 
 Decisions this review cannot make unilaterally (per the pause-and-ask rule).
 
-> **Post-#136/#137 status:** Q5 is resolved (both halves implemented in #136;
-> the error-timing shift was handled by translating the deferred `EOFError` to
-> `TruncatedError` at first read). Q1–Q4 and Q6 remain open; Q1 and Q4 have new
-> evidence noted inline below. `residual-gap.md` gives P2 a concrete lever
-> (decode-chunk granularity: ZIP read-all 1.38× → 1.23× on the review probe),
-> which lowers the stakes of Q1's option (c).
+> **Status (2026-07-18):** Q3, Q5, Q6 **resolved** (#136 / #139). Q1 has a
+> **maintainer direction** (#140) — implementation consequences still open
+> (listing peers, ZIP open+list toward 2–3×). **Still need a decision:** Q2
+> (wall enforcement), Q4 (verify-skip knob; perf case ~nil post-#137). See
+> `../STATUS.md`.
 
-## Q1 — What does "≤1.3× on common paths" cover, exactly?
+## Q1 — What does "≤1.3× on common paths" cover, exactly? — DIRECTION RECORDED
 
 VISION's sentence names "open/list/read/extract on ZIP and TAR". Measured today
 (`budget-table.md`): ZIP read 2.2–2.3×, ZIP extract 2.4–3.7×, ZIP open+list 5–8×,
@@ -49,7 +48,7 @@ Consequences to implement:
    band (met at realistic scale), many-small read_all follows the listing
    story (its cost *is* per-member machinery).
 
-## Q2 — Where should the wall budget be *enforced*?
+## Q2 — Where should the wall budget be *enforced*? — OPEN
 
 Today: nowhere (`gate-efficacy.md` G1) — deliberate, because shared-runner ratios
 flake. Options, not mutually exclusive:
@@ -77,7 +76,7 @@ future corpus, that corpus isn't in the tree.
 added `NONSOLID_DECODE_FACTOR = 1.1` (G4) and ci-scale solid-random
 baseline×1.5 (Q6/G5).
 
-## Q4 — Should container-digest verification be skippable?
+## Q4 — Should container-digest verification be skippable? — OPEN (lean leave-as-is)
 
 `VerifyingStream` wraps every ZIP/7z/RAR member read; the digest itself is cheap
 (CRC32/C) but the wrapper layer costs on hot paths, and some callers (e.g. a
@@ -94,6 +93,9 @@ is now essentially zero. One nuance for whoever designs the knob anyway: the
 fused verifier bounds `read(-1)` to the declared size, which *disables* the
 `readall()` fast path (`residual-gap.md` §1) — worth keeping in mind so a
 "verify off" mode doesn't accidentally have different chunking behaviour.
+
+**Triage note:** unless someone wants the knob for API reasons, treat as
+“leave as-is” and close when archiving this review.
 
 ## Q5 — H1 fix shape: lazy solid positioning vs extraction early-exit? — RESOLVED (#136)
 

--- a/review/performance/SUMMARY.md
+++ b/review/performance/SUMMARY.md
@@ -42,15 +42,15 @@ bounded.
 
 | # | Severity | Finding | Where | Status |
 |---|----------|---------|-------|--------|
-| P1 | **blocker** | ≤1.3× wall budget enforced nowhere; nightly hard-fails only at 10×, VISION band informational | `benchmarks/harness.py:55,826-834`, `benchmark-wall.yml` | open — decision needed (Q2) |
-| P2 | **blocker** | Budget not met: ZIP read-all 2.2–2.3×, extract-all 2.4–3.7×, open+list 5–8×; TAR read 1.8× | `budget-table.md` | **partial** — #136/#137/#139 put large-member ZIP read ≤1.25× and realistic extract ~1.9×; open+list vs the Q1 ratio bands and many-small remain |
+| P1 | **blocker** | ≤1.3× wall budget enforced nowhere; nightly hard-fails only at 10×, VISION band informational | `benchmarks/harness.py:55,826-834`, `benchmark-wall.yml` | **open** — decision needed (Q2) |
+| P2 | **blocker** | Budget not met: ZIP read-all 2.2–2.3×, extract-all 2.4–3.7×, open+list 5–8×; TAR read 1.8× | `budget-table.md` | **partial** — #136/#137/#139: large-member ZIP read ≤1.25×, realistic extract ~1.9×; open+list / many-small remain under Q1 |
 | P3 | **blocker** | Selective solid-7z extraction decodes ~whole folder for one early member (31× needed bytes); CLI `extract archive.7z <name>` hits it | `sevenzip_reader.py:283-323`, `extraction.py:340` | **fixed by #136** — verified 31.0× → 1.00× |
 | P4 | high | Non-solid re-decompression is invisible to the gate: decode-twice-deliver-once ZIP regression passes (byte axis counts delivered output; seek slack ×2+8 absorbs churn; wall ungated) | `gate-efficacy.md` G4, `repro.py` probe 3 | **fixed by #139** — over-decode ×1.1 bound + seek slack baseline+8; probe CAUGHT |
 | P5 | high | A full 2× solid re-decode passes the gate (`SOLID_DECODE_FACTOR = 2.0`, non-strict bound) — VISION says a re-read must fail | `harness.py:51,526-532`, `repro.py` probe 2 | **fixed by #139** — factor 1.25; probe CAUGHT |
-| P6 | med | Harness has no stdlib peer for open/list/extract (why P2's extract miss went unnoticed); no RAR case in committed baseline; ZIP-AES / native-codec / in-ZIP-accelerated paths unbenchmarked | `gate-efficacy.md` G6/G7 | partial — #139 adds ZIP open_list/extract peers; RAR/encrypted/accel cases + Q1 listing peers still missing |
-| P7 | med | Per-`open()` 5–8× zipfile (detection + member-model build ~0.3 ms/archive) — the founding million-archive sweep pays minutes | `hotspots.md` H3 | partial — #136 caches the extension map; rest open |
-| P8 | low | rapidgzip AUTO threshold (1 MiB) conservative: seek workloads win ~1.5× well below it; provenance script never measured compressed sizes near 1 MiB | `hotspots.md` H5 | follow-up |
-| P9 | low | Measurement blind spots: 7z password-confirm folder decode uncounted; RAR byte axis (unrar pipe output) cannot see solid rewind | `gate-efficacy.md` G6 | follow-up |
+| P6 | med | Harness has no stdlib peer for open/list/extract (why P2's extract miss went unnoticed); no RAR case in committed baseline; ZIP-AES / native-codec / in-ZIP-accelerated paths unbenchmarked | `gate-efficacy.md` G6/G7 | **partial** — #139 adds ZIP open_list/extract peers; `py7zr`/`rarfile` listing peers + RAR/encrypted/accel still missing |
+| P7 | med | Per-`open()` 5–8× zipfile (detection + member-model build ~0.3 ms/archive) — the founding million-archive sweep pays minutes | `hotspots.md` H3 | **partial** — #136 caches extension map; model-build toward 2–3× **actionable** (Q1) |
+| P8 | low | rapidgzip AUTO threshold (1 MiB) conservative: seek workloads win ~1.5× well below it; provenance script never measured compressed sizes near 1 MiB | `hotspots.md` H5 | **follow-up** (future) |
+| P9 | low | Measurement blind spots: 7z password-confirm folder decode uncounted; RAR byte axis (unrar pipe output) cannot see solid rewind | `gate-efficacy.md` G6 | **follow-up** (future) |
 
 Blocker rationale (per brief): P1/P4/P5 = "gate can't catch a regression"; P2 = "budget
 missed"; P3 is the VISION-named trap reachable from the shipped CLI.
@@ -75,8 +75,8 @@ selective-solid probe re-run against main, #136, #137 trees):
   stdlib** on this host — under the 1.3× budget. Full numbers, remaining
   per-member overhead (~190 µs/member, distributed), and the investigation
   plan: `residual-gap.md`.
-- **Still open:** P1 (enforcement), P2 (budget — now with a concrete lever),
-  P4/P5 (gate bounds), P6 (stdlib peers), Q1–Q4/Q6.
+- **Still open at that commit (historical):** P1, P2, P4/P5, P6, Q1–Q4/Q6.
+  Superseded by the #139 / #140 / #141 updates below.
 
 ## Second follow-up (#139, `main` @ `93dc28e`) — verified
 
@@ -102,6 +102,27 @@ suite green, gate green, probes re-run, before/after probe on shared fixtures):
   garbage occasionally parses as a zero-member header). Hazard + proposed
   deterministic tightening (reject file-less encoded headers) written up in
   `docs/internal/threat-model.md` O8.
+
+## Third follow-up (#141) — O8 mitigated
+
+**Fixed in #141:** empty decoded `kEncodedHeader` → `EncryptionError` (reader +
+pipeline). Threat-model O8 marked mitigated; residual is only garbage that
+parses as a *non-empty* plausible header.
+
+## Remaining open (triage 2026-07-18 — see `../STATUS.md`)
+
+| # | Status |
+|---|--------|
+| P1 | open — needs **Q2** (enforcement venue) |
+| P2 | **partial** — large-member ZIP read in budget; open+list / many-small follow Q1 direction (actionable); extract realistic in ~2× band |
+| P3 | **fixed** (#136) |
+| P4 / P5 | **fixed** (#139) |
+| P6 | **partial** — ZIP peers in #139; `py7zr`/`rarfile` listing peers + RAR/encrypted/accel cases still missing |
+| P7 | **partial** — extension-map cache in #136; model-build toward 2–3× **actionable** under Q1 |
+| P8 / P9 | **follow-up** (future / archive-copy) |
+| Q1 | **direction recorded** (#140) — implement consequences |
+| Q2 / Q4 | **need decision** |
+| Q3 / Q5 / Q6 | **resolved** |
 
 ## What is actually fine
 

--- a/review/performance/investigation-report.md
+++ b/review/performance/investigation-report.md
@@ -162,14 +162,15 @@ informational for VISION; sanity ceiling stays 10×. Recommendation from #134
 
 ## Open questions (updated)
 
-| # | Status after this PR |
+| # | Status after this PR / later |
 |---|---|
-| Q1 budget scope | Still open; new evidence favors (b)/(c): many-small is a different claim |
+| Q1 budget scope | **Direction recorded** (#140): listing = peer ratios (2–3× ZIP/TAR; parity 7z/RAR). Implementation open — see `../STATUS.md` |
 | Q2 wall enforcement | Still open; peers added for ZIP open/extract |
 | Q3 `SOLID_DECODE_FACTOR` | **Done here** (1.25) |
-| Q4 verify-skip knob | Unchanged; perf case still ~nil post-#137 |
+| Q4 verify-skip knob | Unchanged; perf case still ~nil post-#137 — lean leave-as-is |
 | Q5 H1 fix shape | Resolved in #136 |
 | Q6 solid-random bound | **Done here** (ci ×1.5) |
+| O8 (side-finding) | **Mitigated in #141** |
 
 ## How to re-verify
 

--- a/review/stream-layering/QUESTIONS.md
+++ b/review/stream-layering/QUESTIONS.md
@@ -1,6 +1,11 @@
 # Questions for the maintainer
 
-## Q1 — Accept the partial-collapse verdict?
+> **Status (2026-07-18):** Q1–Q3 decided and implemented in #137. **Q4** is the
+> only leftover — recommend **park** (future / archive-copy). This review is
+> otherwise complete and can move to `archive/` once Q4 is deferred. See
+> `../STATUS.md`.
+
+## Q1 — Accept the partial-collapse verdict? — DONE (#137)
 
 **Implemented in this PR** (on top of #136): `MemberVerifier` fused into
 `ArchiveStream`; ZIP/7z/RAR backends pass `expected_hashes` /
@@ -16,19 +21,23 @@ Alternatives considered and rejected:
 - **Sell fusion as closing the ≤1.3× gap** — numbers say ~5% STORED end-to-end;
   deflate remains Topic 6.
 
-## Q2 — F1 severity / fix venue
+## Q2 — F1 severity / fix venue — DONE (#137)
 
 **Done in this PR** with the fusion (`MemberVerifier.read` treats `n == 0` as
 a no-op).
 
-## Q3 — Keep `VerifyingStream` as a helper type?
+## Q3 — Keep `VerifyingStream` as a helper type? — DONE (#137)
 
 **Chose (b):** `MemberVerifier` holds the logic; `VerifyingStream` remains a
 thin wrapper for `codecs.py`'s length-only backstop and unit tests. Member
 backends no longer construct it. Deleting the class later is optional cleanup.
 
-## Q4 — `SlicingStream.readinto` follow-up?
+## Q4 — `SlicingStream.readinto` follow-up? — PARK (future)
 
 The brief hoped a fused `readinto` would matter more than dispatch count. On
 this host it does not, until the slice layer also stops allocating. Worth a
 follow-up task, or park until an extract path is shown `readinto`-bound?
+
+**Triage (2026-07-18):** **park** — copy to `backlog.md` / Topic 6 adjacency
+when archiving this review. Not a 0.2.0 blocker; no extract path has been
+shown `readinto`-bound.

--- a/review/stream-layering/SUMMARY.md
+++ b/review/stream-layering/SUMMARY.md
@@ -44,10 +44,14 @@ budget closer.
 
 | # | Sev | Finding | Where | Status |
 |---|-----|---------|-------|--------|
-| F1 | **Medium** | `VerifyingStream.read(0)` (and mid-stream `read(0)`) is treated as EOF — false `CorruptionError` / `TruncatedError`. `_GzipTruncationCheckStream` already pins the opposite contract. | `verify.py` (`MemberVerifier.read`) | **fixed** (this PR) |
-| F2 | Low | `VerifyingStream.close()` can leave wrapper+inner unclosed when the EOF probe raises a non-`CorruptionError`/`TruncatedError` `ArchiveyError` (e.g. `EncryptionError`). | `verify.py` (`finish_on_close`) | **fixed** (this PR) |
-| D1 | design | **Fuse verify into `ArchiveStream`** (conditional when hashes/size present); leave `SlicingStream`/`SharedSource`/`LockedStream` and the decode engine separate. Ranked sequence in `collapse-design.md`. | `archive_stream.py`, backends | **implemented** (this PR) |
-| D2 | design | Nested codec `ArchiveStream` under `VerifyingStream` remains after #136; verify-fusion is what lets `_collapse_nested` finish the job. | live STORED stack: `AS → SlicingStream` | **fixed** by D1 |
+| F1 | **Medium** | `VerifyingStream.read(0)` (and mid-stream `read(0)`) is treated as EOF — false `CorruptionError` / `TruncatedError`. `_GzipTruncationCheckStream` already pins the opposite contract. | `verify.py` (`MemberVerifier.read`) | **fixed** (#137) |
+| F2 | Low | `VerifyingStream.close()` can leave wrapper+inner unclosed when the EOF probe raises a non-`CorruptionError`/`TruncatedError` `ArchiveyError` (e.g. `EncryptionError`). | `verify.py` (`finish_on_close`) | **fixed** (#137) |
+| D1 | design | **Fuse verify into `ArchiveStream`** (conditional when hashes/size present); leave `SlicingStream`/`SharedSource`/`LockedStream` and the decode engine separate. Ranked sequence in `collapse-design.md`. | `archive_stream.py`, backends | **implemented** (#137) |
+| D2 | design | Nested codec `ArchiveStream` under `VerifyingStream` remains after #136; verify-fusion is what lets `_collapse_nested` finish the job. | live STORED stack: `AS → SlicingStream` | **fixed** by D1 (#137) |
+| Q4 | follow-up | Real `SlicingStream.readinto` (seek+`readinto` under lock) | `slicing.py` | **parked** — future / archive-copy |
+
+> **Archive readiness (2026-07-18):** all actionable findings done. Park Q4 then
+> move this directory to `archive/`. See `../STATUS.md`.
 
 ## What is actually fine
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Docs-only reconciliation of the four in-flight reviews against merged PRs (#133–#141).

## What landed

- New [`review/STATUS.md`](./review/STATUS.md) — single triage of remaining work:
  **actionable now** / **needs decisions** / **future (archive-copy targets)**
- Status banners + table updates in each review's `SUMMARY.md` / `QUESTIONS.md`
  so "still open" matches reality
- `README.md` in-flight table now shows per-review status; `cli-product` brief
  marked not-yet-run; `backlog.md` notes stream-layering Q4 → Topic 6 adjacency

## Headline triage (see STATUS.md for full tables)

| Bucket | Highlights |
|--------|------------|
| **Already done** | stream-layering F1/F2/D1/D2 (#137); perf P3 (#136), P4/P5 + decode-feed (#139), Q1 *direction* (#140), O8 (#141) |
| **Actionable now** | perf P7 open+list toward 2–3×; `py7zr`/`rarfile` listing peers; run `cli-product/`; archive stream-layering after parking Q4 |
| **Needs decisions** | api-coherence Q1–Q6 (esp. P1 `is_current`); perf Q2 (wall enforcement), Q4 (verify-skip lean leave-as-is) |
| **Future / archive-copy** | perf P8/P9; stream-layering Q4 `readinto`; api D1 → cli-product; backlog Topics 4–7 |

No library code changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5a86e927-a4d7-4ef8-ba75-13fe6c3b7962"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5a86e927-a4d7-4ef8-ba75-13fe6c3b7962"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

