### PR TITLE
docs(api-coherence): record Q1–Q6 decisions (+ Q3 RAR investigation)

### DIFF
--- a/IDEAS.md
+++ b/IDEAS.md
@@ -281,6 +281,10 @@
   "skip damaged unit" mode) so `test` can continue where the format allows.
   Overlaps salvage (above) but is narrower — integrity reporting, not
   best-effort recovery of truncated archives.
+- **Library `verify` / `VerifyReport` primitive** (api-coherence E2 / Q5) —
+  **deferred past 0.2.0.** CLI `test` hand-rolls the loop today; unclear whether
+  callers verify without extracting often enough to justify a first-class API.
+  Adjacent to skip-damaged-member iteration above.
 
 ## Strategy & adoption (2026-07 review backlog)
 

--- a/openspec/changes/surface-stored-stream-digests/.openspec.yaml
+++ b/openspec/changes/surface-stored-stream-digests/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: library
+created: 2026-07-18

--- a/openspec/changes/surface-stored-stream-digests/brief.md
+++ b/openspec/changes/surface-stored-stream-digests/brief.md
@@ -1,0 +1,20 @@
+<!--
+The "coffee brief": a spoken-word-friendly summary of this change, readable (or
+read aloud) in under a minute. Prose only — NO tables, NO code blocks, minimal
+symbols — so text-to-speech reads cleanly. Aim for ~200–280 words. Derive it from
+proposal.md / design.md / tasks.md; do not introduce new decisions here.
+-->
+
+# surface-stored-stream-digests — fill zlib Adler-32 and multi-member lzip CRC32 without decompressing
+
+**Status:** Ready to implement. Depends on the api-coherence hashes typing fix shipping HashAlgorithm with byte values first. Blocks nothing. Not breaking once that typing landed. Effort: medium.
+
+**Why it matters:** VISION wants hashes without decompression for cheap dedupe. Docs still say zlib has no stored digest, but RFC 1950 puts Adler-32 at the end of every zlib stream. Lzip’s index already walks every member’s CRC and size, then throws the CRC away, so multi-member lzip stays blank for no good reason.
+
+**What it does:** Peeks zlib’s trailer into hashes as Adler-32 on seekable single streams. For lzip, keeps per-member CRCs from the backward index and combines them into one whole-member CRC32 that matches hashing the concatenated uncompressed payloads. Teaches the verify path to compute Adler-32. Updates specs, formats docs, and the corpus digest matrix.
+
+**Decided:** Pure-Python crc32 and adler32 combine helpers because CPython only adds those in three point fifteen. Lzip always surfaces a combined CRC when the index exists. Gzip and xz multi-unit combine stay deferred. Derived combined digests are documented as derived, not as a single on-disk field.
+
+**Your call later:** None — the design is settled.
+
+**Bottom line:** Additive parity after the hashes type cleanup; do the typing PR first, then this.

--- a/openspec/changes/surface-stored-stream-digests/design.md
+++ b/openspec/changes/surface-stored-stream-digests/design.md
@@ -1,0 +1,132 @@
+## Context
+
+api-coherence Q6 investigated stored-digest parity for single-file compressors
+(`review/api-coherence/QUESTIONS.md`). Today:
+
+- Gzip peeks a single-member trailer CRC-32; multi-member → omit.
+- Lzip’s `_read_index_backwards` walks every trailer (`crc32`, `data_size`,
+  `member_size`) but **discards** the CRC; metadata surfaces CRC only when the
+  file is a single member (`member_size == compressed_size`).
+- Zlib is documented as “no cheap whole-member CRC” — wrong: RFC 1950 stores
+  Adler-32 of uncompressed data as the last 4 bytes (network order).
+- XZ index knows per-block sizes + check *type* but does not read check bytes;
+  default check is CRC64; SHA-256 is not combinable.
+- `zlib.crc32_combine` / `adler32_combine` exist in CPython only from 3.15;
+  archivey pins 3.11+.
+
+The **type** change (`HashAlgorithm`, values always `bytes`) is a separate
+api-coherence review fix and is a **prerequisite** for this change’s public
+surface. This design assumes that typing is already landed.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Cheap zlib `ADLER32` on seekable single-stream sources.
+- Whole-member `CRC32` for multi-member lzip via combine over index trailers.
+- Verify path can check `adler32` when expected.
+- Spec/docs/sweep matrix match reality.
+
+**Non-Goals:**
+
+- Introducing `HashAlgorithm` / migrating crc32 `int`→`bytes` (review fix).
+- Gzip multi-member combine (mid-member trailers not cheap without decompress;
+  ISIZE mod 2³²).
+- XZ multi-block / CRC64 / SHA-256 whole-stream digests.
+- Zstd content checksums (no frame parser yet).
+- Claiming derived combined digests are “stored as one field by the format” —
+  they are derived from stored per-unit digests; still valid for dedupe.
+
+## Investigations
+
+### Combine algebra (verified on CPython 3.11)
+
+| Algorithm | Combine with `(d1, d2, len2)`? | Stdlib on 3.11 |
+|---|---|---|
+| Adler-32 | Yes (`adler32_combine`) | No — implement ~15 lines |
+| CRC-32 (ISO/zlib poly) | Yes (`crc32_combine`) | No — implement GF(2) helper |
+| CRC32c / CRC64 | Same idea, different poly | N/A this change |
+| SHA-256 | No | — |
+
+Adler combine matched `zlib.adler32(a+b)` in a smoke check. CRC combine is the
+well-known zlib `crc32_combine_` (matrix powers of the zero operator).
+
+### Per-format acquisition
+
+| Format | Single-unit peek | Multi-unit combine |
+|---|---|---|
+| zlib | Last 4 bytes = Adler-32 if complete single stream | Concatenated zlib rare; omit unless we detect splits |
+| lzip | Already | Index has every CRC + exact u64 size → **do it** |
+| gzip | Already | Blocked on finding mid trailers without decompress |
+| xz | Single-block CRC32 possible later | Default CRC64; SHA-256 no; out of scope |
+
+### Lzip index today
+
+`_read_index_backwards` unpacks `<IQQ` then keeps only `(start, data_size,
+member_size)`. Changing the entry to retain `crc32` is localized; combine folds
+left-to-right over members in archive order (same order as decompressed
+concatenation).
+
+## Decisions
+
+### 1. Prerequisite: HashAlgorithm typing from api-coherence
+
+Implement against `Mapping[HashAlgorithm, bytes]` and
+`HashAlgorithm.ADLER32` / `CRC32`. **Rejected:** shipping string keys `"adler32"`
+in this change then migrating twice.
+
+### 2. Small pure-Python combine helpers under `internal/hashing/`
+
+Add `crc32_combine` and `adler32_combine` (and tests) rather than waiting for
+3.15 or adding a native dep. **Rejected:** soft-depend on 3.15-only stdlib;
+**Rejected:** shell out / copy entire zlib C.
+
+### 3. Zlib: peek last 4 bytes, gate like gzip
+
+Seekable/path, file long enough for header+deflate+Adler, treat as single
+stream (no concat detector unless we already have one). Store
+`hashes[ADLER32]` as 4 bytes big-endian (matches wire + digest convention).
+Omit on non-seekable. **Rejected:** forcing a decompress pass to “confirm”
+Adler placement.
+
+### 4. Lzip: always surface combined CRC32 when index is available
+
+Whether one or many members: fold trailer CRCs with `crc32_combine` and exact
+`data_size`s. Single-member degenerates to the trailer CRC. SEEKABLE/path gate
+unchanged (index already requires that). **Rejected:** exposing only the last
+member’s CRC (lies about whole synthetic member). **Rejected:** leaving
+multi-member empty forever.
+
+### 5. Docs: call multi-member lzip digest “derived” where it matters
+
+`docs/formats.md` matrix: zlib → `adler32`; lzip → `crc32` (combined when
+multi-member). One sentence that multi-member lzip’s value equals
+`crc32(concat(parts))` derived from stored per-member CRCs. **Rejected:**
+hiding the derivation (VISION: no surprises as data/docs).
+
+### 6. Defer gzip/xz multi-unit
+
+Keep current single-unit-only rules. Revisit if a cheap member walker appears.
+**Rejected:** shipping a heuristic gzip magic-scan combiner (false boundaries).
+
+### 7. Verify registry gains `adler32`
+
+Mirror `crc32` hasher wrapping `zlib.adler32`, digest 4 bytes big-endian.
+Needed so a future path that installs expected Adler (or standalone codec
+streams) verifies instead of `DIGEST_UNVERIFIABLE`.
+
+## Risks / Trade-offs
+
+- **[Risk] Trailing junk after zlib stream** → last-4-byte peek is wrong.
+  **Mitigation:** same class of risk as trusting gzip EOF trailer; omit if we
+  later detect trailing bytes; document “complete single zlib file” assumption.
+- **[Risk] Combined lzip CRC used for dedupe across tools that hash only the
+  last member** → mismatch with naive tools.
+  **Mitigation:** document derivation; value matches full decompressed concat.
+- **[Risk] Stacking before HashAlgorithm lands** → churn.
+  **Mitigation:** tasks explicitly wait on / assume the type PR.
+
+## Open Questions
+
+None blocking — endianness of crc32 bytes is owned by the typing prerequisite
+change; Adler wire order is already BE.

--- a/openspec/changes/surface-stored-stream-digests/proposal.md
+++ b/openspec/changes/surface-stored-stream-digests/proposal.md
@@ -1,0 +1,51 @@
+## Why
+
+VISION’s “hashes without decompression” path is incomplete for single-file
+compressors: docs/specs claim zlib has no cheap stored digest (false — RFC 1950
+Adler-32 trailer), and multi-member lzip already walks every trailer CRC+size in
+its index but discards the CRCs instead of combining them into one whole-member
+digest. Filling those gaps is additive parity work, separate from the
+api-coherence **type** cleanup (`HashAlgorithm` + `bytes` values).
+
+## What Changes
+
+- Surface standalone **zlib** Adler-32 as `member.hashes[HashAlgorithm.ADLER32]`
+  when cheaply peekable (seekable/path, single complete stream).
+- Surface **lzip** whole-member `CRC32` for **multi-member** streams by combining
+  per-trailer CRCs with known uncompressed lengths (`crc32_combine`), not only
+  the single-member case.
+- Teach the shared verify hasher table to compute/compare `adler32` (stdlib
+  `zlib.adler32`) so surfaced values stay consistent with read-path checks.
+- Update `format-single-file-compressors` / formats docs / corpus assertions for
+  the new matrix rows.
+- **Out of scope here:** `HashAlgorithm` enum introduction and crc32 `int`→`bytes`
+  migration (api-coherence Q6 review fix). gzip/xz multi-unit combine (hard to
+  acquire mid-unit trailers / CRC64 default) — deferred; single-unit-only stays.
+
+## Capabilities
+
+### New Capabilities
+
+<!-- none -->
+
+### Modified Capabilities
+
+- `format-single-file-compressors` — stored-digest surfacing matrix (zlib Adler-32;
+  lzip multi-member combined CRC32)
+- `compressed-streams` — verify path recognizes `adler32` as a computable digest
+- `testing-contract` — cross-format stored-digest expectations for zlib / multi-lzip
+- `documentation` — `docs/formats.md` stored-digests table (zlib / lzip rows)
+
+## Impact
+
+- Modules: `codecs.py` (zlib/lzip `extract_metadata`), `single_file_reader.py`
+  (probes), `lzip.py` (retain trailer CRCs in index), new small
+  `crc32_combine`/`adler32_combine` helpers (3.11 has no stdlib combine),
+  `verify.py` hasher registry.
+- Public API: additive `hashes` keys/values only (after `HashAlgorithm` lands);
+  no signature breaks in this change.
+- Extras/deps: none (stdlib `zlib`).
+- Tests: unit tests for combine helpers; single-file metadata tests for zlib
+  Adler-32 and multi-member lzip; update formats matrix / sweep expectations.
+- **Prerequisite:** api-coherence Q6 hashes typing (`Mapping[HashAlgorithm, bytes]`)
+  merged or stacked first so this change writes enum keys, not stringly `"crc32"`.

--- a/openspec/changes/surface-stored-stream-digests/specs/compressed-streams/spec.md
+++ b/openspec/changes/surface-stored-stream-digests/specs/compressed-streams/spec.md
@@ -1,0 +1,33 @@
+## MODIFIED Requirements
+
+### Requirement: Decompressed output digests are verified at clean EOF
+
+The verification stage SHALL compute available expected digest algorithms
+incrementally over decompressed bytes and raise `CorruptionError` for a
+computable mismatch at clean EOF. A mismatch SHALL surface from the terminal read
+after all data chunks have been delivered; a bytes-returning full read raises and
+returns no bytes. Partial/random-access reads SHALL NOT produce a digest verdict.
+
+Supported computable algorithms SHALL include `crc32` (via `zlib.crc32`),
+`adler32` (via `zlib.adler32`), the `hashlib.algorithms_available` set, and
+`blake2sp` (the 8-way parallel BLAKE2s tree hash used by RAR5), computed via an
+internal zero-dependency hasher. A well-formed member carrying only a `blake2sp`
+digest SHALL therefore be verified, not skipped. A well-formed zlib member
+carrying only `adler32` SHALL likewise be verified, not skipped.
+
+When an expected digest cannot be computed because the algorithm is genuinely unknown
+or a backend is missing, the system SHALL emit `DIGEST_UNVERIFIABLE` with algorithm,
+non-secret reason, and member identity when available. Diagnostic policy controls
+collection, logging/callback delivery, member attachment, and escalation.
+
+#### Scenario: digest matrix
+
+| Case | Expected |
+| --- | --- |
+| Expected `blake2sp` on a well-formed RAR5 member | Computed and verified; mismatch raises `CorruptionError` |
+| Expected `adler32` on a well-formed zlib member | Computed and verified; mismatch raises `CorruptionError` |
+| Expected digest under a genuinely-unknown algorithm name | `DIGEST_UNVERIFIABLE` counted/retained/logged; bytes still returned without that check |
+| Full member read reaches EOF with computable digest mismatch | `CorruptionError` naming the algorithm |
+| Chunked read reaches EOF with mismatch | All valid chunks delivered; following terminal read raises |
+| Caller abandons stream before clean EOF | No digest verdict or mismatch exception |
+| Unverifiable digest resolves to `RAISE` | `DiagnosticRaisedError` halts open/read |

--- a/openspec/changes/surface-stored-stream-digests/specs/documentation/spec.md
+++ b/openspec/changes/surface-stored-stream-digests/specs/documentation/spec.md
@@ -1,0 +1,22 @@
+## MODIFIED Requirements
+
+### Requirement: Document the stored-digest matrix and cheap-dedupe recipe
+
+The end-user documentation SHALL include a stored-digest matrix stating, per format, which
+`member.hashes` keys are populated from data the archive already stores (or, for
+multi-member lzip, derived via CRC combine from per-member stored CRCs) without
+decompression, and under what conditions (e.g. single-member/seekable gzip; seekable
+zlib Adler-32; seekable lzip including multi-member). It SHALL include a cheap-dedupe
+recipe showing how to key on `member.hashes` for a first-pass dedupe and fall back to
+computing a digest while reading when no stored digest is present, and SHALL state the
+"best available digest + provenance (stored vs computed)" recommendation so an indexer
+can choose cheap-but-weak vs costly-but-strong uniformly. The matrix SHALL NOT claim
+zlib has no stored digest.
+
+#### Scenario: stored-digest documentation
+
+| Case | Expected |
+| --- | --- |
+| Reader consults the guide for dedupe | Finds the per-format stored-digest matrix and the cheap→computed fallback recipe |
+| Format stores no cheap digest (e.g. bzip2, tar) | Matrix states so; recipe covers the computed-on-read fallback |
+| zlib / multi-member lzip | Matrix lists `adler32` / combined `crc32` respectively |

--- a/openspec/changes/surface-stored-stream-digests/specs/format-single-file-compressors/spec.md
+++ b/openspec/changes/surface-stored-stream-digests/specs/format-single-file-compressors/spec.md
@@ -1,0 +1,46 @@
+## RENAMED Requirements
+
+- FROM: `### Requirement: Surface the stored decompressed CRC without decompression`
+- TO: `### Requirement: Surface stored decompressed digests without decompression`
+
+## MODIFIED Requirements
+
+### Requirement: Surface stored decompressed digests without decompression
+
+The single-file backend SHALL surface a codec's stored (or cheaply derived-from-stored)
+decompressed-content digest(s) on `member.hashes` when readable without decompressing,
+and SHALL omit them otherwise. This serves cheap dedupe (`VISION.md` "hashes without
+decompression") and never triggers a decompression pass.
+
+Keys and value types follow the public `HashAlgorithm` / `bytes` contract (api-coherence
+hashes typing). Surfacing SHALL NOT change read behavior: a full read still verifies via
+the existing path; stored/derived values are metadata only.
+
+- **GZIP:** trailer `CRC32` only when exactly one member and the source is seekable/path.
+  Multi-member → omit (trailer covers only the last member; mid-member trailers are not
+  cheap without decompress).
+- **LZIP:** when the seekable lzip index is available, surface `CRC32` of the whole
+  synthetic member. For multi-member files, the value SHALL equal
+  `crc32(concat(member payloads))` derived by combining per-trailer CRC-32 values with
+  each member's exact uncompressed `data_size` (combine algebra). Single-member
+  degenerates to the trailer CRC.
+- **ZLIB:** seekable/path complete single-stream file → surface trailer `ADLER32`
+  (RFC 1950, last 4 bytes, network order). Non-seekable or unrecognized layout → omit.
+- **Non-seekable source:** omit digests that require a trailer/index peek (no forced
+  decode).
+- **BZ2, XZ, BR, `.Z`:** no cheap whole-member stored digest in this change — omit.
+
+#### Scenario: stored-digest surfacing by codec
+
+| Case | `member.hashes` |
+| --- | --- |
+| Single-member `.gz`, seekable/path | `CRC32` present |
+| Multi-member `.gz` | no digest key |
+| `.gz` non-seekable | no digest key |
+| Single-member `.lz`, seekable lzip index | `CRC32` present (= trailer) |
+| Multi-member `.lz`, seekable lzip index | `CRC32` present (= combine of per-member trailers) |
+| `.lz` without seekable index | no digest key |
+| Standalone zlib, seekable/path single stream | `ADLER32` present |
+| zlib non-seekable | no digest key |
+| `.bz2` / `.xz` / `.br` / `.Z` | no digest key |
+| Any of the above, full `read()` | verification unchanged; hashes are metadata only |

--- a/openspec/changes/surface-stored-stream-digests/specs/testing-contract/spec.md
+++ b/openspec/changes/surface-stored-stream-digests/specs/testing-contract/spec.md
@@ -1,0 +1,33 @@
+## MODIFIED Requirements
+
+### Requirement: Stored-digest parity across backends
+
+The corpus conformance sweep SHALL assert stored-digest parity: for every applicable
+member, each backend SHALL surface the stored digest(s) documented for its format, and
+SHALL omit digest keys where the format stores none. This turns silent parity drift ("a
+backend quietly stopped populating `crc32`") into a test failure.
+
+The asserted matrix SHALL match the documented policy:
+
+| Format | Member kind | Expected `hashes` keys |
+| --- | --- | --- |
+| ZIP | FILE / SYMLINK | `crc32` present |
+| 7z | FILE | `crc32` present |
+| RAR5 | FILE with CRC32 | `crc32` present |
+| RAR5 | FILE with Blake2sp only | `blake2sp` present, `crc32` absent |
+| single-file GZIP | single member, seekable | `crc32` present |
+| single-file GZIP | multi-member or non-seekable | digest keys absent |
+| single-file LZIP | seekable lzip index (one or many members) | `crc32` present |
+| single-file LZIP | no seekable index | digest keys absent |
+| single-file ZLIB | seekable/path single stream | `adler32` present |
+| single-file ZLIB | non-seekable | digest keys absent |
+| single-file BZ2/XZ/BR/`.Z`, TAR, directory | any | no stored-digest key |
+
+#### Scenario: parity sweep
+
+| Case | Expected |
+| --- | --- |
+| Backend surfaces its documented stored digest for an applicable member | Sweep passes |
+| A backend stops populating a documented digest | Sweep fails |
+| A backend populates a digest the format does not store | Sweep fails |
+| Multi-member lzip combined `crc32` matches `crc32` of full decompressed concat | Sweep or focused unit test passes |

--- a/openspec/changes/surface-stored-stream-digests/tasks.md
+++ b/openspec/changes/surface-stored-stream-digests/tasks.md
@@ -1,0 +1,44 @@
+## 1. Prerequisites
+
+- [ ] 1.1 Confirm api-coherence Q6 hashes typing is merged (`HashAlgorithm`,
+      `Mapping[HashAlgorithm, bytes]`); stack or rebase this change on it
+- [ ] 1.2 Add `HashAlgorithm.ADLER32` if the typing PR only shipped `CRC32` /
+      `BLAKE2SP`
+
+## 2. Combine helpers
+
+- [ ] 2.1 Implement `crc32_combine` + `adler32_combine` under
+      `archivey.internal.hashing` (pure Python; 3.11-compatible)
+- [ ] 2.2 Unit tests: combine equals `zlib.crc32` / `zlib.adler32` of
+      concatenation for empty/short/multi-chunk cases
+
+## 3. Zlib Adler-32 surfacing
+
+- [ ] 3.1 Add seekable probe for last-4-byte Adler-32 (single-file reader /
+      zlib codec `extract_metadata`)
+- [ ] 3.2 Set `member.hashes[HashAlgorithm.ADLER32]` as 4-byte big-endian;
+      omit on non-seekable / too-short
+- [ ] 3.3 Register `adler32` in `verify.py` hasher table (`zlib.adler32`)
+
+## 4. Lzip multi-member CRC32
+
+- [ ] 4.1 Retain per-member CRC32 in lzip backward index entries
+- [ ] 4.2 In `extract_metadata`, combine CRCs with `data_size` via
+      `crc32_combine`; surface `HashAlgorithm.CRC32` for one- and multi-member
+- [ ] 4.3 Test: multi-member fixture’s surfaced CRC equals CRC of full
+      decompressed concat; single-member still matches trailer
+
+## 5. Specs, docs, sweep
+
+- [ ] 5.1 Sync main specs from this change’s deltas (`format-single-file-compressors`,
+      `compressed-streams`, `testing-contract`, `documentation`)
+- [ ] 5.2 Update `docs/formats.md` stored-digests table (zlib `adler32`; lzip
+      multi-member combined `crc32`; note derivation)
+- [ ] 5.3 Extend corpus / focused tests for zlib + multi-lzip parity rows
+
+## 6. Verify
+
+- [ ] 6.1 Targeted tests for combine helpers, zlib Adler peek, multi-lzip CRC
+- [ ] 6.2 `uv run --no-sync pytest` for affected tests; `ruff format` / check on
+      touched paths
+- [ ] 6.3 `openspec validate --strict surface-stored-stream-digests`

--- a/review/README.md
+++ b/review/README.md
@@ -22,7 +22,7 @@ Round commissioned 2026-07-17 — the **non-security** pass toward the first pub
 
 | Dir | Review | Status (2026-07-18) |
 |-----|--------|---------------------|
-| `api-coherence/` | Public API & member-model coherence / ergonomics (incl. cross-backend parity) | Findings in (#133); **no fixes yet** — Q1–Q6 open |
+| `api-coherence/` | Public API & member-model coherence / ergonomics (incl. cross-backend parity) | Findings in (#133); **Q1–Q6 decided** (QUESTIONS); code follow-ups open; Q7 → next round |
 | `cli-product/` | The CLI as a **product** — UX, grammar, exit codes, output (not code correctness; #131 did that) | **Brief only** — review not run |
 | `performance/` | The ≤1.3× stdlib perf budget — benchmark-gate efficacy + the real traps | Findings + partial fixes (#134/#136/#137/#139/#140/#141); P1/P2/P6/P7 + Q2/Q4 remain |
 | `stream-layering/` | Stream wrapper stack — are the checks correct, and can slicing+verification collapse into one stream under `ArchiveStream`? | **Essentially done** (#137); park Q4 then archive |

--- a/review/STATUS.md
+++ b/review/STATUS.md
@@ -41,7 +41,7 @@ or the finding is a clear proposed fix with no spec conflict).
 | **S2 / Q6** | `ArchiveFormat.display_name` **property** so the CLI stops parsing `repr()`. |
 | **E1** | Public measurement / IO-stats API so CLI `--track-io` leaves `internal/`. |
 | **E3 / Q6** | Split `ExtractionStatus.SKIPPED` into distinct statuses (overwrite vs non-current). |
-| **Q6 hashes** | Add `HashAlgorithm` enum; type becomes `Mapping[HashAlgorithm, bytes]` (crc32 `int` → 4-byte `bytes`; blake2sp already `bytes`). Keys are `str` today — no enum yet. |
+| **Q6 hashes** | Add `HashAlgorithm` enum (`CRC32` / `BLAKE2SP` / `ADLER32`); type `Mapping[HashAlgorithm, bytes]` (crc32 `int` → 4-byte `bytes`). **Also:** surface standalone zlib’s trailer Adler-32 (cheap peek; docs today wrongly say zlib has no stored digest). Keys are `str` today — no enum yet. |
 | **Q6 WriteError / `[7z-write]`** | Demote/unexport `WriteError` for read-only 0.2.0; remove or stop advertising `[7z-write]` until writing lands (py7zr remains a dev oracle). |
 
 ### Process

--- a/review/STATUS.md
+++ b/review/STATUS.md
@@ -41,7 +41,7 @@ or the finding is a clear proposed fix with no spec conflict).
 | **S2 / Q6** | `ArchiveFormat.display_name` **property** so the CLI stops parsing `repr()`. |
 | **E1** | Public measurement / IO-stats API so CLI `--track-io` leaves `internal/`. |
 | **E3 / Q6** | Split `ExtractionStatus.SKIPPED` into distinct statuses (overwrite vs non-current). |
-| **Q6 hashes** | Convert `crc32` hash values to hex `str`; prefer `blake2sp` → hex `str` too (`Mapping[str, str]`). |
+| **Q6 hashes** | Add `HashAlgorithm` enum; type becomes `Mapping[HashAlgorithm, bytes]` (crc32 `int` → 4-byte `bytes`; blake2sp already `bytes`). Keys are `str` today — no enum yet. |
 | **Q6 WriteError / `[7z-write]`** | Demote/unexport `WriteError` for read-only 0.2.0; remove or stop advertising `[7z-write]` until writing lands (py7zr remains a dev oracle). |
 
 ### Process

--- a/review/STATUS.md
+++ b/review/STATUS.md
@@ -41,7 +41,7 @@ or the finding is a clear proposed fix with no spec conflict).
 | **S2 / Q6** | `ArchiveFormat.display_name` **property** so the CLI stops parsing `repr()`. |
 | **E1** | Public measurement / IO-stats API so CLI `--track-io` leaves `internal/`. |
 | **E3 / Q6** | Split `ExtractionStatus.SKIPPED` into distinct statuses (overwrite vs non-current). |
-| **Q6 hashes** | Add `HashAlgorithm` enum (`CRC32` / `BLAKE2SP` / `ADLER32`); type `Mapping[HashAlgorithm, bytes]` (crc32 `int` → 4-byte `bytes`). **Also:** surface standalone zlib’s trailer Adler-32 (cheap peek; docs today wrongly say zlib has no stored digest). Keys are `str` today — no enum yet. |
+| **Q6 hashes** | Add `HashAlgorithm` enum (`CRC32` / `BLAKE2SP` / `ADLER32`); type `Mapping[HashAlgorithm, bytes]`. Surface zlib Adler-32; **lzip multi-member via `crc32_combine`** (index already has per-member CRC+size). gzip/xz stay single-unit-only for now (combine math works; acquiring mid-unit digests is the hard part). See QUESTIONS §Q6 multi-member. |
 | **Q6 WriteError / `[7z-write]`** | Demote/unexport `WriteError` for read-only 0.2.0; remove or stop advertising `[7z-write]` until writing lands (py7zr remains a dev oracle). |
 
 ### Process

--- a/review/STATUS.md
+++ b/review/STATUS.md
@@ -41,7 +41,7 @@ or the finding is a clear proposed fix with no spec conflict).
 | **S2 / Q6** | `ArchiveFormat.display_name` **property** so the CLI stops parsing `repr()`. |
 | **E1** | Public measurement / IO-stats API so CLI `--track-io` leaves `internal/`. |
 | **E3 / Q6** | Split `ExtractionStatus.SKIPPED` into distinct statuses (overwrite vs non-current). |
-| **Q6 hashes** | Add `HashAlgorithm` enum (`CRC32` / `BLAKE2SP` / `ADLER32`); type `Mapping[HashAlgorithm, bytes]`. Surface zlib Adler-32; **lzip multi-member via `crc32_combine`** (index already has per-member CRC+size). gzip/xz stay single-unit-only for now (combine math works; acquiring mid-unit digests is the hard part). See QUESTIONS §Q6 multi-member. |
+| **Q6 hashes** | **Typing (review fix now):** `HashAlgorithm` enum + `Mapping[HashAlgorithm, bytes]` (crc32 `int` → 4-byte `bytes`; include `ADLER32` member). **Filling digests:** OpenSpec `surface-stored-stream-digests` (zlib Adler peek, lzip multi-member `crc32_combine`) — separate change, depends on typing. |
 | **Q6 WriteError / `[7z-write]`** | Demote/unexport `WriteError` for read-only 0.2.0; remove or stop advertising `[7z-write]` until writing lands (py7zr remains a dev oracle). |
 
 ### Process
@@ -107,6 +107,7 @@ dedicated follow-up brief — they are not 0.2.0 blockers from the current round
 | **D1** | CLI list marks for `ANTI` / non-current — belongs to **`cli-product/`** when that review runs. |
 | **E2 / Q5** | Library `verify` / `VerifyReport` — deferred past 0.2.0; uncertain whether callers verify without extracting often enough. Park in `IDEAS.md`. |
 | **Q7** | Partial members + honest error accessor — **next review round** (VISION claim 3). Option F interim stands. |
+| **Stored stream digests** | zlib Adler-32 + lzip multi-member combine — OpenSpec **`surface-stored-stream-digests`** (after hashes typing). |
 
 ### Already on `backlog.md` (not from this round’s findings)
 

--- a/review/STATUS.md
+++ b/review/STATUS.md
@@ -11,7 +11,7 @@ item is fixed or consciously deferred here / in `backlog.md`.
 |--------|---------------------|----------------------|-------------------|
 | `stream-layering/` | yes (#137) | **done** (F1/F2/D1/D2); Q4 parked → future | **almost** — park Q4 then archive |
 | `performance/` | yes (#134 + #139/#140/#143/#146) | partial (P3–P5 done; P7 listing L0–L2 done, L3 partial; P1/P2/P6 open) | no |
-| `api-coherence/` | yes (#133) | **none yet** — all findings still open | no |
+| `api-coherence/` | yes (#133) | **Q1–Q6 decided** (docs in QUESTIONS); code follow-ups open | no |
 | `cli-product/` | **no** — brief only | review not run | no |
 
 ---
@@ -30,17 +30,19 @@ or the finding is a clear proposed fix with no spec conflict).
 | **P2 remainder** | Many-small `read_all` follows the listing story (same per-member machinery as P7). Large-member ZIP read already ≤1.25× after #139; realistic extract ~1.9× (inside ~2× band) — no further extract code pending Q2. |
 | **VISION/docs** | Re-word the ≤1.3× claim to match Q1 (decompression-dominated ≤1.3×; listing as peer ratios) once enforcement (Q2) is chosen. |
 
-### From `api-coherence/` (no decision blocker once Q4 is a blanket “yes”)
+### From `api-coherence/` (Q1–Q6 decided 2026-07-18 — implement)
 
-These are pre-release surface/doc fixes the review already proposed; they still
-need an explicit Q4/Q6 nod, but the *implementation* is mechanical:
-
-| ID | Action (after Q4 / Q6 confirm) |
-|----|--------------------------------|
-| **S1 / S3** | Demote `*Context` + `RAPIDGZIP_AUTO_MIN_COMPRESSED_SIZE` from `__all__`; export `PasswordInput` / decide `OnDiagnostic`; drop `core.source_name`; document `open_stream` in `api.md`. |
-| **S2** | `ArchiveFormat.display_name` (or similar) so the CLI stops parsing `repr()`. |
+| ID | Action |
+|----|--------|
+| **P1 / Q1** | Unify last-entry-wins `is_current` on ZIP/TAR RA materialization; align specs; sweep asserts uniform duplicate contract. **Not already done** — only 7z/RAR set the field today. |
+| **Q2** | Docs/recipes only (listing stays “everything”); pairs with P1. |
+| **P2 / Q3** | Keep RAR `listing_cost=INDEXED`; fix `cost.py` docstring + grab-bag prose; document open always walks headers / QO unused; add RAR row to `test_cost_receipt.py`. |
+| **S1 / S3 / Q4** | Demote `*Context` + `RAPIDGZIP_AUTO_MIN_COMPRESSED_SIZE` from `__all__`; export `PasswordInput` + `OnDiagnostic`; drop `core.source_name`; document `open_stream` in `api.md`. |
+| **S2 / Q6** | `ArchiveFormat.display_name` **property** so the CLI stops parsing `repr()`. |
 | **E1** | Public measurement / IO-stats API so CLI `--track-io` leaves `internal/`. |
-| **E3** | Split or reason-tag `ExtractionStatus.SKIPPED` (non-current vs overwrite). |
+| **E3 / Q6** | Split `ExtractionStatus.SKIPPED` into distinct statuses (overwrite vs non-current). |
+| **Q6 hashes** | Convert `crc32` hash values to hex `str`; prefer `blake2sp` → hex `str` too (`Mapping[str, str]`). |
+| **Q6 WriteError / `[7z-write]`** | Demote/unexport `WriteError` for read-only 0.2.0; remove or stop advertising `[7z-write]` until writing lands (py7zr remains a dev oracle). |
 
 ### Process
 
@@ -57,15 +59,10 @@ Do not implement these until the maintainer answers (pause-and-ask).
 
 ### `api-coherence/QUESTIONS.md`
 
-| Q | Finding | Why blocked |
-|---|---------|-------------|
-| **Q1** | **P1** duplicate-name / `is_current` | Spec conflict (`safe-extraction` vs `archive-data-model`) + three format behaviours. Recommended: unify last-entry-wins on random-access formats. |
-| **Q2** | `members()` scope | Recommendation is “keep everything, no include/exclude arg” — needs explicit yes/no. |
-| **Q3** | **P2** RAR `listing_cost` | Doc says `REQUIRES_SCANNING` for no-quick-open; impl always `INDEXED`. |
-| **Q4** | Surface demote/add list | Blanket approval or line-item veto. |
-| **Q5** | **E2** library `verify` primitive | Priority: now vs post-0.2.0 (additive either way). |
-| **Q6** | Freeze nits | `WriteError` keep/demote; SKIPPED split shape; `hashes` int/bytes; display-name spelling. |
-| **Q7** | Partial members + honest error accessor | **Later-surfaced** (from #149 Option F review), not in #133. Adjacent to Q5/salvage; park vs explore-change. |
+| Q | Status |
+|---|--------|
+| **Q1–Q6** | **Decided** 2026-07-18 — see §1 and `api-coherence/QUESTIONS.md` |
+| **Q7** | **Deferred to next review round** (partial members + honest error) |
 
 ### `performance/QUESTIONS.md`
 
@@ -108,7 +105,8 @@ dedicated follow-up brief — they are not 0.2.0 blockers from the current round
 | ID | Notes |
 |----|-------|
 | **D1** | CLI list marks for `ANTI` / non-current — belongs to **`cli-product/`** when that review runs. |
-| **E2** (if Q5 = post-0.2.0) | Library `verify` / `VerifyReport` — `IDEAS.md` or a post-freeze change. |
+| **E2 / Q5** | Library `verify` / `VerifyReport` — deferred past 0.2.0; uncertain whether callers verify without extracting often enough. Park in `IDEAS.md`. |
+| **Q7** | Partial members + honest error accessor — **next review round** (VISION claim 3). Option F interim stands. |
 
 ### Already on `backlog.md` (not from this round’s findings)
 

--- a/review/api-coherence/QUESTIONS.md
+++ b/review/api-coherence/QUESTIONS.md
@@ -194,6 +194,7 @@ next round / backlog (cross-link from EOF design remains fine).
 | Q5 | `IDEAS.md` park only |
 | Q6 WriteError / `[7z-write]` | Demote exception; remove or un-advertise extra |
 | Q6 SKIPPED split | New `ExtractionStatus` value + CLI/report call sites |
-| Q6 hashes → `Mapping[HashAlgorithm, bytes]` | Add enum (`CRC32` / `BLAKE2SP` / `ADLER32`); crc32 `int`→4-byte `bytes`; surface zlib trailer as `ADLER32`; update backends, verify, specs, `docs/formats.md`, CLI formatter |
+| Q6 hashes → `Mapping[HashAlgorithm, bytes]` | Review-fix PR: add enum (`CRC32` / `BLAKE2SP` / `ADLER32`); crc32 `int`→4-byte `bytes`; backends/verify/docs for type only |
+| Q6 hashes fill (zlib/lzip) | **Separate change:** `openspec/changes/surface-stored-stream-digests` |
 | Q6 `display_name` | Property on `ArchiveFormat` + CLI |
 | Q7 | Next round — see `../backlog.md` / STATUS future list |

--- a/review/api-coherence/QUESTIONS.md
+++ b/review/api-coherence/QUESTIONS.md
@@ -159,6 +159,50 @@ Nothing else is exposed. Docs/specs explicitly say `.bz2` / `.xz` / **zlib** / b
 
 Fold Adler-32 zlib surfacing into the same hashes implementation change as the enum + crc32→bytes migration (parity fix, not a separate freeze question).
 
+### Q6 hashes — multi-member streams: single-only vs combine math
+
+Multi-member/framed streams (gzip, lzip, xz, zstd, rare concatenated zlib) are
+common — that’s why we omit digests when we can’t attribute a trailer to the
+*whole* synthetic member. Two strategies:
+
+**A. Single-member only (after index / detection).** Already the gzip/lzip rule.
+Once the index (or `gzip_has_additional_member`) says “one unit,” peek the one
+trailer. Extends cleanly to zlib Adler-32 and to xz when the backward index
+shows a single block (and check type is one we understand). Cheap; no new math.
+
+**B. Combine per-unit digests into a whole-stream digest.** For **CRC-32** and
+**Adler-32**, yes — if you have each unit’s digest *and* the uncompressed length
+of every unit after the first:
+
+- `CRC(A‖B) = crc32_combine(CRC(A), CRC(B), len(B))` (GF(2) polynomial; zlib)
+- `Adler(A‖B) = adler32_combine(Adler(A), Adler(B), len(B))` (mod 65521; simpler)
+
+Same idea for CRC32c / CRC64 with the right polynomial; **not** for SHA-256 /
+full cryptographic hashes (and zstd’s stored value is only the low 32 bits of
+XXH64). CPython exposes `zlib.crc32_combine` / `adler32_combine` only from
+**3.15**; we are on 3.11 → small pure-Python (or vendored) combine helpers if we
+want this before then. Verified Adler combine against `zlib.adler32` on 3.11.
+
+| Format | What we already know | Combine feasible? |
+|---|---|---|
+| **lzip** | Backward index walks *every* trailer: CRC32 + full `data_size` u64 (exact). Today the index **discards** the CRC (`lzip.py` `_read_index_backwards`). | **Best win.** Fold CRCs with `crc32_combine` → one `CRC32` for the synthetic member even when multi-member. |
+| **gzip** | Last trailer only is at EOF; earlier members need decompress or magic scan to find trailers. `ISIZE` is **mod 2³²** (wrong `len2` if a member ≥ 4 GiB). | Math works *if* you have all CRCs + exact lengths; **getting** mid-member trailers without a decompress pass is the blocker. Keep single-member-only unless we grow a real member walker. |
+| **zlib** | One Adler-32 at EOF for a single stream. Concatenated zlib is uncommon. | Single-stream peek; combine only if we ever detect/split concatenated streams. |
+| **xz** | Backward index: per-block uncompressed sizes (full ints) + check *type*; **does not read** check field bytes. Payload check is **per block** (CRC32 / CRC64 default / SHA-256 / none). | Combine only when check type is **CRC32** (or we implement CRC64 combine) *and* we seek-read each block’s check bytes. SHA-256 → no. Default CRC64 → need a CRC64 combine helper. Multi-stream files: combine across streams only if check types match. |
+| **zstd** | No frame parser today; optional content checksum = low 32 of XXH64; sizes optional. | Not practical until we parse frames; XXH64 combine is a different animal and we only have 32 bits stored. |
+
+**Recommendation for the hashes implementation change:**
+
+1. Enum + all values `bytes` + zlib `ADLER32` single-stream peek (as above).
+2. **lzip: surface combined `CRC32` for multi-member** via index CRCs + combine
+   (high value, data already in hand).
+3. gzip/xz: keep **single-unit-only** for v0.2.0; optionally xz single-block
+   CRC32 peek. Document combine as the path if we later want multi-gzip/xz
+   without decompress.
+4. Do not pretend a combined digest is “stored by the format” in docs — it’s
+   **derived** from stored per-unit digests; still valid for cheap dedupe and
+   matches `hash(concat(parts))`.
+
 | **`ArchiveFormat` display name (S2)** | **Add a `display_name` property** (not a method). CLI stops parsing `repr()`. |
 
 ---

--- a/review/api-coherence/QUESTIONS.md
+++ b/review/api-coherence/QUESTIONS.md
@@ -140,7 +140,7 @@ a first-class API (CLI `test` can keep its hand-rolled loop for now). Park in
 |---|---|
 | **`WriteError`** | **Defer / remove from the read-only 0.2.0 surface.** v0.2.0 is read-only; writing is a later major release. Do not ship writing leftovers — demote/unexport `WriteError` for now. Same spirit: drop or stop advertising the `[7z-write]` extra/dep group until writing is real (py7zr stays a *dev* oracle as needed). |
 | **`ExtractionStatus.SKIPPED` split (E3)** | **Split into distinct statuses** (not a `reason` field). Overwrite-skip and non-current-skip are different caller concerns: most tools ignore superseded members but care that an expected extract hit a pre-existing path. Name at implement (`SUPERSEDED` / `NON_CURRENT` / …) — prefer a clear verb/noun over overloading `SKIPPED`. |
-| **`hashes` value convention** | **All values `bytes`; keys become a `HashAlgorithm` enum.** Today: `Mapping[str, int \| bytes]` with string keys `"crc32"` / `"blake2sp"` and **no** hash-algorithm enum (`types.py` — only `CompressionAlgorithm` et al.). Target: `Mapping[HashAlgorithm, bytes]` (crc32 as 4-byte digest, not `int`; blake2sp already `bytes`). Prefer `HashAlgorithm(str, Enum)` with at least `CRC32 = "crc32"`, `BLAKE2SP = "blake2sp"`, **`ADLER32 = "adler32"`**. Endianness of 4-byte crc32/adler32: fix at implement (document clearly — big-endian is the usual “digest bytes” convention; note zlib stores Adler-32 network-order on the wire). |
+| **`hashes` value convention** | **Type cleanup (immediate review fix):** all values `bytes`; keys become `HashAlgorithm` (`CRC32` / `BLAKE2SP` / `ADLER32` stub OK). Today: `Mapping[str, int \| bytes]`. Target: `Mapping[HashAlgorithm, bytes]` (crc32 as 4-byte digest). Prefer `HashAlgorithm(str, Enum)`. Endianness of 4-byte digests: fix at implement (big-endian usual). **Filling missing digests (zlib Adler-32, lzip multi-member combine, …):** **out of this review’s code follow-ups** — tracked as OpenSpec change `surface-stored-stream-digests` (depends on the typing fix). |
 
 ### Q6 hashes — what formats store today / Adler-32 parity
 
@@ -148,60 +148,23 @@ a first-class API (CLI `test` can keep its hand-rolled loop for now). Park in
 
 | Algorithm | Where |
 |---|---|
-| `crc32` | ZIP (CD), 7z (when present), RAR5 (when present), single-file `.gz` (single-member trailer), `.lz` (seekable trailer) |
+| `crc32` | ZIP (CD), 7z (when present), RAR5 (when present), single-file `.gz` (single-member trailer), `.lz` (seekable trailer, single-member only today) |
 | `blake2sp` | RAR5 only (HASH extra) |
 
 Nothing else is exposed. Docs/specs explicitly say `.bz2` / `.xz` / **zlib** / brotli / `.Z` have no cheap whole-member digest — that line is **wrong for zlib**: RFC 1950 puts a 4-byte **Adler-32** of the uncompressed data at the end of every zlib stream (not CRC-32). Gzip uses CRC-32 in its trailer; raw ZIP deflate has neither (ZIP’s CRC lives in the directory).
 
-**Can we fill `adler32`?** Yes, for standalone zlib (`.zz` / detected zlib), same shape as the gzip crc probe: on a seekable/path single-stream source, peek the last 4 bytes without decompressing and set `hashes[HashAlgorithm.ADLER32]`. Wire order is already big-endian (RFC 1950). Caveats to document at implement: trailing junk or concatenated zlib streams make “last 4 bytes” unreliable (gzip already special-cases multi-member); omit on non-seekable sources. Wire verification already happens inside `zlib` decompress; surfacing is for cheap dedupe (VISION). Also teach `verify.py`’s hasher table `adler32` via `zlib.adler32` (today only `crc32` / `blake2sp`).
-
-**Out of scope unless demand shows up:** xz stream checks (CRC32/CRC64/SHA256), zstd content checksums (xxHash), etc. — different algorithms, harder “cheap without decompress” stories. `HashAlgorithm` should be easy to extend when those land.
-
-Fold Adler-32 zlib surfacing into the same hashes implementation change as the enum + crc32→bytes migration (parity fix, not a separate freeze question).
+**Can we fill `adler32` / multi-member lzip?** Yes — see OpenSpec change
+**`surface-stored-stream-digests`** (separate from the type migration). Short
+version: zlib peek last 4 bytes; lzip index already has per-member CRC+size and
+can `crc32_combine`; gzip/xz multi-unit deferred.
 
 ### Q6 hashes — multi-member streams: single-only vs combine math
 
-Multi-member/framed streams (gzip, lzip, xz, zstd, rare concatenated zlib) are
-common — that’s why we omit digests when we can’t attribute a trailer to the
-*whole* synthetic member. Two strategies:
-
-**A. Single-member only (after index / detection).** Already the gzip/lzip rule.
-Once the index (or `gzip_has_additional_member`) says “one unit,” peek the one
-trailer. Extends cleanly to zlib Adler-32 and to xz when the backward index
-shows a single block (and check type is one we understand). Cheap; no new math.
-
-**B. Combine per-unit digests into a whole-stream digest.** For **CRC-32** and
-**Adler-32**, yes — if you have each unit’s digest *and* the uncompressed length
-of every unit after the first:
-
-- `CRC(A‖B) = crc32_combine(CRC(A), CRC(B), len(B))` (GF(2) polynomial; zlib)
-- `Adler(A‖B) = adler32_combine(Adler(A), Adler(B), len(B))` (mod 65521; simpler)
-
-Same idea for CRC32c / CRC64 with the right polynomial; **not** for SHA-256 /
-full cryptographic hashes (and zstd’s stored value is only the low 32 bits of
-XXH64). CPython exposes `zlib.crc32_combine` / `adler32_combine` only from
-**3.15**; we are on 3.11 → small pure-Python (or vendored) combine helpers if we
-want this before then. Verified Adler combine against `zlib.adler32` on 3.11.
-
-| Format | What we already know | Combine feasible? |
-|---|---|---|
-| **lzip** | Backward index walks *every* trailer: CRC32 + full `data_size` u64 (exact). Today the index **discards** the CRC (`lzip.py` `_read_index_backwards`). | **Best win.** Fold CRCs with `crc32_combine` → one `CRC32` for the synthetic member even when multi-member. |
-| **gzip** | Last trailer only is at EOF; earlier members need decompress or magic scan to find trailers. `ISIZE` is **mod 2³²** (wrong `len2` if a member ≥ 4 GiB). | Math works *if* you have all CRCs + exact lengths; **getting** mid-member trailers without a decompress pass is the blocker. Keep single-member-only unless we grow a real member walker. |
-| **zlib** | One Adler-32 at EOF for a single stream. Concatenated zlib is uncommon. | Single-stream peek; combine only if we ever detect/split concatenated streams. |
-| **xz** | Backward index: per-block uncompressed sizes (full ints) + check *type*; **does not read** check field bytes. Payload check is **per block** (CRC32 / CRC64 default / SHA-256 / none). | Combine only when check type is **CRC32** (or we implement CRC64 combine) *and* we seek-read each block’s check bytes. SHA-256 → no. Default CRC64 → need a CRC64 combine helper. Multi-stream files: combine across streams only if check types match. |
-| **zstd** | No frame parser today; optional content checksum = low 32 of XXH64; sizes optional. | Not practical until we parse frames; XXH64 combine is a different animal and we only have 32 bits stored. |
-
-**Recommendation for the hashes implementation change:**
-
-1. Enum + all values `bytes` + zlib `ADLER32` single-stream peek (as above).
-2. **lzip: surface combined `CRC32` for multi-member** via index CRCs + combine
-   (high value, data already in hand).
-3. gzip/xz: keep **single-unit-only** for v0.2.0; optionally xz single-block
-   CRC32 peek. Document combine as the path if we later want multi-gzip/xz
-   without decompress.
-4. Do not pretend a combined digest is “stored by the format” in docs — it’s
-   **derived** from stored per-unit digests; still valid for cheap dedupe and
-   matches `hash(concat(parts))`.
+Full investigation lives in `openspec/changes/surface-stored-stream-digests/design.md`
+(and was drafted here during api-coherence). **CRC-32 and Adler-32 are
+combinable** given `(d1, d2, len2)`; SHA-256 is not. Best immediate win: **lzip
+multi-member**. gzip mid-trailer acquisition and xz CRC64/SHA-256 remain the
+hard parts — deferred in that change.
 
 | **`ArchiveFormat` display name (S2)** | **Add a `display_name` property** (not a method). CLI stops parsing `repr()`. |
 

--- a/review/api-coherence/QUESTIONS.md
+++ b/review/api-coherence/QUESTIONS.md
@@ -1,79 +1,149 @@
 # QUESTIONS — maintainer decisions
 
-> **Status (2026-07-18):** Q1–Q6 still open — no decisions recorded since findings
-> landed in #133. **Q7** was surfaced later (from #149 / Option F review), not in
-> the original api-coherence pass. Triage: `../STATUS.md`.
+> **Status (2026-07-18):** **Q1–Q6 decided** (recorded below). **Q7** deferred to a
+> next review round (not this freeze pass). Triage / follow-up work: `../STATUS.md`.
 
 Per the pause-and-ask rule (`CLAUDE.md`, `CONTRIBUTING.md`): discrepancies and
 judgement calls surfaced, not silently resolved. Ordered by weight.
 
 ## Q1 — Duplicate-name members: unify `is_current`, and what do specs mean? (P1)
 
-Two spec artifacts disagree with each other and with the implementation:
+**Decision: (a) — unify.** Compute last-entry-wins `is_current` in all random-access
+materializations; route exact-same-name duplicates through the non-current skip.
+Update specs so `safe-extraction` and `archive-data-model` agree; make the
+conformance sweep assert the uniform contract (drop the
+`REPLACE if has_duplicates` dodge). Streaming-mode caveat stays documented (forward
+pass cannot know supersession mid-yield).
 
-- `safe-extraction/spec.md:230`: "Content superseded by later same-name or anti →
-  `SKIPPED` on extract" — **no format qualifier**.
-- `archive-data-model/spec.md:206`: the same statement scoped "(7z)".
-- Implementation: ZIP/TAR never compute `is_current`; a duplicate-name ZIP/TAR fails
-  default extraction with `ExtractionError` (O2 collision under `OverwritePolicy.ERROR`)
-  — repro in `parity.md`.
+### Already done? (checked 2026-07-18)
 
-Decision needed: **(a)** compute last-entry-wins `is_current` in all random-access
-materializations and route exact-same-name duplicates through the non-current skip
-(recommended — makes `tar -rf` output extract by default, restores uniformity;
-detailed plan in `members-scope.md` §"What actually needs fixing"), or **(b)** declare
-`is_current` a 7z/RAR-only concept in `archive-data-model`, fix the `safe-extraction`
-scenario wording, and accept that duplicate-name ZIP/TAR needs a non-default
-`OverwritePolicy` (then also fix `get()`'s docstring parenthetical, `reader.py:114`).
-Either way the conformance sweep should assert the chosen contract instead of
-special-casing duplicates (`test_corpus_sweep.py:203`).
+**No — not implemented for ZIP/TAR.** Current code:
+
+| Backend | `is_current` |
+|---|---|
+| 7z | `compute_is_current(...)` in `sevenzip_reader` / `sevenzip_parser` |
+| RAR | history rows get distinct `path;n` names + `is_current=False` |
+| ZIP / TAR | never set — field defaults to `True` (`types.py`) |
+| `base_reader` | no shared last-entry-wins pass |
+
+So a duplicate-name ZIP/TAR still fails default extraction with `ExtractionError`
+(O2 / `OverwritePolicy.ERROR`). The impression that this was already done is
+understandable (7z has the helper; the specs already describe the skip) — but the
+ZIP/TAR materialization path never grew the equivalent. Tracking fix: P1 in
+`SUMMARY.md` / `parity.md`.
+
+---
 
 ## Q2 — `members()` scope: include non-current by default? (maintainer's added question)
 
-Full analysis in `members-scope.md`. Recommendation: keep "everything" as the only
-listing behavior, no include/exclude argument (streaming-TAR can't honor it, a
-boolean doesn't carve the space — anti items are `is_current=True` — and bookkeeping
-alignment breaks); invest in Q1 + docs + predicate recipes instead. Needs an explicit
-yes/no so the visibility table in `safe-extraction` can be marked settled.
+**Decision: yes — keep "everything" as the only listing behavior.** No
+include/exclude argument. Invest in Q1 + docs + predicate recipes
+(`m.is_current`, and `m.is_current and not m.is_anti` for extractable payload).
+Visibility table in `safe-extraction` is settled on this reading.
+
+Full analysis unchanged in `members-scope.md`.
+
+---
 
 ## Q3 — RAR `listing_cost`: `INDEXED` or `REQUIRES_SCANNING`? (P2)
 
-`cost.py:24-27` names "a RAR with no quick-open record" as the canonical
-`REQUIRES_SCANNING` example; `rar_reader.py:773` always reports `INDEXED`; the
-`access-mode-and-cost` spec's example matrix is silent on RAR. Decide which is the
-honest receipt (is the axis "what the format's layout requires" or "what a caller
-pays after open?") and fix the losing artifact + add the RAR row to
-`test_cost_receipt.py`. If the axis is layout-based, distinguishing quick-open RAR5
-from plain requires plumbing a parser fact into the receipt — small but real work,
-which may itself inform the choice.
+**Decision: keep `INDEXED`; fix the docstring / grab-bag prose that claim
+otherwise.** Axis for the receipt: **what the caller pays after `open_archive`
+returns**. Open always materializes the full member table today, so `INDEXED` is
+the honest post-open receipt. Document the *actual* open-time walk (and that QO
+is unused) in format/cost docs — do not invent a `REQUIRES_SCANNING` value the
+caller never observes on `reader.cost`.
+
+### Investigation (2026-07-18)
+
+**How common is “no quick-open”?**
+
+- **RAR 1.5 / 3 / 4:** QO does not exist → 100% of those archives are
+  header-to-header.
+- **RAR5:** QO is optional. WinRAR’s default (`-qo` / bare default) stores QO
+  mainly for *relatively large* files and may omit small-file headers; `-qo+`
+  stores all; `-qo-` stores none (RARLAB technote / 7-Zip FR #1537).
+- **This repo’s fixtures:** 0/15 RAR5 fixtures contain a `QO` service name
+  marker (all small / `-m0` / solid test archives from `scripts/gen_rar_fixtures.py`
+  with no `-qo*` flag). 11 RAR3/4 fixtures never can. So the corpus is entirely
+  “no usable QO,” which matches typical small-archive and non-WinRAR-default
+  producers.
+
+**What does the reader do today?**
+
+- `parse_rar_archive` / `_parse_rar5` / `_parse_rar3` always walk
+  header→packed-skip→header to EOF at open. Service blocks named `QO` are
+  skipped (only `CMT` is special-cased). There is **no locator/QO fast path**.
+- `listing_cost=INDEXED` is unconditional (`rar_reader.py`);
+  `format-rar/spec.md` already describes an indexed backend that builds the
+  member table up front.
+- Member **data** (non-stored) shells out to a fresh `unrar p -n./member …`
+  per open. That process re-parses the archive on the unrar side; native listing
+  work is not reused by unrar.
+
+**How hard would TAR-like lazy scan be?**
+
+Non-trivial and low leverage for v0.2.0:
+
+1. **API shape:** today’s RAR open fails closed on non-seekable sources and
+   publishes `member_count` / full `_members` immediately. A TAR-style
+   `REQUIRES_SCANNING` lazy iterator would need deferred materialization,
+   streaming-mode semantics, and answers for `get()` / extract-prep /
+   solid demux / multi-volume merge / `path;n` history — a real backend redesign,
+   not a receipt tweak.
+2. **QO fast path** (true layout-`INDEXED` without a full walk): parse main-header
+   locator → seek to QO → decode cache structures, with mandatory
+   list/extract same-path discipline (RARLAB security note). Default QO is often
+   *partial*, so you still need a fallback header walk for omitted members.
+   Parser work is real; security footgun if list and extract diverge.
+3. **Payoff vs unrar:** list+stored-hash (founding dedupe path) *would* benefit
+   from cheaper open on huge RAR5-with-QO archives. Extract/open-member workloads
+   remain dominated by `unrar`’s own scan/decompress. Lazy native listing without
+   QO is mostly “pay the same header walk later,” not “avoid it.”
+
+**Conclusion:** keep always-upfront materialization for now → **`INDEXED` is
+correct**. Fix `cost.py`’s `REQUIRES_SCANNING` docstring (drop the “RAR with no
+quick-open record” example), align `docs/grab-bag/SPEC.md` if still cited, add a
+RAR row to `test_cost_receipt.py`, and document in `docs/formats.md` /
+`docs/costs.md`: open always walks headers; QO unused; unrar re-parses on data
+open. Revisit QO-accelerated open only if huge-archive list latency shows up as
+a real workload.
+
+---
 
 ## Q4 — Approve the surface changes (S1/S3)
 
-Pre-release, all free (`surface.md`): demote the 13 `*Context` classes +
-`RAPIDGZIP_AUTO_MIN_COMPRESSED_SIZE` from `__all__`; export `PasswordInput` (and
-decide `OnDiagnostic`); collapse `MemberSelectorArg` into public `MemberSelector`;
-drop `source_name` from `core.__all__`; fill the `api.md` gaps (`open_stream` at
-minimum). Blanket approval or line-item veto?
+**Decision: blanket approve** as proposed in `surface.md`:
+
+- Demote the 13 `*Context` classes + `RAPIDGZIP_AUTO_MIN_COMPRESSED_SIZE` from
+  package `__all__` (remain importable from `archivey.diagnostics` / `config`).
+- Export `PasswordInput`; export `OnDiagnostic` (symmetry with other public
+  callback/param types).
+- Collapse `MemberSelectorArg` into public `MemberSelector`.
+- Drop `source_name` from `core.__all__`.
+- Fill `api.md` gaps (`open_stream` at minimum; other listed gaps).
+
+---
 
 ## Q5 — A `verify` primitive (E2): now or post-0.2.0?
 
-`archivey test` proves the gap (60 lines, generator-semantics traps, poisoned-stream
-data loss). Adding `reader.verify(...) -> VerifyReport` (or `stream_members`
-error-recovery) is additive — it can land after 0.2.0 without breakage, so this is a
-prioritization question, not a freeze question. Related sub-decision: if it lands,
-`ExtractionProgress` gets a neutral-named alias (`ergonomics.md` nits).
+**Decision: defer past 0.2.0.** Additive either way; not worth freezing a shape
+before we know whether callers verify without extracting often enough to justify
+a first-class API (CLI `test` can keep its hand-rolled loop for now). Park in
+`IDEAS.md` / `../STATUS.md` future list; do not block the freeze.
+
+---
 
 ## Q6 — Small freeze-list confirmations
 
-- **`WriteError`**: exported but unraisable until Phase 9. Keep (confident in the
-  name) or demote until writing lands?
-- **`ExtractionStatus.SKIPPED` split (E3)**: add a distinct status or a `reason`
-  field on `ExtractionResult` for non-current skips? Cheap now, negotiation later.
-- **`hashes` value convention**: keep `int` crc32 / `bytes` others (documented), or
-  normalize to `bytes` pre-freeze? Recommendation: keep + document the convention in
-  the field docstring.
-- **`ArchiveFormat` display name** (S2): add `display_name()`/`label` so the CLI
-  stops parsing `repr()`. Name preference?
+| Item | Decision |
+|---|---|
+| **`WriteError`** | **Defer / remove from the read-only 0.2.0 surface.** v0.2.0 is read-only; writing is a later major release. Do not ship writing leftovers — demote/unexport `WriteError` for now. Same spirit: drop or stop advertising the `[7z-write]` extra/dep group until writing is real (py7zr stays a *dev* oracle as needed). |
+| **`ExtractionStatus.SKIPPED` split (E3)** | **Split into distinct statuses** (not a `reason` field). Overwrite-skip and non-current-skip are different caller concerns: most tools ignore superseded members but care that an expected extract hit a pre-existing path. Name at implement (`SUPERSEDED` / `NON_CURRENT` / …) — prefer a clear verb/noun over overloading `SKIPPED`. |
+| **`hashes` value convention** | **Convert `crc32` from `int` to `str`** (hex encoding; exact width/case fixed at implement — recommend lowercase, zero-padded 8 hex digits, no `0x`). No-surprises move; cheap pre-freeze. **Implementer note:** `blake2sp` is already `bytes` — converting only crc32 still leaves a mixed value type. Prefer aligning `blake2sp` to hex `str` in the same change so `hashes: Mapping[str, str]`, unless a follow-up objection lands. |
+| **`ArchiveFormat` display name (S2)** | **Add a `display_name` property** (not a method). CLI stops parsing `repr()`. |
+
+---
 
 ## Q7 — Partial members + honest error accessor (later-surfaced)
 
@@ -81,38 +151,24 @@ prioritization question, not a freeze question. Related sub-decision: if it land
 > Option F) — not part of the original api-coherence finding set in #133. Adjacent to
 > **E2 / Q5** and to salvage in `IDEAS.md` / `../backlog.md`, but not the same question.
 
-For scan-required formats (TAR today; others similarly), a pass can recover a usable
-*prefix* of members and still hit a terminal archive-level error (rejected mid/final
-header, strict missing trailer, mid-pass decode failure, …). VISION claim (3) wants
-**recoverable members + an honest error**, not members *or* an error. Today the
-library forces a false dichotomy:
+**Decision: leave for a next review round.** Do not explore or redesign in this
+freeze pass. Option F’s interim contract (RA fail-closed / streaming
+salvage-then-raise) stands; ownership of the VISION claim-(3) gap moves to the
+next round / backlog (cross-link from EOF design remains fine).
 
-- **Silence the error** (pre-Option F warn on TAR `nonzero`) — dishonest for inventory.
-- **Raise and hide the members** (RA `members()` / `__iter__` / extract-prep fail
-  closed under Option F) — honest error, but throws away the recoverable listing.
-- **Yield then raise** (streaming `__iter__` / `stream_members` / extract) — caller
-  sees members only while iterating; there is still no first-class “here is the
-  list we got + the error” result from materializing APIs.
+---
 
-**Q5 / E2** covers per-member integrity-check recovery (`verify` /
-`stream_members` continuing past a bad *member*). **Salvage** covers best-effort
-resync past damage. **Q7** is narrower: a uniform way to surface a **partial
-listing together with a terminal archive error** without silencing either side —
-and without silently republishing a partial cache as a complete listing (archived
-concurrency N1).
+## Decision → implementation map
 
-Decision needed (exploration, not a freeze blocker):
-
-1. **Park vs explore now** — leave Option F’s RA fail-closed / streaming
-   salvage-then-raise split as the interim contract, or open an OpenSpec explore
-   change (e.g. `explore-partial-members-and-errors`) before 0.2.0 docs freeze the
-   dichotomy?
-2. **API shape if explored** — e.g. `members()` stays raise-on-terminal-error;
-   new `list_with_status()` / report object returns `(members, error|None)`; or
-   error only on `reader.diagnostics` with an explicit “listing incomplete” flag?
-3. **Uniformity** — how RA materialize-then-raise and streaming yield-then-raise
-   reconcile under one contract; interaction with CLI `list` / `test` exit codes.
-
-Recommendation: **park for Option F merge**; add a one-line cross-link from the
-EOF change’s design open-questions; open the explore change (or answer “post-0.2.0
-with salvage”) explicitly so the gap is owned.
+| Decision | Follow-up (code/docs; not this PR unless noted) |
+|---|---|
+| Q1 (a) | Shared last-entry-wins on ZIP/TAR RA materialization; spec delta; sweep asserts |
+| Q2 | Docs / recipes only once Q1 lands |
+| Q3 | Fix `cost.py` docstring + receipt test + formats/costs prose |
+| Q4 | Surface PR (demote/export/docs) |
+| Q5 | `IDEAS.md` park only |
+| Q6 WriteError / `[7z-write]` | Demote exception; remove or un-advertise extra |
+| Q6 SKIPPED split | New `ExtractionStatus` value + CLI/report call sites |
+| Q6 hashes → str | Type + backends + docs/formats matrix + CLI formatter |
+| Q6 `display_name` | Property on `ArchiveFormat` + CLI |
+| Q7 | Next round — see `../backlog.md` / STATUS future list |

--- a/review/api-coherence/QUESTIONS.md
+++ b/review/api-coherence/QUESTIONS.md
@@ -140,7 +140,25 @@ a first-class API (CLI `test` can keep its hand-rolled loop for now). Park in
 |---|---|
 | **`WriteError`** | **Defer / remove from the read-only 0.2.0 surface.** v0.2.0 is read-only; writing is a later major release. Do not ship writing leftovers — demote/unexport `WriteError` for now. Same spirit: drop or stop advertising the `[7z-write]` extra/dep group until writing is real (py7zr stays a *dev* oracle as needed). |
 | **`ExtractionStatus.SKIPPED` split (E3)** | **Split into distinct statuses** (not a `reason` field). Overwrite-skip and non-current-skip are different caller concerns: most tools ignore superseded members but care that an expected extract hit a pre-existing path. Name at implement (`SUPERSEDED` / `NON_CURRENT` / …) — prefer a clear verb/noun over overloading `SKIPPED`. |
-| **`hashes` value convention** | **All values `bytes`; keys become a `HashAlgorithm` enum.** Today: `Mapping[str, int \| bytes]` with string keys `"crc32"` / `"blake2sp"` and **no** hash-algorithm enum (`types.py` — only `CompressionAlgorithm` et al.). Target: `Mapping[HashAlgorithm, bytes]` (crc32 as 4-byte digest, not `int`; blake2sp already `bytes`). Prefer `HashAlgorithm(str, Enum)` with values `"crc32"` / `"blake2sp"` so it sits next to other public enums and stringly access stays tolerable during migration. Endianness of the 4-byte crc32: fix at implement (document clearly — big-endian is the usual “digest bytes” convention). Not crc32c (Castagnoli) — we only surface archive-stored CRC-32. |
+| **`hashes` value convention** | **All values `bytes`; keys become a `HashAlgorithm` enum.** Today: `Mapping[str, int \| bytes]` with string keys `"crc32"` / `"blake2sp"` and **no** hash-algorithm enum (`types.py` — only `CompressionAlgorithm` et al.). Target: `Mapping[HashAlgorithm, bytes]` (crc32 as 4-byte digest, not `int`; blake2sp already `bytes`). Prefer `HashAlgorithm(str, Enum)` with at least `CRC32 = "crc32"`, `BLAKE2SP = "blake2sp"`, **`ADLER32 = "adler32"`**. Endianness of 4-byte crc32/adler32: fix at implement (document clearly — big-endian is the usual “digest bytes” convention; note zlib stores Adler-32 network-order on the wire). |
+
+### Q6 hashes — what formats store today / Adler-32 parity
+
+**Currently surfaced** (only these two algorithms):
+
+| Algorithm | Where |
+|---|---|
+| `crc32` | ZIP (CD), 7z (when present), RAR5 (when present), single-file `.gz` (single-member trailer), `.lz` (seekable trailer) |
+| `blake2sp` | RAR5 only (HASH extra) |
+
+Nothing else is exposed. Docs/specs explicitly say `.bz2` / `.xz` / **zlib** / brotli / `.Z` have no cheap whole-member digest — that line is **wrong for zlib**: RFC 1950 puts a 4-byte **Adler-32** of the uncompressed data at the end of every zlib stream (not CRC-32). Gzip uses CRC-32 in its trailer; raw ZIP deflate has neither (ZIP’s CRC lives in the directory).
+
+**Can we fill `adler32`?** Yes, for standalone zlib (`.zz` / detected zlib), same shape as the gzip crc probe: on a seekable/path single-stream source, peek the last 4 bytes without decompressing and set `hashes[HashAlgorithm.ADLER32]`. Wire order is already big-endian (RFC 1950). Caveats to document at implement: trailing junk or concatenated zlib streams make “last 4 bytes” unreliable (gzip already special-cases multi-member); omit on non-seekable sources. Wire verification already happens inside `zlib` decompress; surfacing is for cheap dedupe (VISION). Also teach `verify.py`’s hasher table `adler32` via `zlib.adler32` (today only `crc32` / `blake2sp`).
+
+**Out of scope unless demand shows up:** xz stream checks (CRC32/CRC64/SHA256), zstd content checksums (xxHash), etc. — different algorithms, harder “cheap without decompress” stories. `HashAlgorithm` should be easy to extend when those land.
+
+Fold Adler-32 zlib surfacing into the same hashes implementation change as the enum + crc32→bytes migration (parity fix, not a separate freeze question).
+
 | **`ArchiveFormat` display name (S2)** | **Add a `display_name` property** (not a method). CLI stops parsing `repr()`. |
 
 ---
@@ -169,6 +187,6 @@ next round / backlog (cross-link from EOF design remains fine).
 | Q5 | `IDEAS.md` park only |
 | Q6 WriteError / `[7z-write]` | Demote exception; remove or un-advertise extra |
 | Q6 SKIPPED split | New `ExtractionStatus` value + CLI/report call sites |
-| Q6 hashes → `Mapping[HashAlgorithm, bytes]` | Add enum; crc32 `int`→4-byte `bytes`; update backends, verify, specs, `docs/formats.md`, CLI formatter |
+| Q6 hashes → `Mapping[HashAlgorithm, bytes]` | Add enum (`CRC32` / `BLAKE2SP` / `ADLER32`); crc32 `int`→4-byte `bytes`; surface zlib trailer as `ADLER32`; update backends, verify, specs, `docs/formats.md`, CLI formatter |
 | Q6 `display_name` | Property on `ArchiveFormat` + CLI |
 | Q7 | Next round — see `../backlog.md` / STATUS future list |

--- a/review/api-coherence/QUESTIONS.md
+++ b/review/api-coherence/QUESTIONS.md
@@ -140,7 +140,7 @@ a first-class API (CLI `test` can keep its hand-rolled loop for now). Park in
 |---|---|
 | **`WriteError`** | **Defer / remove from the read-only 0.2.0 surface.** v0.2.0 is read-only; writing is a later major release. Do not ship writing leftovers — demote/unexport `WriteError` for now. Same spirit: drop or stop advertising the `[7z-write]` extra/dep group until writing is real (py7zr stays a *dev* oracle as needed). |
 | **`ExtractionStatus.SKIPPED` split (E3)** | **Split into distinct statuses** (not a `reason` field). Overwrite-skip and non-current-skip are different caller concerns: most tools ignore superseded members but care that an expected extract hit a pre-existing path. Name at implement (`SUPERSEDED` / `NON_CURRENT` / …) — prefer a clear verb/noun over overloading `SKIPPED`. |
-| **`hashes` value convention** | **Convert `crc32` from `int` to `str`** (hex encoding; exact width/case fixed at implement — recommend lowercase, zero-padded 8 hex digits, no `0x`). No-surprises move; cheap pre-freeze. **Implementer note:** `blake2sp` is already `bytes` — converting only crc32 still leaves a mixed value type. Prefer aligning `blake2sp` to hex `str` in the same change so `hashes: Mapping[str, str]`, unless a follow-up objection lands. |
+| **`hashes` value convention** | **All values `bytes`; keys become a `HashAlgorithm` enum.** Today: `Mapping[str, int \| bytes]` with string keys `"crc32"` / `"blake2sp"` and **no** hash-algorithm enum (`types.py` — only `CompressionAlgorithm` et al.). Target: `Mapping[HashAlgorithm, bytes]` (crc32 as 4-byte digest, not `int`; blake2sp already `bytes`). Prefer `HashAlgorithm(str, Enum)` with values `"crc32"` / `"blake2sp"` so it sits next to other public enums and stringly access stays tolerable during migration. Endianness of the 4-byte crc32: fix at implement (document clearly — big-endian is the usual “digest bytes” convention). Not crc32c (Castagnoli) — we only surface archive-stored CRC-32. |
 | **`ArchiveFormat` display name (S2)** | **Add a `display_name` property** (not a method). CLI stops parsing `repr()`. |
 
 ---
@@ -169,6 +169,6 @@ next round / backlog (cross-link from EOF design remains fine).
 | Q5 | `IDEAS.md` park only |
 | Q6 WriteError / `[7z-write]` | Demote exception; remove or un-advertise extra |
 | Q6 SKIPPED split | New `ExtractionStatus` value + CLI/report call sites |
-| Q6 hashes → str | Type + backends + docs/formats matrix + CLI formatter |
+| Q6 hashes → `Mapping[HashAlgorithm, bytes]` | Add enum; crc32 `int`→4-byte `bytes`; update backends, verify, specs, `docs/formats.md`, CLI formatter |
 | Q6 `display_name` | Property on `ArchiveFormat` + CLI |
 | Q7 | Next round — see `../backlog.md` / STATUS future list |

--- a/review/api-coherence/SUMMARY.md
+++ b/review/api-coherence/SUMMARY.md
@@ -1,10 +1,9 @@
 # API-coherence review — SUMMARY
 
-> **Status (2026-07-18):** findings delivered in #133; **no code follow-ups have
-> landed yet.** Every row in the table below is still open. Blockers that need
-> a maintainer answer first: **Q1–Q6** (`QUESTIONS.md`). **Q7** (partial members +
-> honest error) was surfaced later from #149 — see `QUESTIONS.md`. Mechanical
-> surface work (S1/S2/S3/E1/E3) is actionable after Q4/Q6. Triage: `../STATUS.md`.
+> **Status (2026-07-18):** findings delivered in #133; **Q1–Q6 decided**
+> (`QUESTIONS.md`) — code follow-ups not landed yet. **Q7** deferred to a next
+> review round. Mechanical surface work (S1/S2/S3/E1/E3) and P1/`is_current` are
+> now unblocked. Triage: `../STATUS.md`.
 
 Reviewed at `main` + CLI (#120) merged (`7139c13`). Baseline (all captured before
 review, `[all]` config): pytest **1699 passed / 131 skipped / 3 deselected**, pyrefly
@@ -45,20 +44,20 @@ subtle generator semantics); and `ArchiveFormat` has no display name (the CLI pa
 
 | # | Severity | Finding | Where | Status |
 |---|----------|---------|-------|--------|
-| P1 | **High** | Duplicate-name members: `is_current` computed only by 7z/RAR; ZIP/TAR default extraction *errors* where 7z silently skips — same input, divergent outcome; `safe-extraction` scenario ("superseded by later same-name → SKIPPED") is format-silent and currently false for ZIP/TAR | `sevenzip_parser.py:331`, `extraction.py:351`, repro in `parity.md` | **open — needs Q1** |
-| E1 | Medium | No public measurement/IO-stats API: CLI `--track-io` imports `enable_measurement` + `BaseArchiveReader` from `internal/` and reads three counters not on the `ArchiveReader` ABC | `cli/common.py:15-16,56-68`, `base_reader.py:557-1009` | **open** — proposed fix; actionable after Q4 nod |
-| E2 | Medium | No library "verify" primitive: `archivey test` hand-rolls manual `next()` loop; a mid-pass failure poisons the stream and loses remaining members | `cli/test_cmd.py:56-73` | **open — needs Q5** (now vs post-0.2.0) |
-| S1 | Medium | `__all__` = 90 names: 13 `*Context` classes + `RAPIDGZIP_AUTO_MIN_COMPRESSED_SIZE` should demote; `PasswordInput` / `OnDiagnostic` missing; `MemberSelector` vs internal `MemberSelectorArg` duplicate aliases used inconsistently in one class | `__init__.py:113-204`, `reader.py:27,148` | **open — needs Q4** |
-| P2 | Low-Med | RAR `listing_cost=INDEXED` always, but `cost.py` docstring names "RAR with no quick-open record" as the canonical `REQUIRES_SCANNING` example — doc/impl conflict on an honest-cost axis | `rar_reader.py:773` vs `cost.py:24-27` | **open — needs Q3** |
-| E3 | Low | `ExtractionStatus.SKIPPED` conflates overwrite-skip and non-current-skip; caller must infer reason via `member.is_current` | `extraction_types.py:80-87`, `extraction.py:351` | **open — needs Q6** |
-| S2 | Low | `ArchiveFormat` has no display-name property; CLI string-parses `repr()` | `cli/info_cmd.py:16-23` | **open — needs Q6** |
-| S3 | Low | `archivey.core.__all__` exports internal helper `source_name`; `docs/api.md` omits `open_stream`, `MemberStreams`, selectors, format-support queries | `core.py:78`, `docs/api.md` | **open — needs Q4** |
+| P1 | **High** | Duplicate-name members: `is_current` computed only by 7z/RAR; ZIP/TAR default extraction *errors* where 7z silently skips — same input, divergent outcome; `safe-extraction` scenario ("superseded by later same-name → SKIPPED") is format-silent and currently false for ZIP/TAR | `sevenzip_parser.py:331`, `extraction.py:351`, repro in `parity.md` | **decided Q1=(a)** — unify last-entry-wins; **not yet implemented** (ZIP/TAR still default `True`) |
+| E1 | Medium | No public measurement/IO-stats API: CLI `--track-io` imports `enable_measurement` + `BaseArchiveReader` from `internal/` and reads three counters not on the `ArchiveReader` ABC | `cli/common.py:15-16,56-68`, `base_reader.py:557-1009` | **actionable** (Q4 approved) |
+| E2 | Medium | No library "verify" primitive: `archivey test` hand-rolls manual `next()` loop; a mid-pass failure poisons the stream and loses remaining members | `cli/test_cmd.py:56-73` | **deferred** (Q5 — post-0.2.0 / maybe never) |
+| S1 | Medium | `__all__` = 90 names: 13 `*Context` classes + `RAPIDGZIP_AUTO_MIN_COMPRESSED_SIZE` should demote; `PasswordInput` / `OnDiagnostic` missing; `MemberSelector` vs internal `MemberSelectorArg` duplicate aliases used inconsistently in one class | `__init__.py:113-204`, `reader.py:27,148` | **decided Q4=approve** — implement |
+| P2 | Low-Med | RAR `listing_cost=INDEXED` always, but `cost.py` docstring names "RAR with no quick-open record" as the canonical `REQUIRES_SCANNING` example — doc/impl conflict on an honest-cost axis | `rar_reader.py:773` vs `cost.py:24-27` | **decided Q3=`INDEXED`** — fix docstring + document actual open walk (QO unused); see investigation in `QUESTIONS.md` |
+| E3 | Low | `ExtractionStatus.SKIPPED` conflates overwrite-skip and non-current-skip; caller must infer reason via `member.is_current` | `extraction_types.py:80-87`, `extraction.py:351` | **decided Q6=split statuses** — implement |
+| S2 | Low | `ArchiveFormat` has no display-name property; CLI string-parses `repr()` | `cli/info_cmd.py:16-23` | **decided Q6=`display_name` property** — implement |
+| S3 | Low | `archivey.core.__all__` exports internal helper `source_name`; `docs/api.md` omits `open_stream`, `MemberStreams`, selectors, format-support queries | `core.py:78`, `docs/api.md` | **decided Q4=approve** — implement |
 | D1 | Low | CLI list line has no mark for `ANTI` (falls to `"?"`, same as `OTHER`) and no non-current indicator — the member model's own distinctions are invisible in the first consumer | `cli/format.py:9-15` | **defer to `cli-product/`** |
 
 ## The maintainer's extra question (members scope)
 
-Analyzed in **`members-scope.md`**. Short version: **keep `members()` / iterators
-returning everything, do not add an include/exclude argument** — a default-exclude is
+Analyzed in **`members-scope.md`**. **Decided (Q2): keep `members()` / iterators
+returning everything; no include/exclude argument.** A default-exclude is
 unimplementable for streaming TAR (last-entry-wins is unknowable mid-pass), breaks
 `member_count` and `ExtractionReport` alignment, and doesn't even serve the intuitive
 goal (anti entries are `is_current=True`, so "current only" still shows tombstones).

--- a/review/api-coherence/ergonomics.md
+++ b/review/api-coherence/ergonomics.md
@@ -67,11 +67,11 @@ the CLI proves the gap with working code today. → Q5.
 `SKIPPED` is recorded both for "destination existed under `OverwritePolicy.SKIP`"
 (`extraction_types.py:84`) and for "member is non-current" (`extraction.py:351-354`).
 A report consumer (like the CLI's summary, which prints `skipped: <name>` for both)
-can only distinguish by re-deriving `result.member.is_current`. Cheap pre-release fix:
-either a fourth status (`SUPERSEDED`?) or a `reason` field on `ExtractionResult`.
-Post-freeze this becomes a compatibility negotiation. (The third skip-ish concept —
-user-filter skip — produces *no* result row, which is defensible but worth one
-docstring sentence on `extract_all`.)
+can only distinguish by re-deriving `result.member.is_current`. **Decided (Q6): split into distinct statuses** (not a `reason` field) — overwrite-skip
+vs non-current-skip are different caller concerns. Name at implement
+(`SUPERSEDED` / `NON_CURRENT` / …). (The third skip-ish concept — user-filter skip —
+produces *no* result row, which is defensible but worth one docstring sentence on
+`extract_all`.)
 
 ## The three canonical jobs, walked
 
@@ -89,9 +89,8 @@ Two lines of ceremony; stored-vs-computed fallback documented as a recipe in
 
 - `hashes` values are `int | bytes` (crc32 int, blake2sp bytes) — every consumer
   needs a formatting/normalizing branch (the CLI grew `format_hash_value`,
-  `cli/format.py:46-49`). Faithful-but-annoying; a documented convention ("crc32 is
-  an int; everything else bytes") is probably enough, but normalizing to `bytes` was
-  also available pre-freeze. Judgement call, low stakes.
+  `cli/format.py:46-49`). **Decided (Q6): convert `crc32` to `str` (hex)**; prefer
+  aligning `blake2sp` to hex `str` in the same change so values are uniformly `str`.
 - The recipe iterates *all* members — including superseded 7z revisions and RAR
   history rows, silently hashing dead content. After Q1/Q2, add one `is_current`
   line to the recipe (see `members-scope.md`).

--- a/review/api-coherence/ergonomics.md
+++ b/review/api-coherence/ergonomics.md
@@ -90,9 +90,9 @@ Two lines of ceremony; stored-vs-computed fallback documented as a recipe in
 - `hashes` is `Mapping[str, int | bytes]` today (crc32 int, blake2sp bytes; string
   keys, **no** algorithm enum) — every consumer needs a formatting/normalizing
   branch (the CLI grew `format_hash_value`, `cli/format.py:46-49`). **Decided
-  (Q6): `Mapping[HashAlgorithm, bytes]`** — add the enum (`CRC32` / `BLAKE2SP` /
-  `ADLER32`); crc32 becomes 4-byte `bytes`; surface zlib’s Adler-32 trailer for
-  parity with gzip’s crc32 probe.
+  (Q6 typing): `Mapping[HashAlgorithm, bytes]`** — add the enum (`CRC32` /
+  `BLAKE2SP` / `ADLER32`); crc32 becomes 4-byte `bytes`. **Filling** zlib Adler /
+  multi-lzip CRC: separate OpenSpec change `surface-stored-stream-digests`.
 - The recipe iterates *all* members — including superseded 7z revisions and RAR
   history rows, silently hashing dead content. After Q1/Q2, add one `is_current`
   line to the recipe (see `members-scope.md`).

--- a/review/api-coherence/ergonomics.md
+++ b/review/api-coherence/ergonomics.md
@@ -87,10 +87,11 @@ Two lines of ceremony; stored-vs-computed fallback documented as a recipe in
 `usage.md` with the per-format matrix one link away. **Discoverability is good** —
 `hashes` is on the dataclass with a docstring naming the key convention. Two notes:
 
-- `hashes` values are `int | bytes` (crc32 int, blake2sp bytes) — every consumer
-  needs a formatting/normalizing branch (the CLI grew `format_hash_value`,
-  `cli/format.py:46-49`). **Decided (Q6): convert `crc32` to `str` (hex)**; prefer
-  aligning `blake2sp` to hex `str` in the same change so values are uniformly `str`.
+- `hashes` is `Mapping[str, int | bytes]` today (crc32 int, blake2sp bytes; string
+  keys, **no** algorithm enum) — every consumer needs a formatting/normalizing
+  branch (the CLI grew `format_hash_value`, `cli/format.py:46-49`). **Decided
+  (Q6): `Mapping[HashAlgorithm, bytes]`** — add the enum; crc32 becomes 4-byte
+  `bytes` like every other digest.
 - The recipe iterates *all* members — including superseded 7z revisions and RAR
   history rows, silently hashing dead content. After Q1/Q2, add one `is_current`
   line to the recipe (see `members-scope.md`).

--- a/review/api-coherence/ergonomics.md
+++ b/review/api-coherence/ergonomics.md
@@ -90,8 +90,9 @@ Two lines of ceremony; stored-vs-computed fallback documented as a recipe in
 - `hashes` is `Mapping[str, int | bytes]` today (crc32 int, blake2sp bytes; string
   keys, **no** algorithm enum) — every consumer needs a formatting/normalizing
   branch (the CLI grew `format_hash_value`, `cli/format.py:46-49`). **Decided
-  (Q6): `Mapping[HashAlgorithm, bytes]`** — add the enum; crc32 becomes 4-byte
-  `bytes` like every other digest.
+  (Q6): `Mapping[HashAlgorithm, bytes]`** — add the enum (`CRC32` / `BLAKE2SP` /
+  `ADLER32`); crc32 becomes 4-byte `bytes`; surface zlib’s Adler-32 trailer for
+  parity with gzip’s crc32 probe.
 - The recipe iterates *all* members — including superseded 7z revisions and RAR
   history rows, silently hashing dead content. After Q1/Q2, add one `is_current`
   line to the recipe (see `members-scope.md`).

--- a/review/api-coherence/members-scope.md
+++ b/review/api-coherence/members-scope.md
@@ -107,4 +107,4 @@ raw surface; anti entries need a decision (they are current); and `7z l` parity 
 lost. This is strictly more surface and more per-format caveats than the
 recommendation — which is why it isn't the recommendation.
 
-→ Decision recorded as **Q2** in `QUESTIONS.md`.
+→ **Decided (Q2):** keep everything; no include/exclude argument. See `QUESTIONS.md`.

--- a/review/api-coherence/parity.md
+++ b/review/api-coherence/parity.md
@@ -80,14 +80,15 @@ one spec delta + backend materialization change + sweep assertion.
 
 `ListingCost.REQUIRES_SCANNING`'s docstring names its canonical examples: "an
 uncompressed tar, **or a RAR with no quick-open record**" (`cost.py:24-27`). The RAR
-backend reports `INDEXED` unconditionally (`rar_reader.py:773`). The native parser does
-walk headers file-by-file at open (there is no central index in RAR without the
-quick-open record), so by the receipt's own definition ("describes static open-time
-properties" — `access-mode-and-cost` spec) the honest value for a no-quick-open RAR is
-arguably `REQUIRES_SCANNING`; by the "cost you'll pay *now*" reading it's `INDEXED`
-because open already paid the scan. The two public artifacts disagree — **Q3**.
-(`access-mode-and-cost`'s example matrix lists ZIP/tar/7z but is silent on RAR, so the
-spec doesn't break the tie.)
+backend reports `INDEXED` unconditionally. The native parser always walks
+headers at open and never reads QO; after open, listing is already paid.
+
+**Decided (Q3): keep `INDEXED`; fix the docstring.** Receipt axis = what the
+caller pays *after* open. Investigation (prevalence of no-QO, cost of a
+TAR-like lazy scan, unrar re-parse on member open) is in `QUESTIONS.md` §Q3 —
+short version: no-QO is common (all RAR3/4; small/default-partial RAR5; **0/15**
+of this repo’s RAR5 fixtures have a QO marker); lazy/QO paths are real work with
+limited payoff while data opens go through `unrar` anyway.
 
 ## The rest of the matrix — checked, uniform
 

--- a/review/api-coherence/surface.md
+++ b/review/api-coherence/surface.md
@@ -65,8 +65,9 @@ having decided what it promises. Either document or demote each. Migration: doc-
   `file_extension()`-style method `display_name()`) returning `"ZIP"`, `"TAR_GZ"`, or
   the constructed fallback. One property; the CLI helper collapses.
 - **`WriteError`** — exported and documented in the tree, but nothing raises it until
-  Phase 9 writing lands. Freezing an unraisable exception is harmless-but-odd; keep
-  only if you're confident Phase 9 keeps the name (Q6).
+  Phase 9 writing lands. **Decided (Q6): demote / remove from the 0.2.0 read-only
+  surface** (and stop advertising `[7z-write]` until writing is real). Do not freeze
+  writing leftovers into the first public release.
 
 ## Smallest surface that still serves the three use cases
 

--- a/review/backlog.md
+++ b/review/backlog.md
@@ -140,3 +140,9 @@ unbuilt; reads are all-or-error. This is a feature to *design and propose* (an
 OpenSpec change), not something a review finds. Flagged here only so it doesn't get
 lost among the review topics — it likely outranks both topics above in product value,
 and `--salvage` is already reserved in the CLI grammar waiting for it.
+
+**Partial members + honest error accessor (api-coherence Q7)** — adjacent to salvage
+but narrower: a uniform way for scan-required formats to return a *prefix* listing
+together with a terminal archive error, without silencing either side. Surfaced from
+#149 Option F; **deferred to a next review round** (not the 0.2.0 freeze). See
+`api-coherence/QUESTIONS.md` §Q7.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Records maintainer decisions for `review/api-coherence` open questions, plus a new OpenSpec change for filling stored stream digests.

## Decisions (api-coherence)

| Q | Decision |
|---|---|
| **Q1** | Unify last-entry-wins `is_current` (a). Not already implemented on ZIP/TAR. |
| **Q2** | Keep `members()` = everything. |
| **Q3** | Keep RAR `listing_cost=INDEXED`; fix docs. |
| **Q4** | Blanket approve surface demotions/exports. |
| **Q5** | Defer `verify` past 0.2.0. |
| **Q6** | Demote `WriteError` / `[7z-write]`; split `SKIPPED` statuses; **`hashes: Mapping[HashAlgorithm, bytes]`** (typing only in review fixes); `display_name` property. |
| **Q7** | Next review round. |

## New OpenSpec change: `surface-stored-stream-digests`

Filling digests is a **separate** change (depends on the hashes typing PR):

- zlib Adler-32 cheap peek
- lzip multi-member CRC via `crc32_combine`
- verify `adler32` support
- gzip/xz multi-unit deferred

Artifacts complete (`proposal` / `design` / `specs` / `tasks` / `brief`). Ready for `/opsx:apply` after typing lands.

Follow-up implementation: review-fix PRs from `STATUS.md` §1; then `surface-stored-stream-digests`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e8825279-a5ba-4b35-a0e1-684834430f72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e8825279-a5ba-4b35-a0e1-684834430f72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

