### PR TITLE
perf: listing L1/L2/L3 — 7z bulk names, ArchiveMember slots, volume skip

### DIFF
--- a/review/STATUS.md
+++ b/review/STATUS.md
@@ -25,7 +25,7 @@ or the finding is a clear proposed fix with no spec conflict).
 
 | ID | Action |
 |----|--------|
-| **P7 / H3** | **partial** — model-build fast paths landed (ASCII bidi/utf8, normalize, compression-tuple cache, no-link short-circuit, cheaper metadata accounting). ZIP open+list ~4.4×→~3.7× many-small / ~4.6×→~4.1× realistic; still above 2–3×. Further cuts need deeper open-path work. |
+| **P7 / H3** | **partial** — #143 model-build fast paths + L1 (7z bulk UTF-16 names) / L2 (`ArchiveMember` slots + trimmed kwargs) from `listing-attribution.md`. ZIP many-small ~3.7×; 7z open+list probe ~2.0× (was ~3.4×). Still above Q1 bands; L4 deferred, L5 needs OpenSpec. |
 | **P6 remainder** | **partial** — `py7zr` / `rarfile` / TAR `open_list` peers + Q1 band labels in harness. RAR/encrypted/accel *data* cases still missing. |
 | **P2 remainder** | Many-small `read_all` follows the listing story (same per-member machinery as P7). Large-member ZIP read already ≤1.25× after #139; realistic extract ~1.9× (inside ~2× band) — no further extract code pending Q2. |
 | **VISION/docs** | Re-word the ≤1.3× claim to match Q1 (decompression-dominated ≤1.3×; listing as peer ratios) once enforcement (Q2) is chosen. |

--- a/review/performance/QUESTIONS.md
+++ b/review/performance/QUESTIONS.md
@@ -37,11 +37,13 @@ Consequences to implement:
    `zipfile`/`tarfile` peers + `py7zr`/`rarfile` listing peers in the harness;
    report labels use Q1 bands (ZIP/TAR ≤3×, native ≈1.25×). Still asserted the
    same way the wall budget ends up asserted (Q2 — informational only today).
-2. ZIP open+list: measured **~4.1–6.1×** after model-build fast paths (was
-   4.6–6.6× on this host) — still above 2–3×. Remaining cost is mostly fixed
-   per-`open()` overhead (detection + ZipReader/ZipFile setup) on small
-   archives, plus residual per-member `ArchiveMember` construction. 7z/RAR vs
-   peers measured **~2.2–3.0×** (above parity; not optimized this pass).
+2. ZIP open+list: measured **~3.7–4×** after #143 model-build + L2
+   (`slots=True` / trimmed kwargs) — still above 2–3×. Remaining cost is
+   `_to_member` derivation (~3.3 µs/member) + registration (~1.3 µs); further
+   gains need L5 lazy derivation (OpenSpec). 7z open+list after L1 bulk name
+   decode: probe **~2.0×** / harness ~**2.2×** vs py7zr (was ~3.4×); still
+   above the 1.25× native band. RAR harness ratio remains a small-fixture
+   artifact until a larger listing fixture exists (L3).
 3. Read/extract regimes stay as previously framed: decompression-dominated
    ≤1.3× (met for large-member ZIP after #139), extract inside the ~2× safety
    band (met at realistic scale), many-small read_all follows the listing

--- a/review/performance/SUMMARY.md
+++ b/review/performance/SUMMARY.md
@@ -114,13 +114,13 @@ parses as a *non-empty* plausible header.
 | # | Status |
 |---|--------|
 | P1 | open — needs **Q2** (enforcement venue) |
-| P2 | **partial** — large-member ZIP read in budget; many-small / open+list improved toward Q1 2–3× (ZIP many-small ~4.4×→~3.7×) but not yet inside band; extract realistic in ~2× band |
+| P2 | **partial** — large-member ZIP read in budget; many-small / open+list improved (ZIP many-small ~3.7× after L2; 7z open+list ~2.0× after L1) but not yet inside Q1 bands; extract realistic in ~2× band |
 | P3 | **fixed** (#136) |
 | P4 / P5 | **fixed** (#139) |
-| P6 | **partial** — ZIP peers in #139; **py7zr/rarfile + TAR open_list peers added** (this change); RAR/encrypted/accel data cases still missing |
-| P7 | **partial** — model-build fast paths landed (ASCII bidi/utf8, normalize, compression tuples, no-link short-circuit, cheaper metadata accounting); still above 2–3× on ZIP open+list |
+| P6 | **partial** — ZIP peers in #139; **py7zr/rarfile + TAR open_list peers added** (#143); RAR/encrypted/accel data cases still missing |
+| P7 | **partial** — #143 model-build fast paths + L1/L2 listing fixes (`listing-attribution.md`); ZIP open+list still above 2–3×; 7z closer to native band |
 | P8 / P9 | **follow-up** (future / archive-copy) |
-| Q1 | **direction recorded** (#140) — listing peers + ZIP model-build pass implemented; residual band miss remains |
+| Q1 | **direction recorded** (#140) — listing peers + ZIP model-build (#143) + L1/L2 from attribution worklist; residual band miss remains |
 | Q2 / Q4 | **need decision** |
 | Q3 / Q5 / Q6 | **resolved** |
 
@@ -159,4 +159,8 @@ parses as a *non-empty* plausible header.
   threshold, verify-skip knob).
 - `residual-gap.md` — post-#136/#137 attribution of the remaining ZIP gap +
   next investigation areas and methodology.
-- `repro.py`, `measurements.py`, `attrib.py` — runnable evidence.
+- `listing-attribution.md` — post-#143 per-format listing decomposition
+  (ZIP derivation / 7z parser byte-loop / RAR fixture artifact) with the
+  **L0–L5 worklist**; L0 (#143), L1/L2 (implemented), L3 partial, L4/L5 deferred.
+- `repro.py`, `measurements.py`, `attrib.py`, `listing_probe.py` — runnable
+  evidence.

--- a/review/performance/listing-attribution.md
+++ b/review/performance/listing-attribution.md
@@ -1,0 +1,126 @@
+# Listing attribution — per-format decomposition and fix worklist
+
+**Measured at:** PR #143's tree initially; **L1/L2/L3 partial re-measured** on
+`cursor/listing-l1-l3-7360` after implementing the worklist below. CPython 3.11,
+review host. All wall numbers are warmed in-process medians (see
+`residual-gap.md` methodology). Written after #143's small listing gains, to
+answer: *why* are ZIP/7z/RAR open+list still far from their Q1 peers, and is
+`ArchiveMember` the problem?
+
+**Answer in one line:** three different bottlenecks — ZIP is per-member
+*derivation* (of which `ArchiveMember` construction is only ~20%), 7z was a
+**parser byte-loop defect** (names read 2 bytes at a time — **fixed L1**), and
+the RAR ratio is currently a **fixture artifact** that measures nothing about
+the parser.
+
+## ZIP — 3.8–4.1× on many-small; overhead is derivation, not the dataclass
+
+Fixture: 2,000 × 64 B STORED members. archivey open+list 19.1 ms vs `zipfile`
+5.1 ms → **7.0 µs/member overhead**, decomposed by ablation (open-only /
+open+`_to_member`-only / full `members()`):
+
+| Stage | per member | share |
+|---|---:|---:|
+| fixed per-open cost (detection, info, etc.) | 0.29 ms/archive | ~4% |
+| `_to_member` derivation (`zip_reader.py:547`) | **5.2 µs** | **72%** |
+| registration + accounting + name index (`base_reader.py:769`) | 1.9 µs | 26% |
+
+`ArchiveMember` construction micro-bench (20 k objects, no profiler):
+
+| Variant | µs/object |
+|---|---:|
+| `ArchiveMember(type=…, name=…)` minimal | 0.64 |
+| `ArchiveMember(...)` with ~20 kwargs (as `_to_member` calls it) | 1.51 |
+| `@dataclass(slots=True)` clone, 10 non-None kwargs | 0.96 |
+| `zipfile.ZipInfo(...)` (reference) | 0.34 |
+
+So the object contributes ~1.5 µs of the 7 µs (~20%) — and half of *that* is
+kwargs marshalling, not the class. Instance weight: 296-byte `__dict__` + 56-byte
+object (no `__slots__`) — matters for million-member listings.
+
+## 7z — 3.4× vs py7zr; the parser reads UTF-16 names 2 bytes at a time (defect)
+
+Fixture: 2,000 × 64 B members, py7zr-written. archivey 62–67 ms vs
+`py7zr.list()` ~18 ms → **3.4–3.6×**. cProfile: `_read_utf16` cumulative is
+~58% of the whole listing; the census (`listing_probe.py sevenzip`) counts
+**~45,000 `read_exact` calls per listing ≈ 22.5/member** — roughly one call
+per name *character* plus a few per fixed field.
+
+Mechanism (`sevenzip_parser.py`):
+
+- `_read_utf16` (`:920`) loops `_read_exact(buffer, 2, …)` per UTF-16 code unit
+  until the `\x00\x00` terminator.
+- `_read_exact` (`:982`) runs a truncation pre-check per call:
+  `_buffer_len(buffer) - buffer.tell()`, and `_buffer_len` (`:636`) is a
+  `tell` + `seek(0, END)` + `seek(back)` triple.
+- Net: ~5 Python calls + 3 BytesIO ops **per name character**. py7zr decodes the
+  whole names blob with one C-level `decode("utf-16le")` + split.
+
+## RAR — 2.42× vs rarfile is a fixture artifact; parser cost is unmeasured
+
+The harness `rar_open_list` fixture (`tests/fixtures/rar/basic_solid__.rar`) is
+**366 bytes / 6 members**. archivey 0.35 ms vs rarfile 0.14 ms — the entire delta
+is *fixed per-open* cost: profiling shows **3 `io.open` + 7 `posix.stat` per
+`open_archive`** (detection sniff + volume-sibling discovery) vs rarfile's ~1
+open. Per-member parse cost cannot be measured from 6 members; no conclusion
+about the RAR parser is currently supported by the harness number.
+
+## Worklist (ordered; each item independent)
+
+### L0 — ~~BLOCKER on #143~~ **fixed in #143**
+
+`normalize_member_name` fast path trailing-slash on FILE/SYMLINK — fixed +
+regression test landed with #143.
+
+### L1 — 7z: bulk-decode names; stop the per-read seek dance — **done (this PR)**
+
+1. `_handle_name` bulk-decodes the `kName` payload (`_decode_utf16_names`).
+2. `_buffer_len` / `_buffer_remaining` are O(1) for `BytesIO` (no seek dance).
+
+**After (same 2,000-member probe):** archivey **24.8 ms** vs py7zr 12.6 ms →
+**1.96×** (was 3.4–3.6× / ~62 ms); `read_exact` **4.0/member** (was ~22.5).
+Harness `sevenzip_open_list` realistic ~**2.2×** (was ~2.9×). Still above the
+1.25× native band — residual is non-name parse + model build.
+
+### L2 — ArchiveMember: `slots=True` + skip None kwargs — **done (this PR)**
+
+`@dataclass(slots=True)` on `ArchiveMember`; ZIP/TAR `_to_member` stop
+passing defaulted None/False fields.
+
+**After:** many-small ZIP probe **3.57×** / **4.71 µs/member** overhead
+(derivation 3.28 + register 1.35); construction micro **0.42 µs** minimal /
+**0.86 µs** full-kwargs; object **256 B** with no `__dict__` (was ~296+56).
+
+### L3 — RAR: real fixture deferred; volume-discovery fast reject — **partial (this PR)**
+
+Committed large RAR listing fixture still needs the `rar` writer (or offline
+generation). Shipped: `discover_volume_siblings` returns `None` without a
+`stat` when the name cannot be volume-shaped (ZIP/TAR/gz/plain `.7z` benefit).
+
+### L4 — ZIP registration slice: measure-first
+
+Registration is **1.35 µs/member** after L2 — no ≥10% lever found this pass;
+left deferred.
+
+### L5 — deferred (design change): lazy derivation
+
+Unchanged — needs its own OpenSpec change.
+
+## Repro
+
+All numbers above reproduce with the committed probe (needs `[all]` for the
+7z/RAR sections):
+
+```bash
+uv run --no-sync python review/performance/listing_probe.py zip       # ablation
+uv run --no-sync python review/performance/listing_probe.py member    # micro-bench
+uv run --no-sync python review/performance/listing_probe.py sevenzip  # + read census
+uv run --no-sync python review/performance/listing_probe.py rar       # artifact demo
+uv run --no-sync python -m benchmarks.harness --mode full --scale realistic
+```
+
+The `sevenzip` section's `read_exact` census is the L1 accept metric
+(~22.5/member before the fix — O(name length); target a small constant per
+member after). The `zip` section's per-member decomposition is the L2 accept
+metric. On `main` without #143's fast paths the `zip` section reads slightly
+higher (~9.4 µs/member overhead vs the 7.0 µs measured on #143's tree).

--- a/review/performance/listing_probe.py
+++ b/review/performance/listing_probe.py
@@ -1,0 +1,242 @@
+"""Listing decomposition probes (listing-attribution.md).
+
+Sections:
+
+    zip      2000x64B STORED ZIP: zipfile vs archivey, ablated into
+             open-only / open+derivation / full members()
+    member   ArchiveMember construction micro-bench (minimal / full kwargs)
+    sevenzip 2000-member 7z vs py7zr.list, plus a name-read call census
+    rar      committed 6-member fixture vs rarfile (fixed-cost artifact demo)
+
+Usage: python review/performance/listing_probe.py <section> [workdir]
+
+Warm, in-process medians; compare only numbers from one process (see
+residual-gap.md methodology). Accept criteria for the L1/L2 worklist items in
+listing-attribution.md are defined against these probes.
+"""
+
+from __future__ import annotations
+
+import io
+import statistics
+import sys
+import time
+import zipfile
+from pathlib import Path
+
+from archivey import open_archive
+
+MEMBERS = 2000
+
+
+def bench(fn, rounds: int = 15) -> float:
+    times = []
+    for _ in range(rounds):
+        t0 = time.perf_counter()
+        fn()
+        times.append(time.perf_counter() - t0)
+    return statistics.median(times) * 1000
+
+
+def _zip_fixture(work: Path) -> Path:
+    zp = work / "listing-many.zip"
+    if not zp.exists():
+        with zipfile.ZipFile(zp, "w", compression=zipfile.ZIP_STORED) as zf:
+            for i in range(MEMBERS):
+                zf.writestr(f"dir{i % 20}/file{i:04d}.txt", b"x" * 64)
+    return zp
+
+
+def section_zip(work: Path) -> None:
+    zp = _zip_fixture(work)
+
+    def std() -> None:
+        with zipfile.ZipFile(zp) as zf:
+            zf.infolist()
+
+    def open_only() -> None:
+        with open_archive(zp):
+            pass
+
+    def derive_only() -> None:
+        # zipfile parse + _to_member derivation; no registration/accounting/index.
+        with open_archive(zp) as ar:
+            for info in ar._archive.infolist():
+                ar._to_member(info)
+
+    def full() -> None:
+        with open_archive(zp) as ar:
+            _ = ar.info
+            list(ar.members())
+
+    std(), open_only(), derive_only(), full()
+    s, o, d, f = bench(std), bench(open_only), bench(derive_only), bench(full)
+    n = MEMBERS
+    print(f"zipfile infolist   {s:6.2f} ms")
+    print(f"open_archive only  {o:6.2f} ms   (fixed open cost {o - s:.2f} ms)")
+    print(f"open + derivation  {d:6.2f} ms   ({(d - o) / n * 1000:.2f} us/member)")
+    print(
+        f"full members()     {f:6.2f} ms   (register/account/index {(f - d) / n * 1000:.2f} us/member)"
+    )
+    print(f"ratio {f / s:.2f}x   total overhead {(f - s) / n * 1000:.2f} us/member")
+
+
+def section_member(work: Path) -> None:
+    del work
+    from archivey.types import (
+        ArchiveMember,
+        CompressionAlgorithm,
+        CompressionMethod,
+        CreateSystem,
+        MemberType,
+    )
+
+    comp = (CompressionMethod(algo=CompressionAlgorithm.STORED),)
+    n = 20000
+
+    def minimal() -> None:
+        for _ in range(n):
+            ArchiveMember(type=MemberType.FILE, name="a.txt")
+
+    def full_kwargs() -> None:
+        # Mirrors how zip_reader._to_member calls it (explicit Nones included).
+        for _ in range(n):
+            ArchiveMember(
+                type=MemberType.FILE,
+                name="dir/file.txt",
+                raw_name=b"dir/file.txt",
+                size=64,
+                compressed_size=64,
+                modified=None,
+                accessed=None,
+                created=None,
+                mode=0o644,
+                uid=None,
+                gid=None,
+                uname=None,
+                gname=None,
+                link_target=None,
+                compression=comp,
+                is_encrypted=False,
+                comment=None,
+                create_system=CreateSystem.UNIX,
+                windows_attrs=None,
+                hashes={"crc32": 12345},
+                extra={},
+            )
+
+    def zipinfo() -> None:
+        for _ in range(n):
+            zipfile.ZipInfo("dir/file.txt")
+
+    minimal(), full_kwargs(), zipinfo()
+    for label, fn in (
+        ("minimal args", minimal),
+        ("~20 kwargs  ", full_kwargs),
+        ("ZipInfo ref ", zipinfo),
+    ):
+        per = bench(fn, rounds=9) / n * 1000
+        print(f"ArchiveMember {label}: {per:.2f} us/object")
+    m = ArchiveMember(type=MemberType.FILE, name="a.txt")
+    # slots=True: no __dict__; report object size only.
+    print(f"slots object {sys.getsizeof(m)} B (no __dict__)")
+
+
+def section_sevenzip(work: Path) -> None:
+    import py7zr
+
+    from archivey.internal.streams.streamtools import binaryio
+
+    sz = work / "listing-many.7z"
+    if not sz.exists():
+        with py7zr.SevenZipFile(sz, "w") as zf:
+            for i in range(MEMBERS):
+                zf.writef(io.BytesIO(b"x" * 64), f"dir{i % 20}/file{i:04d}.txt")
+
+    def ay() -> None:
+        with open_archive(sz) as ar:
+            _ = ar.info
+            list(ar.members())
+
+    def peer() -> None:
+        with py7zr.SevenZipFile(sz, "r") as a:
+            list(a.list())
+
+    ay(), peer()
+    a, p = bench(ay, rounds=9), bench(peer, rounds=9)
+    print(
+        f"7z {MEMBERS} members: archivey {a:.2f} ms   py7zr.list {p:.2f} ms   ratio {a / p:.2f}x"
+    )
+
+    # Census: how many read_exact calls does one listing make? (L1 target: a small
+    # constant per member, not O(name-length). Pre-fix: ~22.5/member here.)
+    calls = 0
+    real = binaryio.read_exact
+
+    def counting(stream, length):  # type: ignore[no-untyped-def]
+        nonlocal calls
+        calls += 1
+        return real(stream, length)
+
+    binaryio.read_exact = counting
+    try:
+        # The parser imports read_exact via the streamtools package; patch both.
+        from archivey.internal.backends import sevenzip_parser
+
+        parser_real = sevenzip_parser.read_exact
+        sevenzip_parser.read_exact = counting
+        try:
+            ay()
+        finally:
+            sevenzip_parser.read_exact = parser_real
+    finally:
+        binaryio.read_exact = real
+    print(f"read_exact calls per listing: {calls}  ({calls / MEMBERS:.1f}/member)")
+
+
+def section_rar(work: Path) -> None:
+    del work
+    import rarfile
+
+    fx = (
+        Path(__file__).resolve().parents[2]
+        / "tests"
+        / "fixtures"
+        / "rar"
+        / "basic_solid__.rar"
+    )
+
+    def ay() -> None:
+        with open_archive(fx) as ar:
+            _ = ar.info
+            list(ar.members())
+
+    def peer() -> None:
+        with rarfile.RarFile(str(fx)) as a:
+            a.infolist()
+
+    ay(), peer()
+    a, p = bench(ay, rounds=25), bench(peer, rounds=25)
+    with open_archive(fx) as ar:
+        n = len(list(ar.members()))
+    print(f"RAR fixture ({n} members, {fx.stat().st_size} B):")
+    print(f"  archivey {a:.3f} ms   rarfile {p:.3f} ms   ratio {a / p:.2f}x")
+    print("  NOTE: fixed-cost artifact — too few members to measure per-member parse")
+
+
+def main() -> None:
+    section = sys.argv[1] if len(sys.argv) > 1 else "zip"
+    work = (
+        Path(sys.argv[2]) if len(sys.argv) > 2 else Path("/tmp/archivey-listing-probe")
+    )
+    work.mkdir(parents=True, exist_ok=True)
+    {
+        "zip": section_zip,
+        "member": section_member,
+        "sevenzip": section_sevenzip,
+        "rar": section_rar,
+    }[section](work)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/archivey/internal/backends/sevenzip_parser.py
+++ b/src/archivey/internal/backends/sevenzip_parser.py
@@ -738,6 +738,12 @@ def _handle_name(
 
 def _decode_utf16_names(blob: bytes, *, expected_count: int) -> list[str]:
     """Decode a 7z ``kName`` property payload into ``expected_count`` filenames."""
+    # Zero names: the payload is empty (no terminators). Match the old per-file
+    # loop's no-op; ``endswith(b"\\x00\\x00")`` below would mis-reject ``b""``.
+    if expected_count == 0:
+        if blob:
+            raise CorruptionError("7z name payload is non-empty for zero files")
+        return []
     if len(blob) % 2 != 0:
         raise CorruptionError("7z UTF-16 name payload has an odd byte length")
     if not blob.endswith(b"\x00\x00"):

--- a/src/archivey/internal/backends/sevenzip_parser.py
+++ b/src/archivey/internal/backends/sevenzip_parser.py
@@ -634,10 +634,24 @@ def _read_substreams_info(
 
 
 def _buffer_len(buffer: BinaryIO) -> int:
+    # Header payloads are BytesIO — ``getbuffer().nbytes`` is O(1). The seek/tell
+    # triple is only for real file objects (signature / next-header reads).
+    if isinstance(buffer, io.BytesIO):
+        return buffer.getbuffer().nbytes
     pos = buffer.tell()
     end = buffer.seek(0, io.SEEK_END)
     buffer.seek(pos)
     return end
+
+
+def _buffer_remaining(buffer: BinaryIO) -> int | None:
+    """Bytes left in ``buffer``, or ``None`` when length cannot be determined."""
+    try:
+        if isinstance(buffer, io.BytesIO):
+            return buffer.getbuffer().nbytes - buffer.tell()
+        return _buffer_len(buffer) - buffer.tell()
+    except (OSError, OverflowError, ValueError):
+        return None
 
 
 def _read_files_info(buffer: BinaryIO) -> tuple[list[SevenZipFileRecord], str | None]:
@@ -713,8 +727,39 @@ def _handle_name(
     external = _read_byte(payload)
     if external != 0:
         raise UnsupportedFeatureError("External 7z filename data is not supported")
-    for file_props in files:
-        file_props.filename = _read_utf16(payload).replace("\\", "/")
+    # Bulk-decode the whole names blob (known size, null-terminated UTF-16LE
+    # strings). Per-character ``_read_exact`` was ~22 calls/member and dominated
+    # listing (perf review L1 / listing-attribution.md).
+    blob = payload.read()
+    names = _decode_utf16_names(blob, expected_count=len(files))
+    for file_props, name in zip(files, names, strict=True):
+        file_props.filename = name.replace("\\", "/")
+
+
+def _decode_utf16_names(blob: bytes, *, expected_count: int) -> list[str]:
+    """Decode a 7z ``kName`` property payload into ``expected_count`` filenames."""
+    if len(blob) % 2 != 0:
+        raise CorruptionError("7z UTF-16 name payload has an odd byte length")
+    if not blob.endswith(b"\x00\x00"):
+        raise CorruptionError("7z UTF-16 name list is not null-terminated")
+    try:
+        text = blob.decode("utf-16le")
+    except UnicodeDecodeError as exc:
+        raise CorruptionError(f"Could not decode 7z UTF-16 names: {exc!r}") from exc
+    # Final NUL from the last terminator → trailing empty from split; drop it.
+    if not text.endswith("\x00"):
+        raise CorruptionError("7z UTF-16 name list is not null-terminated")
+    names = text[:-1].split("\x00")
+    if len(names) != expected_count:
+        raise CorruptionError(
+            f"7z name count {len(names)} does not match file count {expected_count}"
+        )
+    for name in names:
+        if len(name) > _MAX_UTF16_CHARS:
+            raise CorruptionError(
+                f"7z UTF-16 name exceeds {_MAX_UTF16_CHARS} characters"
+            )
+    return names
 
 
 def _handle_time(
@@ -918,6 +963,10 @@ def _read_boolean(
 
 
 def _read_utf16(buffer: BinaryIO) -> str:
+    """Read one null-terminated UTF-16LE string (legacy / single-name helper).
+
+    Prefer :func:`_decode_utf16_names` for the ``kName`` property (bulk path).
+    """
     chunks = bytearray()
     for _ in range(_MAX_UTF16_CHARS):
         unit = _read_exact(buffer, 2, "7z UTF-16 name")
@@ -988,10 +1037,7 @@ def _read_exact(buffer: BinaryIO, length: int, context: str) -> bytes:
             f"Claimed {context} length {length} exceeds the "
             f"{_MAX_NEXT_HEADER_SIZE}-byte parser limit"
         )
-    try:
-        remaining = _buffer_len(buffer) - buffer.tell()
-    except (OSError, OverflowError, ValueError):
-        remaining = None
+    remaining = _buffer_remaining(buffer)
     if remaining is not None and length > remaining:
         raise CorruptionError(
             f"Truncated {context}: claimed {length} bytes, only {remaining} remain"

--- a/src/archivey/internal/backends/tar_reader.py
+++ b/src/archivey/internal/backends/tar_reader.py
@@ -455,22 +455,29 @@ class TarReader(BaseArchiveReader):
             name=name,
             raw_name=raw_name,
             size=info.size if member_type == MemberType.FILE else None,
-            compressed_size=None,  # tar stores members uncompressed; no per-member figure
             modified=modified,
-            accessed=_pax_time(info, "atime"),
-            created=_pax_time(info, "ctime"),
             mode=stat.S_IMODE(info.mode),
             uid=info.uid,
             gid=info.gid,
-            uname=info.uname or None,
-            gname=info.gname or None,
-            link_target=link_target,
             compression=compression,
-            is_encrypted=False,  # TAR has no encryption
-            is_sparse=info.type == tarfile.GNUTYPE_SPARSE,
             extra=extra,
             _raw=info,  # carry the TarInfo so _open_member needs no name/id lookup table
         )
+        # Skip defaulted None/False fields on the listing hot path (perf review L2).
+        accessed = _pax_time(info, "atime")
+        if accessed is not None:
+            member.accessed = accessed
+        created = _pax_time(info, "ctime")
+        if created is not None:
+            member.created = created
+        if info.uname:
+            member.uname = info.uname
+        if info.gname:
+            member.gname = info.gname
+        if link_target is not None:
+            member.link_target = link_target
+        if info.type == tarfile.GNUTYPE_SPARSE:
+            member.is_sparse = True
         emit_member_name_normalized(
             self._diagnostics_collector,
             member=member,

--- a/src/archivey/internal/backends/zip_reader.py
+++ b/src/archivey/internal/backends/zip_reader.py
@@ -625,24 +625,32 @@ class ZipReader(BaseArchiveReader):
             extra["zip.aes_vendor_version"] = aes_info.vendor_version
             extra["zip.aes_strength"] = aes_info.strength
             extra["zip.aes_actual_method"] = aes_info.actual_method
+        # Skip defaulted None/False kwargs on the listing hot path (perf review L2).
         member = ArchiveMember(
             type=member_type,
             name=name,
             raw_name=raw_name,
             size=info.file_size,
             compressed_size=info.compress_size,
-            modified=modified,
-            accessed=accessed,
-            created=created,
-            mode=mode,
             compression=compression,
-            is_encrypted=bool(info.flag_bits & 0x1),
-            comment=_decode_with_fallback(info.comment) if info.comment else None,
-            create_system=create_system,
             hashes=hashes,
             extra=extra,
             _raw=info,  # carry the ZipInfo so _open_member needs no name/id lookup table
         )
+        if modified is not None:
+            member.modified = modified
+        if accessed is not None:
+            member.accessed = accessed
+        if created is not None:
+            member.created = created
+        if mode is not None:
+            member.mode = mode
+        if info.flag_bits & 0x1:
+            member.is_encrypted = True
+        if info.comment:
+            member.comment = _decode_with_fallback(info.comment)
+        if create_system is not None:
+            member.create_system = create_system
         if inferred_encoding is not None:
             self._diagnostics_collector.emit(
                 code=DiagnosticCode.MEMBER_NAME_ENCODING_INFERRED,

--- a/src/archivey/internal/volumes.py
+++ b/src/archivey/internal/volumes.py
@@ -36,10 +36,21 @@ def _rnn_part_number(name: str) -> int:
 
 def discover_volume_siblings(path: Path) -> list[Path] | None:
     """Return ordered sibling paths when ``path`` is part of a volume set, else ``None``."""
+    name = path.name
+    lower = name.lower()
+    # Fast reject before any filesystem op: most opens (ZIP/TAR/gz/plain .7z) are
+    # not volume-shaped. Saves a ``stat`` per open_archive (perf review L3).
+    maybe_volume = (
+        _7Z_VOLUME_RE.match(name) is not None
+        or _RAR_PART_RE.match(name) is not None
+        or _RAR_RNN_RE.match(name) is not None
+        or lower.endswith(".rar")
+    )
+    if not maybe_volume:
+        return None
     if not path.is_file():
         return None
     parent = path.parent
-    name = path.name
 
     match = _7Z_VOLUME_RE.match(name)
     if match is not None:
@@ -73,7 +84,7 @@ def discover_volume_siblings(path: Path) -> list[Path] | None:
         )
         return siblings if len(siblings) > 1 else None
 
-    if name.lower().endswith(".rar") and _RAR_PART_RE.match(name) is None:
+    if lower.endswith(".rar") and _RAR_PART_RE.match(name) is None:
         base = name[:-4]
         r00 = parent / f"{base}.r00"
         if r00.is_file():

--- a/src/archivey/types.py
+++ b/src/archivey/types.py
@@ -259,7 +259,7 @@ class CreateSystem(Enum):
 EXTRA_IS_JUNCTION = "is_junction"
 
 
-@dataclass
+@dataclass(slots=True)
 class ArchiveMember:
     """Represents a single archive entry. Mutable; callers must treat as read-only."""
 

--- a/tests/test_sevenzip_reader.py
+++ b/tests/test_sevenzip_reader.py
@@ -1091,6 +1091,10 @@ def test_decode_utf16_names_bulk() -> None:
     assert blob[0] == 0
     names = _decode_utf16_names(blob[1:], expected_count=2)
     assert names == ["a.txt", "dir/b"]
+    # Zero files: empty blob is the legitimate encoding (old loop was a no-op).
+    assert _decode_utf16_names(b"", expected_count=0) == []
+    with pytest.raises(CorruptionError, match="non-empty for zero files"):
+        _decode_utf16_names(b"\x00\x00", expected_count=0)
     with pytest.raises(CorruptionError, match="odd byte length"):
         _decode_utf16_names(b"abc", expected_count=1)
     with pytest.raises(CorruptionError, match="not null-terminated"):

--- a/tests/test_sevenzip_reader.py
+++ b/tests/test_sevenzip_reader.py
@@ -1082,6 +1082,23 @@ def test_lz4_7z_fixture_reads_members() -> None:
             # Header CRC (when present) is checked by VerifyingStream on read.
 
 
+def test_decode_utf16_names_bulk() -> None:
+    from archivey.exceptions import CorruptionError
+    from archivey.internal.backends.sevenzip_parser import _decode_utf16_names
+
+    blob = _names_payload(["a.txt", "dir/b"])
+    # _names_payload includes the external flag byte; strip it for the decoder.
+    assert blob[0] == 0
+    names = _decode_utf16_names(blob[1:], expected_count=2)
+    assert names == ["a.txt", "dir/b"]
+    with pytest.raises(CorruptionError, match="odd byte length"):
+        _decode_utf16_names(b"abc", expected_count=1)
+    with pytest.raises(CorruptionError, match="not null-terminated"):
+        _decode_utf16_names(b"a\x00", expected_count=1)
+    with pytest.raises(CorruptionError, match="name count"):
+        _decode_utf16_names(blob[1:], expected_count=3)
+
+
 def test_lz4_without_lz4_package_raises(monkeypatch: pytest.MonkeyPatch) -> None:
     reader = _reader_for_unit_tests()
     monkeypatch.setattr(codecs, "_lz4_frame", None)

--- a/tests/test_volumes.py
+++ b/tests/test_volumes.py
@@ -18,6 +18,14 @@ _7Z_MAGIC = bytes.fromhex("377abcaf271c")
 _RAR_MAGIC = b"Rar!\x1a\x07\x00"
 
 
+def test_discover_skips_stat_for_non_volume_names(tmp_path: Path) -> None:
+    """Non-volume-shaped names return None without requiring the path to exist."""
+    missing = tmp_path / "common.zip"
+    assert discover_volume_siblings(missing) is None
+    (tmp_path / "plain.7z").write_bytes(b"x")
+    assert discover_volume_siblings(tmp_path / "plain.7z") is None
+
+
 def test_discover_7z_volume_siblings_natural_order(tmp_path: Path) -> None:
     for name in ("set.7z.010", "set.7z.002", "set.7z.001"):
         (tmp_path / name).write_bytes(b"")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements the actionable items from PR #145’s `listing-attribution.md` worklist (new PR; does not reuse #143).

## Before / after (this host)

Compared **`main` @ `77faec9`** (post-#143) vs **this branch @ `2244b9a`**. Same machine, separate venvs (editable install per tree), warmed in-process medians via `listing_probe.py` and the realistic harness.

### Listing probes (`listing_probe.py`)

| Probe | Before | After | Δ |
|-------|--------|-------|---|
| **7z** 2000×64 B vs `py7zr.list` | 42.61 ms / **3.37×** | 24.79 ms / **1.93×** | **−42% wall**; ratio −1.44× |
| 7z `read_exact` / member | **22.5** | **4.0** | L1 accept metric |
| **ZIP** 2000×64 B vs `zipfile` | 13.56 ms / **3.91×** (5.05 µs/member overhead) | 12.94 ms / **3.54×** (4.64 µs/member) | **−5% wall**; ratio −0.37× |
| ZIP derivation / register | 3.68 / 1.26 µs | 3.37 / 1.23 µs | |
| `ArchiveMember` construct (min / ~20 kwargs) | 0.46 / 0.89 µs | 0.42 / 0.84 µs | |
| `ArchiveMember` size | 56 + 296 `__dict__` = **352 B** | **256 B** slots (no `__dict__`) | **−27%** |
| RAR 6-member fixture | 2.23× | 2.59× | noise / fixed-cost artifact (unchanged conclusion) |

### Harness (`benchmarks.harness --mode full --scale realistic`)

| Case | Before | After |
|------|--------|-------|
| `zip_open_list` | 3.96× | **3.74×** |
| `tar_open_list` | 1.35× | 1.35× |
| `sevenzip_open_list` | 2.74× | **2.32×** |
| `rar_open_list` | 2.13× | 2.34× (fixture artifact; not a parser signal) |

Harness exit 0 both trees.

```bash
# before
git worktree add /tmp/archivey-main main && cd /tmp/archivey-main
uv sync --group dev --extra all
# copy listing_probe.py from this PR if measuring main alone
uv run --no-sync python review/performance/listing_probe.py zip
uv run --no-sync python review/performance/listing_probe.py sevenzip
uv run --no-sync python -m benchmarks.harness --mode full --scale realistic

# after (this branch)
uv run --no-sync python review/performance/listing_probe.py zip
uv run --no-sync python review/performance/listing_probe.py sevenzip
uv run --no-sync python -m benchmarks.harness --mode full --scale realistic
```

## What landed

| Item | Status | Result |
|------|--------|--------|
| **L0** | already in #143 | trailing-slash normalize bug |
| **L1** | done | 7z `kName` bulk UTF-16 decode + O(1) `BytesIO` buffer length — dominant win above |
| **L2** | done | `ArchiveMember(slots=True)`; ZIP/TAR skip default None/False kwargs — modest ZIP wall + memory |
| **L3** | partial | Volume-discovery fast-reject (no `stat` when name isn’t volume-shaped). Large RAR listing fixture still needs the `rar` writer — deferred. |
| **L4** | deferred | Registration ~1.2 µs/member after L2; no ≥10% lever. |
| **L5** | deferred | Lazy derivation needs its own OpenSpec change. |

Also brings in `review/performance/listing-attribution.md` + `listing_probe.py` (from #145) with after-numbers, and updates STATUS / SUMMARY / QUESTIONS.

### Follow-up

- `_decode_utf16_names`: `expected_count=0` + empty blob returns `[]` (old loop no-op); non-empty blob with zero files still raises `CorruptionError`.

## Still open (unchanged)

- Q2 wall-budget enforcement, Q4 verify-skip knob — need maintainer decisions.
- ZIP open+list still above the Q1 2–3× band; further gains need L5.
- 7z still above the ~1.25× native parity band (residual non-name parse + model build).

## Checks

- Focused suite: sevenzip / zip / tar / rar / volumes / naming / data_model green
- `ruff` / `pyrefly` / `ty` clean on touched modules
- Realistic harness green on both before and after trees

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e6fb433e-5a35-4f28-840f-a570d4327360"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e6fb433e-5a35-4f28-840f-a570d4327360"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

