### PR TITLE
docs(api-coherence): add Q7 — partial members + honest error

### DIFF
--- a/review/STATUS.md
+++ b/review/STATUS.md
@@ -65,6 +65,7 @@ Do not implement these until the maintainer answers (pause-and-ask).
 | **Q4** | Surface demote/add list | Blanket approval or line-item veto. |
 | **Q5** | **E2** library `verify` primitive | Priority: now vs post-0.2.0 (additive either way). |
 | **Q6** | Freeze nits | `WriteError` keep/demote; SKIPPED split shape; `hashes` int/bytes; display-name spelling. |
+| **Q7** | Partial members + honest error accessor | **Later-surfaced** (from #149 Option F review), not in #133. Adjacent to Q5/salvage; park vs explore-change. |
 
 ### `performance/QUESTIONS.md`
 

--- a/review/api-coherence/QUESTIONS.md
+++ b/review/api-coherence/QUESTIONS.md
@@ -1,7 +1,8 @@
 # QUESTIONS — maintainer decisions
 
-> **Status (2026-07-18):** all six questions still open — no decisions recorded
-> since findings landed in #133. Triage: `../STATUS.md`.
+> **Status (2026-07-18):** Q1–Q6 still open — no decisions recorded since findings
+> landed in #133. **Q7** was surfaced later (from #149 / Option F review), not in
+> the original api-coherence pass. Triage: `../STATUS.md`.
 
 Per the pause-and-ask rule (`CLAUDE.md`, `CONTRIBUTING.md`): discrepancies and
 judgement calls surfaced, not silently resolved. Ordered by weight.
@@ -73,3 +74,45 @@ prioritization question, not a freeze question. Related sub-decision: if it land
   the field docstring.
 - **`ArchiveFormat` display name** (S2): add `display_name()`/`label` so the CLI
   stops parsing `repr()`. Name preference?
+
+## Q7 — Partial members + honest error accessor (later-surfaced)
+
+> **Surfaced later** (2026-07-18), during review of #149 (`decide-strict-archive-eof-default`
+> Option F) — not part of the original api-coherence finding set in #133. Adjacent to
+> **E2 / Q5** and to salvage in `IDEAS.md` / `../backlog.md`, but not the same question.
+
+For scan-required formats (TAR today; others similarly), a pass can recover a usable
+*prefix* of members and still hit a terminal archive-level error (rejected mid/final
+header, strict missing trailer, mid-pass decode failure, …). VISION claim (3) wants
+**recoverable members + an honest error**, not members *or* an error. Today the
+library forces a false dichotomy:
+
+- **Silence the error** (pre-Option F warn on TAR `nonzero`) — dishonest for inventory.
+- **Raise and hide the members** (RA `members()` / `__iter__` / extract-prep fail
+  closed under Option F) — honest error, but throws away the recoverable listing.
+- **Yield then raise** (streaming `__iter__` / `stream_members` / extract) — caller
+  sees members only while iterating; there is still no first-class “here is the
+  list we got + the error” result from materializing APIs.
+
+**Q5 / E2** covers per-member integrity-check recovery (`verify` /
+`stream_members` continuing past a bad *member*). **Salvage** covers best-effort
+resync past damage. **Q7** is narrower: a uniform way to surface a **partial
+listing together with a terminal archive error** without silencing either side —
+and without silently republishing a partial cache as a complete listing (archived
+concurrency N1).
+
+Decision needed (exploration, not a freeze blocker):
+
+1. **Park vs explore now** — leave Option F’s RA fail-closed / streaming
+   salvage-then-raise split as the interim contract, or open an OpenSpec explore
+   change (e.g. `explore-partial-members-and-errors`) before 0.2.0 docs freeze the
+   dichotomy?
+2. **API shape if explored** — e.g. `members()` stays raise-on-terminal-error;
+   new `list_with_status()` / report object returns `(members, error|None)`; or
+   error only on `reader.diagnostics` with an explicit “listing incomplete” flag?
+3. **Uniformity** — how RA materialize-then-raise and streaming yield-then-raise
+   reconcile under one contract; interaction with CLI `list` / `test` exit codes.
+
+Recommendation: **park for Option F merge**; add a one-line cross-link from the
+EOF change’s design open-questions; open the explore change (or answer “post-0.2.0
+with salvage”) explicitly so the gap is owned.

--- a/review/api-coherence/SUMMARY.md
+++ b/review/api-coherence/SUMMARY.md
@@ -2,8 +2,9 @@
 
 > **Status (2026-07-18):** findings delivered in #133; **no code follow-ups have
 > landed yet.** Every row in the table below is still open. Blockers that need
-> a maintainer answer first: **Q1–Q6** (`QUESTIONS.md`). Mechanical surface
-> work (S1/S2/S3/E1/E3) is actionable after Q4/Q6. Triage: `../STATUS.md`.
+> a maintainer answer first: **Q1–Q6** (`QUESTIONS.md`). **Q7** (partial members +
+> honest error) was surfaced later from #149 — see `QUESTIONS.md`. Mechanical
+> surface work (S1/S2/S3/E1/E3) is actionable after Q4/Q6. Triage: `../STATUS.md`.
 
 Reviewed at `main` + CLI (#120) merged (`7139c13`). Baseline (all captured before
 review, `[all]` config): pytest **1699 passed / 131 skipped / 3 deselected**, pyrefly


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds **Q7** to `review/api-coherence/QUESTIONS.md`: a later-surfaced question about a uniform **partial listing + honest error** accessor (VISION “recoverable members + an honest error”).

Also updates the status blurb in `SUMMARY.md` and the triage / future tables in `STATUS.md`.

## Why

Surfaced during review of #149 (Option F TAR EOF). api-coherence’s original pass covered adjacent ground (**E2 / Q5** verify / per-member recovery; salvage in `IDEAS.md`) but not this exact gap: RA fail-closed vs streaming salvage-then-raise forces members *or* error, with no first-class dual result.

Marked explicitly as **later-surfaced** (not part of #133) so it is not mistaken for an original finding.

## Not in this PR

No OpenSpec explore change yet — Q7 recommends parking Option F’s interim contract and optionally opening `explore-partial-members-and-errors` once the maintainer picks park vs explore.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6105c4ca-4110-4846-a973-5999198b2028"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6105c4ca-4110-4846-a973-5999198b2028"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

