### PR TITLE
Implement api-coherence Q1–Q6 follow-ups

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,8 +87,8 @@ Notes:
 7z and RAR are read with **native** parsers, not `py7zr` / `rarfile`:
 - 7z: native header parse + stdlib `lzma`/`bz2`/`zlib` for the common codecs
   (core, zero-dep). PPMd/Deflate64 via the `[7z]` extra; AES decryption via
-  `[crypto]`; BCJ2 is detected and rejected. `py7zr` is kept only for 7z *writing*
-  (`[7z-write]`) and as a test oracle.
+  `[crypto]`; BCJ2 is detected and rejected. `py7zr` is a **dev oracle** only
+  (7z writing is not shipped; no `[7z-write]` extra).
 - RAR: native RAR3/RAR5 metadata parser (drops `rarfile`); the external `unrar`
   binary remains the decompressor for member data. Encrypted headers are decrypted
   natively via `[crypto]`. `rarfile` is a test oracle only.

--- a/PLAN.md
+++ b/PLAN.md
@@ -223,8 +223,8 @@ All codec/detection-dependent formats stay unwired until Phases 2–3.
 ### Tasks
 1. **`pyproject.toml`** (clean slate): `hatchling`; `[project]` `archivey`,
    `0.2.0.dev0`, Python `>=3.11`; extras exactly per `packaging-and-extras/spec.md`
-   (`[7z]`, `[rar]`, `[crypto]`, `[7z-write]`, `[iso]`, `[zstd]`, `[lz4]`, `[cli]`,
-   `[seekable]`, `[recommended-lite]`, `[recommended]`, `[all]`); `dev`
+   (`[7z]`, `[rar]`, `[crypto]`, `[iso]`, `[zstd]`, `[lz4]`, `[cli]`,
+   `[seekable]`, `[recommended-lite]`, `[recommended]`, `[all]`; no `[7z-write]` until writing ships); `dev`
    `[dependency-groups]` for tooling + oracles (`py7zr`, `rarfile`); `pyrefly` + `ty`
    (strict, both kept clean — no mypy), `ruff`, `coverage` (report only, no gate).
 2. **Package layout:** `src/archivey/` with `internal/`, `formats/`, the public
@@ -496,8 +496,9 @@ the parallel-extraction entry in `IDEAS.md`.
    files info) + decode via stdlib `lzma`(raw)/`bz2`/`zlib` + STORED; true pull
    streaming for `stream_members()`, decode-from-folder-start for random `open()`;
    PPMd/Deflate64 via `[7z]`, AES via `[crypto]`; **BCJ2 and unknown method IDs
-   rejected explicitly** (never silent fallback). 7z **writing** stays on `py7zr`
-   behind `[7z-write]` (writing phase); reads import no third-party lib.
+   rejected explicitly** (never silent fallback). 7z **writing** is deferred (no
+   `[7z-write]` extra in the current release); `py7zr` remains a **dev oracle** only;
+   reads import no third-party lib.
 2. **Native RAR** RAR4/RAR5 metadata parse (listing without `unrar`); member data
    via a single `unrar p -inul` pipe demultiplexed by header sizes with incremental
    CRC32; header-encrypted RAR5 decrypted via `[crypto]`; multi-volume joining.

--- a/docs/acknowledgements.md
+++ b/docs/acknowledgements.md
@@ -32,7 +32,7 @@ These are not on the primary read path (except where noted).
 
 | Project | Role |
 | --- | --- |
-| [py7zr](https://github.com/miurahr/py7zr) (Hiroshi Miura et al.) | 7z **format reference**, write backend under `[7z-write]`, and **dev oracle** / optional external corpus (`ARCHIVEY_PY7ZR_TEST_FILES`). Reading is native — see [ADR 0001](decisions/0001-native-7z-not-py7zr.md). |
+| [py7zr](https://github.com/miurahr/py7zr) (Hiroshi Miura et al.) | 7z **format reference** and **dev oracle** / optional external corpus (`ARCHIVEY_PY7ZR_TEST_FILES`). Reading is native; writing is not shipped yet — see [ADR 0001](decisions/0001-native-7z-not-py7zr.md). |
 | [rarfile](https://github.com/markokr/rarfile) | RAR **format reference**, **dev oracle**, optional corpus (`ARCHIVEY_RARFILE_TEST_FILES`), and two legacy fixtures under `tests/fixtures/rar/` (RAR 1.5 / 2.0). Reading metadata is native; data uses RARLAB `unrar` — see [ADR 0002](decisions/0002-native-rar-metadata-unrar-data.md). |
 | [libarchive](https://github.com/libarchive/libarchive) (+ [libarchive-c](https://github.com/Changaco/python-libarchive-c)) | Optional **cross-format corpus** oracle (`ARCHIVEY_LIBARCHIVE_TEST_FILES` → libarchive’s `libarchive/test` uuencoded archives). Dev-only; not a runtime backend. |
 | [7-Zip](https://www.7-zip.org/) / `7z` CLI ([p7zip](https://github.com/p7zip-project/p7zip)) | Fixture builder and anti-item / encrypted-ZIP oracle in tests (when installed). |
@@ -62,7 +62,6 @@ Bare `pip install archivey` has **no** third-party runtime deps. Named extras pu
 | --- | --- |
 | `[7z]` | [pyppmd](https://github.com/miurahr/pyppmd), [inflate64](https://github.com/miurahr/inflate64), [brotli](https://github.com/google/brotli), [lz4](https://github.com/python-lz4/python-lz4), [cryptography](https://github.com/pyca/cryptography), [pybcj](https://github.com/miurahr/pybcj), [backports.zstd](https://github.com/Rogdham/backports.zstd) (Python before 3.14) |
 | `[rar]` / `[crypto]` | [cryptography](https://github.com/pyca/cryptography) (Blake2sp backend still TBD) |
-| `[7z-write]` | [py7zr](https://github.com/miurahr/py7zr) |
 | `[iso]` | [pycdlib](https://github.com/clalancette/pycdlib) |
 | `[zstd]` | [backports.zstd](https://github.com/Rogdham/backports.zstd) on Python before 3.14; 3.14+ uses stdlib `compression.zstd` |
 | `[lz4]` | [lz4](https://github.com/python-lz4/python-lz4) |

--- a/docs/api.md
+++ b/docs/api.md
@@ -7,13 +7,19 @@ contracts: `openspec/specs/`.
 ## Opening archives
 
 ::: archivey.open_archive
+::: archivey.open_stream
 ::: archivey.extract
 ::: archivey.detect_format
+::: archivey.format_availability
+::: archivey.list_supported_formats
+::: archivey.list_known_formats
 
 ## The reader interface
 
 ::: archivey.ArchiveReader
 ::: archivey.ArchiveStream
+::: archivey.MemberSelector
+::: archivey.MemberStreams
 
 ## Data model
 
@@ -23,6 +29,8 @@ contracts: `openspec/specs/`.
 ::: archivey.ContainerFormat
 ::: archivey.StreamFormat
 ::: archivey.MemberType
+::: archivey.HashAlgorithm
+::: archivey.crc32_digest
 ::: archivey.CompressionAlgorithm
 ::: archivey.CompressionMethod
 ::: archivey.CreateSystem
@@ -38,6 +46,7 @@ spec for lifecycle, retention, and policy.
 ::: archivey.DiagnosticDisposition
 ::: archivey.DiagnosticPolicy
 ::: archivey.DiagnosticSummary
+::: archivey.OnDiagnostic
 ::: archivey.ExtractionReport
 
 ## Extraction
@@ -47,6 +56,7 @@ spec for lifecycle, retention, and policy.
 ::: archivey.ExtractionPolicy
 ::: archivey.OverwritePolicy
 ::: archivey.OnError
+::: archivey.MemberFilter
 
 ## Configuration
 
@@ -54,6 +64,9 @@ spec for lifecycle, retention, and policy.
 ::: archivey.ExtractionLimits
 ::: archivey.ListingLimits
 ::: archivey.AcceleratorMode
+::: archivey.PasswordInput
+::: archivey.PasswordRequest
+::: archivey.PasswordProvider
 
 ## Access cost
 
@@ -61,6 +74,11 @@ spec for lifecycle, retention, and policy.
 ::: archivey.ListingCost
 ::: archivey.AccessCost
 ::: archivey.StreamCapability
+
+## Measurement
+
+::: archivey.IoStats
+::: archivey.enable_measurement
 
 ## Errors
 

--- a/docs/costs.md
+++ b/docs/costs.md
@@ -16,6 +16,15 @@ Every open archive exposes a machine-readable receipt:
 
 Cost never changes what is *legal* — it describes what your access pattern will *pay*.
 
+### RAR listing cost
+
+RAR reports `listing_cost=INDEXED`: the native parser walks all file headers at open
+time and builds the member table in memory before `members()` is called. The optional
+**Quick Open** record (a pre-built central directory in some RAR5 archives) is read but
+is not the primary source — every archive header is still traversed, so the open-time
+cost scales with member count. Once open, `members()` / `get()` return from the
+in-memory table at O(1) cost.
+
 ## Solid archives: prefer one forward pass
 
 On solid 7z / RAR (and compressed TAR, which is solid for random member access), opening

--- a/docs/decisions/0001-native-7z-not-py7zr.md
+++ b/docs/decisions/0001-native-7z-not-py7zr.md
@@ -14,9 +14,9 @@ intractable. Third-party quirks also leaked into the unified contract.
 ## Decision
 
 Parse 7z headers natively. Decode common codecs with stdlib `lzma` / `bz2` / `zlib`
-(pull-based, folder decoded once per streaming pass). Keep `py7zr` only for optional
-writing (`[7z-write]`) and as a test oracle. Reject BCJ2 explicitly rather than falling
-back to another reader.
+(pull-based, folder decoded once per streaming pass). Keep `py7zr` as a **dev oracle**
+only; 7z writing is deferred and not shipped as a user-facing extra. Reject BCJ2
+explicitly rather than falling back to another reader.
 
 ## Consequences
 

--- a/docs/formats.md
+++ b/docs/formats.md
@@ -81,7 +81,7 @@ Third-party credits (deps, oracles, design refs): [Acknowledgements](acknowledge
   rejected as `EncryptionError` (never a silent empty listing). See threat-model O8.
 - `NumCyclesPower` is capped at ≤24 or the `0x3F` no-hash sentinel (7-Zip’s own clamp);
   values 25–62 raise `UnsupportedFeatureError`.
-- Writing needs `[7z-write]` (`py7zr`).
+- Writing is not shipped in the current release (`py7zr` is a **dev oracle** only).
 
 ## RAR
 
@@ -131,10 +131,11 @@ Third-party credits (deps, oracles, design refs): [Acknowledgements](acknowledge
 
 ## Stored digests (cheap dedupe)
 
-`member.hashes` holds digests the archive **already stores**, keyed by algorithm
-(`"crc32"` as `int`, `"blake2sp"` as `bytes`). They are readable without decompressing
-when the backend documents them. They are **not** computed digests — a full `read()` still
-verifies through the normal path.
+`member.hashes` holds digests the archive **already stores**, keyed by
+:class:`~archivey.HashAlgorithm` (values always ``bytes`` — CRC-32 is four
+big-endian bytes via :func:`~archivey.crc32_digest`). They are readable without
+decompressing when the backend documents them. They are **not** computed digests —
+a full `read()` still verifies through the normal path.
 
 | Format | When present | Keys |
 | --- | --- | --- |
@@ -146,6 +147,8 @@ verifies through the normal path.
 | `.bz2` / `.xz` / zlib / brotli / `.Z`, TAR, directory | — | none |
 
 See [usage](usage.md#cheap-dedupe-with-stored-hashes) for the cheap→computed fallback recipe.
+(Zlib Adler-32 and multi-member lzip CRC combine are tracked in OpenSpec
+`surface-stored-stream-digests`.)
 
 ## Detection
 

--- a/docs/internal/library-analysis.md
+++ b/docs/internal/library-analysis.md
@@ -333,8 +333,9 @@ zstd fixture generation.
 
 A guard test (`tests/test_extras_imported.py`) asserts that every package pinned in a
 user-facing extra is actually imported by some `src/` code path (with a small, documented
-allowlist for features whose implementation is a later phase: `tqdm` for `[cli]`, `py7zr` for
-`[7z-write]`), so a dead or test-only dependency cannot slip back into an extra.
+allowlist for features whose implementation is a later phase — currently empty), so a
+dead or test-only dependency cannot slip back into an extra. `py7zr` is a **dev** oracle
+only (7z writing is not shipped as a user-facing extra).
 
 ## Follow-up changes
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -85,13 +85,14 @@ see the [stored-digest matrix](formats.md#stored-digests-cheap-dedupe). Recipe:
 ```python
 import hashlib
 import archivey
+from archivey import HashAlgorithm
 
 def content_key(reader, member):
     """Best available digest for a first-pass dedupe index."""
-    if "blake2sp" in member.hashes:
-        return ("stored", "blake2sp", member.hashes["blake2sp"])
-    if "crc32" in member.hashes:
-        return ("stored", "crc32", member.hashes["crc32"])
+    if HashAlgorithm.BLAKE2SP in member.hashes:
+        return ("stored", "blake2sp", member.hashes[HashAlgorithm.BLAKE2SP])
+    if HashAlgorithm.CRC32 in member.hashes:
+        return ("stored", "crc32", member.hashes[HashAlgorithm.CRC32])
     # No cheap stored digest (e.g. tar, bzip2): compute while reading.
     h = hashlib.sha256()
     with reader.open(member) as stream:
@@ -101,12 +102,42 @@ def content_key(reader, member):
 
 with archivey.open_archive("backups.zip") as reader:
     for member in reader:
-        if member.is_file:
+        if member.is_file and member.is_current:
             print(member.name, content_key(reader, member))
 ```
 
 Stored digests are weaker or format-specific; computed digests are stronger but cost a
 full decode. Pick by provenance (`stored` vs `computed`) for your index policy.
+
+## Duplicate names and is_current
+
+Appended tarballs, 7z update operations, and similar workflows can produce archives
+where **the same member name appears more than once**. Archivey always returns all
+entries — `members()` / `__iter__` never hide anything — but marks which one is
+"live" with `member.is_current`:
+
+- The **last** entry with a given name has `is_current=True` (last-entry-wins).
+- All earlier same-name entries have `is_current=False` (superseded).
+
+`extract_all` honours this automatically: non-current entries get
+`ExtractionStatus.SUPERSEDED` (distinct from overwrite `SKIPPED`) and are not written,
+so the final on-disk state matches what you would get from a fresh write.
+
+To enumerate only the live state in your own code, filter with a one-liner:
+
+```python
+with archivey.open_archive("updated.tar") as reader:
+    current = [m for m in reader if m.is_current]
+```
+
+If you need all versions (e.g. a history view), iterate without filtering:
+
+```python
+with archivey.open_archive("history.tar") as reader:
+    for member in reader:
+        tag = "" if member.is_current else " [superseded]"
+        print(f"{member.name}{tag}")
+```
 
 ## Passwords
 

--- a/openspec/project.md
+++ b/openspec/project.md
@@ -41,7 +41,7 @@ See `openspec/schemas/library/README.md` and the `rules:` / `context:` blocks in
 |------|------------|
 | Python version | 3.11+ |
 | Core dependencies | None (stdlib only) |
-| Optional extras | `[7z]`, `[rar]`, `[crypto]`, `[7z-write]` (py7zr), `[iso]` (pycdlib), `[zstd]`, `[lz4]`, `[cli]`, `[seekable]`, `[recommended-lite]`, `[recommended]`, `[all]` — RAR data needs the system `unrar` binary (see `packaging-and-extras`) |
+| Optional extras | `[7z]`, `[rar]`, `[crypto]`, `[iso]` (pycdlib), `[zstd]`, `[lz4]`, `[cli]`, `[seekable]`, `[recommended-lite]`, `[recommended]`, `[all]` — RAR data needs the system `unrar` binary (see `packaging-and-extras`); 7z writing is not shipped (no `[7z-write]`) |
 | OS support | Linux, macOS, Windows |
 | Thread safety | The `ArchiveReader` object is not generally thread-safe. Declared `MemberStreams.CONCURRENT` coordinates first-touch materialization and draining `close()`, then unlocks concurrent `open()` / independent streams (see `reader-concurrency`); free-threaded correctness is covered by the Linux `3.13t` `free-threaded-concurrency` CI job. Writers are not thread-safe. |
 | Concurrency model | Synchronous API only for v1 (async is a deferred follow-on). |
@@ -74,9 +74,9 @@ not `py7zr`/`rarfile`. 7z reading decodes common codecs through stdlib
 `lzma`/`bz2`/`zlib` (zero runtime deps); PPMd/Deflate64 come from the `[7z]` extra,
 AES decryption from `[crypto]`, and only BCJ2 is detect-and-rejected. RAR metadata
 is parsed natively (encrypted RAR5 headers decrypted via `[crypto]`) while the
-external `unrar` binary does the proprietary data decompression. `py7zr` is kept
-only for 7z *writing* (`[7z-write]`); `py7zr` and `rarfile` otherwise serve only as
-`dev`-group test oracles (see `testing-contract`). Provenance: the `archivey-dev`
+external `unrar` binary does the proprietary data decompression. `py7zr` and
+`rarfile` serve only as `dev`-group test oracles (see `testing-contract`);
+7z writing is deferred and not shipped as a user-facing extra. Provenance: the `archivey-dev`
 `sevenzip-native-reader` / `rar-native-metadata-reader` explorations (clone per
 `CLAUDE.md`).
 

--- a/openspec/specs/archive-data-model/spec.md
+++ b/openspec/specs/archive-data-model/spec.md
@@ -149,7 +149,7 @@ class ArchiveMember:
     comment: str | None = None
     create_system: "CreateSystem | None" = None
     windows_attrs: int | None = None
-    hashes: Mapping[str, int | bytes] = field(default_factory=dict, compare=False)
+    hashes: Mapping[HashAlgorithm, bytes] = field(default_factory=dict, compare=False)
     diagnostics: tuple[Diagnostic, ...] = field(default=(), compare=False)
     extra: dict[str, Any] = field(default_factory=dict, compare=False)
 
@@ -175,10 +175,15 @@ class ArchiveMember:
 ```
 
 `is_anti` SHALL be derived (`type == MemberType.ANTI`); there is no `is_anti` field.
-`is_current` SHALL mean “live for default extract / path identity”: 7z computes
-last-entry-wins (including anti supersession); RAR file-version history rows
-(`format-rar`) SHALL set `is_current=False` while the live revision stays
-`True`; other formats MAY default `True`. Unavailable values SHALL be `None`;
+`is_current` SHALL mean “live for default extract / path identity”: last-entry-wins
+semantics apply uniformly across ALL container formats (ZIP, TAR, 7z, RAR, ISO,
+directory); when the same name appears more than once in an archive, the **last** entry
+in archive order has `is_current=True` and all earlier same-name entries have
+`is_current=False`. RAR file-version history rows (`format-rar`) use the `;N` suffix
+convention (unique presentation names) and MUST still set `is_current=False` on those
+rows; the shared last-entry-wins pass MUST NOT overwrite format-specific flags on
+names that appear only once. Anti entries (7z delete markers)
+supersede their targets per `format-7z`. Unavailable values SHALL be `None`;
 `name` follows normalization while `raw_name` preserves stored bytes; timestamp
 timezone semantics are preserved; digest keys name their real algorithms; there
 is no `crc32` alias. Sizes, link targets, hashes, and diagnostics MAY be
@@ -200,7 +205,7 @@ point-in-time snapshots.
 | Caller needs a renamed member | Uses `member.replace(name=...)`; original unchanged |
 | `ArchiveMember` used as set item/dict key | Fails because the type is unhashable |
 | Naive and aware `modified` values pass through `modified_utc()` | Returned values are aware UTC; original `modified` fields unchanged |
-| ZIP CRC32 and RAR5 Blake2sp hashes | Stored under `"crc32"` int and `"blake2sp"` bytes keys respectively |
+| ZIP CRC32 and RAR5 Blake2sp hashes | Stored under `HashAlgorithm.CRC32` / `BLAKE2SP` with `bytes` values |
 | Extraction report holds a member later completed in place | Report's result tuple is immutable; member object reflects late field update |
 | `type == MemberType.ANTI` | `is_anti` true; `is_file` false |
 | Content superseded by later same-name / anti (7z) | Earlier member `is_current` false |

--- a/openspec/specs/backend-registry/spec.md
+++ b/openspec/specs/backend-registry/spec.md
@@ -160,7 +160,7 @@ command from the same metadata exposed by `format_availability()`.
 | --- | --- | --- |
 | Single-codec format backend/codec missing (ISO without `pycdlib`, `.zst` without zstd backend before 3.14, `.lz4` without `lz4`) | NONE | `UnsupportedFormatError` at open with hint |
 | Multi-codec container missing optional member codec/tool | PARTIAL | Opens/lists; member read raises `PackageNotInstalledError` or documented missing-tool error |
-| 7z writing without `py7zr` / `[7z-write]` | Read support unaffected | Write raises `UnsupportedOperationError` naming `[7z-write]` |
+| 7z writing (not yet implemented) | Read support unaffected | Write raises `UnsupportedOperationError` |
 
 #### Scenario: graceful degradation matrix
 

--- a/openspec/specs/format-7z/spec.md
+++ b/openspec/specs/format-7z/spec.md
@@ -19,7 +19,7 @@ readers. It follows the `archivey-dev` `sevenzip-native-reader` exploration.
 | `archive-reading` | `open_archive`, multi-source input, passwords, bounded storage, `stream_members` |
 | `access-mode-and-cost` | Seek requirement, cost receipt, solid access semantics |
 | `compressed-streams` | Decoder composition, CRC verification, optional codec backends |
-| `packaging-and-extras` | `[7z]`, `[crypto]`, `[7z-write]` extras |
+| `packaging-and-extras` | `[7z]`, `[crypto]` extras |
 | `testing-contract` | Native parser coverage and `py7zr` oracle checks |
 
 ## Requirements
@@ -31,10 +31,10 @@ The 7-Zip backend SHALL expose these properties:
 | Property | Value |
 | --- | --- |
 | Read dependency | None; native parser + shared stdlib-backed decoders |
-| Write dependency | `py7zr` via optional `[7z-write]` |
+| Write dependency | Not shipped in the current release (writing deferred; no `[7z-write]` extra) |
 | Listing cost | O(1); native header parse, no file-data decompression |
 | Access cost | `SOLID` when any folder packs multiple files; `DIRECT` for single-file folders |
-| Supports write | Yes, via `[7z-write]` |
+| Supports write | No (read-only until the writing phase) |
 | Requires seek | Yes |
 
 #### Scenario: format property matrix
@@ -43,8 +43,7 @@ The 7-Zip backend SHALL expose these properties:
 | --- | --- |
 | Open a seekable 7z for listing | Header is parsed natively; full member list is available; no third-party reader imports |
 | Open from a non-seekable source | Open fails because 7z requires seek |
-| Attempt 7z write with `[7z-write]` installed | Archive is written through `py7zr` |
-| Attempt 7z write without `[7z-write]` | Clear missing-extra error |
+| Attempt 7z write | `UnsupportedOperationError` (writing not implemented) |
 
 ### Requirement: Parse 7-Zip headers natively
 

--- a/openspec/specs/packaging-and-extras/spec.md
+++ b/openspec/specs/packaging-and-extras/spec.md
@@ -47,13 +47,13 @@ The build SHALL use `hatchling` and the distribution name `archivey`.
 | Core read of `.tar.Z` / bare `.Z` | Native LZW decode; no `uncompresspy` |
 | Core RAR listing | Native metadata/listing works |
 | Core RAR data read with no `unrar` on `PATH` | Clear error says the external `unrar` tool is required |
-| Core-only 7z write | Unavailable until `[7z-write]`; 7z reading still works |
+| Core-only 7z write | Unavailable (writing not shipped); 7z reading still works |
 
 ### Requirement: Optional extras enable specific capabilities
 
 The system SHALL gate each optional capability behind a named extra that pulls the
 third-party dependency required for that capability. 7z and RAR reading are native
-for the common case, so extras cover less-common 7z codecs, encryption, 7z writing,
+for the common case, so extras cover less-common 7z codecs, encryption,
 ISO, extra compression formats, seeking accelerators, and the CLI.
 
 | Extra | Pulls in | Enables |
@@ -62,13 +62,12 @@ ISO, extra compression formats, seeking accelerators, and the CLI.
 | `[7z]` | `pyppmd`, `inflate64`, `backports.zstd` on Python <3.14, `brotli`, `lz4`, `cryptography`, `pybcj` | All 7z reading features: PPMd, Deflate64, Zstd, Brotli, LZ4, AES, LZMA1+BCJ |
 | `[rar]` | `cryptography`, Blake2sp backend | Header-encrypted RAR5 and Blake2sp checksum verification; RAR data still needs RARLAB `unrar` |
 | `[crypto]` | `cryptography` | AES/crypto backend subset used by `[7z]` / `[rar]` |
-| `[7z-write]` | `py7zr` | 7z writing only; reading remains native |
 | `[iso]` | `pycdlib` | ISO 9660 (`.iso`) |
 | `[zstd]` | `backports.zstd` on Python <3.14 | Standalone Zstandard (`.zst`, `.tar.zst`); Python 3.14+ uses stdlib `compression.zstd` |
 | `[lz4]` | `lz4` | Standalone LZ4 (`.lz4`, `.tar.lz4`) and 7z LZ4 folders |
 | `[cli]` | `tqdm` | `archivey` command-line interface progress output |
 | `[seekable]` | `rapidgzip` | Faster gzip/bzip2 decompression and random access into gz/bz2 streams via rapidgzip / bundled `IndexedBzip2File` |
-| `[recommended-lite]` | `[7z]` + `[rar]` + `[7z-write]` + `[iso]` + `[zstd]` + `[lz4]` + `[cli]` | Every broadly wheeled format/codec dependency; excludes build-finicky C++ seek libs |
+| `[recommended-lite]` | `[7z]` + `[rar]` + `[iso]` + `[zstd]` + `[lz4]` + `[cli]` | Every broadly wheeled format/codec dependency; excludes build-finicky C++ seek libs |
 | `[recommended]` | `[recommended-lite]` + `[seekable]` | Recommended install: every primary backend plus gz/bz2 seeking and speed |
 | `[all]` | `[recommended]` plus every alternative/secondary backend, currently none | Everything; currently resolves exactly to `[recommended]` |
 
@@ -88,8 +87,10 @@ raise `PackageNotInstalledError` or `UnsupportedFeatureError` only when bytes ca
 be produced, and skip any integrity check that cannot be computed with an integrity
 diagnostic/warning instead of failing the read.
 
-The system SHALL keep `py7zr` and `rarfile` as dev-only test oracles except for
-`py7zr` under `[7z-write]`. BCJ2-filtered 7z members MUST remain unsupported by every
+The system SHALL keep `py7zr` and `rarfile` as **dev-only** test oracles.
+7z writing is not shipped in the current release (no `[7z-write]` extra); when
+writing lands in a later phase it MAY reintroduce a dedicated write extra.
+BCJ2-filtered 7z members MUST remain unsupported by every
 extra. Installing any individual extra MUST make that capability available without
 requiring unrelated extras. `[all]` MUST be equivalent to installing every runtime
 extra. No user-facing extra SHALL pull an alternate RAR decompressor library or tool
@@ -139,7 +140,7 @@ absent from every user-facing extra.
 The per-codec library choice and rationale SHALL be recorded in
 `docs/internal/library-analysis.md`. A guard test or check script SHALL prevent dead or
 test-only dependencies from returning to user-facing extras. A dependency pinned
-ahead of its implementation phase, such as `[cli]` or `[7z-write]`, is permitted only
+ahead of its implementation phase, such as `[cli]`, is permitted only
 through an explicit documented allowlist in that guard.
 
 #### Scenario: dependency-audit matrix

--- a/openspec/specs/safe-extraction/spec.md
+++ b/openspec/specs/safe-extraction/spec.md
@@ -204,11 +204,12 @@ of this requirement — it belongs to the future opt-in `SANITIZE` extraction po
 ### Requirement: Skip non-current members by default
 
 `extract` / `extract_all` SHALL skip members with `is_current is False` by default
-(`ExtractionStatus.SKIPPED`; no write; no bomb-limit counting for the skip). This
+(`ExtractionStatus.SUPERSEDED`; no write; no bomb-limit counting for the skip). This
 is **hardwired coordinator behavior**, not the policy `filter` / `MemberFilter`
 pipeline: the skip happens after the optional user `filter` runs so callers can
 inspect or rewrite non-current members, then the coordinator still skips writing
-them unless a future explicit opt-in lands.
+them unless a future explicit opt-in lands. `SUPERSEDED` is distinct from
+`ExtractionStatus.SKIPPED` (pre-existing destination under `OverwritePolicy.SKIP`).
 
 How surfaces interact:
 
@@ -217,7 +218,7 @@ How surfaces interact:
 | `members()` / `__iter__` / `get` | Visible (metadata + `is_current=False`) |
 | `members=` selector | May select them; they still participate in the extract walk |
 | User `filter` (`MemberFilter`) | **Invoked** on them (same as current members) |
-| Default extract write | Skipped after filter; `SKIPPED` result |
+| Default extract write | Skipped after filter; `SUPERSEDED` result |
 | `open`/`read` on superseded `FILE` | Still allowed (payload exists); not gated by `is_current` |
 
 There is no extract-all flag in this change to force writing non-current
@@ -227,7 +228,7 @@ revisions; callers that need those bytes use `open`/`read` (or a future opt-in).
 
 | Case | Expected |
 | --- | --- |
-| Content superseded by later same-name or anti | `SKIPPED` on extract; path absent on fresh dest |
+| Content superseded by later same-name or anti | `SUPERSEDED` on extract; path absent on fresh dest |
 | User `filter` receives non-current member | Filter is called; returning the member does not force a write |
 | `open` superseded content `FILE` | Bytes returned (random access still works) |
 
@@ -528,6 +529,7 @@ class ExtractionResult:
 class ExtractionStatus(str, Enum):
     EXTRACTED = "extracted"
     SKIPPED = "skipped"
+    SUPERSEDED = "superseded"
     REJECTED = "rejected"
     FAILED = "failed"
 ```
@@ -535,9 +537,11 @@ class ExtractionStatus(str, Enum):
 Statuses SHALL mean: `EXTRACTED` created an entry (`path` set, `error=None`);
 `SKIPPED` intentionally bypassed writing because the user filter returned `None`
 or `OverwritePolicy.SKIP` found an existing destination (`path=None`,
-`error=None`); `REJECTED` is a continued `FilterRejectionError`; `FAILED` is a
-continued non-rejection per-member `ArchiveyError` or permitted filesystem
-`OSError`. `SKIPPED` is not a failure and emits no diagnostic. `requested_path`
+`error=None`); `SUPERSEDED` is a non-current duplicate skipped by the hardwired
+last-entry-wins rule (`path=None`, `error=None`); `REJECTED` is a continued
+`FilterRejectionError`; `FAILED` is a continued non-rejection per-member
+`ArchiveyError` or permitted filesystem `OSError`. `SKIPPED` and `SUPERSEDED`
+are not failures and emit no diagnostic. `requested_path`
 carries the destination the coordinator intended before overwrite/rename
 resolution; it equals `path` for an ordinary write, and `requested_path != path
 and status == EXTRACTED` marks an `OverwritePolicy.RENAME` (see the cross-platform

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,9 +42,6 @@ rar = [
 crypto = [
     "cryptography>=45.0.0",
 ]
-7z-write = [
-    "py7zr>=1.0.0",
-]
 iso = [
     "pycdlib>=1.16.0",
 ]
@@ -65,7 +62,7 @@ seekable = [
     "rapidgzip>=0.16.0",
 ]
 recommended-lite = [
-    "archivey[7z,rar,7z-write,iso,zstd,lz4,cli]",
+    "archivey[7z,rar,iso,zstd,lz4,cli]",
 ]
 recommended = [
     "archivey[recommended-lite,seekable]",

--- a/review/README.md
+++ b/review/README.md
@@ -22,7 +22,7 @@ Round commissioned 2026-07-17 — the **non-security** pass toward the first pub
 
 | Dir | Review | Status (2026-07-18) |
 |-----|--------|---------------------|
-| `api-coherence/` | Public API & member-model coherence / ergonomics (incl. cross-backend parity) | Findings in (#133); **Q1–Q6 decided** (QUESTIONS); code follow-ups open; Q7 → next round |
+| `api-coherence/` | Public API & member-model coherence / ergonomics (incl. cross-backend parity) | Findings in (#133); **Q1–Q6 decided + implemented**; digest fill → `surface-stored-stream-digests`; Q7 → next round |
 | `cli-product/` | The CLI as a **product** — UX, grammar, exit codes, output (not code correctness; #131 did that) | **Brief only** — review not run |
 | `performance/` | The ≤1.3× stdlib perf budget — benchmark-gate efficacy + the real traps | Findings + partial fixes (#134/#136/#137/#139/#140/#141); P1/P2/P6/P7 + Q2/Q4 remain |
 | `stream-layering/` | Stream wrapper stack — are the checks correct, and can slicing+verification collapse into one stream under `ArchiveStream`? | **Essentially done** (#137); park Q4 then archive |

--- a/review/STATUS.md
+++ b/review/STATUS.md
@@ -11,7 +11,7 @@ item is fixed or consciously deferred here / in `backlog.md`.
 |--------|---------------------|----------------------|-------------------|
 | `stream-layering/` | yes (#137) | **done** (F1/F2/D1/D2); Q4 parked → future | **almost** — park Q4 then archive |
 | `performance/` | yes (#134 + #139/#140/#143/#146) | partial (P3–P5 done; P7 listing L0–L2 done, L3 partial; P1/P2/P6 open) | no |
-| `api-coherence/` | yes (#133) | **Q1–Q6 decided** (docs in QUESTIONS); code follow-ups open | no |
+| `api-coherence/` | yes (#133) | **Q1–Q6 decided + implemented** (hashes typing done; digest filling → `surface-stored-stream-digests`; Q5/Q7 deferred) | **almost** — park digest fill / Q5 / Q7 then archive |
 | `cli-product/` | **no** — brief only | review not run | no |
 
 ---
@@ -30,19 +30,19 @@ or the finding is a clear proposed fix with no spec conflict).
 | **P2 remainder** | Many-small `read_all` follows the listing story (same per-member machinery as P7). Large-member ZIP read already ≤1.25× after #139; realistic extract ~1.9× (inside ~2× band) — no further extract code pending Q2. |
 | **VISION/docs** | Re-word the ≤1.3× claim to match Q1 (decompression-dominated ≤1.3×; listing as peer ratios) once enforcement (Q2) is chosen. |
 
-### From `api-coherence/` (Q1–Q6 decided 2026-07-18 — implement)
+### From `api-coherence/` (Q1–Q6 decided 2026-07-18 — implemented)
 
 | ID | Action |
 |----|--------|
-| **P1 / Q1** | Unify last-entry-wins `is_current` on ZIP/TAR RA materialization; align specs; sweep asserts uniform duplicate contract. **Not already done** — only 7z/RAR set the field today. |
-| **Q2** | Docs/recipes only (listing stays “everything”); pairs with P1. |
-| **P2 / Q3** | Keep RAR `listing_cost=INDEXED`; fix `cost.py` docstring + grab-bag prose; document open always walks headers / QO unused; add RAR row to `test_cost_receipt.py`. |
-| **S1 / S3 / Q4** | Demote `*Context` + `RAPIDGZIP_AUTO_MIN_COMPRESSED_SIZE` from `__all__`; export `PasswordInput` + `OnDiagnostic`; drop `core.source_name`; document `open_stream` in `api.md`. |
-| **S2 / Q6** | `ArchiveFormat.display_name` **property** so the CLI stops parsing `repr()`. |
-| **E1** | Public measurement / IO-stats API so CLI `--track-io` leaves `internal/`. |
-| **E3 / Q6** | Split `ExtractionStatus.SKIPPED` into distinct statuses (overwrite vs non-current). |
-| **Q6 hashes** | **Typing (review fix now):** `HashAlgorithm` enum + `Mapping[HashAlgorithm, bytes]` (crc32 `int` → 4-byte `bytes`; include `ADLER32` member). **Filling digests:** OpenSpec `surface-stored-stream-digests` (zlib Adler peek, lzip multi-member `crc32_combine`) — separate change, depends on typing. |
-| **Q6 WriteError / `[7z-write]`** | Demote/unexport `WriteError` for read-only 0.2.0; remove or stop advertising `[7z-write]` until writing lands (py7zr remains a dev oracle). |
+| **P1 / Q1** | **implemented** — `_apply_last_entry_wins_is_current` in `base_reader.py`; ZIP/TAR/all RA formats now set `is_current`; `archive-data-model` spec updated; corpus sweep uses default ERROR policy. |
+| **Q2** | **implemented** — `docs/usage.md` duplicate-name section + filter recipe. |
+| **P2 / Q3** | **implemented** — `cost.py` docstrings fixed; RAR open-walk note in `docs/costs.md`; RAR row in `test_cost_receipt.py`. |
+| **S1 / S3 / Q4** | **implemented** — 13 `*Context` classes + `RAPIDGZIP_AUTO_MIN_COMPRESSED_SIZE` + `WriteError` demoted from `__all__`; `PasswordInput` / `OnDiagnostic` / `HashAlgorithm` / `crc32_digest` / `IoStats` / `enable_measurement` added; `source_name` dropped from `core.__all__`; `MemberSelector` used consistently. |
+| **S2 / Q6** | **implemented** — `ArchiveFormat.display_name` property; CLI `_format_label` uses it. |
+| **E1** | **implemented** — public `archivey.measurement` with `IoStats` + `enable_measurement`; `ArchiveReader.io_stats()` on the ABC; CLI `common.py` uses public API only. |
+| **E3 / Q6** | **implemented** — `ExtractionStatus.SUPERSEDED` for non-current skip; `SKIPPED` is overwrite-skip only. |
+| **Q6 hashes** | **typing done** (c7b88b5) — `HashAlgorithm` enum + `Mapping[HashAlgorithm, bytes]`; filling digests deferred to OpenSpec `surface-stored-stream-digests`. |
+| **Q6 WriteError / `[7z-write]`** | **implemented** — `WriteError` demoted from `__all__`; `[7z-write]` extra removed from pyproject.toml and `recommended-lite`; `py7zr` kept in dev. |
 
 ### Process
 

--- a/review/api-coherence/SUMMARY.md
+++ b/review/api-coherence/SUMMARY.md
@@ -1,7 +1,8 @@
 # API-coherence review — SUMMARY
 
 > **Status (2026-07-18):** findings delivered in #133; **Q1–Q6 decided**
-> (`QUESTIONS.md`) — code follow-ups not landed yet. **Q7** deferred to a next
+> (`QUESTIONS.md`) — **Q1–Q6 code follow-ups implemented** on this branch (except
+> digest *filling*, which is OpenSpec `surface-stored-stream-digests`). **Q7** deferred to a next
 > review round. Mechanical surface work (S1/S2/S3/E1/E3) and P1/`is_current` are
 > now unblocked. Triage: `../STATUS.md`.
 
@@ -44,14 +45,14 @@ subtle generator semantics); and `ArchiveFormat` has no display name (the CLI pa
 
 | # | Severity | Finding | Where | Status |
 |---|----------|---------|-------|--------|
-| P1 | **High** | Duplicate-name members: `is_current` computed only by 7z/RAR; ZIP/TAR default extraction *errors* where 7z silently skips — same input, divergent outcome; `safe-extraction` scenario ("superseded by later same-name → SKIPPED") is format-silent and currently false for ZIP/TAR | `sevenzip_parser.py:331`, `extraction.py:351`, repro in `parity.md` | **decided Q1=(a)** — unify last-entry-wins; **not yet implemented** (ZIP/TAR still default `True`) |
-| E1 | Medium | No public measurement/IO-stats API: CLI `--track-io` imports `enable_measurement` + `BaseArchiveReader` from `internal/` and reads three counters not on the `ArchiveReader` ABC | `cli/common.py:15-16,56-68`, `base_reader.py:557-1009` | **actionable** (Q4 approved) |
+| P1 | **High** | Duplicate-name members: `is_current` computed only by 7z/RAR; ZIP/TAR default extraction *errors* where 7z silently skips — same input, divergent outcome; `safe-extraction` scenario ("superseded by later same-name → SKIPPED") is format-silent and currently false for ZIP/TAR | `sevenzip_parser.py:331`, `extraction.py:351`, repro in `parity.md` | **implemented** — `_apply_last_entry_wins_is_current` in `base_reader.py`; `ExtractionStatus.SUPERSEDED` distinguishes non-current skip |
+| E1 | Medium | No public measurement/IO-stats API: CLI `--track-io` imports `enable_measurement` + `BaseArchiveReader` from `internal/` and reads three counters not on the `ArchiveReader` ABC | `cli/common.py:15-16,56-68`, `base_reader.py:557-1009` | **implemented** — public `archivey.measurement` module with `IoStats` + `enable_measurement`; `ArchiveReader.io_stats()` on the ABC |
 | E2 | Medium | No library "verify" primitive: `archivey test` hand-rolls manual `next()` loop; a mid-pass failure poisons the stream and loses remaining members | `cli/test_cmd.py:56-73` | **deferred** (Q5 — post-0.2.0 / maybe never) |
-| S1 | Medium | `__all__` = 90 names: 13 `*Context` classes + `RAPIDGZIP_AUTO_MIN_COMPRESSED_SIZE` should demote; `PasswordInput` / `OnDiagnostic` missing; `MemberSelector` vs internal `MemberSelectorArg` duplicate aliases used inconsistently in one class | `__init__.py:113-204`, `reader.py:27,148` | **decided Q4=approve** — implement |
-| P2 | Low-Med | RAR `listing_cost=INDEXED` always, but `cost.py` docstring names "RAR with no quick-open record" as the canonical `REQUIRES_SCANNING` example — doc/impl conflict on an honest-cost axis | `rar_reader.py:773` vs `cost.py:24-27` | **decided Q3=`INDEXED`** — fix docstring + document actual open walk (QO unused); see investigation in `QUESTIONS.md` |
-| E3 | Low | `ExtractionStatus.SKIPPED` conflates overwrite-skip and non-current-skip; caller must infer reason via `member.is_current` | `extraction_types.py:80-87`, `extraction.py:351` | **decided Q6=split statuses** — implement |
-| S2 | Low | `ArchiveFormat` has no display-name property; CLI string-parses `repr()` | `cli/info_cmd.py:16-23` | **decided Q6=`display_name` property** — implement |
-| S3 | Low | `archivey.core.__all__` exports internal helper `source_name`; `docs/api.md` omits `open_stream`, `MemberStreams`, selectors, format-support queries | `core.py:78`, `docs/api.md` | **decided Q4=approve** — implement |
+| S1 | Medium | `__all__` = 90 names: 13 `*Context` classes + `RAPIDGZIP_AUTO_MIN_COMPRESSED_SIZE` should demote; `PasswordInput` / `OnDiagnostic` missing; `MemberSelector` vs internal `MemberSelectorArg` duplicate aliases used inconsistently in one class | `__init__.py:113-204`, `reader.py:27,148` | **implemented** — 13 concrete context classes demoted from `__all__`; `PasswordInput` / `OnDiagnostic` / `HashAlgorithm` / `crc32_digest` / `IoStats` / `enable_measurement` added; `MemberSelector` used consistently |
+| P2 | Low-Med | RAR `listing_cost=INDEXED` always, but `cost.py` docstring names "RAR with no quick-open record" as the canonical `REQUIRES_SCANNING` example — doc/impl conflict on an honest-cost axis | `rar_reader.py:773` vs `cost.py:24-27` | **implemented** — `cost.py` docstrings updated; `test_cost_receipt.py` RAR row added; `costs.md` RAR open-walk note added |
+| E3 | Low | `ExtractionStatus.SKIPPED` conflates overwrite-skip and non-current-skip; caller must infer reason via `member.is_current` | `extraction_types.py:80-87`, `extraction.py:351` | **implemented** — `ExtractionStatus.SUPERSEDED` added for non-current skip |
+| S2 | Low | `ArchiveFormat` has no display-name property; CLI string-parses `repr()` | `cli/info_cmd.py:16-23` | **implemented** — `ArchiveFormat.display_name` property; CLI uses it |
+| S3 | Low | `archivey.core.__all__` exports internal helper `source_name`; `docs/api.md` omits `open_stream`, `MemberStreams`, selectors, format-support queries | `core.py:78`, `docs/api.md` | **implemented** — `source_name` dropped from `core.__all__`; `WriteError` demoted from top-level `__all__`; `[7z-write]` extra removed |
 | D1 | Low | CLI list line has no mark for `ANTI` (falls to `"?"`, same as `OTHER`) and no non-current indicator — the member model's own distinctions are invisible in the first consumer | `cli/format.py:9-15` | **defer to `cli-product/`** |
 
 ## The maintainer's extra question (members scope)

--- a/src/archivey/__init__.py
+++ b/src/archivey/__init__.py
@@ -9,11 +9,12 @@ except PackageNotFoundError:
 
 from archivey.config import (
     DEFAULT_ARCHIVEY_CONFIG,
-    RAPIDGZIP_AUTO_MIN_COMPRESSED_SIZE,
+    RAPIDGZIP_AUTO_MIN_COMPRESSED_SIZE,  # noqa: F401 — not in __all__ but kept importable
     AcceleratorMode,
     ArchiveyConfig,
     ExtractionLimits,
     ListingLimits,
+    PasswordInput,
     PasswordProvider,
     PasswordRequest,
 )
@@ -38,7 +39,7 @@ from archivey.cost import (
     StreamCapability,
 )
 from archivey.diagnostics import (
-    ArchiveEofContext,
+    ArchiveEofContext,  # noqa: F401 — not in __all__ but kept importable
     Diagnostic,
     DiagnosticCode,
     DiagnosticContext,
@@ -46,19 +47,20 @@ from archivey.diagnostics import (
     DiagnosticPolicy,
     DiagnosticSeverity,
     DiagnosticSummary,
-    DigestContext,
-    ExtractionOutcomeContext,
+    DigestContext,  # noqa: F401
+    ExtractionOutcomeContext,  # noqa: F401
     ExtractionReport,
-    FormatConflictContext,
-    MemberTimestampContext,
-    NameCollisionContext,
-    NameEncodingContext,
-    NameNormalizationContext,
-    NameSanitizedContext,
-    ScanRaceContext,
-    SeekIndexContext,
-    StreamRewindContext,
-    SymlinkTargetContext,
+    FormatConflictContext,  # noqa: F401
+    MemberTimestampContext,  # noqa: F401
+    NameCollisionContext,  # noqa: F401
+    NameEncodingContext,  # noqa: F401
+    NameNormalizationContext,  # noqa: F401
+    NameSanitizedContext,  # noqa: F401
+    OnDiagnostic,
+    ScanRaceContext,  # noqa: F401
+    SeekIndexContext,  # noqa: F401
+    StreamRewindContext,  # noqa: F401
+    SymlinkTargetContext,  # noqa: F401
 )
 from archivey.exceptions import (
     ArchiveyError,
@@ -84,7 +86,7 @@ from archivey.exceptions import (
     UnsupportedFeatureError,
     UnsupportedFormatError,
     UnsupportedOperationError,
-    WriteError,
+    WriteError,  # noqa: F401 — not in __all__ but kept importable
 )
 from archivey.internal.extraction_types import (
     ExtractionPolicy,
@@ -96,6 +98,7 @@ from archivey.internal.extraction_types import (
     OverwritePolicy,
 )
 from archivey.internal.streams.archive_stream import ArchiveStream
+from archivey.measurement import IoStats, enable_measurement
 from archivey.reader import ArchiveReader, MemberSelector
 from archivey.types import (
     ArchiveFormat,
@@ -105,9 +108,11 @@ from archivey.types import (
     CompressionMethod,
     ContainerFormat,
     CreateSystem,
+    HashAlgorithm,
     MemberStreams,
     MemberType,
     StreamFormat,
+    crc32_digest,
 )
 
 __all__ = [
@@ -120,9 +125,10 @@ __all__ = [
     "ExtractionLimits",
     "ListingLimits",
     "AcceleratorMode",
-    "RAPIDGZIP_AUTO_MIN_COMPRESSED_SIZE",
+    "PasswordInput",
     "PasswordRequest",
     "PasswordProvider",
+    "OnDiagnostic",
     "ExtractionPolicy",
     "OverwritePolicy",
     "OnError",
@@ -153,10 +159,14 @@ __all__ = [
     "CompressionAlgorithm",
     "CompressionMethod",
     "CreateSystem",
+    "HashAlgorithm",
+    "crc32_digest",
     "CostReceipt",
     "ListingCost",
     "AccessCost",
     "StreamCapability",
+    "IoStats",
+    "enable_measurement",
     "Diagnostic",
     "DiagnosticCode",
     "DiagnosticContext",
@@ -165,19 +175,6 @@ __all__ = [
     "DiagnosticPolicy",
     "DiagnosticSummary",
     "DiagnosticRaisedError",
-    "ArchiveEofContext",
-    "DigestContext",
-    "ExtractionOutcomeContext",
-    "FormatConflictContext",
-    "MemberTimestampContext",
-    "NameCollisionContext",
-    "NameSanitizedContext",
-    "NameEncodingContext",
-    "NameNormalizationContext",
-    "ScanRaceContext",
-    "SeekIndexContext",
-    "StreamRewindContext",
-    "SymlinkTargetContext",
     "ArchiveyError",
     "ArchiveyUsageError",
     "ConcurrentAccessError",
@@ -190,7 +187,6 @@ __all__ = [
     "TruncatedError",
     "EncryptionError",
     "LinkTargetNotFoundError",
-    "WriteError",
     "ExtractionError",
     "FilterRejectionError",
     "PathTraversalError",

--- a/src/archivey/cli/common.py
+++ b/src/archivey/cli/common.py
@@ -12,8 +12,7 @@ from archivey import open_archive
 from archivey.cli.errors import CliError
 from archivey.cli.exit_codes import EXIT_USAGE
 from archivey.config import PasswordInput
-from archivey.internal.base_reader import BaseArchiveReader
-from archivey.internal.measurement import enable_measurement
+from archivey.measurement import enable_measurement
 from archivey.reader import ArchiveReader
 
 
@@ -54,15 +53,19 @@ def open_for_cli(
 
 
 def _report_track_io(reader: ArchiveReader, err: TextIO) -> None:
-    if not isinstance(reader, BaseArchiveReader):
+    stats = reader.io_stats()
+    if stats is None:
         print("track-io: counters unavailable for this reader", file=err)
         return
-    consumed = reader.compressed_bytes_consumed
-    consumed_s = "-" if consumed is None else str(consumed)
+    consumed_s = (
+        "-"
+        if stats.compressed_bytes_consumed is None
+        else str(stats.compressed_bytes_consumed)
+    )
     print(
         "track-io:"
-        f" bytes_decompressed={reader.bytes_decompressed}"
+        f" bytes_decompressed={stats.bytes_decompressed}"
         f" compressed_bytes_consumed={consumed_s}"
-        f" source_seek_count={reader.source_seek_count}",
+        f" source_seek_count={stats.source_seek_count}",
         file=err,
     )

--- a/src/archivey/cli/extract_cmd.py
+++ b/src/archivey/cli/extract_cmd.py
@@ -312,6 +312,10 @@ def _report_extraction(
             # Skips also change outcomes under --overwrite skip; always note.
             where = result.requested_path or result.member.name
             print(f"skipped: {where}", file=err)
+        elif status is ExtractionStatus.SUPERSEDED:
+            skipped += 1  # count superseded entries alongside skipped in summary
+            if verbose:
+                print(f"superseded: {result.member.name}", file=err)
         elif status is ExtractionStatus.REJECTED:
             rejected += 1
             detail = f": {result.error}" if result.error is not None else ""

--- a/src/archivey/cli/format.py
+++ b/src/archivey/cli/format.py
@@ -43,7 +43,8 @@ def format_size(size: int | None) -> str:
     return str(size)
 
 
-def format_hash_value(value: int | bytes) -> str:
+def format_hash_value(value: bytes | int) -> str:
+    """Format a stored digest for CLI display (values are ``bytes``; ``int`` accepted)."""
     if isinstance(value, int):
         return f"{value:08x}" if value <= 0xFFFFFFFF else hex(value)
     return value.hex()

--- a/src/archivey/cli/info_cmd.py
+++ b/src/archivey/cli/info_cmd.py
@@ -15,12 +15,7 @@ from archivey.types import ArchiveFormat
 
 def _format_label(fmt: ArchiveFormat) -> str:
     """Human format name (``ZIP``) rather than ``ArchiveFormat.ZIP``."""
-    label = repr(fmt)
-    return (
-        label.removeprefix("ArchiveFormat.")
-        if label.startswith("ArchiveFormat.")
-        else label
-    )
+    return fmt.display_name
 
 
 def _line(key: str, value: object, out: TextIO) -> None:

--- a/src/archivey/core.py
+++ b/src/archivey/core.py
@@ -48,7 +48,6 @@ from archivey.internal.streams.streamtools import (
     fix_stream_start_position,
     is_seekable,
     is_stream,
-    source_name,
 )
 from archivey.internal.volumes import ConcatenatedFile, OpenSourceInput, resolve_source
 from archivey.reader import ArchiveReader
@@ -75,7 +74,6 @@ __all__ = [
     "list_supported_formats",
     "open_archive",
     "open_stream",
-    "source_name",  # re-exported from streamtools (the single implementation)
 ]
 
 

--- a/src/archivey/cost.py
+++ b/src/archivey/cost.py
@@ -19,12 +19,15 @@ class ListingCost(Enum):
     """An index / central directory is present (ZIP central directory, 7z header, ISO
     directory tree parsed at open); members can be enumerated without scanning header-to-header
     or decompressing payload. A filesystem directory is NOT indexed — its walk is a scan
-    (`REQUIRES_SCANNING`)."""
+    (`REQUIRES_SCANNING`). RAR is ``INDEXED``: the reader walks all file headers at open
+    time to build the member table (the optional Quick Open record is parsed but not
+    relied on as the sole source), so by the time ``members()`` is called the list is
+    already in memory at O(1) cost."""
 
     REQUIRES_SCANNING = "requires_scanning"
     """No index, but members can be enumerated by seeking/scanning header-to-header
-    without decompressing payload (e.g. an uncompressed tar, or a RAR with no quick-open
-    record)."""
+    without decompressing payload (e.g. an uncompressed tar, or a filesystem directory
+    walk)."""
 
     REQUIRES_DECOMPRESSION = "requires_decompression"
     """The stream must be decompressed to reach the member headers (e.g. a compressed tar)."""

--- a/src/archivey/internal/backends/rar_reader.py
+++ b/src/archivey/internal/backends/rar_reader.py
@@ -65,9 +65,11 @@ from archivey.types import (
     CompressionAlgorithm,
     CompressionMethod,
     CreateSystem,
+    HashAlgorithm,
     MagicSignature,
     MemberStreams,
     MemberType,
+    crc32_digest,
 )
 
 # rarfile / RAR host_os values (parser maps RAR5 Windows→2, Unix→3).
@@ -123,7 +125,7 @@ def _crc_is_tweaked(info: RarMemberInfo) -> bool:
     return bool(enc.flags & _RAR_ENCDATA_FLAG_TWEAKED_CHECKSUMS)
 
 
-def _member_hashes(info: RarMemberInfo) -> dict[str, int | bytes]:
+def _member_hashes(info: RarMemberInfo) -> dict[HashAlgorithm, bytes]:
     """Plaintext digests safe for member verification without a HashKey.
 
     When ``RAR5_XENC_TWEAKED`` / ``HASHMAC`` (0x02) is set, the stored CRC32 and
@@ -132,12 +134,12 @@ def _member_hashes(info: RarMemberInfo) -> dict[str, int | bytes]:
     forward-transform when a password is available (see
     :meth:`RarReader._tweaked_verify_spec`).
     """
-    hashes: dict[str, int | bytes] = {}
+    hashes: dict[HashAlgorithm, bytes] = {}
     tweaked = _crc_is_tweaked(info)
     if info.crc32 is not None and not tweaked:
-        hashes["crc32"] = info.crc32
+        hashes[HashAlgorithm.CRC32] = crc32_digest(info.crc32)
     if info.blake2sp_hash is not None and not tweaked:
-        hashes["blake2sp"] = info.blake2sp_hash
+        hashes[HashAlgorithm.BLAKE2SP] = info.blake2sp_hash
     return hashes
 
 
@@ -519,8 +521,8 @@ class RarReader(BaseArchiveReader):
         if _crc_is_tweaked(info) and self._unrar_password is None:
             # No password → cannot forward-transform; surface as unverifiable digests.
             for algorithm in (
-                ("crc32", info.crc32 is not None),
-                ("blake2sp", info.blake2sp_hash is not None),
+                (HashAlgorithm.CRC32, info.crc32 is not None),
+                (HashAlgorithm.BLAKE2SP, info.blake2sp_hash is not None),
             ):
                 algo, present = algorithm
                 if not present:
@@ -535,7 +537,7 @@ class RarReader(BaseArchiveReader):
                         archive_name=self._archive_name,
                         member_name=member.name,
                         member_id=member._member_id,
-                        algorithm=algo,
+                        algorithm=algo.value,
                         reason="tweaked_checksum",
                     ),
                     member=member,
@@ -634,7 +636,13 @@ class RarReader(BaseArchiveReader):
 
     def _tweaked_verify_spec(
         self, info: RarMemberInfo
-    ) -> tuple[dict[str, int | bytes], dict[str, Callable[[bytes], bytes]]] | None:
+    ) -> (
+        tuple[
+            dict[HashAlgorithm, bytes],
+            dict[HashAlgorithm, Callable[[bytes], bytes]],
+        ]
+        | None
+    ):
         """Build ``(expected, digest_transforms)`` for tweaked RAR5 checksums.
 
         Returns ``None`` when checksums are not tweaked, no password is available, or
@@ -651,16 +659,16 @@ class RarReader(BaseArchiveReader):
         hash_key = _tweaked_hash_key(enc, password)
         if hash_key is None:
             return None
-        expected: dict[str, int | bytes] = {}
-        transforms: dict[str, Callable[[bytes], bytes]] = {}
+        expected: dict[HashAlgorithm, bytes] = {}
+        transforms: dict[HashAlgorithm, Callable[[bytes], bytes]] = {}
         if info.crc32 is not None:
-            expected["crc32"] = info.crc32
-            transforms["crc32"] = lambda digest, hk=hash_key: convert_crc_to_mac(
-                int.from_bytes(digest, "big"), hk
-            ).to_bytes(4, "big")
+            expected[HashAlgorithm.CRC32] = crc32_digest(info.crc32)
+            transforms[HashAlgorithm.CRC32] = lambda digest, hk=hash_key: (
+                convert_crc_to_mac(int.from_bytes(digest, "big"), hk).to_bytes(4, "big")
+            )
         if info.blake2sp_hash is not None:
-            expected["blake2sp"] = info.blake2sp_hash
-            transforms["blake2sp"] = lambda digest, hk=hash_key: (
+            expected[HashAlgorithm.BLAKE2SP] = info.blake2sp_hash
+            transforms[HashAlgorithm.BLAKE2SP] = lambda digest, hk=hash_key: (
                 convert_blake2sp_to_mac(digest, hk)
             )
         if not expected:
@@ -670,9 +678,9 @@ class RarReader(BaseArchiveReader):
     def _payload_verify_args(
         self, member: ArchiveMember
     ) -> tuple[
-        Mapping[str, int | bytes] | None,
+        Mapping[HashAlgorithm, bytes] | None,
         int | None,
-        Mapping[str, Callable[[bytes], bytes]] | None,
+        Mapping[HashAlgorithm, Callable[[bytes], bytes]] | None,
         ArchiveMember | None,
     ]:
         """Return ``(hashes, size, transforms, member)`` for fused verify, or Nones.
@@ -681,8 +689,8 @@ class RarReader(BaseArchiveReader):
         read. Tweaked RAR5 digests (HASHMAC) use ConvertHashToMAC transforms when
         a password is available.
         """
-        expected: Mapping[str, int | bytes] = member.hashes
-        transforms: Mapping[str, Callable[[bytes], bytes]] | None = None
+        expected: Mapping[HashAlgorithm, bytes] = member.hashes
+        transforms: Mapping[HashAlgorithm, Callable[[bytes], bytes]] | None = None
         raw = member._raw
         if isinstance(raw, RarMemberInfo):
             tweaked = self._tweaked_verify_spec(raw)

--- a/src/archivey/internal/backends/sevenzip_parser.py
+++ b/src/archivey/internal/backends/sevenzip_parser.py
@@ -487,18 +487,6 @@ def encoded_folder_slices(
     return slices
 
 
-def compute_is_current(files: list[SevenZipFileRecord]) -> list[bool]:
-    """Last-entry-wins by filename."""
-    current = [False] * len(files)
-    seen: set[str] = set()
-    for index in range(len(files) - 1, -1, -1):
-        filename = files[index].filename
-        if filename not in seen:
-            current[index] = True
-            seen.add(filename)
-    return current
-
-
 def folder_unpack_size(folder: SevenZipFolder) -> int:
     bound_out_streams = {out_stream for _, out_stream in folder.bind_pairs}
     for index in range(len(folder.unpack_sizes) - 1, -1, -1):
@@ -537,7 +525,6 @@ __all__ = [
     "SevenZipFolder",
     "SignatureInfo",
     "compression_method_for_coder",
-    "compute_is_current",
     "empty_archive",
     "encoded_folder_slices",
     "folder_is_encrypted",

--- a/src/archivey/internal/backends/sevenzip_reader.py
+++ b/src/archivey/internal/backends/sevenzip_reader.py
@@ -80,9 +80,11 @@ from archivey.types import (
     ArchiveMember,
     CompressionAlgorithm,
     CreateSystem,
+    HashAlgorithm,
     MagicSignature,
     MemberStreams,
     MemberType,
+    crc32_digest,
 )
 
 _WINDOWS_FILE_ATTRIBUTE_REPARSE_POINT = 0x400
@@ -349,9 +351,9 @@ class SevenZipReader(BaseArchiveReader):
             )
             if method.algo is not CompressionAlgorithm.UNKNOWN
         )
-        hashes: dict[str, int] = {}
+        hashes: dict[HashAlgorithm, bytes] = {}
         if record.crc32 is not None:
-            hashes["crc32"] = record.crc32
+            hashes[HashAlgorithm.CRC32] = crc32_digest(record.crc32)
         attrs = record.attributes
         unix_mode = (attrs >> 16) if attrs is not None and attrs >> 16 else None
         mode = stat.S_IMODE(unix_mode) if unix_mode is not None else None
@@ -542,12 +544,12 @@ class SevenZipReader(BaseArchiveReader):
         for folder_member in self._folder_members.get(folder_index, []):
             size = _member_stream_size(folder_member)
             raw_expected = (
-                folder_member.hashes.get("crc32") if folder_member.hashes else None
+                folder_member.hashes.get(HashAlgorithm.CRC32)
+                if folder_member.hashes
+                else None
             )
             if isinstance(raw_expected, bytes):
                 expected: int | None = int.from_bytes(raw_expected, "big") & 0xFFFFFFFF
-            elif isinstance(raw_expected, int):
-                expected = raw_expected & 0xFFFFFFFF
             else:
                 expected = None
             member_digests.append((size, expected))

--- a/src/archivey/internal/backends/sevenzip_reader.py
+++ b/src/archivey/internal/backends/sevenzip_reader.py
@@ -33,7 +33,6 @@ from archivey.internal.backends.sevenzip_parser import (
     SevenZipFileRecord,
     SevenZipFolder,
     compression_method_for_coder,
-    compute_is_current,
     empty_archive,
     folder_is_encrypted,
     materialize_archive,
@@ -267,13 +266,8 @@ class SevenZipReader(BaseArchiveReader):
         return starts
 
     def _build_members(self) -> list[ArchiveMember]:
-        current_flags = compute_is_current(self._archive.files)
-        return [
-            self._to_member(record, is_current=is_current)
-            for record, is_current in zip(
-                self._archive.files, current_flags, strict=True
-            )
-        ]
+        # is_current is stamped by BaseArchiveReader's shared last-entry-wins pass.
+        return [self._to_member(record) for record in self._archive.files]
 
     def _members_by_folder(self) -> dict[int, list[ArchiveMember]]:
         grouped: dict[int, list[ArchiveMember]] = {}
@@ -329,9 +323,7 @@ class SevenZipReader(BaseArchiveReader):
             if solid is not None:
                 solid.close()
 
-    def _to_member(
-        self, record: SevenZipFileRecord, *, is_current: bool
-    ) -> ArchiveMember:
+    def _to_member(self, record: SevenZipFileRecord) -> ArchiveMember:
         member_type = self._member_type(record)
         presented_name = record.filename
         if presented_name == "":
@@ -386,7 +378,6 @@ class SevenZipReader(BaseArchiveReader):
             mode=mode,
             compression=compression,
             is_encrypted=record.is_encrypted,
-            is_current=is_current,
             create_system=CreateSystem.UNIX
             if unix_mode is not None
             else CreateSystem.WINDOWS_NTFS,

--- a/src/archivey/internal/backends/zip_reader.py
+++ b/src/archivey/internal/backends/zip_reader.py
@@ -90,9 +90,11 @@ from archivey.types import (
     CompressionAlgorithm,
     CompressionMethod,
     CreateSystem,
+    HashAlgorithm,
     MagicSignature,
     MemberStreams,
     MemberType,
+    crc32_digest,
 )
 
 # Comment decoding: try UTF-8 first, else fall back to cp437 (the ZIP appnote default,
@@ -611,15 +613,15 @@ class ZipReader(BaseArchiveReader):
             )
 
         modified, accessed, created, ts_issues = _zip_timestamps(info)
-        # Surface the central-directory CRC-32 as a stored digest (archive-data-model spec:
-        # "ZIP CRC32 … stored under the 'crc32' int key"), so a dedupe pass can key on it
+        # Surface the central-directory CRC-32 as a stored digest (archive-data-model:
+        # HashAlgorithm.CRC32 → 4 big-endian bytes), so a dedupe pass can key on it
         # without decompressing (VISION "hashes without decompression"). Only for FILE and
         # SYMLINK members, which have data: a directory's stored CRC is a meaningless 0.
         # AE-2 stores CRC as 0 and relies on the HMAC — do not surface a fake crc32.
-        hashes: dict[str, int] = {}
+        hashes: dict[HashAlgorithm, bytes] = {}
         if member_type in (MemberType.FILE, MemberType.SYMLINK):
             if aes_info is None or not aes_info.is_ae2:
-                hashes = {"crc32": info.CRC & 0xFFFFFFFF}
+                hashes = {HashAlgorithm.CRC32: crc32_digest(info.CRC)}
         extra: dict[str, object] = {"zip.compress_type": info.compress_type}
         if aes_info is not None:
             extra["zip.aes_vendor_version"] = aes_info.vendor_version
@@ -834,7 +836,9 @@ class ZipReader(BaseArchiveReader):
         except _ZIP_MEMBER_READ_ERRORS as exc:
             self._reraise_member_error(exc, member_name)
 
-        hashes = member.hashes if member is not None else {}
+        hashes: Mapping[HashAlgorithm, bytes] = (
+            member.hashes if member is not None else {}
+        )
         size = member.size if member is not None else info.file_size
         if hashes or size is not None:
             return self._wrap_member_stream(
@@ -1050,7 +1054,9 @@ class ZipReader(BaseArchiveReader):
         except _ZIP_MEMBER_READ_ERRORS as exc:
             self._reraise_member_error(exc, member_name)
 
-        hashes = member.hashes if member is not None else {}
+        hashes: Mapping[HashAlgorithm, bytes] = (
+            member.hashes if member is not None else {}
+        )
         size = member.size if member is not None else info.file_size
         if hashes or size is not None:
             return self._wrap_member_stream(

--- a/src/archivey/internal/base_reader.py
+++ b/src/archivey/internal/base_reader.py
@@ -72,6 +72,7 @@ from archivey.types import (
     ArchiveFormat,
     ArchiveInfo,
     ArchiveMember,
+    HashAlgorithm,
     MagicSignature,
     MemberStreams,
     MemberType,
@@ -580,9 +581,10 @@ class BaseArchiveReader(ArchiveReader):
         size: int | None = None,
         track_output: bool = True,
         seekable: bool | None = None,
-        expected_hashes: Mapping[str, int | bytes] | None = None,
+        expected_hashes: Mapping[HashAlgorithm, bytes] | None = None,
         expected_size: int | None = None,
-        digest_transforms: Mapping[str, Callable[[bytes], bytes]] | None = None,
+        digest_transforms: Mapping[HashAlgorithm, Callable[[bytes], bytes]]
+        | None = None,
         verify_member: ArchiveMember | None = None,
     ) -> ArchiveStream:
         """Wrap a raw member stream so read/seek errors route through the backend's

--- a/src/archivey/internal/base_reader.py
+++ b/src/archivey/internal/base_reader.py
@@ -19,6 +19,7 @@ from typing import (
 
 if TYPE_CHECKING:
     from archivey.internal.password import _PasswordCandidates
+    from archivey.measurement import IoStats
 
 from archivey.config import DEFAULT_ARCHIVEY_CONFIG, ArchiveyConfig, ExtractionLimits
 from archivey.cost import CostReceipt
@@ -77,6 +78,28 @@ from archivey.types import (
     MemberStreams,
     MemberType,
 )
+
+
+def _apply_last_entry_wins_is_current(members: list[ArchiveMember]) -> None:
+    """Stamp is_current for duplicate names (last same-name entry wins).
+
+    Members whose ``name`` appears only once are left unchanged so format-specific
+    non-current rows (RAR ``path;N`` file-version history) keep the flag the backend
+    already set.
+    """
+    counts: dict[str, int] = {}
+    for member in members:
+        counts[member.name] = counts.get(member.name, 0) + 1
+
+    seen: set[str] = set()
+    for member in reversed(members):
+        if counts[member.name] < 2:
+            continue
+        if member.name in seen:
+            member.is_current = False
+        else:
+            member.is_current = True
+            seen.add(member.name)
 
 
 class ReadBackend(ABC):
@@ -708,6 +731,7 @@ class BaseArchiveReader(ArchiveReader):
             self._listing_tracker.reset()
             self._account_archive_comment(enforce=enforce_listing_limits)
             members = list(self._iter_members())
+            _apply_last_entry_wins_is_current(members)
             by_name_lists: dict[str, list[ArchiveMember]] = {}
             has_links = False
             for idx, member in enumerate(members):
@@ -765,6 +789,7 @@ class BaseArchiveReader(ArchiveReader):
         self._listing_tracker.reset()
         self._account_archive_comment(enforce=True)
         members = list(self._iter_members())
+        _apply_last_entry_wins_is_current(members)
         for idx, member in enumerate(members):
             self._register_member(idx, member, enforce_listing_limits=True)
         return members
@@ -952,6 +977,7 @@ class BaseArchiveReader(ArchiveReader):
         for member in self._pass_scanned:
             if member.is_link and member.link_target:
                 self._resolve_link(member, self._pass_by_name_lists)
+        _apply_last_entry_wins_is_current(self._pass_scanned)
         # Same publication order as _get_members_registered: name map before the
         # `_members_cache` sentinel (streaming passes are single-owner, so this is
         # consistency rather than a live race here).
@@ -1432,6 +1458,26 @@ class BaseArchiveReader(ArchiveReader):
             exc.archive_name = self._archive_name
         if exc.member_name is None and member_name is not None:
             exc.member_name = member_name
+
+    def io_stats(self) -> "IoStats | None":
+        """Return I/O counters if measurement is enabled, else ``None``.
+
+        Enable measurement via :func:`archivey.measurement.enable_measurement` around
+        the :func:`archivey.open_archive` call. Returns ``None`` when the reader was not
+        opened inside an ``enable_measurement()`` context.
+        """
+        if not self._measure:
+            return None
+        from archivey.measurement import IoStats
+
+        c_bytes = self._compressed_input_counter
+        return IoStats(
+            bytes_decompressed=self.bytes_decompressed,
+            compressed_bytes_consumed=c_bytes.bytes_read
+            if c_bytes is not None
+            else None,
+            source_seek_count=self.source_seek_count,
+        )
 
 
 class _ProgressivePassIterator(Iterator[ArchiveMember]):

--- a/src/archivey/internal/extraction.py
+++ b/src/archivey/internal/extraction.py
@@ -360,7 +360,9 @@ class ExtractionCoordinator:
                     pass
                 elif not original.is_current:
                     results.append(
-                        ExtractionResult(original, None, ExtractionStatus.SKIPPED, None)
+                        ExtractionResult(
+                            original, None, ExtractionStatus.SUPERSEDED, None
+                        )
                     )
                 else:
                     result_index = len(results)

--- a/src/archivey/internal/extraction_types.py
+++ b/src/archivey/internal/extraction_types.py
@@ -77,7 +77,7 @@ class OnError(Enum):
     CONTINUE = "continue"  # record the failure, clean up, proceed to the next member
 
 
-class ExtractionStatus(Enum):
+class ExtractionStatus(str, Enum):
     """The outcome recorded for a single member in its :class:`ExtractionResult`."""
 
     EXTRACTED = "extracted"

--- a/src/archivey/internal/extraction_types.py
+++ b/src/archivey/internal/extraction_types.py
@@ -82,6 +82,7 @@ class ExtractionStatus(Enum):
 
     EXTRACTED = "extracted"
     SKIPPED = "skipped"  # pre-existing destination under OverwritePolicy.SKIP
+    SUPERSEDED = "superseded"  # non-current entry (a later same-name entry overwrites)
     REJECTED = "rejected"  # blocked by a safety filter (universal or policy check)
     FAILED = "failed"  # error while extracting (corrupt data, ratio bomb, write error)
 

--- a/src/archivey/internal/streams/archive_stream.py
+++ b/src/archivey/internal/streams/archive_stream.py
@@ -30,6 +30,7 @@ from archivey.internal.diagnostics_collector import resolve_collector
 from archivey.internal.logs import streams as logger
 from archivey.internal.streams.streamtools import ReadOnlyIOStream, is_seekable
 from archivey.internal.streams.verify import MemberVerifier, build_member_verifier
+from archivey.types import HashAlgorithm
 
 if TYPE_CHECKING:
     from _typeshed import WriteableBuffer
@@ -85,9 +86,10 @@ class ArchiveStream(ReadOnlyIOStream):
         size: int | None = None,
         collector: DiagnosticCollector | None = None,
         on_close: CloseHook | None = None,
-        expected_hashes: Mapping[str, int | bytes] | None = None,
+        expected_hashes: Mapping[HashAlgorithm, bytes] | None = None,
         expected_size: int | None = None,
-        digest_transforms: Mapping[str, Callable[[bytes], bytes]] | None = None,
+        digest_transforms: Mapping[HashAlgorithm, Callable[[bytes], bytes]]
+        | None = None,
         verify_member: ArchiveMember | None = None,
         archive_name: str | None = None,
         verifier: MemberVerifier | None = None,

--- a/src/archivey/internal/streams/codecs.py
+++ b/src/archivey/internal/streams/codecs.py
@@ -69,9 +69,11 @@ from archivey.types import (
     ArchiveFormat,
     ArchiveMember,
     ContainerFormat,
+    HashAlgorithm,
     MagicSignature,
     MissingComponent,
     StreamFormat,
+    crc32_digest,
 )
 
 if TYPE_CHECKING:
@@ -734,8 +736,8 @@ class GzipCodec(StreamCodec):
         RFC 1952 specifies the FNAME field as ISO-8859-1 (Latin-1), so the decoded value in
         ``extra`` uses that encoding; ``raw_name`` keeps the verbatim stored bytes.
 
-        The 8-byte trailer CRC-32 is surfaced as ``member.hashes["crc32"]`` only when the
-        header is a valid gzip magic *and* the stream is a single member on a
+        The 8-byte trailer CRC-32 is surfaced as ``member.hashes[HashAlgorithm.CRC32]``
+        only when the header is a valid gzip magic *and* the stream is a single member on a
         seekable/path source (multi-member trailers cover only the last member). Never
         triggers a decompression pass.
         """
@@ -765,7 +767,7 @@ class GzipCodec(StreamCodec):
         crc32 = ctx.probe_gzip_stored_crc32()
         if crc32 is not None:
             hashes = dict(member.hashes)
-            hashes["crc32"] = crc32
+            hashes[HashAlgorithm.CRC32] = crc32_digest(crc32)
             member.hashes = hashes
 
 
@@ -909,7 +911,7 @@ class LzipCodec(_SizedLzmaCodec):
         crc32, _data_size, member_size = struct.unpack_from("<IQQ", trailer, 0)
         if member_size == member.compressed_size:
             hashes = dict(member.hashes)
-            hashes["crc32"] = crc32
+            hashes[HashAlgorithm.CRC32] = crc32_digest(crc32)
             member.hashes = hashes
 
 

--- a/src/archivey/internal/streams/verify.py
+++ b/src/archivey/internal/streams/verify.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 
 import hashlib
 import zlib
-from typing import TYPE_CHECKING, BinaryIO, Callable, Mapping, Protocol
+from typing import TYPE_CHECKING, Any, BinaryIO, Callable, Mapping, Protocol
 
 from archivey.diagnostics import DiagnosticCode, DigestContext
 from archivey.exceptions import ArchiveyError, CorruptionError, TruncatedError
@@ -37,9 +37,26 @@ from archivey.internal.streams.streamtools import (
     ReadOnlyIOStream,
     is_seekable,
 )
+from archivey.types import HashAlgorithm
 
 if TYPE_CHECKING:
     from archivey.types import ArchiveMember
+
+# Keys: ``HashAlgorithm`` or algorithm name string (``hashlib`` / legacy). Values are
+# ``bytes``; ``int`` CRC32 accepted briefly for internal/test callers.
+_ExpectedHashes = Mapping[Any, bytes | int]
+_DigestTransforms = Mapping[Any, Callable[[bytes], bytes]]
+
+
+def _algo_key(algorithm: Any) -> str:
+    """Normalize a hash key to a lowercase algorithm name.
+
+    ``str(HashAlgorithm.CRC32)`` is ``"HashAlgorithm.CRC32"``; use the enum value
+    so registry lookup matches ``"crc32"``.
+    """
+    if isinstance(algorithm, HashAlgorithm):
+        return algorithm.value
+    return str(algorithm).lower()
 
 
 class _IncrementalHasher(Protocol):
@@ -66,9 +83,9 @@ class _Crc32Hasher:
         return (self._value & 0xFFFFFFFF).to_bytes(self.digest_size, "big")
 
 
-def _make_hasher(algorithm: str) -> Callable[[], _IncrementalHasher] | None:
+def _make_hasher(algorithm: Any) -> Callable[[], _IncrementalHasher] | None:
     """Return a zero-arg factory for an incremental hasher, or ``None`` if unavailable."""
-    name = algorithm.lower()
+    name = _algo_key(algorithm)
     if name == "crc32":
         return _Crc32Hasher
     if name == "blake2sp":
@@ -79,12 +96,12 @@ def _make_hasher(algorithm: str) -> Callable[[], _IncrementalHasher] | None:
     return None
 
 
-def _expected_as_bytes(value: int | bytes, hasher: _IncrementalHasher) -> bytes:
+def _expected_as_bytes(value: bytes | int, hasher: _IncrementalHasher) -> bytes:
     """Normalize a stored digest to ``bytes`` once, in the hasher's own width.
 
-    A digest may be stored as raw bytes or as a big-endian integer (e.g. CRC32 as int).
-    Converting the *expected* value up front lets verification be a plain ``bytes ==
-    bytes`` compare against ``hasher.digest()`` — no per-read int<->bytes round-trip.
+    Digests are ``bytes`` (CRC-32 as four big-endian bytes). An ``int`` form is still
+    accepted briefly for internal callers; oversized ints produce a longer byte string
+    that fails the digest compare rather than raising here.
     """
     if isinstance(value, int):
         # Size the buffer to whichever is larger: the hasher's digest width (so a normal,
@@ -108,26 +125,28 @@ class MemberVerifier:
 
     def __init__(
         self,
-        expected: Mapping[str, int | bytes],
+        expected: _ExpectedHashes,
         *,
         expected_size: int | None = None,
         collector: DiagnosticCollector | None = None,
         member: ArchiveMember | None = None,
         archive_name: str | None = None,
-        digest_transforms: Mapping[str, Callable[[bytes], bytes]] | None = None,
+        digest_transforms: _DigestTransforms | None = None,
     ) -> None:
         self._expected_size = expected_size
         self._short = False
         self._expected: dict[str, bytes] = {}
         self._hashers: dict[str, _IncrementalHasher] = {}
-        self._digest_transforms: dict[str, Callable[[bytes], bytes]] = (
-            dict(digest_transforms) if digest_transforms else {}
-        )
+        self._digest_transforms: dict[str, Callable[[bytes], bytes]] = {}
+        if digest_transforms:
+            for key, transform in digest_transforms.items():
+                self._digest_transforms[_algo_key(key)] = transform
         for algorithm, value in expected.items():
-            factory = _make_hasher(algorithm)
+            key = _algo_key(algorithm)
+            factory = _make_hasher(key)
             if factory is None:
                 message = (
-                    f"Cannot verify digest {algorithm!r} (unknown algorithm or backend "
+                    f"Cannot verify digest {key!r} (unknown algorithm or backend "
                     f"not installed); skipping integrity check for it."
                 )
                 resolve_collector(collector).emit(
@@ -137,7 +156,7 @@ class MemberVerifier:
                         archive_name=archive_name,
                         member_name=member.name if member is not None else "",
                         member_id=member._member_id if member is not None else None,
-                        algorithm=algorithm,
+                        algorithm=key,
                         reason="unknown_algorithm_or_backend",
                     ),
                     member=member,
@@ -146,8 +165,8 @@ class MemberVerifier:
                 )
                 continue
             hasher = factory()
-            self._hashers[algorithm] = hasher
-            self._expected[algorithm] = _expected_as_bytes(value, hasher)
+            self._hashers[key] = hasher
+            self._expected[key] = _expected_as_bytes(value, hasher)
         self._verified = False
         self._pos = 0  # bytes read so far — the sequential verification frontier
         self._verify_enabled = True  # cleared by a seek off the frontier
@@ -305,13 +324,13 @@ class MemberVerifier:
 
 
 def build_member_verifier(
-    expected: Mapping[str, int | bytes] | None,
+    expected: _ExpectedHashes | None,
     *,
     expected_size: int | None = None,
     collector: DiagnosticCollector | None = None,
     member: ArchiveMember | None = None,
     archive_name: str | None = None,
-    digest_transforms: Mapping[str, Callable[[bytes], bytes]] | None = None,
+    digest_transforms: _DigestTransforms | None = None,
 ) -> MemberVerifier | None:
     """Return a :class:`MemberVerifier` when there is something to check, else ``None``."""
     hashes = expected if expected is not None else {}
@@ -337,13 +356,13 @@ class VerifyingStream(ReadOnlyIOStream):
     def __init__(
         self,
         inner: BinaryIO,
-        expected: Mapping[str, int | bytes],
+        expected: _ExpectedHashes,
         *,
         expected_size: int | None = None,
         collector: DiagnosticCollector | None = None,
         member: ArchiveMember | None = None,
         archive_name: str | None = None,
-        digest_transforms: Mapping[str, Callable[[bytes], bytes]] | None = None,
+        digest_transforms: _DigestTransforms | None = None,
     ) -> None:
         super().__init__()
         self._inner = inner

--- a/src/archivey/internal/streams/verify.py
+++ b/src/archivey/internal/streams/verify.py
@@ -43,8 +43,8 @@ if TYPE_CHECKING:
     from archivey.types import ArchiveMember
 
 # Keys: ``HashAlgorithm`` or algorithm name string (``hashlib`` / legacy). Values are
-# ``bytes``; ``int`` CRC32 accepted briefly for internal/test callers.
-_ExpectedHashes = Mapping[Any, bytes | int]
+# digest ``bytes`` (CRC-32 as four big-endian bytes).
+_ExpectedHashes = Mapping[Any, bytes]
 _DigestTransforms = Mapping[Any, Callable[[bytes], bytes]]
 
 
@@ -94,24 +94,6 @@ def _make_hasher(algorithm: Any) -> Callable[[], _IncrementalHasher] | None:
     if name in hashlib.algorithms_available:
         return lambda: hashlib.new(name)
     return None
-
-
-def _expected_as_bytes(value: bytes | int, hasher: _IncrementalHasher) -> bytes:
-    """Normalize a stored digest to ``bytes`` once, in the hasher's own width.
-
-    Digests are ``bytes`` (CRC-32 as four big-endian bytes). An ``int`` form is still
-    accepted briefly for internal callers; oversized ints produce a longer byte string
-    that fails the digest compare rather than raising here.
-    """
-    if isinstance(value, int):
-        # Size the buffer to whichever is larger: the hasher's digest width (so a normal,
-        # in-range value compares equal to digest()) or the value's own minimum width. A
-        # malformed/oversized stored int (e.g. a "crc32" > 2**32) thus produces a longer
-        # byte string that simply won't equal the digest — surfacing as a CorruptionError on
-        # verify — rather than raising OverflowError here and leaking a non-ArchiveyError.
-        width = max(hasher.digest_size, (value.bit_length() + 7) // 8)
-        return value.to_bytes(width, "big")
-    return value
 
 
 class MemberVerifier:
@@ -166,7 +148,7 @@ class MemberVerifier:
                 continue
             hasher = factory()
             self._hashers[key] = hasher
-            self._expected[key] = _expected_as_bytes(value, hasher)
+            self._expected[key] = value
         self._verified = False
         self._pos = 0  # bytes read so far — the sequential verification frontier
         self._verify_enabled = True  # cleared by a seek off the frontier

--- a/src/archivey/measurement.py
+++ b/src/archivey/measurement.py
@@ -1,0 +1,46 @@
+"""Public measurement / IO-stats API.
+
+Enable performance counters by wrapping ``open_archive()`` in
+:func:`enable_measurement`::
+
+    import archivey
+    from archivey.measurement import enable_measurement
+
+    with enable_measurement():
+        with archivey.open_archive("data.zip") as reader:
+            data = reader.read("file.txt")
+            stats = reader.io_stats()
+            if stats:
+                print(stats.bytes_decompressed)
+
+Counters stay at zero (and :meth:`~archivey.ArchiveReader.io_stats` returns
+``None``) unless the reader was opened inside an :func:`enable_measurement`
+context — zero overhead on the hot path when measurement is off.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from archivey.internal.measurement import enable_measurement
+
+__all__ = ["IoStats", "enable_measurement"]
+
+
+@dataclass(frozen=True)
+class IoStats:
+    """I/O counters sampled from an archive reader with measurement enabled.
+
+    Returned by :meth:`~archivey.ArchiveReader.io_stats`; ``None`` when the reader
+    was not opened inside :func:`enable_measurement`.
+    """
+
+    bytes_decompressed: int
+    """Total decoded / output bytes delivered through member streams so far."""
+
+    compressed_bytes_consumed: int | None
+    """Compressed bytes pulled from the archive's outer source so far, or ``None``
+    when the source size is statically known (the static ratio is used instead)."""
+
+    source_seek_count: int
+    """Number of ``seek()`` calls on the instrumented archive source."""

--- a/src/archivey/reader.py
+++ b/src/archivey/reader.py
@@ -13,7 +13,6 @@ from archivey.internal.extraction_types import (
     ExtractionPolicy,
     ExtractionProgress,
     MemberFilter,
-    MemberSelectorArg,
     OnError,
     OverwritePolicy,
 )
@@ -21,6 +20,7 @@ from archivey.types import ArchiveFormat, ArchiveInfo, ArchiveMember
 
 if TYPE_CHECKING:
     from archivey.internal.streams.archive_stream import ArchiveStream
+    from archivey.measurement import IoStats
 
 # Type alias for the member selector passed to stream_members() and extract_all().
 # Accepts a predicate, a collection of names / ArchiveMember objects, or None (all).
@@ -145,7 +145,7 @@ class ArchiveReader(ABC):
         self,
         dest: str | Path,
         *,
-        members: MemberSelectorArg = None,
+        members: MemberSelector = None,
         filter: MemberFilter | None = None,
         policy: ExtractionPolicy = ExtractionPolicy.STRICT,
         overwrite: OverwritePolicy = OverwritePolicy.ERROR,
@@ -163,6 +163,16 @@ class ArchiveReader(ABC):
         config the reader was opened with; ``limits`` overrides its extraction limits for
         this call only. Returns an :class:`~archivey.ExtractionReport` whose diagnostic
         summary is the delta for this extraction call.
+        """
+        ...
+
+    @abstractmethod
+    def io_stats(self) -> "IoStats | None":
+        """Return I/O counters if measurement was enabled at open time, else ``None``.
+
+        Enable via :func:`archivey.measurement.enable_measurement` around the
+        :func:`archivey.open_archive` call. Counters cover bytes decompressed, compressed
+        bytes consumed from the outer source, and source seek calls.
         """
         ...
 

--- a/src/archivey/types.py
+++ b/src/archivey/types.py
@@ -108,6 +108,18 @@ class ArchiveFormat:
             return self.container.value
         return f"{self.container.value}.{self.stream.value}"
 
+    @property
+    def display_name(self) -> str:
+        """Human-readable name for this format, e.g. ``"ZIP"``, ``"TAR_GZ"``.
+
+        Uses the predefined named-instance attribute name (``ZIP``, ``TAR_GZ``, …);
+        falls back to ``repr()`` for an ad-hoc combination not in the named set.
+        ``_FORMAT_NAMES`` is populated just after the class definition — safe at
+        runtime because this property is never called before the module is fully loaded.
+        """
+        name = _FORMAT_NAMES.get(self)
+        return name if name is not None else repr(self)
+
     def __repr__(self) -> str:
         name = _FORMAT_NAMES.get(self)
         if name is not None:

--- a/src/archivey/types.py
+++ b/src/archivey/types.py
@@ -195,6 +195,19 @@ class MemberType(Enum):
     ANTI = "anti"
 
 
+class HashAlgorithm(str, Enum):
+    """Digest algorithms that may appear as keys in :attr:`ArchiveMember.hashes`."""
+
+    CRC32 = "crc32"
+    BLAKE2SP = "blake2sp"
+    ADLER32 = "adler32"
+
+
+def crc32_digest(value: int) -> bytes:
+    """Encode a CRC-32 as four big-endian bytes for :attr:`ArchiveMember.hashes`."""
+    return (value & 0xFFFFFFFF).to_bytes(4, "big")
+
+
 class CompressionAlgorithm(Enum):
     """A compression/filter codec. Extensible: codecs Archivey does not recognize
     map to ``UNKNOWN`` rather than raising, so callers should treat the set as
@@ -329,8 +342,11 @@ class ArchiveMember:
     windows_attrs: int | None = None
     """Raw Windows file-attribute bitmask, if recorded."""
 
-    hashes: Mapping[str, int | bytes] = field(default_factory=dict, compare=False)
-    """Stored content digests keyed by algorithm name (e.g. ``"crc32"``). Excluded from equality."""
+    hashes: Mapping[HashAlgorithm, bytes] = field(default_factory=dict, compare=False)
+    """Stored content digests keyed by :class:`HashAlgorithm` (values always ``bytes``).
+
+    CRC-32 is four big-endian bytes (:func:`crc32_digest`). Excluded from equality.
+    """
 
     extra: dict[str, Any] = field(default_factory=dict, compare=False)
     """Format-specific extra fields (e.g. ``extra["is_junction"]``). Excluded from equality."""

--- a/tests/test_blake2sp.py
+++ b/tests/test_blake2sp.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import pytest
 
 from archivey.internal.hashing.blake2sp import Blake2sp, blake2sp
+from archivey.types import HashAlgorithm
 
 # (input_length, expected_hex). Input bytes are ``bytes(range(n))`` as in the
 # official KATs (``in`` is 000102… for length n).
@@ -57,5 +58,5 @@ def test_blake2sp_matches_rar5_fixture_payload() -> None:
     payload = b"stored payload"
     with open_archive(fixture) as archive:
         member = next(m for m in archive.members() if m.is_file)
-        assert member.hashes["blake2sp"] == blake2sp(payload)
-        assert len(member.hashes["blake2sp"]) == 32
+        assert member.hashes[HashAlgorithm.BLAKE2SP] == blake2sp(payload)
+        assert len(member.hashes[HashAlgorithm.BLAKE2SP]) == 32

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -743,15 +743,15 @@ def test_verify_crc32_accepts_bytes_form() -> None:
     assert stream.read() == CONTENT
 
 
-def test_verify_oversized_int_digest_mismatches_not_raises() -> None:
-    """A malformed stored digest wider than the hash must surface as CorruptionError.
+def test_verify_wrong_width_digest_mismatches_not_raises() -> None:
+    """A stored digest wider than the hasher's digest_size must surface as CorruptionError.
 
-    A "crc32" int > 2**32 can't equal a 4-byte digest; normalization must not raise
-    OverflowError (which would leak a non-ArchiveyError out of the stream layer).
+    Callers always pass ``bytes``; a malformed width must compare unequal (and raise
+    :class:`CorruptionError`) rather than raising a non-ArchiveyError from the
+    stream layer.
     """
-    stream = VerifyingStream(
-        io.BytesIO(CONTENT), {"crc32": (zlib.crc32(CONTENT) & 0xFFFFFFFF) + (1 << 40)}
-    )
+    wrong_width = _crc32(CONTENT) + b"\x00\x00"  # 6 bytes vs CRC-32's 4
+    stream = VerifyingStream(io.BytesIO(CONTENT), {HashAlgorithm.CRC32: wrong_width})
     with pytest.raises(CorruptionError, match="crc32"):
         while stream.read(64):  # read to EOF; the terminal read verifies
             pass

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -33,7 +33,7 @@ from archivey.internal.streams.codecs import (
     resolve_codec,
 )
 from archivey.internal.streams.verify import VerifyingStream
-from archivey.types import StreamFormat
+from archivey.types import HashAlgorithm, StreamFormat, crc32_digest
 from tests.conftest import requires, requires_binary, requires_zstd, zstd_backend
 from tests.streams_util import (
     NonSeekableBytesIO,
@@ -542,24 +542,30 @@ def test_translated_error_is_stamped() -> None:
 # --- digest verification ---------------------------------------------------------------
 
 
-def _crc32(data: bytes) -> int:
-    return zlib.crc32(data) & 0xFFFFFFFF
+def _crc32(data: bytes) -> bytes:
+    return crc32_digest(zlib.crc32(data))
 
 
 def test_verify_matching_crc32_passes() -> None:
-    stream = VerifyingStream(io.BytesIO(CONTENT), {"crc32": _crc32(CONTENT)})
+    stream = VerifyingStream(
+        io.BytesIO(CONTENT), {HashAlgorithm.CRC32: _crc32(CONTENT)}
+    )
     assert stream.read() == CONTENT
     assert stream.read() == b""  # terminal read verifies; no error
 
 
 def test_verify_multiple_algorithms() -> None:
-    expected = {"crc32": _crc32(CONTENT), "sha256": hashlib.sha256(CONTENT).digest()}
+    expected = {
+        HashAlgorithm.CRC32: _crc32(CONTENT),
+        "sha256": hashlib.sha256(CONTENT).digest(),
+    }
     stream = VerifyingStream(io.BytesIO(CONTENT), expected)
     assert stream.read() == CONTENT
 
 
 def test_verify_mismatch_raises_at_eof_without_losing_final_chunk() -> None:
-    stream = VerifyingStream(io.BytesIO(CONTENT), {"crc32": _crc32(CONTENT) ^ 0xFFFF})
+    bad = crc32_digest(zlib.crc32(CONTENT) ^ 0xFFFF)
+    stream = VerifyingStream(io.BytesIO(CONTENT), {HashAlgorithm.CRC32: bad})
     collected = bytearray()
     with pytest.raises(CorruptionError, match="crc32"):
         while True:
@@ -571,14 +577,16 @@ def test_verify_mismatch_raises_at_eof_without_losing_final_chunk() -> None:
 
 
 def test_verify_partial_read_is_not_verified() -> None:
-    stream = VerifyingStream(io.BytesIO(CONTENT), {"crc32": _crc32(CONTENT) ^ 0xFFFF})
+    bad = crc32_digest(zlib.crc32(CONTENT) ^ 0xFFFF)
+    stream = VerifyingStream(io.BytesIO(CONTENT), {HashAlgorithm.CRC32: bad})
     assert stream.read(10) == CONTENT[:10]
     stream.close()  # abandoned before EOF — must not raise
 
 
 def test_verify_on_close_after_full_single_read() -> None:
     """A single read()-to-end must still verify when the stream is closed."""
-    stream = VerifyingStream(io.BytesIO(CONTENT), {"crc32": _crc32(CONTENT) ^ 0xFFFF})
+    bad = crc32_digest(zlib.crc32(CONTENT) ^ 0xFFFF)
+    stream = VerifyingStream(io.BytesIO(CONTENT), {HashAlgorithm.CRC32: bad})
     assert stream.read() == CONTENT
     with pytest.raises(CorruptionError, match="crc32"):
         stream.close()
@@ -622,7 +630,7 @@ def test_verify_hashed_overlong_with_matching_crc_still_capped() -> None:
     bloated = b"A" * 200
     stream = VerifyingStream(
         io.BytesIO(bloated),
-        {"crc32": _crc32(bloated)},
+        {HashAlgorithm.CRC32: _crc32(bloated)},
         expected_size=declared,
     )
     out = bytearray()
@@ -639,7 +647,7 @@ def test_verify_expected_size_short_with_hash_is_digest_mismatch() -> None:
     """A hashed short read surfaces as the digest mismatch, not a truncation error."""
     stream = VerifyingStream(
         io.BytesIO(CONTENT),
-        {"crc32": _crc32(CONTENT + b"more")},
+        {HashAlgorithm.CRC32: _crc32(CONTENT + b"more")},
         expected_size=len(CONTENT) + 4,
     )
     assert stream.read() == CONTENT
@@ -656,7 +664,9 @@ def test_verify_expected_size_partial_read_then_close_is_ok() -> None:
 
 def test_verify_read0_is_not_eof() -> None:
     """F1: read(0) must not run end-of-stream verification (BytesIO / file contract)."""
-    stream = VerifyingStream(io.BytesIO(CONTENT), {"crc32": _crc32(CONTENT)})
+    stream = VerifyingStream(
+        io.BytesIO(CONTENT), {HashAlgorithm.CRC32: _crc32(CONTENT)}
+    )
     assert stream.read(0) == b""
     assert stream.read(5) == CONTENT[:5]
     assert stream.read(0) == b""  # mid-stream
@@ -713,20 +723,22 @@ def test_verify_unverifiable_algorithm_skipped_with_warning(
 def test_verify_blake2sp_match() -> None:
     from archivey.internal.hashing.blake2sp import blake2sp
 
-    expected = {"blake2sp": blake2sp(CONTENT)}
+    expected = {HashAlgorithm.BLAKE2SP: blake2sp(CONTENT)}
     stream = VerifyingStream(io.BytesIO(CONTENT), expected)
     assert stream.read() == CONTENT
 
 
 def test_verify_blake2sp_mismatch_raises() -> None:
-    stream = VerifyingStream(io.BytesIO(CONTENT), {"blake2sp": b"\x00" * 32})
+    stream = VerifyingStream(
+        io.BytesIO(CONTENT), {HashAlgorithm.BLAKE2SP: b"\x00" * 32}
+    )
     with pytest.raises(CorruptionError, match="blake2sp"):
         while stream.read(64):
             pass
 
 
 def test_verify_crc32_accepts_bytes_form() -> None:
-    expected = {"crc32": _crc32(CONTENT).to_bytes(4, "big")}
+    expected = {HashAlgorithm.CRC32: _crc32(CONTENT)}
     stream = VerifyingStream(io.BytesIO(CONTENT), expected)
     assert stream.read() == CONTENT
 
@@ -738,7 +750,7 @@ def test_verify_oversized_int_digest_mismatches_not_raises() -> None:
     OverflowError (which would leak a non-ArchiveyError out of the stream layer).
     """
     stream = VerifyingStream(
-        io.BytesIO(CONTENT), {"crc32": _crc32(CONTENT) + (1 << 40)}
+        io.BytesIO(CONTENT), {"crc32": (zlib.crc32(CONTENT) & 0xFFFFFFFF) + (1 << 40)}
     )
     with pytest.raises(CorruptionError, match="crc32"):
         while stream.read(64):  # read to EOF; the terminal read verifies

--- a/tests/test_corpus_sweep.py
+++ b/tests/test_corpus_sweep.py
@@ -31,6 +31,7 @@ from archivey import (
     format_availability,
     open_archive,
 )
+from archivey.types import HashAlgorithm
 from tests.conftest import _has_zstd_backend
 from tests.sample_archives import (
     BUILDER_BINARIES,
@@ -140,33 +141,37 @@ def _check_listing(ar, entry: CorpusEntry, key: str) -> None:
 def _assert_stored_digest_parity(member, key: str) -> None:
     """Assert documented stored-digest keys are present/absent (testing-contract)."""
     keys = set(member.hashes)
-    digest_keys = keys & {"crc32", "blake2sp"}
+    digest_keys = keys & {HashAlgorithm.CRC32, HashAlgorithm.BLAKE2SP}
     if key == "zip":
         if member.type in (MemberType.FILE, MemberType.SYMLINK):
             # AE-2 (WinZip AES) stores CRC as 0 and relies on the HMAC — no crc32 digest.
             if member.extra.get("zip.aes_vendor_version") == 2:
-                assert "crc32" not in keys, (
+                assert HashAlgorithm.CRC32 not in keys, (
                     f"zip AE-2 {member.name!r} should not surface crc32"
                 )
             else:
-                assert "crc32" in keys, f"zip {member.name!r} missing crc32"
+                assert HashAlgorithm.CRC32 in keys, f"zip {member.name!r} missing crc32"
         else:
-            assert "crc32" not in keys, f"zip {member.name!r} unexpected crc32"
+            assert HashAlgorithm.CRC32 not in keys, (
+                f"zip {member.name!r} unexpected crc32"
+            )
         return
     if key == "7z":
         if member.type is MemberType.FILE:
-            assert "crc32" in keys, f"7z {member.name!r} missing crc32"
+            assert HashAlgorithm.CRC32 in keys, f"7z {member.name!r} missing crc32"
         elif member.type is MemberType.DIRECTORY:
-            assert "crc32" not in keys, f"7z {member.name!r} unexpected crc32"
+            assert HashAlgorithm.CRC32 not in keys, (
+                f"7z {member.name!r} unexpected crc32"
+            )
         # SYMLINK may carry a CRC of the stored link payload; do not require or forbid.
         return
     if key == "rar":
         if member.type is MemberType.FILE:
             # RAR5 may store Blake2sp instead of (or in addition to) CRC32.
             assert digest_keys, f"rar FILE {member.name!r} missing stored digest"
-            if "blake2sp" in keys and "crc32" not in keys:
+            if HashAlgorithm.BLAKE2SP in keys and HashAlgorithm.CRC32 not in keys:
                 return
-            assert "crc32" in keys or "blake2sp" in keys
+            assert HashAlgorithm.CRC32 in keys or HashAlgorithm.BLAKE2SP in keys
         else:
             assert not digest_keys, (
                 f"rar {member.name!r} unexpected digests {digest_keys}"
@@ -278,12 +283,12 @@ def _check_single_file(entry: CorpusEntry, key: str, source: Path) -> None:
         # Stored-digest parity: single-member gzip always (path source); lzip only with
         # declared SEEKABLE (same gate as size); other codecs omit.
         if key in ("gz", "gz-meta"):
-            assert "crc32" in member.hashes
+            assert HashAlgorithm.CRC32 in member.hashes
         elif key == "lz":
-            assert "crc32" not in member.hashes
+            assert HashAlgorithm.CRC32 not in member.hashes
         else:
-            assert "crc32" not in member.hashes
-            assert "blake2sp" not in member.hashes
+            assert HashAlgorithm.CRC32 not in member.hashes
+            assert HashAlgorithm.BLAKE2SP not in member.hashes
     if key == "lz":
         with open_archive(source, member_streams=MemberStreams.SEEKABLE) as ar:
-            assert "crc32" in ar.members()[0].hashes
+            assert HashAlgorithm.CRC32 in ar.members()[0].hashes

--- a/tests/test_corpus_sweep.py
+++ b/tests/test_corpus_sweep.py
@@ -27,7 +27,6 @@ from archivey import (
     MemberStreams,
     MemberType,
     OnError,
-    OverwritePolicy,
     format_availability,
     open_archive,
 )
@@ -200,14 +199,10 @@ def _check_reads(ar, entry: CorpusEntry) -> None:
 
 def _check_extraction(tmp_path: Path, source, entry: CorpusEntry, key: str) -> None:
     dest = tmp_path / "extracted"
-    has_duplicates = len({m.name for m in entry.members}) != len(entry.members)
     with open_archive(source, password=list(entry.passwords) or None) as ar:
         results = ar.extract_all(
             dest,
             on_error=OnError.CONTINUE,
-            overwrite=OverwritePolicy.REPLACE
-            if has_duplicates
-            else OverwritePolicy.ERROR,
         ).results
 
     by_member_name: dict[str, list] = {}

--- a/tests/test_cost_receipt.py
+++ b/tests/test_cost_receipt.py
@@ -14,6 +14,7 @@ import bz2
 import gzip
 import io
 import lzma
+import shutil
 import tarfile
 import zipfile
 from pathlib import Path
@@ -30,6 +31,8 @@ try:
     _HAVE_PYCDLIB = True
 except ImportError:
     _HAVE_PYCDLIB = False
+
+_HAVE_UNRAR = shutil.which("unrar") is not None
 
 
 def _zip(tmp: Path) -> Path:
@@ -158,6 +161,25 @@ _PARAMS.append(
         CostReceipt(ListingCost.INDEXED, AccessCost.DIRECT, StreamCapability.SEEKABLE),
         id="iso",
         marks=pytest.mark.skipif(not _HAVE_PYCDLIB, reason="pycdlib not installed"),
+    )
+)
+
+
+def _rar(tmp: Path) -> Path:
+    fixture = Path(__file__).parent / "fixtures" / "rar" / "basic_nonsolid__.rar"
+    dest = tmp / "a.rar"
+    import shutil as _shutil
+
+    _shutil.copy2(fixture, dest)
+    return dest
+
+
+_PARAMS.append(
+    pytest.param(
+        _rar,
+        CostReceipt(ListingCost.INDEXED, AccessCost.DIRECT, StreamCapability.SEEKABLE),
+        id="rar",
+        marks=pytest.mark.skipif(not _HAVE_UNRAR, reason="unrar binary not installed"),
     )
 )
 

--- a/tests/test_crypto_findings.py
+++ b/tests/test_crypto_findings.py
@@ -53,6 +53,7 @@ from archivey.internal.diagnostics_collector import DiagnosticCollector
 from archivey.internal.hashing.blake2sp import Blake2sp
 from archivey.internal.streams import crypto
 from archivey.internal.streams.verify import VerifyingStream
+from archivey.types import HashAlgorithm, crc32_digest
 from tests.conftest import requires, requires_binary
 
 _RAR = Path(__file__).parent / "fixtures" / "rar"
@@ -123,7 +124,10 @@ def test_f1_member_hashes_keeps_untweaked_digests() -> None:
         crc32=0x11, blake2sp_hash=b"\x22" * 32, flags=0x01
     )  # checkval only
     assert not _crc_is_tweaked(info)
-    assert _member_hashes(info) == {"crc32": 0x11, "blake2sp": b"\x22" * 32}
+    assert _member_hashes(info) == {
+        HashAlgorithm.CRC32: crc32_digest(0x11),
+        HashAlgorithm.BLAKE2SP: b"\x22" * 32,
+    }
 
 
 def test_f1_convert_hash_to_mac_crc_and_blake2sp_roundtrip() -> None:
@@ -147,12 +151,15 @@ def test_f1_convert_hash_to_mac_crc_and_blake2sp_roundtrip() -> None:
 
     # VerifyingStream with transforms accepts good data and rejects a wrong MAC.
     transforms = {
-        "crc32": lambda d, hk=hash_key: convert_crc_to_mac(
+        HashAlgorithm.CRC32: lambda d, hk=hash_key: convert_crc_to_mac(
             int.from_bytes(d, "big"), hk
         ).to_bytes(4, "big"),
-        "blake2sp": lambda d, hk=hash_key: convert_blake2sp_to_mac(d, hk),
+        HashAlgorithm.BLAKE2SP: lambda d, hk=hash_key: convert_blake2sp_to_mac(d, hk),
     }
-    expected = {"crc32": tweaked_crc, "blake2sp": tweaked_blake}
+    expected = {
+        HashAlgorithm.CRC32: crc32_digest(tweaked_crc),
+        HashAlgorithm.BLAKE2SP: tweaked_blake,
+    }
     stream = VerifyingStream(
         io.BytesIO(plaintext), expected, digest_transforms=transforms
     )
@@ -161,7 +168,7 @@ def test_f1_convert_hash_to_mac_crc_and_blake2sp_roundtrip() -> None:
 
     bad = VerifyingStream(
         io.BytesIO(plaintext),
-        {"blake2sp": bytes(32)},
+        {HashAlgorithm.BLAKE2SP: bytes(32)},
         digest_transforms=transforms,
     )
     with pytest.raises(CorruptionError, match="blake2sp"):
@@ -237,7 +244,7 @@ def test_f1_encryption_blake2sp_reads_without_false_corruption() -> None:
 
     with open_archive(path, password="password") as reader:
         member = next(m for m in reader.members() if m.is_file)
-        assert "blake2sp" not in member.hashes
+        assert HashAlgorithm.BLAKE2SP not in member.hashes
         assert member.extra["rar.tweaked_blake2sp"] == info.blake2sp_hash
         assert reader.read(member) == b"stored payload"
         # Password known → forward-transform verify; no DIGEST_UNVERIFIABLE.
@@ -366,7 +373,7 @@ def test_f2_normal_aes_archive_has_crc_anchor_no_diagnostic(tmp_path: Path) -> N
     _write_py7zr_archive(archive, {"a.txt": b"hello"}, password="secret")
     with open_archive(archive, password="secret") as reader:
         member = next(m for m in reader.members() if m.is_file)
-        assert "crc32" in member.hashes
+        assert HashAlgorithm.CRC32 in member.hashes
         assert reader.diagnostics.counts.get(DiagnosticCode.DIGEST_UNVERIFIABLE, 0) == 0
         assert reader.read(member) == b"hello"
 

--- a/tests/test_crypto_findings.py
+++ b/tests/test_crypto_findings.py
@@ -356,7 +356,7 @@ def test_f2_no_anchor_encrypted_member_emits_diagnostic() -> None:
         is_solid=False,
         compression_methods=(),
     )
-    member = reader._to_member(record, is_current=True)  # noqa: SLF001
+    member = reader._to_member(record)  # noqa: SLF001
     assert member.hashes == {}
     summary = collector.snapshot()
     assert summary.counts.get(DiagnosticCode.DIGEST_UNVERIFIABLE, 0) == 1

--- a/tests/test_data_model.py
+++ b/tests/test_data_model.py
@@ -18,8 +18,10 @@ from archivey.types import (
     CompressionAlgorithm,
     CompressionMethod,
     ContainerFormat,
+    HashAlgorithm,
     MemberType,
     StreamFormat,
+    crc32_digest,
 )
 
 # ---------------------------------------------------------------------------
@@ -103,10 +105,16 @@ def test_equality_excludes_hashes_and_extra() -> None:
     # hashes vary by format and extra is format-specific overflow; neither affects logical
     # identity, so both are excluded from __eq__.
     a = ArchiveMember(
-        type=MemberType.FILE, name="a.txt", hashes={"crc32": 1}, extra={"x": 1}
+        type=MemberType.FILE,
+        name="a.txt",
+        hashes={HashAlgorithm.CRC32: crc32_digest(1)},
+        extra={"x": 1},
     )
     b = ArchiveMember(
-        type=MemberType.FILE, name="a.txt", hashes={"crc32": 2}, extra={"y": 2}
+        type=MemberType.FILE,
+        name="a.txt",
+        hashes={HashAlgorithm.CRC32: crc32_digest(2)},
+        extra={"y": 2},
     )
     assert a == b
 

--- a/tests/test_directory.py
+++ b/tests/test_directory.py
@@ -476,7 +476,7 @@ def test_archive_format_named_instances() -> None:
 
 
 def test_source_name_for_path_and_stream(tmp_path: Path) -> None:
-    from archivey.core import source_name
+    from archivey.internal.streams.streamtools import source_name
 
     p = tmp_path / "x.bin"
     p.write_bytes(b"")

--- a/tests/test_duplicates_is_current.py
+++ b/tests/test_duplicates_is_current.py
@@ -1,0 +1,93 @@
+"""Tests for is_current last-entry-wins duplicate-name behaviour.
+
+Verifies that ZIP and TAR archives with two same-name entries:
+- mark the earlier one is_current=False and the later one is_current=True
+- extract_all under default policy succeeds (no ExtractionError), recording
+  SUPERSEDED for the non-current entry and EXTRACTED for the current one
+- leaves the *last* entry's content on disk
+"""
+
+from __future__ import annotations
+
+import io
+import tarfile
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from archivey import ExtractionStatus, open_archive
+
+
+def _zip_with_duplicate(tmp_path: Path, name: str, contents: list[bytes]) -> Path:
+    """Create a ZIP with multiple entries under the same ``name``."""
+    p = tmp_path / "dup.zip"
+    with zipfile.ZipFile(p, "w", zipfile.ZIP_STORED) as zf:
+        for data in contents:
+            zf.writestr(name, data)
+    return p
+
+
+def _tar_with_duplicate(tmp_path: Path, name: str, contents: list[bytes]) -> Path:
+    """Create a TAR with multiple entries under the same ``name``."""
+    p = tmp_path / "dup.tar"
+    with tarfile.open(p, "w:") as tf:
+        for data in contents:
+            info = tarfile.TarInfo(name)
+            info.size = len(data)
+            tf.addfile(info, io.BytesIO(data))
+    return p
+
+
+@pytest.mark.parametrize("format_", ["zip", "tar"])
+def test_duplicate_name_is_current(tmp_path: Path, format_: str) -> None:
+    """Two same-name entries: first is_current=False, last is_current=True."""
+    name = "file.txt"
+    first_content = b"first version"
+    last_content = b"last version"
+
+    if format_ == "zip":
+        archive = _zip_with_duplicate(tmp_path, name, [first_content, last_content])
+    else:
+        archive = _tar_with_duplicate(tmp_path, name, [first_content, last_content])
+
+    with open_archive(archive) as reader:
+        members = reader.members()
+        assert len(members) == 2
+        assert members[0].name == name
+        assert members[1].name == name
+        assert members[0].is_current is False, "first entry should be non-current"
+        assert members[1].is_current is True, "last entry should be current"
+
+
+@pytest.mark.parametrize("format_", ["zip", "tar"])
+def test_duplicate_name_extract_succeeds(tmp_path: Path, format_: str) -> None:
+    """extract_all on a dup-name archive: SUPERSEDED + EXTRACTED, last content on disk."""
+    name = "file.txt"
+    first_content = b"first version"
+    last_content = b"last version"
+
+    if format_ == "zip":
+        archive = _zip_with_duplicate(tmp_path, name, [first_content, last_content])
+    else:
+        archive = _tar_with_duplicate(tmp_path, name, [first_content, last_content])
+
+    dest = tmp_path / "out"
+    with open_archive(archive) as reader:
+        # Default policy (ERROR overwrite) must not raise despite duplicate names,
+        # because the non-current entry is skipped as SUPERSEDED before writing.
+        report = reader.extract_all(dest)
+
+    results = report.results
+    assert len(results) == 2
+    by_id = {r.member.member_id: r for r in results}
+    first_result = by_id[0]
+    last_result = by_id[1]
+
+    assert first_result.status is ExtractionStatus.SUPERSEDED
+    assert first_result.path is None
+    assert last_result.status is ExtractionStatus.EXTRACTED
+    assert last_result.path is not None
+
+    written = (dest / name).read_bytes()
+    assert written == last_content, "disk content must be the last entry's content"

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -1458,7 +1458,13 @@ def test_hardlink_duplicate_name_extraction_links_first_inode(tmp_path: Path) ->
     dest = tmp_path / "out"
     with open_archive(src) as r:
         results = r.extract_all(dest, overwrite=OverwritePolicy.REPLACE).results
-    assert all(res.status is ExtractionStatus.EXTRACTED for res in results)
+    # First A.txt is superseded; hardlink still materializes its target bytes;
+    # the live A.txt is the last entry.
+    assert [res.status for res in results] == [
+        ExtractionStatus.SUPERSEDED,
+        ExtractionStatus.EXTRACTED,
+        ExtractionStatus.EXTRACTED,
+    ]
     assert (dest / "L.txt").read_bytes() == b"content1"
     assert (dest / "A.txt").read_bytes() == b"content2"
     # L was linked against the first A.txt inode; the second duplicate replaced the path.
@@ -1494,6 +1500,7 @@ def test_selector_archivemember_entry_matches_by_identity(tmp_path: Path) -> Non
     # The collection selector's ArchiveMember entries match by object identity (the Phase 5
     # semantics, now specced in safe-extraction): with duplicate names, passing one member
     # object selects only that occurrence — while a str entry matches every duplicate.
+    # Non-current duplicates are reported as SUPERSEDED (no write).
     src = tmp_path / "a.tar"
     src.write_bytes(
         _tar_bytes([("file", "dup.txt", b"first"), ("file", "dup.txt", b"second")])
@@ -1502,15 +1509,22 @@ def test_selector_archivemember_entry_matches_by_identity(tmp_path: Path) -> Non
     with open_archive(src) as r:
         first, second = r.members()
         assert first.name == second.name == "dup.txt"
+        assert first.is_current is False
+        assert second.is_current is True
         results = r.extract_all(tmp_path / "by_member", members=[first]).results
     assert len(results) == 1
-    assert (tmp_path / "by_member" / "dup.txt").read_bytes() == b"first"
+    assert results[0].status is ExtractionStatus.SUPERSEDED
+    assert not (tmp_path / "by_member" / "dup.txt").exists()
 
     with open_archive(src) as r:
         results = r.extract_all(
             tmp_path / "by_name", members=["dup.txt"], overwrite=OverwritePolicy.REPLACE
         ).results
     assert len(results) == 2  # a str entry matches every same-named duplicate
+    assert [res.status for res in results] == [
+        ExtractionStatus.SUPERSEDED,
+        ExtractionStatus.EXTRACTED,
+    ]
     assert (tmp_path / "by_name" / "dup.txt").read_bytes() == b"second"
 
 
@@ -1781,28 +1795,26 @@ def test_o7_plain_percent_name_untouched(tmp_path: Path) -> None:
 
 
 def test_rename_inserts_counter_before_suffix(tmp_path: Path) -> None:
-    archive = _tar_bytes(
-        [
-            ("file", "photo.jpg", b"A"),
-            ("file", "photo.jpg", b"B"),
-            ("file", "photo.jpg", b"C"),
-        ]
-    )
+    # RENAME applies to destination collisions, not archive duplicate names
+    # (duplicates are SUPERSEDED / last-entry-wins instead).
+    archive = _tar_bytes([("file", "photo.jpg", b"from-archive")])
     dest = tmp_path / "out"
+    dest.mkdir()
+    (dest / "photo.jpg").write_bytes(b"preexisting")
     report = extract(io.BytesIO(archive), dest, overwrite=OverwritePolicy.RENAME)
-    assert all(r.status is ExtractionStatus.EXTRACTED for r in report.results)
+    assert len(report.results) == 1
+    assert report.results[0].status is ExtractionStatus.EXTRACTED
     assert sorted(p.name for p in dest.iterdir()) == [
         "photo (1).jpg",
-        "photo (2).jpg",
         "photo.jpg",
     ]
-    assert (dest / "photo.jpg").read_bytes() == b"A"
-    assert (dest / "photo (1).jpg").read_bytes() == b"B"
+    assert (dest / "photo.jpg").read_bytes() == b"preexisting"
+    assert (dest / "photo (1).jpg").read_bytes() == b"from-archive"
     # The rename is observable via requested_path != path.
-    second = report.results[1]
-    assert second.path.name == "photo (1).jpg"
-    assert second.requested_path.name == "photo.jpg"
-    assert second.requested_path != second.path
+    written = report.results[0]
+    assert written.path.name == "photo (1).jpg"
+    assert written.requested_path.name == "photo.jpg"
+    assert written.requested_path != written.path
 
 
 @pytest.mark.parametrize(
@@ -1814,10 +1826,13 @@ def test_rename_inserts_counter_before_suffix(tmp_path: Path) -> None:
     ],
 )
 def test_rename_suffix_edge_cases(tmp_path: Path, name: str, expected: str) -> None:
-    archive = _tar_bytes([("file", name, b"A"), ("file", name, b"B")])
+    archive = _tar_bytes([("file", name, b"from-archive")])
     dest = tmp_path / "out"
+    dest.mkdir()
+    (dest / name).write_bytes(b"preexisting")
     extract(io.BytesIO(archive), dest, overwrite=OverwritePolicy.RENAME)
     assert expected in {p.name for p in dest.iterdir()}
+    assert (dest / name).read_bytes() == b"preexisting"
 
 
 def test_requested_path_equals_path_for_normal_write(tmp_path: Path) -> None:

--- a/tests/test_extras_imported.py
+++ b/tests/test_extras_imported.py
@@ -35,9 +35,8 @@ _IMPORT_NAME = {
 # Packages pinned ahead of their implementation phase: the extra is part of the documented
 # packaging surface, but the feature's ``src/`` code lands later. Keep this list short and
 # justified; remove an entry once the feature is implemented and imports its package.
-_PENDING_IMPLEMENTATION = {
-    "py7zr": "7z writing ([7z-write]) lands with the native 7z reader work (Phase 7)",
-}
+# Empty while every user-facing extra package is already wired in ``src/``.
+_PENDING_IMPLEMENTATION: dict[str, str] = {}
 
 
 def _load_optional_dependencies() -> dict[str, list[str]]:

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -58,8 +58,32 @@ def test_all_has_no_duplicates() -> None:
 
 def test_public_symbols_are_in_all() -> None:
     """Imported public symbols (classes/functions, not modules or dunders) must be
-    listed in __all__, so a new export can't be silently omitted."""
+    listed in __all__, so a new export can't be silently omitted.
+
+    Names deliberately demoted from ``__all__`` but kept importable (Q4) are
+    allowlisted here — they remain reachable as ``archivey.X`` for compatibility
+    without advertising them as part of the curated public surface.
+    """
     import inspect
+
+    # Demoted from ``__all__`` but still imported at package level (api-coherence Q4).
+    demoted_but_importable = {
+        "ArchiveEofContext",
+        "DigestContext",
+        "ExtractionOutcomeContext",
+        "FormatConflictContext",
+        "MemberTimestampContext",
+        "NameCollisionContext",
+        "NameEncodingContext",
+        "NameNormalizationContext",
+        "NameSanitizedContext",
+        "RAPIDGZIP_AUTO_MIN_COMPRESSED_SIZE",
+        "ScanRaceContext",
+        "SeekIndexContext",
+        "StreamRewindContext",
+        "SymlinkTargetContext",
+        "WriteError",
+    }
 
     public = {
         name
@@ -68,5 +92,10 @@ def test_public_symbols_are_in_all() -> None:
         and not inspect.ismodule(obj)
         and name not in ("annotations",)
     }
-    not_listed = public - set(archivey.__all__)
+    not_listed = public - set(archivey.__all__) - demoted_but_importable
     assert not not_listed, f"public symbols missing from __all__: {sorted(not_listed)}"
+    # Demoted names must stay importable (do not silently drop the re-exports).
+    missing_demoted = demoted_but_importable - public
+    assert not missing_demoted, (
+        f"demoted symbols no longer importable from archivey: {sorted(missing_demoted)}"
+    )

--- a/tests/test_rar_reader.py
+++ b/tests/test_rar_reader.py
@@ -21,7 +21,7 @@ from archivey.exceptions import (
 )
 from archivey.internal.backends import rar_unrar
 from archivey.internal.backends.rar_parser import RAR5_ID, RAR_ID, parse_rar_archive
-from archivey.types import MemberType
+from archivey.types import HashAlgorithm, MemberType
 from tests.conftest import requires, requires_binary
 
 _FIXTURES = Path(__file__).parent / "fixtures" / "rar"
@@ -241,8 +241,8 @@ def test_file_version_solid_demux_aligned() -> None:
 def test_blake2sp_only_hash() -> None:
     with open_archive(_fixture("blake2sp.rar")) as archive:
         member = next(m for m in archive.members() if m.is_file)
-        assert "crc32" not in member.hashes
-        assert "blake2sp" in member.hashes
+        assert HashAlgorithm.CRC32 not in member.hashes
+        assert HashAlgorithm.BLAKE2SP in member.hashes
         assert archive.read(member) == b"stored payload"
 
 
@@ -274,7 +274,7 @@ def test_blake2sp_corrupt_payload_raises(tmp_path: Path) -> None:
     corrupt.write_bytes(mutated)
     with open_archive(corrupt) as archive:
         member = next(m for m in archive.members() if m.is_file)
-        assert "blake2sp" in member.hashes
+        assert HashAlgorithm.BLAKE2SP in member.hashes
         with pytest.raises(CorruptionError, match="blake2sp"):
             archive.read(member)
 

--- a/tests/test_rar_reader.py
+++ b/tests/test_rar_reader.py
@@ -206,8 +206,8 @@ def test_file_version_extract_all_skips_history(name: str, tmp_path: Path) -> No
     with open_archive(_fixture(name)) as archive:
         results = archive.extract_all(dest).results
     by_name = {r.member.name: r for r in results if r.member.is_file}
-    assert by_name["file.txt;1"].status is ExtractionStatus.SKIPPED
-    assert by_name["file.txt;2"].status is ExtractionStatus.SKIPPED
+    assert by_name["file.txt;1"].status is ExtractionStatus.SUPERSEDED
+    assert by_name["file.txt;2"].status is ExtractionStatus.SUPERSEDED
     assert by_name["file.txt"].status is ExtractionStatus.EXTRACTED
     assert (dest / "file.txt").read_bytes() == _FILE_VERSION_CONTENTS["file.txt"]
     assert not (dest / "file.txt;1").exists()

--- a/tests/test_sevenzip_oracle.py
+++ b/tests/test_sevenzip_oracle.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import pytest
 
 from archivey import MemberType, open_archive
+from archivey.types import HashAlgorithm, crc32_digest
 from tests.sample_archives import CORPUS, CorpusEntry, corpus_archive_path
 
 _ORACLE_ENTRY_IDS = {"basic", "encoding", "permissions", "large", "encrypted"}
@@ -54,5 +55,9 @@ def test_native_sevenzip_matches_py7zr_metadata_and_bytes(
             assert member.size == oracle_info.uncompressed
             if oracle_info.compressed is not None:
                 assert member.compressed_size == oracle_info.compressed
-            assert member.hashes.get("crc32") == oracle_info.crc32
+            assert member.hashes.get(HashAlgorithm.CRC32) == (
+                crc32_digest(oracle_info.crc32)
+                if oracle_info.crc32 is not None
+                else None
+            )
             assert native.read(member) == (oracle_dir / name).read_bytes()

--- a/tests/test_sevenzip_reader.py
+++ b/tests/test_sevenzip_reader.py
@@ -766,7 +766,7 @@ def test_synthetic_anti_item_lists_and_extracts_safely(tmp_path: Path) -> None:
     with open_archive(archive) as reader:
         results = reader.extract_all(fresh).results
     assert [result.status for result in results] == [
-        ExtractionStatus.SKIPPED,
+        ExtractionStatus.SUPERSEDED,
         ExtractionStatus.EXTRACTED,
     ]
     assert not (fresh / "gone.txt").exists()

--- a/tests/test_sevenzip_reader.py
+++ b/tests/test_sevenzip_reader.py
@@ -23,7 +23,7 @@ from archivey.internal.backends.sevenzip_parser import SevenZipCoder, SevenZipFo
 from archivey.internal.backends.sevenzip_reader import SevenZipReader
 from archivey.internal.config import DEFAULT_STREAM_CONFIG
 from archivey.internal.streams import codecs, crypto
-from archivey.types import CompressionAlgorithm, MemberType
+from archivey.types import CompressionAlgorithm, HashAlgorithm, MemberType
 from tests.conftest import requires, requires_binary, requires_zstd
 
 _FILES = {
@@ -923,7 +923,7 @@ def test_cursor_parse_matches_open_archive_fixture(tmp_path: Path) -> None:
         for name, data in files.items():
             m = members[name]
             assert m.size == len(data)
-            assert "crc32" in m.hashes
+            assert HashAlgorithm.CRC32 in m.hashes
             assert m.modified is not None
             assert archive.read(m) == data
         # Archive-level comment is optional; presence must not break listing.

--- a/tests/test_single_file.py
+++ b/tests/test_single_file.py
@@ -36,6 +36,7 @@ from archivey.exceptions import (
     TruncatedError,
     UnsupportedOperationError,
 )
+from archivey.types import HashAlgorithm, crc32_digest
 from tests.conftest import requires, requires_zstd, zstd_backend
 from tests.streams_util import NonSeekableBytesIO, make_lzip_member, make_unix_compress
 
@@ -236,14 +237,14 @@ def test_single_member_gzip_exposes_stored_crc32(tmp_path: Path) -> None:
     path.write_bytes(gzip.compress(payload))
     with open_archive(path) as ar:
         member = ar.members()[0]
-        assert member.hashes["crc32"] == zlib.crc32(payload) & 0xFFFFFFFF
+        assert member.hashes[HashAlgorithm.CRC32] == crc32_digest(zlib.crc32(payload))
 
 
 def test_multi_member_gzip_omits_crc32(tmp_path: Path) -> None:
     path = tmp_path / "multi.gz"
     path.write_bytes(gzip.compress(b"first") + gzip.compress(b"second"))
     with open_archive(path) as ar:
-        assert "crc32" not in ar.members()[0].hashes
+        assert HashAlgorithm.CRC32 not in ar.members()[0].hashes
 
 
 def test_gzip_metadata_omits_crc_without_gzip_magic() -> None:
@@ -262,7 +263,7 @@ def test_gzip_metadata_omits_crc_without_gzip_magic() -> None:
         probe_gzip_stored_crc32=boom,
     )
     GzipCodec().extract_metadata(ctx, member)
-    assert "crc32" not in member.hashes
+    assert HashAlgorithm.CRC32 not in member.hashes
 
 
 def test_gzip_omits_crc32_on_nonseekable_source() -> None:
@@ -270,7 +271,7 @@ def test_gzip_omits_crc32_on_nonseekable_source() -> None:
     with open_archive(NonSeekableBytesIO(data), streaming=True) as ar:
         members = ar.get_members_if_available()
         assert members is not None
-        assert "crc32" not in members[0].hashes
+        assert HashAlgorithm.CRC32 not in members[0].hashes
 
 
 def test_lzip_exposes_stored_crc32(tmp_path: Path) -> None:
@@ -279,10 +280,10 @@ def test_lzip_exposes_stored_crc32(tmp_path: Path) -> None:
     path.write_bytes(make_lzip_member(payload))
     with open_archive(path, member_streams=MemberStreams.SEEKABLE) as ar:
         member = ar.members()[0]
-        assert member.hashes["crc32"] == zlib.crc32(payload) & 0xFFFFFFFF
+        assert member.hashes[HashAlgorithm.CRC32] == crc32_digest(zlib.crc32(payload))
     # Same gate as size: without declared SEEKABLE, omit the trailer CRC.
     with open_archive(path) as ar:
-        assert "crc32" not in ar.members()[0].hashes
+        assert HashAlgorithm.CRC32 not in ar.members()[0].hashes
 
 
 def test_other_single_file_codecs_omit_stored_crc32(tmp_path: Path) -> None:
@@ -296,7 +297,7 @@ def test_other_single_file_codecs_omit_stored_crc32(tmp_path: Path) -> None:
         path = tmp_path / name
         path.write_bytes(blob)
         with open_archive(path) as ar:
-            assert "crc32" not in ar.members()[0].hashes, name
+            assert HashAlgorithm.CRC32 not in ar.members()[0].hashes, name
 
 
 def test_stored_gzip_crc32_does_not_change_read_or_verification(tmp_path: Path) -> None:
@@ -305,7 +306,7 @@ def test_stored_gzip_crc32_does_not_change_read_or_verification(tmp_path: Path) 
     path.write_bytes(gzip.compress(payload))
     with open_archive(path) as ar:
         member = ar.members()[0]
-        assert "crc32" in member.hashes
+        assert HashAlgorithm.CRC32 in member.hashes
         assert ar.read(member) == payload
         # Second open still succeeds (path source; codec verifies its own trailer).
         assert ar.read(member) == payload

--- a/tests/test_zip.py
+++ b/tests/test_zip.py
@@ -30,6 +30,7 @@ from archivey.exceptions import (
     TruncatedError,
     UnsupportedFeatureError,
 )
+from archivey.types import HashAlgorithm, crc32_digest
 from tests.streams_util import NonSeekableBytesIO
 
 # ---------------------------------------------------------------------------
@@ -162,12 +163,13 @@ def test_directory_member_type(simple_zip: Path) -> None:
 
 
 def test_file_member_exposes_stored_crc32(simple_zip: Path) -> None:
-    # archive-data-model spec: ZIP CRC32 is surfaced under hashes["crc32"] as an int,
-    # so a dedupe pass can key on it without decompressing (VISION).
+    # archive-data-model: ZIP CRC32 under HashAlgorithm.CRC32 as 4 big-endian bytes.
     with open_archive(simple_zip) as ar:
         member = ar.get("hello.txt")
         assert member is not None
-        assert member.hashes["crc32"] == zlib.crc32(b"hello world") & 0xFFFFFFFF
+        assert member.hashes[HashAlgorithm.CRC32] == crc32_digest(
+            zlib.crc32(b"hello world")
+        )
 
 
 def test_directory_member_has_no_crc32(tmp_path: Path) -> None:
@@ -178,9 +180,9 @@ def test_directory_member_has_no_crc32(tmp_path: Path) -> None:
     with open_archive(path) as ar:
         by_name = {m.name: m for m in ar.members()}
         # A directory's stored CRC is a meaningless 0; do not present it as a digest.
-        assert "crc32" not in by_name["adir/"].hashes
-        assert (
-            by_name["adir/file.txt"].hashes["crc32"] == zlib.crc32(b"data") & 0xFFFFFFFF
+        assert HashAlgorithm.CRC32 not in by_name["adir/"].hashes
+        assert by_name["adir/file.txt"].hashes[HashAlgorithm.CRC32] == crc32_digest(
+            zlib.crc32(b"data")
         )
 
 

--- a/tests/test_zip_aes.py
+++ b/tests/test_zip_aes.py
@@ -25,7 +25,7 @@ from archivey.internal.zip_aes import (
     derive_winzip_aes_keys,
     parse_winzip_aes_extra,
 )
-from archivey.types import CompressionAlgorithm
+from archivey.types import CompressionAlgorithm, HashAlgorithm
 from tests.conftest import requires, requires_binary
 
 _PASSWORD = b"secret"
@@ -181,9 +181,9 @@ def test_handbuilt_aes_roundtrip(
         assert member.extra["zip.aes_vendor_version"] == vendor_version
         assert member.extra["zip.aes_strength"] == strength
         if vendor_version == 2:
-            assert "crc32" not in member.hashes
+            assert HashAlgorithm.CRC32 not in member.hashes
         else:
-            assert "crc32" in member.hashes
+            assert HashAlgorithm.CRC32 in member.hashes
         expected_algo = (
             CompressionAlgorithm.STORED if method == 0 else CompressionAlgorithm.DEFLATE
         )
@@ -199,7 +199,7 @@ def test_7z_aes_zip_roundtrip(tmp_path: Path, strength: str) -> None:
     with open_archive(archive, password=_PASSWORD) as ar:
         (member,) = ar.members()
         assert member.is_encrypted
-        assert "crc32" not in member.hashes  # 7z emits AE-2
+        assert HashAlgorithm.CRC32 not in member.hashes  # 7z emits AE-2
         assert ar.read(member) == payload
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements the decided api-coherence review follow-ups (Q1–Q6), leaving digest *filling* and Q5/Q7 deferred.

## What’s in

- **Q1 / P1** — Shared last-entry-wins `is_current` for duplicate names on all RA formats; unique names keep backend flags (RAR `;N` history stays non-current). Dropped redundant 7z `compute_is_current`.
- **Q2** — Keep `members()` = everything; document filter recipes in `docs/usage.md`.
- **Q3** — Keep RAR `listing_cost=INDEXED`; fix misleading cost docstrings / `docs/costs.md`.
- **Q4 / S1 / S3** — Demote `*Context`, `RAPIDGZIP_*`, `WriteError` from `__all__`; export `PasswordInput`, `OnDiagnostic`, `HashAlgorithm`, `crc32_digest`, measurement; drop `core.source_name`.
- **Q6** — `ExtractionStatus.SUPERSEDED` (now `str, Enum` per spec); `ArchiveFormat.display_name`; remove `[7z-write]` extra; hashes typing; verify expected digests are bytes-only.
- **E1** — Public `archivey.measurement` (`IoStats`, `enable_measurement`) + `ArchiveReader.io_stats()`; CLI uses the public API.

## Deferred (not this PR)

- Digest *filling* (zlib Adler / lzip combine) → OpenSpec `surface-stored-stream-digests`
- Library `verify` (Q5)
- Partial members + honest error (Q7)

## Tests

- Full suite green: `1767 passed, 87 skipped`
- `ruff format` / `ruff check` / `pyrefly check` clean

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e8825279-a5ba-4b35-a0e1-684834430f72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e8825279-a5ba-4b35-a0e1-684834430f72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

