### PR TITLE
review: listing attribution — L0–L5 worklist (L0–L3 done in #143/#146)

### DIFF
--- a/review/STATUS.md
+++ b/review/STATUS.md
@@ -10,7 +10,7 @@ item is fixed or consciously deferred here / in `backlog.md`.
 | Review | Findings delivered? | Code/docs follow-ups | Ready to archive? |
 |--------|---------------------|----------------------|-------------------|
 | `stream-layering/` | yes (#137) | **done** (F1/F2/D1/D2); Q4 parked → future | **almost** — park Q4 then archive |
-| `performance/` | yes (#134 + #139/#140) | partial (P3–P5 done; P1/P2/P6/P7 open) | no |
+| `performance/` | yes (#134 + #139/#140/#143/#146) | partial (P3–P5 done; P7 listing L0–L2 done, L3 partial; P1/P2/P6 open) | no |
 | `api-coherence/` | yes (#133) | **none yet** — all findings still open | no |
 | `cli-product/` | **no** — brief only | review not run | no |
 
@@ -25,7 +25,7 @@ or the finding is a clear proposed fix with no spec conflict).
 
 | ID | Action |
 |----|--------|
-| **P7 / H3** | **partial** — #143 model-build fast paths + L1 (7z bulk UTF-16 names) / L2 (`ArchiveMember` slots + trimmed kwargs) from `listing-attribution.md`. ZIP many-small ~3.7×; 7z open+list probe ~2.0× (was ~3.4×). Still above Q1 bands; L4 deferred, L5 needs OpenSpec. |
+| **P7 / H3** | **partial** — #143 model-build + **#146** L1 (7z bulk UTF-16 names) / L2 (`ArchiveMember` slots + trimmed kwargs) / L3 volume fast-reject. ZIP many-small ~3.7×; 7z open+list probe ~2.0× (was ~3.4×). Still above Q1 bands; L3 large RAR fixture + L4 deferred; L5 needs OpenSpec. |
 | **P6 remainder** | **partial** — `py7zr` / `rarfile` / TAR `open_list` peers + Q1 band labels in harness. RAR/encrypted/accel *data* cases still missing. |
 | **P2 remainder** | Many-small `read_all` follows the listing story (same per-member machinery as P7). Large-member ZIP read already ≤1.25× after #139; realistic extract ~1.9× (inside ~2× band) — no further extract code pending Q2. |
 | **VISION/docs** | Re-word the ≤1.3× claim to match Q1 (decompression-dominated ≤1.3×; listing as peer ratios) once enforcement (Q2) is chosen. |

--- a/review/performance/QUESTIONS.md
+++ b/review/performance/QUESTIONS.md
@@ -3,8 +3,8 @@
 Decisions this review cannot make unilaterally (per the pause-and-ask rule).
 
 > **Status (2026-07-18):** Q3, Q5, Q6 **resolved** (#136 / #139). Q1 has a
-> **maintainer direction** (#140) — listing peers + ZIP/TAR model-build fast paths
-> landed (this change); ZIP open+list still above the 2–3× band. **Still need a
+> **maintainer direction** (#140) — listing peers (#143) + L1/L2/L3 listing
+> fixes (#146) landed; ZIP open+list still above the 2–3× band. **Still need a
 > decision:** Q2 (wall enforcement), Q4 (verify-skip knob; perf case ~nil
 > post-#137). See `../STATUS.md`.
 

--- a/review/performance/SUMMARY.md
+++ b/review/performance/SUMMARY.md
@@ -118,9 +118,9 @@ parses as a *non-empty* plausible header.
 | P3 | **fixed** (#136) |
 | P4 / P5 | **fixed** (#139) |
 | P6 | **partial** — ZIP peers in #139; **py7zr/rarfile + TAR open_list peers added** (#143); RAR/encrypted/accel data cases still missing |
-| P7 | **partial** — #143 model-build fast paths + L1/L2 listing fixes (`listing-attribution.md`); ZIP open+list still above 2–3×; 7z closer to native band |
+| P7 | **partial** — #143 model-build fast paths + #146 L1/L2/L3 listing fixes (`listing-attribution.md`); ZIP open+list still above 2–3×; 7z closer to native band |
 | P8 / P9 | **follow-up** (future / archive-copy) |
-| Q1 | **direction recorded** (#140) — listing peers + ZIP model-build (#143) + L1/L2 from attribution worklist; residual band miss remains |
+| Q1 | **direction recorded** (#140) — listing peers + ZIP model-build (#143) + L1/L2/L3 from attribution worklist (#146); residual band miss remains |
 | Q2 / Q4 | **need decision** |
 | Q3 / Q5 / Q6 | **resolved** |
 
@@ -161,6 +161,7 @@ parses as a *non-empty* plausible header.
   next investigation areas and methodology.
 - `listing-attribution.md` — post-#143 per-format listing decomposition
   (ZIP derivation / 7z parser byte-loop / RAR fixture artifact) with the
-  **L0–L5 worklist**; L0 (#143), L1/L2 (implemented), L3 partial, L4/L5 deferred.
+  **L0–L5 worklist**; L0 **done (#143)**, L1/L2 **done (#146)**, L3 **partial
+  (#146)** (volume skip shipped; large RAR fixture open), L4/L5 deferred.
 - `repro.py`, `measurements.py`, `attrib.py`, `listing_probe.py` — runnable
   evidence.

--- a/review/performance/listing-attribution.md
+++ b/review/performance/listing-attribution.md
@@ -1,17 +1,16 @@
 # Listing attribution — per-format decomposition and fix worklist
 
-**Measured at:** PR #143's tree initially; **L1/L2/L3 partial re-measured** on
-`cursor/listing-l1-l3-7360` after implementing the worklist below. CPython 3.11,
-review host. All wall numbers are warmed in-process medians (see
-`residual-gap.md` methodology). Written after #143's small listing gains, to
-answer: *why* are ZIP/7z/RAR open+list still far from their Q1 peers, and is
-`ArchiveMember` the problem?
+**Measured at:** PR #143's tree initially; **L1/L2/L3 re-measured** on #146
+(`cursor/listing-l1-l3-7360`). CPython 3.11, review host. All wall numbers are
+warmed in-process medians (see `residual-gap.md` methodology). Written after
+#143's small listing gains, to answer: *why* are ZIP/7z/RAR open+list still far
+from their Q1 peers, and is `ArchiveMember` the problem?
 
 **Answer in one line:** three different bottlenecks — ZIP is per-member
 *derivation* (of which `ArchiveMember` construction is only ~20%), 7z was a
-**parser byte-loop defect** (names read 2 bytes at a time — **fixed L1**), and
-the RAR ratio is currently a **fixture artifact** that measures nothing about
-the parser.
+**parser byte-loop defect** (names read 2 bytes at a time — **fixed in #146
+L1**), and the RAR ratio is currently a **fixture artifact** that measures
+nothing about the parser.
 
 ## ZIP — 3.8–4.1× on many-small; overhead is derivation, not the dataclass
 
@@ -37,8 +36,12 @@ open+`_to_member`-only / full `members()`):
 So the object contributes ~1.5 µs of the 7 µs (~20%) — and half of *that* is
 kwargs marshalling, not the class. Instance weight: 296-byte `__dict__` + 56-byte
 object (no `__slots__`) — matters for million-member listings.
+(**Post-#146 L2:** slots object is 256 B with no `__dict__`; see worklist.)
 
 ## 7z — 3.4× vs py7zr; the parser reads UTF-16 names 2 bytes at a time (defect)
+
+> **Status:** fixed in **#146** (L1). Numbers below are the *pre-fix*
+> attribution; after numbers are under L1 in the worklist.
 
 Fixture: 2,000 × 64 B members, py7zr-written. archivey 62–67 ms vs
 `py7zr.list()` ~18 ms → **3.4–3.6×**. cProfile: `_read_utf16` cumulative is
@@ -46,12 +49,12 @@ Fixture: 2,000 × 64 B members, py7zr-written. archivey 62–67 ms vs
 **~45,000 `read_exact` calls per listing ≈ 22.5/member** — roughly one call
 per name *character* plus a few per fixed field.
 
-Mechanism (`sevenzip_parser.py`):
+Mechanism (`sevenzip_parser.py`, pre-#146):
 
-- `_read_utf16` (`:920`) loops `_read_exact(buffer, 2, …)` per UTF-16 code unit
-  until the `\x00\x00` terminator.
-- `_read_exact` (`:982`) runs a truncation pre-check per call:
-  `_buffer_len(buffer) - buffer.tell()`, and `_buffer_len` (`:636`) is a
+- `_read_utf16` loops `_read_exact(buffer, 2, …)` per UTF-16 code unit until
+  the `\x00\x00` terminator.
+- `_read_exact` runs a truncation pre-check per call:
+  `_buffer_len(buffer) - buffer.tell()`, and `_buffer_len` is a
   `tell` + `seek(0, END)` + `seek(back)` triple.
 - Net: ~5 Python calls + 3 BytesIO ops **per name character**. py7zr decodes the
   whole names blob with one C-level `decode("utf-16le")` + split.
@@ -64,47 +67,52 @@ is *fixed per-open* cost: profiling shows **3 `io.open` + 7 `posix.stat` per
 `open_archive`** (detection sniff + volume-sibling discovery) vs rarfile's ~1
 open. Per-member parse cost cannot be measured from 6 members; no conclusion
 about the RAR parser is currently supported by the harness number.
+(Volume-discovery fast reject for non-volume-shaped names landed in **#146** L3;
+a large RAR listing fixture is still outstanding.)
 
 ## Worklist (ordered; each item independent)
 
-### L0 — ~~BLOCKER on #143~~ **fixed in #143**
+### L0 — ~~BLOCKER on #143~~ **done (#143)**
 
 `normalize_member_name` fast path trailing-slash on FILE/SYMLINK — fixed +
 regression test landed with #143.
 
-### L1 — 7z: bulk-decode names; stop the per-read seek dance — **done (this PR)**
+### L1 — 7z: bulk-decode names; stop the per-read seek dance — **done (#146)**
 
 1. `_handle_name` bulk-decodes the `kName` payload (`_decode_utf16_names`).
 2. `_buffer_len` / `_buffer_remaining` are O(1) for `BytesIO` (no seek dance).
 
-**After (same 2,000-member probe):** archivey **24.8 ms** vs py7zr 12.6 ms →
-**1.96×** (was 3.4–3.6× / ~62 ms); `read_exact` **4.0/member** (was ~22.5).
-Harness `sevenzip_open_list` realistic ~**2.2×** (was ~2.9×). Still above the
-1.25× native band — residual is non-name parse + model build.
+**After (same 2,000-member probe on #146):** archivey **24.8 ms** vs py7zr
+12.6 ms → **1.96×** (was 3.4–3.6× / ~62 ms); `read_exact` **4.0/member**
+(was ~22.5). Harness `sevenzip_open_list` realistic ~**2.2×** (was ~2.9×).
+Still above the 1.25× native band — residual is non-name parse + model build.
 
-### L2 — ArchiveMember: `slots=True` + skip None kwargs — **done (this PR)**
+### L2 — ArchiveMember: `slots=True` + skip None kwargs — **done (#146)**
 
 `@dataclass(slots=True)` on `ArchiveMember`; ZIP/TAR `_to_member` stop
 passing defaulted None/False fields.
 
-**After:** many-small ZIP probe **3.57×** / **4.71 µs/member** overhead
+**After (#146):** many-small ZIP probe **3.57×** / **4.71 µs/member** overhead
 (derivation 3.28 + register 1.35); construction micro **0.42 µs** minimal /
 **0.86 µs** full-kwargs; object **256 B** with no `__dict__` (was ~296+56).
 
-### L3 — RAR: real fixture deferred; volume-discovery fast reject — **partial (this PR)**
+### L3 — RAR: volume-discovery fast reject — **partial (#146)**
 
-Committed large RAR listing fixture still needs the `rar` writer (or offline
-generation). Shipped: `discover_volume_siblings` returns `None` without a
-`stat` when the name cannot be volume-shaped (ZIP/TAR/gz/plain `.7z` benefit).
+**Done in #146:** `discover_volume_siblings` returns `None` without a `stat`
+when the name cannot be volume-shaped (ZIP/TAR/gz/plain `.7z` benefit).
 
-### L4 — ZIP registration slice: measure-first
+**Still open:** committed large RAR listing fixture (needs the `rar` writer or
+offline generation) so per-member parse cost can be measured vs `rarfile`.
 
-Registration is **1.35 µs/member** after L2 — no ≥10% lever found this pass;
+### L4 — ZIP registration slice: measure-first — **deferred (#146)**
+
+Registration is **1.35 µs/member** after L2 — no ≥10% lever found in #146;
 left deferred.
 
 ### L5 — deferred (design change): lazy derivation
 
-Unchanged — needs its own OpenSpec change.
+Unchanged — needs its own OpenSpec change. Only lever that gets ZIP many-small
+listing near 1×; touches equality/accounting/listing contract.
 
 ## Repro
 


### PR DESCRIPTION
Docs + probe script only. Post-#143 investigation of why ZIP/7z/RAR open+list still miss the Q1 peer bands, packaged as an implementable worklist (`review/performance/listing-attribution.md`) so an agent can be pointed at it directly.

## Findings (measured, reproducible via `listing_probe.py`)

- **ZIP (3.8–4.9× vs zipfile, many-small):** 72% of the per-member overhead is `_to_member` derivation; registration/accounting is 26%; the fixed per-open cost is now negligible. `ArchiveMember` construction is ~1.5 µs of the 7–9 µs/member — ~20%, and half of that is marshalling ~20 kwargs (many explicit `None`s). The object is a factor, not the bottleneck.
- **7z (3.4–3.6× vs `py7zr.list`): parser defect, not model cost.** `_read_utf16` reads names two bytes at a time, and each `_read_exact` runs a `tell`/`seek(END)`/`seek(back)` triple for its truncation pre-check — ~45,000 `read_exact` calls per 2,000-member listing (≈ one per name character). Bulk-decoding the names blob + computing the buffer length once is the biggest available listing win, plausibly to peer parity.
- **RAR (2.4–2.8× vs rarfile): fixture artifact.** The peer fixture is 366 bytes / 6 members, so the ratio measures fixed per-open cost only (3 file opens + 7 `stat`s: detection + volume-sibling discovery). The parser's per-member cost is currently unmeasured — needs a real fixture before any optimization.

## Worklist (in the doc, ordered)

- **L0** — the #143 `normalize_member_name` fast-path trailing-slash bug (fix + regression test; details in the PR #143 review comment).
- **L1** — 7z bulk name decode + one-time buffer length. Accept: `read_exact` census from ~22.5/member to a small constant; `sevenzip_open_list` toward the ~1.25× native band.
- **L2** — `ArchiveMember` `slots=True` + stop passing `None` kwargs. Accept: ≥10% on the many-small ZIP probe; halves per-member memory (296-byte `__dict__` today).
- **L3** — real RAR listing fixture (needs the `rar` writer), measure, then decide; plus a cheap volume-discovery skip.
- **L4** — registration slice: measure-first, ≥10% bar.
- **L5** — lazy derivation: deferred; needs its own OpenSpec change, not a perf patch.

`listing_probe.py` sections (`zip` / `member` / `sevenzip` / `rar`) reproduce every number and define the L1/L2 accept metrics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KUVVDfbfxWdmLugeyRz4JF

---
_Generated by [Claude Code](https://claude.ai/code/session_01KUVVDfbfxWdmLugeyRz4JF)_