### PR TITLE
review: CLI product deep review — grammar, output, errors, exit codes

### DIFF
--- a/review/cli-product/QUESTIONS.md
+++ b/review/cli-product/QUESTIONS.md
@@ -1,0 +1,116 @@
+# Maintainer decisions — CLI product review
+
+Decisions this review surfaced that are not plain fixes. Q1–Q3 shape 0.2.0
+user-visible behavior; Q4–Q6 can land after. #131's D1–D8 are settled and not
+reopened.
+
+## Q1 — Extraction continuation: reject-and-continue for the CLI? (drives P1)
+
+Today `extract` inherits the library's `OnError.STOP`: the first rejected or
+failed member raises, nothing after it is extracted, and the already-written
+members are never reported. A traversal member means zero files extracted
+under every `--policy` — `unzip` extracts the safe files and warns, so the
+"safer unzip" is currently also the *less useful* unzip on exactly the input
+the pitch is about. The CLI already has dead plumbing for the better story
+(`rejected:`/`failed:` lines + summary counts, `cli/extract_cmd.py:315-336`).
+
+Sub-decisions:
+
+1. **Semantics**: should the CLI extract with record-and-continue for (a)
+   policy rejections only, or (b) rejections *and* per-member read failures
+   (digest mismatch, decode error), continuing where the stream allows?
+   Recommend (b) — it is `test`'s semantics applied to extraction, and it is
+   the VISION #3 claim.
+2. **Mechanism**: CLI passes an `OnError`-style argument (library gains/
+   exposes it), or the library default changes? Recommend: CLI-side opt-in
+   via the existing library knob if it exists/is cheap; the library default
+   staying STOP is fine for programmatic callers.
+3. **Exit code**: completed-with-rejections = 1, or break out the reserved
+   `3` ("refused by safety policy") now? The design already argued 3 is "a
+   genuinely useful distinction for the safer-unzip story" and callers were
+   told not to assume 1 is exhaustive, so it's compatible. Recommend: 3 for
+   "completed but ≥1 member rejected by policy", 1 for other failures.
+4. **Flag**: is a `--stop-on-error` opt-back needed at the same time, or
+   later on demand? Recommend later.
+5. Either way (even if STOP stays): on the stop path, report what *was*
+   extracted before the stop (count at minimum). Today even `-v` says
+   nothing.
+
+## Q2 — `--json` timing and minimal schema (drives P4)
+
+Design (Open Question 7) deferred `--json` pending a stable member schema —
+correctly, for the *full* `ArchiveMember` model. But the CLI needs only the
+fields it already prints: name, type, size, mtime, mode, encrypted,
+link_target, hashes. Options:
+
+1. Ship minimal `--json` (JSON-lines) on `list` + `info` in 0.2.0 with an
+   additive-only promise on those fields.
+2. First 0.2.x follow-up (recommended if 0.2.0 is time-boxed — but then say
+   so in docs so the scripting audience knows it's coming and doesn't
+   scrape).
+3. Wait for the `hash` verb / full schema work.
+
+Recommend 1 if any slack exists, else 2. Naming: `--json` (tool-standard) vs
+`--porcelain` (git-ism) — recommend `--json`.
+
+## Q3 — No-match filters: warning + which exit code? (drives P2)
+
+Agreed shape (P2): stderr warning per unmatched include pattern; the open
+question is the exit code when zero members matched on `extract`/`test`:
+
+1. Warn, exit 0 (gentlest; scripts still blind).
+2. Warn, exit 1 (recommended — "the operation did not do what was asked";
+   matches `tar`'s nonzero).
+3. Warn, dedicated code in the reserved ≥3 space (unzip's 11-style
+   "no files matched"); most script-friendly, spends a reserved code.
+
+And for `list` with no matches: silent-0 (grep-like it is not), or the same
+warning with exit 0? Recommend warning + exit 0 for `list` (listing nothing
+is an answer), warning + nonzero for `extract`/`test`.
+
+Also: adopt the `(did you mean -d out?)` hint when a sole unmatched extract
+pattern names an existing directory / ends with `/`?
+
+## Q4 — Control-byte quoting style for member names (drives P3)
+
+Escape in all CLI output (recommended) or only when the stream is a TTY?
+Style: backslash-escapes (`\r`, `\x1b` — GNU-ish, lossless) vs U+FFFD
+replacement (prettier, lossy)? Is a `--raw` escape hatch needed for the
+pipe-to-script case, or does that wait for `--json` (where raw names are
+naturally safe)? Recommend: escape everywhere, backslash style, no `--raw`
+until someone asks — scripts get exact names via `--json` (Q2).
+
+## Q5 — Should `info` tell the cost/access story? (drives P14)
+
+`info` answers "what is this file" but not the library's signature "what
+will it cost" claim. Minimal version: one derived `access:` line (e.g.
+`random (indexed central directory)` / `sequential-only (solid; reading one
+member decodes its folder prefix)` / `sequential (no gzip index; install
+[seekable] for random access)`). Is that in-scope for the CLI, or does it
+wait for a `CostReceipt`-shaped public surface in the library? The CLI can
+derive today's version from `info.is_solid` + format + accelerator presence
+without new public API.
+
+## Q6 — A "what can this install read" view (drives P14)
+
+Design Decision 10 listed `--version` as "version + optional dependency
+matrix"; shipped `--version` prints only the version string. The per-failure
+messages ("install the 'crypto' extra") are excellent but reactive. Options:
+`--version -v`, `archivey info` with no argument, or a future `archivey
+formats`/`doctor`. Any preference, or defer entirely? (Cheap and high-demo
+value: the maintainer's own "why can't I open this" debugging tool.)
+
+## Q7 — Two library-side message fixes surfaced here (P7, P9) — confirm owners
+
+Not CLI decisions, but they land in library code and deserve issues/changes:
+
+1. Truncated/corrupt zip: `BadZipFile('File is not a zip file')` repr (and
+   the misleading "not a zip file" for a magic-matched truncated file);
+   enum-name leaks (`ArchiveFormat.TAR_ZST`, `SEVEN_Z` label in `info`,
+   `format=ArchiveFormat.ZIP` suffixes); zipcrypto "Wrong password" when no
+   password was supplied (#131 D8 residue).
+2. The backward-seek warning firing with rapidgzip installed but size-gated
+   off, telling the user to install what they have
+   (`archive_stream.py:408` + `codecs.py:239-251`) — text should
+   distinguish "not installed" from "not engaged", and arguably not fire
+   below the size threshold at all.

--- a/review/cli-product/SUMMARY.md
+++ b/review/cli-product/SUMMARY.md
@@ -1,0 +1,141 @@
+# CLI-as-a-product review — SUMMARY
+
+Deep review per `brief.md`: the merged `src/archivey/cli/` on `main` (post-#120,
+post-#131 fixes), judged as a **product** — muscle memory, output, errors, exit
+codes, discoverability — not re-reviewing implementation correctness.
+
+**Baseline** (2026-07-18, `main` @ `0136024`, config `[all]`+`[cli]`, Python 3.11):
+1709 passed / 131 skipped / 3 deselected; `pyrefly` 0 errors; `ty` clean; `ruff
+check` clean (`ruff format --check` flags only pre-existing files under
+`review/archive/`). Core-only findings reproduced in a fresh no-extras venv
+(`uv venv` + `pip install -e .`); everything else reproduces in `[all]`.
+
+## Headline
+
+**The grammar is a success and the safety demo mostly delivers — but the
+"honest damage" story collapses at the exact moment it's supposed to shine.**
+Typing `archivey foo.zip` and getting an instant listing is genuinely
+delightful; the smart destination, the `renamed:` notices, and the closing
+`N extracted … → dir/` summary make the tarbomb protection *legible*, which is
+the whole demo. The two things that would make a new user walk away are both
+about damage and absence, not grammar: **one bad or hostile member aborts the
+entire extraction** (a traversal entry means *zero* files extracted, under
+every `--policy` — `unzip` skips it and extracts the rest), and **a filter or
+positional that matches nothing succeeds silently with exit 0** — which is
+precisely what the `unzip a.zip out`/`tar` muscle-memory reflex produces. Both
+failure modes are silence-shaped, so they cost trust in a way a loud error
+never would. Alongside those: member names can inject terminal escapes into
+output (a quoting gap for a safety-branded tool), there is no `--json` for the
+scripting audience VISION names, and several error paths still show
+translated-exception reprs (`BadZipFile('File is not a zip file')`,
+`ArchiveFormat.TAR_ZST`) instead of prose.
+
+## First five minutes (new-user walkthrough)
+
+Everything below is a real session (config `[all]`, cwd is an empty dir).
+
+1. `archivey photos.zip` → aligned listing, instantly. **Delight.** The
+   default-to-list gamble pays off; nothing to learn.
+2. `archivey x photos.zip` → `extracting into photos/` … `4 extracted, 0
+   renamed, 0 skipped → photos/`. **Delight** — the tarbomb protection
+   announces itself; I never read a man page. Running it *again* gave
+   `extracting into photos (1)/` — visible, sensible.
+3. `archivey x photos.zip out` — my `unzip`/`7z` reflex for "extract into
+   `out`". Output: `0 extracted, 0 renamed, 0 skipped → .`, **exit 0**.
+   **Confusion.** Nothing told me `out` was treated as an include filter that
+   matched nothing, and the success exit meant my script wouldn't notice
+   either. I only found `-d` by reading `--help`. (P2)
+4. `archivey x project.zip project` — tar reflex for "extract that dir".
+   Same silent `0 extracted`, exit 0; fnmatch needs `project/*`. (P2)
+5. `archivey x evil.tar` (one `../` member) → `Path traversal ('..') in member
+   name … extraction stopped; remaining members were not extracted`, exit 1,
+   and **nothing extracted at all** — `unzip` would have extracted the three
+   safe files and warned. First impression: "the safe tool is the one that
+   couldn't extract my archive." (P1)
+6. `archivey t photos.zip` → `4 OK, 0 failed`, quiet, exit 0; with a
+   deliberately flipped byte → `FAIL docs/guide.md: Digest mismatch for
+   'crc32' …`, exit 1. **Trust-building** — this is the crisp verify contract.
+7. `archivey secret.7z` prompted `Password:` on a TTY (no echo, worked), and
+   `--password` worked pre- and post-verb. Pressing **Ctrl-D at the prompt
+   dumped a 30-line traceback** (`EOFError`). (P5)
+8. `archivey lsit photos.zip` (typo) → `[Errno 2] No such file or directory:
+   'lsit'` — raw errno, no hint my *verb* was wrong. (P6)
+
+Verdict: minutes 1–2 convert; minutes 3–5 are where the wedge audience leaks.
+
+## Findings (ranked by adoption impact)
+
+Severity: **H** would change a new user's adoption decision; **M** costs trust
+or a named audience; **L** polish. Status: blocker = fix before the first
+public 0.2.0; polish = after.
+
+| # | Sev | Where | One-liner | 0.2.0 |
+|---|-----|-------|-----------|-------|
+| P1 | **H** | `cli/extract_cmd.py:384-400` (+ library `OnError` default) | One bad/hostile member aborts the whole extraction: `x evil.tar` (traversal) extracts **0** files under every `--policy`; `x badcrc.zip` stops mid-archive and never says which files *were* written. VISION #3's "recoverable members + honest error" fails at the shell; the CLI's own `rejected:`/`failed:` reporting (`_report_extraction`) is unreachable on this path. | blocker (needs Q1 decision) |
+| P2 | **H** | `cli/filters.py:11`, `cli/extract_cmd.py:406`, `cli/list_cmd.py:36` | Include patterns that match nothing succeed **silently with exit 0** — and this is exactly what the `unzip a.zip out` positional-dest reflex and the `tar`-style bare-dir-name reflex (`x a.zip project` vs `project/*`) produce. `unzip` prints "filename not matched" and exits 11. | blocker |
+| P3 | **M** | `cli/format.py:52-85`, `cli/test_cmd.py`, `cli/extract_cmd.py` notices, tqdm desc | Member names print raw to the terminal: ANSI escapes render (demo'd red text) and `\r` rewrites the line (`line1\rOK  everything fine.txt`). A safety-branded tool should quote control bytes like `ls`/GNU `tar` do. | blocker |
+| P4 | **M** | (absent) | No `--json`/`--porcelain` anywhere; the "iterate members and hash" scripting audience must parse aligned human columns with no stability promise. Deliberately deferred in `cli-v1` design (needs a member schema) — but it is the wedge gap for one of VISION's two named audiences. | Q2 (recommend: first 0.2.x) |
+| P5 | **M** | `cli/password.py:19` | Ctrl-D (EOF) at the `Password:` prompt → uncaught `EOFError`, full traceback, exit 1. Catch → treat as "no password given". | blocker (small) |
+| P6 | **M** | `cli/main.py:362-364` | Missing file and verb typos surface as raw errno reprs: `archivey lsit a.zip` → `[Errno 2] No such file or directory: 'lsit'`. No prose, no "did you mean a verb?" even though the signature (open failed + leftover pattern args) is detectable. | blocker (message), hint = polish |
+| P7 | **M** | library messages, `cli/info_cmd.py:16` | Exception/enum reprs leak into user prose: truncated zip → `Could not open ZIP archive: BadZipFile('File is not a zip file')` (misleading *and* repr-y); suffixes like `format=ArchiveFormat.ZIP`; `info` prints `SEVEN_Z`; zstd message says `Format ArchiveFormat.TAR_ZST is not available`; zipcrypto with **no** password says "Wrong password" (#131 D8 residue). | partial (worst cases) |
+| P8 | **M** | `cli/test_cmd.py:56-73,127` | Archive-wide failures under-report: missing `unrar` on a 4-member RAR → `0 OK, 1 failed` (one FAIL line for a whole-archive condition; solid-abort loses the remaining members with no "N not tested" note). The pass/fail exit contract is right; the *counts* aren't honest. | polish |
+| P9 | **L** | `internal/streams/archive_stream.py:408` (library, CLI-visible) | Tripped bug: `[all]` install, `x src.tar.gz` warns "Install the 'seekable' extra (rapidgzip)" — rapidgzip **is** installed; the AUTO size-gate declined it, and the warning text doesn't know that. Misleading advice on the flagship demo path. | polish (fix text) |
+| P10 | **L** | `cli/main.py` help | `--help` is clean but example-free: smart-dest, `-d .`, filter grammar, `--exclude` are invisible until the man-page moment. One epilog with 4 examples fixes it. | polish |
+| P11 | **L** | `cli/extract_cmd.py:268,324-336` | Hoist/summary micro-copy: `extracting into src/` … `moved to src/` reads as a no-op; single-root reuse says `→ .` when everything actually landed in `./project/`. | polish |
+| P12 | **L** | argparse positionals | `archivey x` → "the following arguments are required: archive, patterns" — `patterns` is not required. | polish |
+| P13 | **L** | `cli/main.py:134-139` | Reserved-surface asymmetry: `--salvage` pre-verb is `unrecognized arguments` (globals otherwise work pre-verb); `-x`/`-l` get no "verbs are bare words — did you mean `x`?" hint. | polish |
+| P14 | **L** | `cli/main.py:158-162`, `cli/info_cmd.py` | No capability/dependency view: `--version` prints only the version (design Decision 10 mentioned a dependency matrix); `info` answers "what is this file" but not "can *this install* read it / what will it cost" (no `CostReceipt` story). | Q5/Q6 |
+
+## What is actually fine
+
+Verified hands-on and worth defending as-is:
+
+- **The grammar.** Bare-word verbs + single-letter aliases, default-to-list,
+  known-verb-wins with the `list <path>` escape hatch — zero friction in
+  practice, and `archivey foo.zip` is the ten-second demo the design hoped.
+  `-x` correctly rejected as an option; reserved verbs (`hash`/`create`/
+  `convert`/`cat`) give clean "not implemented yet" at exit 2; `-` gives the
+  reserved-stdin message at exit 2 (#131 D7 unified — confirmed).
+- **The smart destination, end to end.** Multi-top → `./photos/` announced as
+  `extracting into photos/`; rerun → `photos (1)/`; single-root zip reuses
+  `.`; `src.tar.gz` wrap+hoist lands `src/` correctly; `notes.txt.gz` →
+  `notes.txt` in cwd; `-d .` splatters on request. Every spec row I exercised
+  behaved as documented.
+- **Collision visibility** (#131 F3/D2 fixed): every `renamed:`/`skipped:` is
+  printed, plus the always-on closing summary — the `rename` default is now
+  defensible because it's loud.
+- **Stream hygiene.** Listings pipe clean (`| head` → exit 0, no noise —
+  BrokenPipe fixed); data on stdout, everything else on stderr; progress
+  auto-suppresses when piped; `--track-io` goes to stderr.
+- **Progress.** tqdm bar under a TTY shows member name + bytes/total/%,
+  leaves a 100% line, closes before the summary; absent cleanly without
+  `[cli]` (core-only venv: no import, no complaint).
+- **Password UX.** TTY prompt (no echo) works; non-TTY quietly declines to
+  prompt; `--password` works pre- and post-verb (#131 F1 fixed).
+- **Exit codes.** 0/1/2 exactly as spec'd everywhere I probed; `test` has the
+  crisp contract (`3 OK, 1 failed` → 1) and quiet-by-default matches
+  `unzip -t` norms.
+- **Dependency honesty (core-only venv).** Command runs from the base
+  install; AES 7z → "The 'cryptography' package is required for AES
+  decryption (install the 'crypto' extra)"; missing `unrar` message is
+  best-in-class ("Install RARLAB unrar — unrar-free / unar / 7z are not
+  supported as substitutes"); RAR *listing* works without `unrar`.
+- **Scale.** 10k-member listing in ~0.4 s, aligned, greppable.
+- **Help hygiene.** No SUPPRESS leakage, no internal structure visible,
+  aliases shown, reserved verbs labeled "reserved".
+
+## Theme files
+
+- `grammar-and-defaults.md` — muscle memory, filters, smart dest (P1, P2, P10–P13)
+- `output.md` — human + machine output, progress, track-io (P3, P4, P8, P11, P14)
+- `errors-and-exit-codes.md` — error prose, damage story, exit codes (P1, P5–P9)
+- `QUESTIONS.md` — maintainer decisions (Q1–Q6)
+
+## Provenance
+
+#131's F1–F12/D1–D8/R1–R4 were verified fixed where this review touched them
+(pre-verb globals, BrokenPipe, rename visibility, hoist, exit-code flavor,
+logging handler) and are **not** re-reported. P1 is distinct from #131 D3
+(which fixed `test`'s continue-on-failure): it is about `extract`, where STOP
+still rules. P7 overlaps #131 D8 (wrong-password message) only for the ZIP
+no-password case, which remains.

--- a/review/cli-product/errors-and-exit-codes.md
+++ b/review/cli-product/errors-and-exit-codes.md
@@ -1,0 +1,165 @@
+# Errors, exit codes, and the honest-damage story
+
+Lens C of the brief: VISION #3 ("damaged input is a first-class citizen —
+recoverable members + an honest error") as experienced at the shell, plus the
+error-prose audit. Real transcripts (config noted where it matters).
+
+## Exit codes: the contract holds
+
+Everything probed matched the spec'd 0/1/2 shape, uniformly:
+
+| Invocation | Exit | Notes |
+|---|---|---|
+| `l photos.zip` / `x` / `t` / `info` success | 0 | |
+| `l many.zip \| head -3` | 0 | BrokenPipe clean, no stderr noise |
+| `l nope.zip` (missing) | 1 | |
+| `l random.bin` (not an archive) | 1 | |
+| `t badcrc.zip` (digest mismatch) | 1 | `3 OK, 1 failed` |
+| `x badcrc.zip` / `x evil.tar` (stop) | 1 | |
+| `t --password wrong secret.7z` | 1 | |
+| `--badflag`, unknown flag, missing archive | 2 | argparse |
+| `create` / `hash` / `convert` / `cat` / `--salvage` / `-` | 2 | unified "not yet" (#131 D7 done) |
+| Ctrl-C | 130 | code path + tests; not exercisable here (extracts too fast) |
+
+`test`'s pass/fail contract is crisp: quiet `N OK, M failed` on stderr, 1 on
+any failure, 0 otherwise — scripts can branch today. The "codes ≥3 reserved,
+don't assume 1 is exhaustive" documentation stance is right and leaves room
+for the P1/P2 recommendations below without breaking anyone.
+
+## P1 — the honest-damage story fails at the shell (0.2.0, needs Q1)
+
+The founding claim is "recoverable members + an honest error." `test`
+delivers it (#131 D3 fixed: failures are counted and the run continues). But
+`extract` — the verb in the demo, the verb in the README — delivers neither:
+
+**Damaged archive** (one flipped byte in `docs/guide.md`, 4-member zip):
+
+```
+$ archivey x badcrc.zip -v
+extracting into badcrc/
+Digest mismatch for 'crc32': stored value does not match the decompressed
+  content. (archive='badcrc.zip', member='docs/guide.md', format=ArchiveFormat.ZIP)
+extraction stopped; remaining members were not extracted
+                                                 exit 1
+$ find badcrc/
+badcrc/readme.txt        ← extracted, but nobody said so
+badcrc/docs/             ← empty
+```
+
+`readme.txt` and `setup.py`/`main.py` are perfectly recoverable; the CLI
+stopped at member 2 of 4 and — even with `-v` — never reported which members
+*were* written (the stop path bypasses `_report_extraction`,
+`cli/extract_cmd.py:392-400`). "Remaining members were not extracted" is
+honest about the future but silent about the past.
+
+**Hostile archive** (one `../escape.txt` member + three safe entries):
+
+```
+$ archivey x evil.tar -d evilout
+Path traversal ('..') in member name: '../escape.txt' (member='../escape.txt')
+extraction stopped; remaining members were not extracted
+                                                 exit 1   (0 files on disk)
+```
+
+Identical under `--policy standard` and `--policy trusted`. So the flagship
+"safer unzip" comparison currently reads: `unzip` warns on the `../` entry,
+**extracts the three safe files**, exits 1 — archivey extracts **nothing**.
+The safety block is right; refusing to deliver the deliverable members is the
+part that loses the demo. And the machinery to do better already exists and
+is *dead code in practice*: `_report_extraction` prints `rejected: <name>:
+<why>` lines and a `N rejected` summary column (`cli/extract_cmd.py:315-336`)
+that can only trigger if the library records rejections instead of raising —
+which `OnError.STOP` (the library default the CLI inherits) never does.
+
+**Recommendation:** make the CLI extract with reject-and-continue semantics —
+policy rejections and per-member read failures are recorded (`rejected:` /
+`failed:` lines), extraction continues where the stream allows, summary shows
+`3 extracted, 1 rejected → evilout/`, exit nonzero. Whether that's the CLI
+passing an `OnError`-style option, a new library default, or CLI-only is a
+maintainer call (Q1) — as is whether "stopped early" should also list what
+was already written (cheap: the report is in hand at the except site for the
+`ExtractionReport`-carrying failure paths; for raised paths, at least count).
+Note this is *not* `--salvage` (decoding damaged data best-effort); it is
+completing the members that are fine. The reserved exit code 3 ("refused by
+safety policy", design Decision 12) becomes genuinely useful here.
+
+## Error prose audit (P5, P6, P7)
+
+The brief asks: does each common failure produce a message a human can act
+on, or a translated-exception repr? Verbatim results, worst first:
+
+| Scenario | Message (verbatim) | Verdict |
+|---|---|---|
+| Ctrl-D at password prompt | 30-line traceback ending `EOFError` | **P5, bug.** Catch `EOFError` in `cli/password.py:19` provider → return None ("no password given" flow). Reproduced under a real PTY; exit 1 with raw traceback. |
+| Verb typo: `archivey lsit photos.zip` | `[Errno 2] No such file or directory: 'lsit'` | **P6.** Raw errno repr; the archive arg silently became a filter. Minimum: `archivey: cannot open 'lsit': no such file or directory`. Better: when open fails ENOENT and pattern positionals exist, add `('lsit' was treated as an archive path; verbs are list/test/extract/info)`. |
+| Missing file: `l nope.zip` | `[Errno 2] No such file or directory: 'nope.zip'` | **P6.** Same errno repr for the most common error a CLI ever prints (`unzip: cannot find or open nope.zip`). One `except OSError` formatting site (`cli/main.py:362-364`) fixes both rows. |
+| Truncated zip | `Could not open ZIP archive: BadZipFile('File is not a zip file') (archive='truncated.zip', format=ArchiveFormat.ZIP)` | **P7.** Nested exception repr *and* misleading content ("not a zip file" for a file that is a truncated zip — magic matched!). Library-side message; the CLI is where it's felt. |
+| Not an archive | `Could not detect archive format: no magic-byte match and no usable file extension. (archive='random.bin')` | Good prose; the parenthetical context suffix is tolerable. |
+| Wrong password (7z) | `FAIL: Wrong password or corrupt 7z folder` | Good — honest about the ambiguity. |
+| No password, non-TTY (7z) | `FAIL: Password required to read this encrypted member` | Good. |
+| No password, non-TTY (zipcrypto) | `FAIL zc.txt: Wrong password for this ZIP member` | **P7 / #131-D8 residue:** says "wrong password" when *none was supplied* — reads as "my flag was ignored". |
+| Encrypted RAR headers, no password | `Password required to decrypt RAR headers` | Good. |
+| AES 7z, core-only install | `The 'cryptography' package is required for AES decryption (install the 'crypto' extra).` | **Excellent** — names the package, the extra, the operation. |
+| RAR data, no `unrar` binary | `RARLAB unrar is required to read RAR member data, but it was not found on PATH (or the unrar on PATH is not RARLAB unrar). Install RARLAB unrar — unrar-free / unar / 7z are not supported as substitutes.` | **Excellent**, best message in the tool. Listing still works without it — the degradation story is exactly right. |
+| tar.zst, core-only install | `Format ArchiveFormat.TAR_ZST is not available: missing backports.zstd (pip install archivey[zstd]) (format=ArchiveFormat.TAR_ZST)` | Actionable, but leaks the enum name twice (P7); `tar.zst` is the human spelling. |
+
+Pattern in P7: the `ArchiveyError` tree's messages are mostly *good prose
+already* — the leaks are (a) wrapped third-party exception reprs
+(`BadZipFile(…)`), and (b) `ArchiveFormat.X` enum names in interpolations.
+Both are library-side string hygiene, worth one targeted pass since the CLI
+surfaces them verbatim (correctly — the CLI should not be rewriting library
+messages).
+
+## P8 — `test` counts vs archive-wide failures
+
+```
+$ archivey t hardlinks_solid__.rar        # 4 members, unrar absent
+FAIL: RARLAB unrar is required to read RAR member data, …
+0 OK, 1 failed                                   exit 1
+```
+
+Exit code and message are right; `0 OK, 1 failed` is not — one FAIL line
+represents a whole-archive condition and three members were never tested
+(solid-stream aborts have the same shape: the generator dies, remaining
+members are silently lost — the known library limitation noted at
+`cli/test_cmd.py:56-60`). When the iterator ends early relative to the
+selected set, append the honest remainder: `0 OK, 1 failed, 3 not tested`.
+The selected count is already computed when an index exists (it feeds the
+progress total).
+
+## P9 — tripped library bug: misleading accelerator warning on `[all]`
+
+```
+$ archivey x src.tar.gz          # rapidgzip 0.16.0 IS installed
+WARNING: Seeking backward in a gzip stream without a random-access
+accelerator re-decompresses from the start (O(n) per rewind). Install the
+'seekable' extra (rapidgzip) for indexed random access.
+```
+
+Reproduced via plain library calls too (`open_archive(...).extract_all(...)`)
+— not a CLI defect, but the CLI's new logging handler (#131 D4) puts it in
+every tar.gz demo. Cause: `use_rapidgzip=AUTO` declines the accelerator below
+the size threshold (`internal/streams/codecs.py:239-251`), then the
+backward-seek warning (`internal/streams/archive_stream.py:408`) assumes
+"no accelerator" means "not installed" and tells the user to install what
+they have. For a sub-MB file the rewind costs microseconds — the warning
+shouldn't fire at all there, and its text should distinguish "not installed"
+from "not engaged (below size threshold)". Filed as CLI-visible because the
+first `x something.tar.gz` a new user runs prints a scary WARNING with wrong
+advice on a default `[recommended]` install.
+
+## What is actually fine (this lens)
+
+- The stop notice itself (`extraction stopped; remaining members were not
+  extracted`) is honest and well-worded — P1 is about what it doesn't say
+  and what didn't happen before it.
+- `--overwrite error` stops with `Destination already exists: out/readme.txt
+  (member='readme.txt')` — clear, correct exit 1.
+- Hostile *paths* are blocked under every policy (traversal above; the
+  name-safety layer extracted my ANSI-escape-named files as-is on Linux,
+  which is that capability's documented Linux posture, not a CLI issue —
+  the CLI-side display problem is P3 in `output.md`).
+- `info` on failure: prints the identity block it could determine, then the
+  open error, exit 1 — the "answer what you can" shape is right.
+- Exit 2 flavor unified across the whole reserved surface; scripts can rely
+  on "2 = you asked for grammar that doesn't exist (yet)".

--- a/review/cli-product/grammar-and-defaults.md
+++ b/review/cli-product/grammar-and-defaults.md
@@ -1,0 +1,187 @@
+# Grammar, muscle memory, and the safe-extract defaults
+
+Lens A of the brief: does the CLI meet the muscle memory of `unzip`/`tar`/`7z`
+users, and where it diverges, is the divergence earned? All transcripts are
+real sessions (config `[all]` unless noted; `$` lines are the exact argv).
+
+## The verdict on the grammar itself: earned, and it works
+
+The `cli-v1` decisions survive contact with hands. What I actually typed as a
+new user worked on the first try:
+
+```
+$ archivey photos.zip
+f-  rw-r--r--           6  2026-07-18 04:26  readme.txt
+f-  rw-r--r--         800  2026-07-18 04:26  docs/guide.md
+...                                              exit 0
+```
+
+- Default-to-list is a **delight**, not a surprise: the reflex command gives a
+  read-only answer instantly. The 7z user's `archivey l`/`x`/`t` aliases all
+  land where expected.
+- `archivey -x photos.zip` → `error: unrecognized arguments: -x`, exit 2. The
+  divergence from `tar -x` is deliberate and the rejection is clean — though
+  hintless (P13 below).
+- Reserved verbs behave: `archivey create new.zip` → `archive creation is not
+  implemented yet`, exit 2. Same for `hash`, `convert`, `cat`, `--salvage`
+  (post-verb), and `-` (`stdin archives are not supported yet…`). All exit 2,
+  uniformly (#131 D7 confirmed done).
+- The verb-named-file casualty is as small as the design claimed: with a file
+  literally named `t` in cwd, `archivey t` runs the *verb* and errors asking
+  for an archive; `archivey l t` lists the file. Acceptable, documented.
+
+## The smart destination: the demo works and is legible
+
+Every scenario row I exercised behaved as spec'd, and — crucially for the
+wedge — the protection is *narrated*:
+
+```
+$ archivey x photos.zip            # 4 top-level entries
+extracting into photos/
+4 extracted, 0 renamed, 0 skipped → photos/     exit 0
+
+$ archivey x photos.zip            # again: container collision
+extracting into photos (1)/
+4 extracted, 0 renamed, 0 skipped → photos (1)/ exit 0
+
+$ archivey x project.zip           # single root project/ → reuse cwd
+2 extracted, 0 renamed, 0 skipped → .           exit 0   (→ ./project/)
+
+$ archivey x src.tar.gz            # no index: wrap ./src/, then hoist
+extracting into src/
+moved to src/
+6 extracted, 0 renamed, 0 skipped → src/        exit 0
+
+$ archivey x notes.txt.gz          # raw stream → cwd, gunzip-style
+1 extracted, 0 renamed, 0 skipped → .           exit 0
+```
+
+`-d out/` is verbatim, `-d .` splatters on request, and the default
+`--overwrite rename` is now loud (`renamed: out/readme.txt -> out/readme
+(1).txt`, plus the summary count) — which is what makes the CLI/library
+default split defensible. **Endorsed as-is.**
+
+Two micro-copy nits (P11): the tar.gz hoist prints `extracting into src/` …
+`moved to src/` — a no-op to the reader ("it moved from src/ to src/?"); and
+the single-root-reuse case summarizes `→ .` when everything landed under
+`./project/`. Saying `moved up to ./src/ (removed wrapper)` (or suppressing
+the notice when the name doesn't change) and `→ project/` would finish the
+story the messages are trying to tell.
+
+## P2 — the one real muscle-memory trap: no-match filters are silent successes
+
+The include-positional grammar itself is fine (it matches `unzip`/`7z`
+conventions, `--exclude` reads naturally, exclude-wins is standard). The trap
+is what happens when a positional matches nothing — because two extremely
+common reflexes produce exactly that:
+
+**The positional-dest reflex** (`unzip a.zip -d out` half-remembered,
+`7z x a.zip -oout`, plain `unzip a.zip out`):
+
+```
+$ archivey x photos.zip out
+0 extracted, 0 renamed, 0 skipped → .           exit 0
+$ archivey x photos.zip out/
+0 extracted, 0 renamed, 0 skipped → .           exit 0
+```
+
+Nothing on disk, exit **0**. The user meant a destination; the CLI heard an
+include filter; nobody was told. A script gates on the exit code and marches
+on with an empty directory.
+
+**The tar bare-dir reflex** (`tar -xf a.tar project` extracts the tree):
+
+```
+$ archivey x project.zip project
+0 extracted, 0 renamed, 0 skipped → .           exit 0
+$ archivey x project.zip 'project/*'
+2 extracted, 0 renamed, 0 skipped → .           exit 0
+```
+
+fnmatch semantics (`project` ≠ `project/readme.txt`) are defensible and
+unzip-like — but only if the miss is *visible*. Same silence on `list`:
+`archivey photos.zip '*.rs'` prints nothing, exit 0. An unquoted glob the
+shell expanded against the wrong directory fails the same silent way.
+
+Prior art is unanimous: `unzip` prints `caution: filename not matched:  out`
+and exits **11**; `tar` prints `project: Not found in archive` and exits 2;
+`7z` reports "No files to process". archivey is the outlier, and the outlier
+behavior is silence — the most expensive kind of divergence.
+
+**Recommendation (0.2.0):** per unmatched include pattern, print a stderr
+warning (`warning: pattern matched no members: 'out'`); when *zero* members
+were selected on `extract`/`test`, exit nonzero (see Q3 for which code —
+unzip's dedicated 11 argues for using the reserved ≥3 space, but plain 1
+also satisfies scripts). A cheap bonus hint for the dest reflex: if a sole
+unmatched pattern on `extract` names an existing directory or ends in `/`,
+add `(did you mean -d out?)`. That one line converts the most common failed
+first command into a taught lesson.
+
+## P1 (grammar-adjacent): `--policy` is undemoable because rejection aborts
+
+Full analysis in `errors-and-exit-codes.md`, but it belongs in the defaults
+story too: the brief asks whether the safe-extract defaults "protect a naive
+user and stay un-annoying" — they protect, but the protection currently
+throws away the rest of the archive. One `../escape.txt` member:
+
+```
+$ archivey x evil.tar -d evilout
+Path traversal ('..') in member name: '../escape.txt' (member='../escape.txt')
+extraction stopped; remaining members were not extracted
+                                                 exit 1  (0 files extracted)
+```
+
+Identical outcome with `--policy standard` and `--policy trusted` (traversal
+is rightly non-negotiable) — which means **no policy level demonstrates
+"blocked the bad member, delivered the good ones."** The CLI already has
+`rejected:` lines and a `N rejected` summary column wired up
+(`extract_cmd.py:315-336`); they are unreachable because the library's
+`OnError.STOP` default turns the first rejection into an exception. Decide at
+Q1; the reject-and-continue shape is what makes the "safer unzip" pitch
+concretely better than unzip (which skips `../` entries and continues,
+extracting the 3 safe files here).
+
+## P10 — help is clean but example-free
+
+`--help` output is accurate, leak-free, and shows aliases and reserved verbs
+(paste in `output.md`). But none of the CLI's three signature ideas — smart
+dest (`-d .` to opt out), positional includes + `--exclude`, verb words — is
+*shown*. A user discovers `-d` only after the P2 trap. argparse supports an
+epilog; four lines would do:
+
+```
+examples:
+  archivey archive.zip                  list members
+  archivey x archive.zip                extract safely (into ./archive/ if needed)
+  archivey x archive.zip -d out '*.py'  extract *.py into out/
+  archivey t archive.zip                verify integrity
+```
+
+Add it to the top-level parser and (verb-appropriate variants) to `extract`,
+where the `-d`-not-positional rule most needs advertising.
+
+## P12 / P13 — small grammar burrs
+
+- `archivey x` → `error: the following arguments are required: archive,
+  patterns`. `patterns` is `nargs="*"` and not required; argparse's combined
+  message lies. Cheap fix: give `patterns` a `metavar` like `[pattern ...]`
+  or catch-and-rewrite; low priority but it's the very first error a
+  flag-less experimenter sees. [`cli/main.py:120-131`]
+- `--salvage` is registered only on subparsers, so pre-verb it's
+  `unrecognized arguments: --salvage` (exit 2, but a different, less helpful
+  flavor than the post-verb "not implemented yet"). Either register it on the
+  common parent (rejecting like the others) or leave — noted for symmetry
+  with the "globals work pre-verb" contract. [`cli/main.py:134-139`]
+- `-x`/`-l`/`-t` rejections could hint: `verbs are bare words — try
+  'archivey x ARCHIVE'`. argparse's `error()` can be overridden per-parser;
+  one string check on the unrecognized token covers the three classic
+  spellings. Polish, but it's the `tar` user's literal first keystroke.
+
+## Filters: what is fine
+
+- Positional includes + repeatable long-only `--exclude`: reads naturally,
+  matches the tar/unzip/7z split, and worked in every combination I tried
+  (`x photos.zip '*.py' --exclude 'setup*' -d code` → exactly `main.py`).
+- `fnmatchcase` determinism (#131 nit fixed) — fine.
+- One-archive-per-invocation: never chafed in practice; the shell-loop
+  workaround is honest.

--- a/review/cli-product/output.md
+++ b/review/cli-product/output.md
@@ -1,0 +1,165 @@
+# Output — human and machine
+
+Lens B of the brief: the default views, machine-readability, `info`, progress,
+and `--track-io`. Real transcripts throughout (config `[all]` unless noted).
+
+## The default `list` view: good bones
+
+```
+$ archivey l links.tar
+f-  rw-r--r--           6  2026-07-18 04:26  data/readme.txt
+l-  rw-r--r--           -  1970-01-01 00:00  data/link-to-readme -> readme.txt
+
+$ archivey l secret.7z
+fE  rw-------          11  2026-07-18 04:26  secret.txt
+
+$ archivey l --digests photos.zip
+f-  rw-r--r--           6  2026-07-18 04:26  readme.txt  [crc32=363a3020]
+```
+
+- Scannable and aligned: type+encrypted as a compact two-char lead, mode,
+  right-aligned size (10 wide — fits TB-scale), minute-precision mtime, name
+  last (greppable). Link targets shown `->` style. Hardlinks marked `h`.
+  Missing values are `-`. This is a good layer-1.
+- **Scale:** 10 000 members list in ~0.4 s wall (`l many.zip > /dev/null`),
+  constant-width columns hold. No pager, no truncation — correct for a
+  compose-with-`less` Unix tool.
+- **Piped:** clean. `archivey l many.zip | head -3` → three rows, exit 0, no
+  stderr noise (BrokenPipe handled). Data on stdout only; `--track-io`,
+  summaries, prompts, progress on stderr — verified across verbs.
+- Quiet `test` default + `-v` per-member trace matches `unzip -t`/`gzip -t`
+  norms and reads well:
+
+```
+$ archivey t -v badcrc.zip
+OK   readme.txt
+FAIL docs/guide.md: Digest mismatch for 'crc32': stored value does not match
+  the decompressed content. (archive='badcrc.zip', member='docs/guide.md', format=ArchiveFormat.ZIP)
+OK   setup.py
+OK   main.py
+3 OK, 1 failed                                   exit 1
+```
+
+## P3 — member names are a terminal-injection vector (0.2.0)
+
+`format_member_line` prints `member.name` raw (`cli/format.py:64-68`), and so
+do `test`'s FAIL lines, `extract`'s `renamed:`/`rejected:` notices, and the
+tqdm bar description. Archive names are attacker-controlled. Demo (`cat -v`
+view of actual bytes reaching the terminal):
+
+```
+$ archivey l hostile-name.zip
+f-  rw-------           1  2026-07-18 04:26  innocent.txt
+f-  rw-------           1  2026-07-18 04:26  evil^[[31mRED^[[0m.txt
+f-  rw-------           1  2026-07-18 04:26  line1^MOK  everything fine.txt
+```
+
+On a real TTY the second row renders partially red and the third **rewrites
+its own line** to `OK  everything fine.txt` — name-spoofing inside the tool
+whose pitch is "inspect untrusted archives safely." Escapes can also probe
+terminal features (OSC sequences). GNU `ls` and `tar` both quote control
+bytes for exactly this reason; `unzip` strips high-bit/control characters.
+
+**Recommendation:** escape C0/C1 control bytes (and DEL) in every member name
+the CLI prints — backslash-escape (`\r`, `\x1b`) or U+FFFD replacement — at
+minimum when the destination stream is a TTY; quoting unconditionally is
+simpler and safer for logs. One helper in `cli/format.py` used by list/test/
+extract notices and the tqdm `desc` covers the surface. (The *extracted
+filenames* are the name-safety capability's job; this is only about output.)
+
+## P4 — the machine-readable gap (the named scripting audience)
+
+There is no `--json`, `--porcelain`, `-0`, or any stability promise on the
+human columns. VISION explicitly names the "iterate members and hash"
+scripting audience; today their options are (a) parse aligned columns whose
+format the docs never specify, or (b) import the library — and (b) is the
+answer the *library* wedge wants, but the CLI wedge loses the
+shell-scripting half (dedupe pipelines, CI manifest checks, `jq` users).
+The `cli-v1` design consciously deferred `--json` pending a stable member
+schema (design.md Open Question 7, "highest-value deferred item").
+
+This review's job is to name the gap's cost: `list --digests` output
+(`[crc32=363a3020]`) is precisely the "members and hash" payload, trapped in
+a display format. A minimal contract — `--json` on `list`/`info` emitting one
+object per line (name, type, size, mtime, mode, encrypted, link_target,
+hashes) with a documented "fields may be added, not renamed" promise — is
+cheap (stdlib json, the CLI already has every value in hand) and doesn't
+block on the full `ArchiveMember` schema question. Timing decision at Q2.
+
+## `info`: answers "what is it", not yet "can I read it / what will it cost"
+
+```
+$ archivey info photos.zip              $ archivey info -v secret.7z
+path:        photos.zip                 path:        secret.7z
+format:      ZIP                        format:      SEVEN_Z
+confidence:  certain                    confidence:  certain
+detected_by: magic                      detected_by: magic
+version:     -                          version:     0.4
+solid:       False                      solid:       False
+encrypted:   False                      encrypted:   True
+multivolume: False                      multivolume: False
+members:     4                          members:     1
+                                        extra.7z.volume_count: 1
+```
+
+Good: aligned, human, member-free, degrades correctly (detection failure →
+one-line error, exit 1; open failure after successful detection still prints
+the identity block, then `open: <error>`). Two gaps against the brief's
+"format, confidence, encryption, **the CostReceipt story**" bar (P14):
+
+- **Format label leaks the enum name**: `SEVEN_Z` (and `TAR_GZ` etc. — the
+  label is `repr(fmt)` minus the class prefix, `cli/info_cmd.py:16-23`).
+  `7z` / `tar.gz` are the human names; the enum has `file_extension()`
+  available. Cosmetic but it's the *first* line a "what is this file?" user
+  reads.
+- **No cost/access story.** The library sells honest cost signals
+  (`reader.cost`, solidity implications, seekability), and `info` is the
+  natural place to say "solid 7z: reading one member decodes the folder
+  prefix" or "no random-access accelerator for .gz installed". Today
+  `solid: False` is as far as it goes. Even one derived line
+  (`access: random (indexed)` / `access: sequential-only`) would make `info`
+  answer its third question. Shape at Q5.
+- Related (Q6): neither `info` nor `--version` says *what this install can
+  read* — no dependency/extras matrix (design Decision 10 originally listed
+  one for `--version`). The excellent per-format "install the X extra"
+  errors partially compensate, but only after you've tried and failed.
+
+## Progress: right behavior, verified both ways
+
+Under a PTY (80 MB zip, `x big.zip -d bigout`):
+
+```
+data/blob00.bin:   1%|▌         | 1.00M/80.0M [00:00<00:00, 169GB/s]
+...
+data/blob39.bin: 100%|██████████| 80.0M/80.0M [00:00<00:00, 428MB/s]
+40 extracted, 0 renamed, 0 skipped → bigout/
+```
+
+Member name as description, byte totals, instant appearance on fast extracts
+(the `mininterval=0` choice works), a final 100% line, closed before the
+summary prints. `test` gets the same bar. Piped/non-TTY: no bar, no noise.
+Core-only venv (no tqdm): silent degradation, command fully functional.
+`--hide-progress` honored. **Endorsed** — with the P3 caveat that the bar's
+`desc` needs the same name-escaping as everything else.
+
+## `--track-io`: fine for what it claims to be
+
+```
+$ archivey t --track-io photos.zip
+track-io: bytes_decompressed=1518 compressed_bytes_consumed=- source_seek_count=16
+$ archivey info --track-io photos.zip
+track-io: n/a for info (no member-body decode)
+```
+
+Raw counters on one stderr line, `-` for unavailable, explicit n/a on `info`.
+As a maintainer/debug affordance (its documented role) this is fine; resist
+the temptation to humanize it. No change requested.
+
+## P8 — `test` counts under archive-wide failure (also in errors file)
+
+`t hardlinks_solid__.rar` without `unrar` (4 members) → `FAIL: RARLAB unrar
+is required…` + `0 OK, 1 failed`. One "member" failed, three were never
+tested, and the summary can't tell those apart. Suggested shape:
+`0 OK, 1 failed, 3 not tested` whenever the iterator dies before yielding
+all selected members (the selected-count is already computed for progress
+totals when an index exists). Message content itself is excellent.


### PR DESCRIPTION
## Summary

Docs-only: findings for the `review/cli-product/` deep review (brief commissioned 2026-07-17), run against the merged CLI on `main` (post-#120, post-#131). Product/UX lens — muscle memory, output, errors, exit codes — grounded in real CLI sessions (every claim carries a pasted transcript), not a code-correctness pass.

**Deliverables** (per `review/README.md` conventions):
- `SUMMARY.md` — headline, first-five-minutes walkthrough, ranked findings table (P1–P14, blocker vs polish), "what is actually fine"
- `grammar-and-defaults.md` — muscle memory, filters, smart dest
- `output.md` — human + machine output, progress, `--track-io`
- `errors-and-exit-codes.md` — error prose audit, the honest-damage story, exit codes
- `QUESTIONS.md` — maintainer decisions Q1–Q7

## Headline findings

- **P1 (H)**: one bad/hostile member aborts the whole extraction — a traversal entry means *zero* files extracted under every `--policy` (`unzip` extracts the safe ones); the CLI's `rejected:`/summary plumbing is unreachable behind the library's `OnError.STOP` default. Needs Q1.
- **P2 (H)**: include filters that match nothing succeed silently with exit 0 — exactly what the `unzip a.zip out` / `tar` bare-dir reflexes produce.
- **P3 (M)**: member names print raw to the terminal — ANSI escapes render and `\r` rewrites lines (demoed) — a quoting gap for a safety-branded tool.
- **P4 (M)**: no `--json` for VISION's "iterate members and hash" scripting audience.
- Plus: `EOFError` traceback at the password prompt on Ctrl-D (P5), raw-errno / exception-repr error prose (P6/P7), `test` count honesty on archive-wide failures (P8), and a tripped library bug — the gzip backward-seek warning tells users to install rapidgzip when it's installed but size-gated off (P9).

**Endorsed as-is**: the grammar (default-to-list, verbs+aliases, known-verb-wins), the entire smart-dest/hoist behavior (all scenarios exercised hands-on), rename/skip visibility, stream hygiene + BrokenPipe, exit-code contract, password prompt UX, core-only degradation messages, help hygiene, 10k-member listing performance.

Baseline: `main` @ `0136024`, `[all]`+`[cli]`, 1709 passed / 131 skipped; pyrefly/ty/ruff clean. Core-only findings reproduced in a fresh no-extras venv.

No source changes; `#131` findings verified fixed where touched and not re-reported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XHvxX9PDiyaFFLnVvgxs4h

---
_Generated by [Claude Code](https://claude.ai/code/session_01XHvxX9PDiyaFFLnVvgxs4h)_