### PR TITLE
Clarify zero-tech-debt and specs-as-guidelines in review addendum

### DIFF
--- a/.claude/skills/code-review-skill/SKILL.md
+++ b/.claude/skills/code-review-skill/SKILL.md
@@ -1,12 +1,15 @@
 ---
 name: code-review-skill
 description: |
-  Provides comprehensive code review guidance for Python.
+  Provides comprehensive code review guidance for Python, plus an archivey-specific
+  addendum (VISION, CONTRIBUTING, review/ standards). Wired from Cursor `/code-review`
+  via `.cursor/commands/code-review.md`.
   Covers architecture review, performance review, security audit, code quality anti-patterns,
   and common bugs.
   Use when: reviewing pull requests, conducting PR reviews, code review, reviewing code changes,
     establishing review standards, mentoring developers, architecture reviews, security audits,
-    performance reviews, checking code quality, finding bugs, giving feedback on code.
+    performance reviews, checking code quality, finding bugs, giving feedback on code,
+    or when the user invokes /code-review.
 allowed-tools:
   - Read
   - Grep
@@ -30,6 +33,10 @@ Transform code reviews from gatekeeping to knowledge sharing through constructiv
 > **[reference/archivey-review-addendum.md](reference/archivey-review-addendum.md)** —
 > VISION tie-breakers, CONTRIBUTING contracts, and `review/` deep-review norms.
 > **Read that addendum first** when reviewing changes in this repository.
+>
+> **Cursor entrypoint:** project command [`.cursor/commands/code-review.md`](../../.cursor/commands/code-review.md)
+> wires `/code-review` to this skill + addendum (findings-first defaults + archivey
+> process). Invoking `/code-review-skill` also loads this skill directly.
 
 ## When to Use This Skill
 

--- a/.claude/skills/code-review-skill/reference/archivey-review-addendum.md
+++ b/.claude/skills/code-review-skill/reference/archivey-review-addendum.md
@@ -12,7 +12,7 @@
 |--------|------|
 | [`VISION.md`](../../../../VISION.md) | Product tie-breaker when trade-offs conflict |
 | [`CONTRIBUTING.md`](../../../../CONTRIBUTING.md) | Coding, typing, exceptions, testing, three-config gate |
-| [`openspec/specs/`](../../../../openspec/specs/) | Normative behavior contracts |
+| [`openspec/specs/`](../../../../openspec/specs/) | Capability contracts — starting point for behavior, revisable when wrong (§3) |
 | [`docs/internal/threat-model.md`](../../../../docs/internal/threat-model.md) | Trust boundaries + open security gaps |
 | [`review/README.md`](../../../../review/README.md) | Deep-review conventions, ranking, deliverable shape |
 | [`review/STATUS.md`](../../../../review/STATUS.md) | Live triage of in-flight review follow-ups |
@@ -99,12 +99,40 @@ These are **review blockers** when violated — not style nits.
   otherwise (e.g. safe-extraction `OnError.CONTINUE`)
 - [ ] `ArchiveyUsageError` stays **outside** the archive-error tree (caller misuse)
 
-### Clean-as-you-go
+### Zero tech debt (and clean-as-you-go)
 
-- [ ] Touched code is left in the shape it *should* have (rename/move/doc/spec sync in
-  the same change when the contract moves)
-- [ ] **Pause and ask** on spec↔doc↔code discrepancies — do not silently pick a winner
+The project aim is **debt-free** — not “clean enough,” but *no deliberately carried
+debt* (`review/backlog.md`). Clean-as-you-go is how day-to-day PRs enforce that:
+
+- [ ] Touched code is left in the shape it *should* have (rename / move / small
+  refactor in the same change when the design requires it)
+- [ ] Don’t land a “we’ll clean this later” shortcut without an **explicit, justified
+  decision** (PR note, `QUESTIONS.md`, `IDEAS.md`, or `review/backlog.md`) — unspoken
+  deferrals are debt
+- [ ] Duplication, drift, and TODOs introduced or left adjacent to the change are
+  either **paid now** or recorded as keep-with-reason — not ignored
+- [ ] **Pause and ask** on real design discrepancies — do not silently pick a winner
   (`CONTRIBUTING.md`, `CLAUDE.md`, `review/README.md`)
+
+### Specs & OpenSpec changes
+
+Specs are **guidelines for intended behavior**, not holy writ. Reviewers and authors
+should treat them as the best current description of the contract — and revise them
+when reality or a better design wins.
+
+- [ ] **Not every change needs a spec.** Bug fixes, refactors, tests, tooling, docs
+  polish, and internal cleanups usually do not. Prefer a spec/`openspec/changes/`
+  delta when the **public or cross-format behavior contract** moves (or when an
+  in-flight change proposal already owns the work).
+- [ ] When a change *does* move a contract, update the relevant
+  `openspec/specs/` (or propose via `openspec/changes/`) and matching user/decision
+  docs in the **same** change — don’t leave prose lying.
+- [ ] **If following a spec yields a worse outcome**, don’t contort the code to satisfy
+  the letter of the doc. Surface it: prefer changing the spec (or opening a change
+  proposal / maintainer question) so the written contract matches the better design.
+- [ ] Spec ↔ doc ↔ code conflicts still use **pause-and-ask** — guessing bakes the
+  wrong decision in. The goal is an explicit revision, not silent divergence.
+- [ ] Open threat-model gaps (`O*`) are not “fixed” by marketing language alone
 
 ### Comments
 
@@ -164,11 +192,13 @@ Use alongside the skill’s generic checklist. Severity: 🔴 blocking / 🟡 im
 - [ ] Format backends stay behind the uniform reader contracts
 - [ ] Sync-first: no accidental async public API
 
-### Specs & docs
+### Specs & docs (quick)
 
-- [ ] Behavior changes update the relevant `openspec/specs/` (or an `openspec/changes/`
-  proposal) and user/decision docs in the **same** change
-- [ ] Open threat-model gaps (`O*`) are not “fixed” by marketing language alone
+- [ ] Spec update only when the behavior contract moves — see §3
+- [ ] Don’t reject a better design solely because an old spec forbids it; propose
+  revising the spec instead
+- [ ] Don’t demand a new OpenSpec change for pure refactors / bugfixes with no
+  contract delta
 
 ---
 
@@ -185,7 +215,8 @@ For commissioned deep reviews (not ordinary PR review), inherit
    section.
 4. **Evidence** — `file:line`, concrete triggering input/state, runnable repro when
    practical.
-5. **Pause and ask** — spec/design conflicts go to `QUESTIONS.md`, not silent fixes.
+5. **Pause and ask** — spec/design conflicts go to `QUESTIONS.md`, not silent fixes
+   (including “the spec is wrong; here’s the better contract”).
 6. **Don’t re-litigate settled ground** — check archive tables + `STATUS.md` for
    already-closed findings before spending budget.
 7. **Archive lifecycle** — only move a review to `review/archive/` when every
@@ -207,8 +238,8 @@ In-flight themes to know (see `STATUS.md` for live items):
 
 | Label | Archivey examples |
 |-------|-------------------|
-| 🔴 `[blocking]` | Path escape on default extract; catch-all exception translation; core grows a hard dep; unjustified type suppressions; silent solid O(n²) on a common API; public contract change without spec/decision |
-| 🟡 `[important]` | Dishonest cost signal; format parity hole without docs; missing red-green test for a bugfix; threat-model gap touched but unaddressed; CLI forced to import `internal/` |
+| 🔴 `[blocking]` | Path escape on default extract; catch-all exception translation; core grows a hard dep; unjustified type suppressions; silent solid O(n²) on a common API; deliberate new debt with no recorded decision; public contract change left undocumented *and* undiscussed |
+| 🟡 `[important]` | Dishonest cost signal; format parity hole without docs; missing red-green test for a bugfix; threat-model gap touched but unaddressed; CLI forced to import `internal/`; code contorted to match a questionable spec without raising a revision |
 | 🟢 `[nit]` | Naming, comment polish, non-user-facing refactor suggestions |
 | 💡 / 📚 / 🎉 | Alternatives, teaching notes, praise — non-blocking |
 

--- a/.cursor/commands/code-review.md
+++ b/.cursor/commands/code-review.md
@@ -1,0 +1,50 @@
+# Code review
+
+Review the relevant code with a code review mindset.
+
+## Priorities (Cursor `/code-review` defaults)
+
+Keep these as the primary lens:
+
+1. **Bugs** and correctness errors
+2. **Behavioral regressions**
+3. **Security / safety** issues
+4. **Missing tests** (especially red–green for bug fixes)
+
+**Findings must be the primary focus**, ordered by severity. Do **not** make code
+changes unless the user explicitly asks for them.
+
+## Archivey process (best of both)
+
+This repo vendors a fuller review skill under `.claude/skills/code-review-skill/`.
+Combine the priorities above with that skill’s process:
+
+1. **Read first:** `.claude/skills/code-review-skill/reference/archivey-review-addendum.md`
+   (VISION ranking, zero tech debt, specs-as-guidelines, domain checklist)
+2. **Then follow:** `.claude/skills/code-review-skill/SKILL.md`
+   (four-phase review, severity labels, constructive feedback norms)
+3. Open deeper guides under `.claude/skills/code-review-skill/reference/` only as needed
+   (security, performance, Python, error handling, architecture, quality)
+
+## Scope
+
+- Default: current branch vs `main` (`git diff main...HEAD` and/or `@Branch`), plus any
+  paths or PR the user named.
+- If the user is asking about uncommitted work, include the working-tree diff.
+- Prefer concrete `file:line` evidence and triggering inputs/states.
+
+## Output format
+
+Lead with findings (no long preamble). For each finding:
+
+- Severity from the skill: 🔴 `[blocking]` / 🟡 `[important]` / 🟢 `[nit]` /
+  💡 `[suggestion]` / 📚 `[learning]` / 🎉 `[praise]`
+- Rank archivey blockers using the addendum (VISION claims, exception contract,
+  path/bomb safety, silent solid re-decode, unjustified debt, etc.)
+- Location, what’s wrong, why it matters, and a concrete fix direction
+- Call out missing tests when behavior changed
+
+After findings, a short **Verdict**: Approve / Comment / Request Changes — plus any
+maintainer questions (pause-and-ask; do not silently resolve spec conflicts).
+
+Skip formatting/lint nits that `ruff` / type-checkers already own.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #150 on the archivey review addendum, plus wiring Cursor `/code-review` to it.

### Addendum clarifications
- **Zero tech debt** — debt-free goal stated beside clean-as-you-go; unspoken “fix later” counts as debt unless justified in writing.
- **Specs as guidelines** — not every PR needs a spec; if obeying a spec yields a worse design, revise the spec (or pause-and-ask) rather than contorting the code.

### `/code-review` = best of both
Cursor’s built-in `/code-review` is a **separate short command** (findings-first: bugs, regressions, security, missing tests; no unsolicited edits). It does **not** auto-load `.claude/skills/code-review-skill/`.

This PR adds [`.cursor/commands/code-review.md`](.cursor/commands/code-review.md) so project `/code-review` keeps those defaults **and** instructs the agent to follow the vendored skill + `archivey-review-addendum.md`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8d9426c9-0316-45fb-a59f-9d74c04c4dd0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8d9426c9-0316-45fb-a59f-9d74c04c4dd0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

