### PR TITLE
Propose clarify-extraction-status-names OpenSpec change

### DIFF
--- a/openspec/changes/clarify-extraction-status-names/.openspec.yaml
+++ b/openspec/changes/clarify-extraction-status-names/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: library
+created: 2026-07-18

--- a/openspec/changes/clarify-extraction-status-names/brief.md
+++ b/openspec/changes/clarify-extraction-status-names/brief.md
@@ -1,0 +1,20 @@
+<!--
+The "coffee brief": a spoken-word-friendly summary of this change, readable (or
+read aloud) in under a minute. Prose only — NO tables, NO code blocks, minimal
+symbols — so text-to-speech reads cleanly. Aim for ~200–280 words. Derive it from
+proposal.md / design.md / tasks.md; do not introduce new decisions here.
+-->
+
+# clarify-extraction-status-names — give every ExtractionStatus value a self-evident name
+
+**Status:** Ready to implement once the api-coherence Q1 follow-up with the new SUPERSEDED status has merged. Breaking rename, no aliases, pre-one-point-zero. Effort: small.
+
+**Why it matters:** The extraction status enum now has three different not-written outcomes, and the two older names stopped carrying their own reason. Skipped reads as skipped for some reason even though it now means exactly one thing, an existing file left in place because the overwrite policy said skip. Rejected does not tell you a safety or policy gate blocked the entry. A caller should be able to branch on the status without opening a docstring.
+
+**What it does:** Renames Skipped to Not Overwritten and Rejected to Blocked. Blocked stays honest for both a hardwired path-safety block and a policy filter, so no by-policy suffix, because a zip-slip block is safety, not policy. The rename cascades to the paired diagnostic, so the code becomes Extraction Member Blocked and its status field becomes blocked, keeping one vocabulary across the result and its diagnostic. Extracted, Superseded, and Failed keep their names.
+
+**Also fixes two drifts in the same area:** The spec claimed a filter returning None yields a skipped result, but the coordinator actually records no result at all, like a selector exclusion, so the spec is corrected. And the RAR file-version spec still said history rows extract as skipped, when they are now superseded.
+
+**Your call later:** Whether the enum should become a string enum to match the spec text and the hash algorithm enum. Flagged, not bundled.
+
+**Bottom line:** Honest, self-documenting status names, plus two contract corrections, stacked on the Q1 follow-up.

--- a/openspec/changes/clarify-extraction-status-names/design.md
+++ b/openspec/changes/clarify-extraction-status-names/design.md
@@ -1,0 +1,85 @@
+## Context
+
+`ExtractionStatus` is a public, exported enum surfaced on every
+`ExtractionResult`. After the api-coherence Q1 follow-up split non-current
+duplicates into `SUPERSEDED`, the remaining generic names (`SKIPPED`, `REJECTED`)
+no longer name their own reason. This change is naming + two spec/code
+reconciliations; no extraction *behavior* changes except correcting the written
+contract to match the code.
+
+## Decisions
+
+### D1 — A `filter` returning `None` yields no result (spec corrected)
+
+`safe-extraction` states a user `filter` returning `None` produces a `SKIPPED`
+result. The coordinator (`extraction.py`, `for original, stream in
+reader.stream_members(...)`: `if transformed is None: pass`) appends **no**
+`ExtractionResult` — the member is dropped like a selector exclusion.
+
+Resolved (maintainer, this change): **the code is correct.** A filter returning
+`None` is the caller electing to exclude a member, which is not an extraction
+outcome to report. The spec scenarios and the `SKIPPED` meaning clause are
+corrected to say "no result". This is what makes `NOT_OVERWRITTEN` accurate: the
+only remaining producer of that status is `OverwritePolicy.SKIP` finding an
+existing destination.
+
+Rejected alternative: make the code emit a `SKIPPED`/`FILTERED` result for
+filter-drops. That would keep `SKIPPED` broad (filter-drop + overwrite-skip) and
+force either a vaguer name or a second status; it also reverses long-standing
+behavior for no caller benefit (selector exclusions already produce no result, so
+filter exclusions matching them is the least-surprising contract).
+
+### D2 — `NOT_OVERWRITTEN` over the alternatives
+
+Candidates for the overwrite-skip outcome: `SKIPPED` (keep), `EXISTS` /
+`ALREADY_EXISTS`, `KEPT` / `PRESERVED`, `NOT_OVERWRITTEN`.
+
+Chosen: `NOT_OVERWRITTEN`. It is self-documenting (no docstring needed to know
+why), it is an outcome/past-participle like every other value (`EXTRACTED`,
+`SUPERSEDED`, `BLOCKED`, `FAILED`) rather than a cause (`EXISTS`), and it mirrors
+the policy that produces it (`OverwritePolicy.SKIP` → the existing entry was not
+overwritten). `SKIPPED` is idiomatic in `unzip`/`rsync`, but with `SUPERSEDED`
+and `BLOCKED` also being forms of "skip" it no longer disambiguates.
+
+### D3 — `BLOCKED` over `REJECTED` / `*_BY_POLICY`
+
+The status covers a `FilterRejectionError` from **either** a hardwired universal
+safety check (path traversal, symlink escape) **or** a policy `MemberFilter`.
+
+Chosen: `BLOCKED`. It reads as "a gate stopped this," stays accurate for both
+safety and policy, and does not narrow to one mechanism. `REJECTED` does not say
+who/why. `BLOCKED_BY_POLICY` / `REJECTED_BY_POLICY` is *less* accurate — a
+zip-slip block is safety, not policy — so the suffix would mislabel the
+universal-safety case. `BLOCKED_BY_FILTER` leaks the internal `MemberFilter`
+mechanism into a public status and would rot if the block set grows.
+
+### D4 — Cascade the rename to the paired diagnostic
+
+`EXTRACTION_MEMBER_REJECTED` + `ExtractionOutcomeContext.status="rejected"` are
+emitted for exactly the `BLOCKED` outcome, and a validator enforces the pairing
+(`diagnostics.py`: `EXTRACTION_MEMBER_REJECTED requires status='rejected'`).
+
+Resolved: **cascade.** Rename the code to `EXTRACTION_MEMBER_BLOCKED`
+(`"extraction_member_blocked"`) and the context status literal to `"blocked"`, so
+a caller sees one word for one event across the result status and its diagnostic.
+Leaving the diagnostic as `REJECTED` would be a permanent status/diagnostic
+vocabulary split for a purely cosmetic diff saving.
+
+## Scope boundaries (intentionally unchanged)
+
+- `OverwritePolicy.SKIP` (the *policy* value) keeps its name — the policy is still
+  "skip", the *result* of applying it is `NOT_OVERWRITTEN`.
+- The overwrite-resolution literal `resolution="skipped"` on the overwrite
+  diagnostic (`Literal["renamed","replaced","skipped","errored"]`) is unchanged:
+  it names the resolution *action*, not the result status, and reads correctly
+  ("the overwrite was skipped").
+- `EXTRACTION_MEMBER_FAILED` / `FAILED` are unchanged.
+- No back-compat aliases: archivey is pre-1.0 and prefers an honest rename now
+  over carrying a deprecated misnomer.
+
+## Adjacent drift noted, not fixed here
+
+`safe-extraction` pseudocode declares `class ExtractionStatus(str, Enum)` but the
+implementation is `class ExtractionStatus(Enum)`. Left for a separate decision
+(whether to make it `str, Enum` for serialization symmetry with `HashAlgorithm`,
+or correct the spec). Flagged so it is not silently bundled into a rename.

--- a/openspec/changes/clarify-extraction-status-names/proposal.md
+++ b/openspec/changes/clarify-extraction-status-names/proposal.md
@@ -1,0 +1,62 @@
+## Why
+
+`ExtractionStatus` now has three "not written" outcomes — `SKIPPED`,
+`SUPERSEDED` (added in the api-coherence Q1 follow-up), `REJECTED` — and the two
+older names no longer carry their own reason. `SKIPPED` reads as "skipped for
+*some* reason" even though, post-`SUPERSEDED`, it means exactly one thing: an
+existing destination was left in place under `OverwritePolicy.SKIP`. `REJECTED`
+does not signal *why* an entry was blocked (a safety/policy gate). VISION's
+"one uniform interface with honest signals" wants a status a caller can branch on
+without reading a docstring.
+
+While auditing the names, two spec/code drifts surfaced in the same area:
+
+- The spec claims a user `filter` returning `None` yields a `SKIPPED` result, but
+  the coordinator appends **no result** for that case (like a selector exclusion).
+  The name `NOT_OVERWRITTEN` is only correct once this is reconciled — decision:
+  the code is right; the spec is corrected.
+- `format-rar` still says version-history rows extract as `SKIPPED`; they are
+  non-current, so post-Q1 they are `SUPERSEDED`.
+
+## What Changes
+
+- Rename `ExtractionStatus.SKIPPED` → **`NOT_OVERWRITTEN`** (`"not_overwritten"`):
+  the sole meaning is "existing destination kept under `OverwritePolicy.SKIP`".
+- Rename `ExtractionStatus.REJECTED` → **`BLOCKED`** (`"blocked"`): blocked by a
+  universal safety check *or* a policy filter (`FilterRejectionError`). No
+  `_BY_POLICY` suffix — universal path-safety blocks are safety, not policy.
+- **Cascade** the `BLOCKED` rename to its paired diagnostic:
+  `DiagnosticCode.EXTRACTION_MEMBER_REJECTED` → `EXTRACTION_MEMBER_BLOCKED`
+  (`"extraction_member_blocked"`) and `ExtractionOutcomeContext.status`
+  `"rejected"` → `"blocked"`, so status and diagnostic share one vocabulary.
+- Correct the filter-`None` contract: a `filter` returning `None` drops the
+  member with **no `ExtractionResult`** (matches the coordinator), same as a
+  selector exclusion.
+- Correct `format-rar`: version-history rows extract as `SUPERSEDED`, not
+  `SKIPPED`.
+- Keep `EXTRACTED`, `SUPERSEDED`, `FAILED` unchanged.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `safe-extraction` — `ExtractionStatus` value names/semantics; filter-`None`
+  yields no result; overwrite/hardlink SKIP results
+- `diagnostics` — `EXTRACTION_MEMBER_BLOCKED` code + `status="blocked"` context
+- `format-rar` — history-row extract status is `SUPERSEDED`
+
+## Impact
+
+- **Breaking** public API: `ExtractionStatus` members `SKIPPED`/`REJECTED` and
+  `DiagnosticCode.EXTRACTION_MEMBER_REJECTED` are renamed (no back-compat aliases
+  — pre-1.0, and honest-name churn is preferred over a permanent misnomer).
+- Modules: `types`/`internal.extraction_types` (`ExtractionStatus`),
+  `internal/extraction.py` (status emission + filter-`None` already correct),
+  `diagnostics.py` (`DiagnosticCode`, `ExtractionOutcomeContext.status` literal +
+  validator), `cli/extract_cmd.py` (labels).
+- Docs: `docs/api.md` autodoc picks up new names; sweep any prose that names the
+  old values.
+- Tests: rename assertions across the extraction/diagnostic suites.
+- **Prerequisite:** the api-coherence Q1 follow-up (`ExtractionStatus.SUPERSEDED`,
+  the shared last-entry-wins pass — PR #154) is merged first; this change edits
+  the post-#154 enum and its specs.

--- a/openspec/changes/clarify-extraction-status-names/specs/diagnostics/spec.md
+++ b/openspec/changes/clarify-extraction-status-names/specs/diagnostics/spec.md
@@ -1,0 +1,50 @@
+## MODIFIED Requirements
+
+### Requirement: Immutable diagnostic values with stable codes and safe typed context
+
+Every advisory event SHALL be an immutable `Diagnostic`: opaque process-local
+`occurrence_id`, stable `DiagnosticCode`, `DiagnosticSeverity`, human `message`,
+and code-specific frozen `DiagnosticContext`. Codes are the machine contract;
+messages are not stable.
+
+Contexts are a closed typed union of JSON-safe immutable scalar/tuple values.
+Raw bytes use an explicitly named base64 field. `to_dict()` on diagnostic and
+context SHALL be `json.dumps`-safe without a custom encoder.
+
+| Code | Variant and required fields |
+| --- | --- |
+| `MEMBER_NAME_NORMALIZED` | `NameNormalizationContext`: `kind="name_normalization"`, `archive_name`, `member_name`, `member_id`, `raw_name_base64`, `presented_name`, `normalized_name` |
+| `FORMAT_EXTENSION_CONFLICT` | `FormatConflictContext`: `kind="format_conflict"`, `source_name`, `extension`, `extension_format`, `detected_format` |
+| `SCAN_DIRECTORY_VANISHED` | `ScanRaceContext`: `kind="scan_race"`, `archive_name`, `relative_path`, `entry_kind="directory"` |
+| `SCAN_ENTRY_VANISHED` | `ScanRaceContext`: `kind="scan_race"`, `archive_name`, `relative_path`, `entry_kind="entry"` |
+| `ARCHIVE_EOF_MARKER_MISSING` | `ArchiveEofContext`: `kind="archive_eof"`, `archive_name`, `format`, `expected_marker`, `expected_bytes`, `observed_bytes`, `observed_kind` |
+| `MEMBER_TIMESTAMP_INVALID` | `MemberTimestampContext`: `kind="member_timestamp"`, `archive_name`, `member_name`, `member_id`, `field`, `source`, `value_repr` |
+| `SYMLINK_TARGET_UNAVAILABLE` | `SymlinkTargetContext`: `kind="symlink_target"`, `archive_name`, `member_name`, `member_id`, `reason` |
+| `DIGEST_UNVERIFIABLE` | `DigestContext`: `kind="digest"`, `archive_name`, `member_name`, `member_id`, `algorithm`, `reason` |
+| `SEEK_INDEX_DEGRADED` | `SeekIndexContext`: `kind="seek_index"`, `archive_name`, `member_name`, `member_id`, `codec`, `scan`, `error_type` |
+| `STREAM_REWIND_REDECOMPRESSES` | `StreamRewindContext`: `kind="stream_rewind"`, `archive_name`, `member_name`, `member_id`, `codec`, `from_offset`, `to_offset`, `accelerator` |
+| `EXTRACTION_MEMBER_BLOCKED` | `ExtractionOutcomeContext`: `kind="extraction_outcome"`, `…`, `status="blocked"`, `error_type`, `failure_group_id`, `failure_group_size` |
+| `EXTRACTION_MEMBER_FAILED` | `ExtractionOutcomeContext`: `kind="extraction_outcome"`, `…`, `status="failed"`, `error_type`, `failure_group_id`, `failure_group_size` |
+
+(`str | None` / `int | None` as in the typed variants.) `DiagnosticContext` is
+exactly this union — no backend-defined variants. `observed_kind` ∈
+`{"absent","short","nonzero"}`. `expected_marker` is symbolic (e.g.
+`"two_zero_blocks"`). `member_id` MAY be `None` only before registration.
+`failure_group_id`/`failure_group_size` both set only when multiple hardlink
+results share one failed source; else both `None`. `EXTRACTION_MEMBER_BLOCKED`
+pairs with `ExtractionStatus.BLOCKED`; the two share the `"blocked"` vocabulary.
+
+No diagnostic surface SHALL contain passwords, candidates, provider returns, keys,
+KDF material, or decrypted secrets.
+
+Copies on multiple surfaces MAY share `occurrence_id` by value; object identity
+and cross-run id stability are not promised.
+
+#### Scenario: value-model matrix
+
+| Case | Expected |
+| --- | --- |
+| Name normalization | `MEMBER_NAME_NORMALIZED` + typed JSON-safe context; no backend/mutable mapping |
+| Same occurrence on aggregate + member | Same `occurrence_id`; value equality; no object-identity promise |
+| Encrypted symlink unavailable | May use reason `"password_required"` + member name; no secret material |
+| Member blocked by a universal/policy check | `EXTRACTION_MEMBER_BLOCKED` with `status="blocked"`; pairs with a `BLOCKED` result |

--- a/openspec/changes/clarify-extraction-status-names/specs/format-rar/spec.md
+++ b/openspec/changes/clarify-extraction-status-names/specs/format-rar/spec.md
@@ -1,0 +1,36 @@
+## MODIFIED Requirements
+
+### Requirement: Expose RAR file-version history members
+
+The system SHALL include RAR file-version history FILE blocks in the member list
+instead of omitting them. RAR5 extra type `0x04` (and RAR3 `FILE_VERSION` when
+present) identifies a prior revision. History members SHALL use the WinRAR /
+`unrar` presented name `path;n` (version `n != 0`), set
+`extra["rar.file_version"] = n`, and set `is_current=False`. The live revision of
+the same archive path (no version extra, or version 0) SHALL keep the plain path
+name and `is_current=True`.
+
+`open` / `read` of a history `FILE` SHALL return that revision’s bytes. For
+`unrar`-backed reads the backend SHALL request the exact presented member name
+(`path;n`). Solid ALL-pipe demux SHALL pass `unrar`’s `-ver` switch when the
+member list contains any versioned payload FILE so the pipe includes history
+bytes in archive order; otherwise solid demux MAY omit `-ver`.
+
+Default `extract` / `extract_all` SHALL skip history rows through the existing
+`is_current=False` coordinator behavior (`safe-extraction`), recording each as
+`ExtractionStatus.SUPERSEDED`. History rows have unique `path;n` presentation
+names, so the shared last-entry-wins pass leaves their backend `is_current=False`
+untouched. History rows SHALL count toward listing / parser member ceilings like
+any other FILE.
+
+#### Scenario: file-version matrix
+
+| Case | Expected |
+| --- | --- |
+| RAR5 `-ver` archive with revisions 1..k then live path | Members include `path;1`…`path;k` (`is_current=False`) and `path` (`is_current=True`) |
+| `read("path;1")` / `open` that member | Bytes of revision 1 |
+| `read("path")` | Bytes of the live revision |
+| `extract_all` default | Writes live `path` only; history rows `SUPERSEDED` |
+| Solid archive that includes versioned payload FILEs | ALL-pipe demux uses `-ver`; stream order stays aligned |
+| Nonsolid named `unrar p` of `path;n` | Exact member name; `-ver` not required |
+| Hostile archive with many version rows | Rows count toward member caps |

--- a/openspec/changes/clarify-extraction-status-names/specs/safe-extraction/spec.md
+++ b/openspec/changes/clarify-extraction-status-names/specs/safe-extraction/spec.md
@@ -1,0 +1,191 @@
+## MODIFIED Requirements
+
+### Requirement: Per-ArchiveMember ExtractionResult with Status
+
+`ExtractionReport.results` SHALL contain one `ExtractionResult` for every
+selected member the coordinator processes when the operation completes, including
+members blocked by universal/policy checks before the user filter. Selector
+exclusions are outside the operation and have no result; a user `filter` that
+returns `None` likewise drops the member with **no** `ExtractionResult` (it is a
+caller-elected exclusion, not an extraction outcome).
+
+```python
+@dataclass(frozen=True)
+class ExtractionResult:
+    member: ArchiveMember
+    path: Path | None
+    status: ExtractionStatus
+    error: ArchiveyError | OSError | None = None
+    requested_path: Path | None = None
+
+class ExtractionStatus(str, Enum):
+    EXTRACTED = "extracted"
+    NOT_OVERWRITTEN = "not_overwritten"
+    SUPERSEDED = "superseded"
+    BLOCKED = "blocked"
+    FAILED = "failed"
+```
+
+Statuses SHALL mean: `EXTRACTED` created an entry (`path` set, `error=None`);
+`NOT_OVERWRITTEN` left an existing destination in place because
+`OverwritePolicy.SKIP` found one (`path=None`, `error=None`); `SUPERSEDED` is a
+non-current duplicate skipped by the hardwired last-entry-wins rule (`path=None`,
+`error=None`); `BLOCKED` is a continued `FilterRejectionError` (a universal
+path-safety check or a policy filter blocked the member); `FAILED` is a continued
+non-rejection per-member `ArchiveyError` or permitted filesystem `OSError`.
+`NOT_OVERWRITTEN` and `SUPERSEDED` are not failures and emit no diagnostic.
+`requested_path` carries the destination the coordinator intended before
+overwrite/rename resolution; it equals `path` for an ordinary write, and
+`requested_path != path and status == EXTRACTED` marks an `OverwritePolicy.RENAME`
+(see the cross-platform name-safety requirement).
+
+Continued `BLOCKED`/`FAILED` results SHALL emit exactly one matching
+`EXTRACTION_MEMBER_BLOCKED` / `EXTRACTION_MEMBER_FAILED` occurrence per result.
+`ExtractionResult` has no diagnostics field; `status` and `error` are the
+per-result outcome while diagnostics live in the report/reader aggregate. If one
+failed hardlink source causes `N` hardlink failures under `IGNORE` or `COLLECT`,
+the coordinator emits `N` ordered `EXTRACTION_MEMBER_FAILED` occurrences with
+shared `failure_group_id` and `failure_group_size=N`; under `RAISE`, the first
+ordered occurrence escalates immediately and no completed report/count guarantee
+applies.
+
+#### Scenario: result/status matrix
+
+| Case | Expected |
+| --- | --- |
+| User filter returns `None` | No `ExtractionResult`; no result-count impact (like a selector exclusion) |
+| Selector excludes member | No `ExtractionResult`; no result-count impact |
+| Member blocked by `PathTraversalError` under `CONTINUE` | Result is `BLOCKED` with matching error and diagnostic |
+| Member write raises `OSError` under `CONTINUE` | Result is `FAILED` with matching error and diagnostic |
+| Member written successfully | Result is `EXTRACTED`, `path` points to created entry |
+| Existing destination under `OverwritePolicy.SKIP` | Result is `NOT_OVERWRITTEN`, `path=None` |
+| One failed source causes three hardlink results to fail | Failed count increases by three; retained contexts, if budget permits, share one failure group id/size |
+
+### Requirement: Skip non-current members by default
+
+`extract` / `extract_all` SHALL skip members with `is_current is False` by default
+(`ExtractionStatus.SUPERSEDED`; no write; no bomb-limit counting for the skip). This
+is **hardwired coordinator behavior**, not the policy `filter` / `MemberFilter`
+pipeline: the skip happens after the optional user `filter` runs so callers can
+inspect or rewrite non-current members, then the coordinator still skips writing
+them unless a future explicit opt-in lands. `SUPERSEDED` is distinct from
+`ExtractionStatus.NOT_OVERWRITTEN` (an existing destination left in place under
+`OverwritePolicy.SKIP`).
+
+How surfaces interact:
+
+| Surface | Non-current members |
+| --- | --- |
+| `members()` / `__iter__` / `get` | Visible (metadata + `is_current=False`) |
+| `members=` selector | May select them; they still participate in the extract walk |
+| User `filter` (`MemberFilter`) | **Invoked** on them (same as current members) |
+| Default extract write | Skipped after filter; `SUPERSEDED` result |
+| `open`/`read` on superseded `FILE` | Still allowed (payload exists); not gated by `is_current` |
+
+There is no extract-all flag in this change to force writing non-current
+revisions; callers that need those bytes use `open`/`read` (or a future opt-in).
+
+#### Scenario: non-current skip matrix
+
+| Case | Expected |
+| --- | --- |
+| Content superseded by later same-name or anti | `SUPERSEDED` on extract; path absent on fresh dest |
+| User `filter` receives non-current member | Filter is called; returning the member does not force a write |
+| `open` superseded content `FILE` | Bytes returned (random access still works) |
+
+### Requirement: Overwrite Policy
+
+The system SHALL enforce `OverwritePolicy` whenever a destination entry already
+exists at the transformed member path:
+
+```python
+class OverwritePolicy(Enum):
+    ERROR = "error"
+    SKIP = "skip"
+    REPLACE = "replace"
+    RENAME = "rename"
+```
+
+`ERROR` raises a per-member `ExtractionError` governed by `OnError`; `SKIP`
+records a `NOT_OVERWRITTEN` result and is not a failure. Existence checks SHALL use
+`lstat` semantics so dangling symlinks count as existing entries. `REPLACE` SHALL
+be atomic and never write through a symlink: FILE data streams to a temp file in
+the destination directory, metadata is applied, and `os.replace()` moves it onto
+the destination. A mid-stream failure preserves the old entry and discards only
+the temp. DIR/SYMLINK/HARDLINK replacement removes the existing entry and creates
+fresh; replacing an existing directory with a file removes the directory first.
+`RENAME` writes a colliding entry under a deterministic derived name (`name (1)`,
+inserted before the final suffix) rather than overwriting — see the cross-platform
+name-safety requirement.
+
+#### Scenario: overwrite matrix
+
+| Case | Expected |
+| --- | --- |
+| Existing path under `ERROR` | `ExtractionError`; existing entry unmodified |
+| Existing path under `SKIP` | `ExtractionResult.status == NOT_OVERWRITTEN`, `path=None`, no exception |
+| Existing file under `REPLACE` | Fresh file is written via temp file + `os.replace()` |
+| Existing symlink under `REPLACE` | Symlink entry itself is replaced; bytes never follow the old link |
+| `REPLACE` fails mid-stream | Existing file remains unchanged; temp is discarded |
+| Dangling symlink under `ERROR` or `SKIP` | Treated as existing; no write-through to target |
+
+### Requirement: Hardlink Two-Pass Extraction
+
+The system SHALL support TAR-style hardlinks through the extraction coordinator as
+a pull-based sink over reader streams. Ordinary FILE/DIR/SYMLINK members are
+written as reached; each written FILE path is recorded under its source. A
+HARDLINK whose source already has recorded paths tries `os.link()` against them
+in order; if all fail with cross-device `EXDEV`, the coordinator falls back to
+`shutil.copy2()` and records the copy for later links on that device.
+
+When a selected HARDLINK's source was excluded by `members` or `filter`, the
+system MUST NOT materialize the excluded source at its own destination. It SHALL
+make the source content available only through selected link destinations: write
+the bytes to the first selected link path allowed by `OverwritePolicy`, record
+`NOT_OVERWRITTEN` links under `SKIP`, link further selected links to the
+materialized path, and write nothing if every selected link is skipped. The
+materialized file gets the selected link's transformed metadata. An equivalent
+hidden temp inside `dest` is permitted.
+
+The coordinator SHALL avoid wasted passes: if a free member list exists
+(`get_members_if_available()`), recovery is planned in one forward pass; otherwise
+a seekable source may use one conditional second pass; a forward-only source makes
+the orphaned link unrecoverable and therefore a per-member failure governed by
+`OnError`. A hardlink that merely precedes its selected source is linked after the
+source is written, with one read and one bomb-limit count for the source bytes.
+
+#### Scenario: hardlink matrix
+
+| Case | Expected |
+| --- | --- |
+| HARDLINK reached after its source was extracted | Try `os.link()` against recorded source paths; fallback to copy on all-`EXDEV` |
+| Selected hardlink source was excluded but recoverable | Source content appears at selected link path(s); excluded source path is never created |
+| First selected link destination exists under `OverwritePolicy.SKIP` | That link result is `NOT_OVERWRITTEN`; content moves to the next allowed link; all skipped means no write |
+| Excluded source on a forward-only stream | Per-member failure: `STOP` raises; `CONTINUE` records `FAILED` and proceeds |
+| HARDLINK appears before its also-selected source | After the pass it links to the extracted source inode; source bytes read and counted once |
+
+### Requirement: Error Policy (OnError) for extraction failures
+
+`OnError.STOP` and `OnError.CONTINUE` SHALL govern per-member failures only.
+Under `CONTINUE`, a member-scoped `FilterRejectionError`, other member-scoped
+`ArchiveyError`, permitted read/write `OSError`, or per-member ratio violation
+records `BLOCKED`/`FAILED`, removes partial output, emits the matching diagnostic
+under the active diagnostic policy, and proceeds.
+
+Diagnostic disposition SHALL still be authoritative: `RAISE` emits
+`DiagnosticRaisedError` and halts immediately even under `OnError.CONTINUE`;
+logging-handler and diagnostic-callback exceptions propagate unchanged. Under
+`STOP`, the genuine rejection/failure raises immediately and is not converted to
+an extraction advisory. Global resource guards (`ResourceLimitError` for
+cumulative bytes, archive-wide/live ratio, and max entries), `KeyboardInterrupt`,
+`MemoryError`, and unexpected programming exceptions are always-stop and are not
+swallowed.
+
+#### Scenario: OnError matrix
+
+| Case | Expected |
+| --- | --- |
+| Corrupt member under `CONTINUE` and default diagnostics | Partial output removed; `FAILED` result; `EXTRACTION_MEMBER_FAILED`; later members continue |
+| Extraction diagnostic resolves to `RAISE` under `CONTINUE` | `DiagnosticRaisedError` halts; no report returned |
+| `CorruptionError` under `STOP` | Original `CorruptionError` propagates; no continued-failure diagnostic |
+| Filesystem `OSError` while writing under `CONTINUE` | Partial output removed; `FAILED` result/diagnostic; extraction proceeds |

--- a/openspec/changes/clarify-extraction-status-names/tasks.md
+++ b/openspec/changes/clarify-extraction-status-names/tasks.md
@@ -1,0 +1,50 @@
+## 1. Prerequisites
+
+- [ ] 1.1 Confirm the api-coherence Q1 follow-up (PR #154 — `ExtractionStatus.SUPERSEDED`,
+      shared last-entry-wins pass) is merged; rebase this change onto it
+
+## 2. Enum rename (`ExtractionStatus`)
+
+- [ ] 2.1 Rename `SKIPPED` → `NOT_OVERWRITTEN` (`"skipped"` → `"not_overwritten"`)
+      and `REJECTED` → `BLOCKED` (`"rejected"` → `"blocked"`) in
+      `internal/extraction_types.py`; update the member docstring comments
+- [ ] 2.2 Sweep `internal/extraction.py` status emissions (overwrite/hardlink SKIP
+      → `NOT_OVERWRITTEN`; rejection → `BLOCKED`); confirm filter-`None` still
+      appends **no** result (D1 — already correct, add/keep the covering comment)
+
+## 3. Diagnostic cascade (D4)
+
+- [ ] 3.1 Rename `DiagnosticCode.EXTRACTION_MEMBER_REJECTED` → `EXTRACTION_MEMBER_BLOCKED`
+      (`"extraction_member_rejected"` → `"extraction_member_blocked"`) in `diagnostics.py`
+- [ ] 3.2 Change `ExtractionOutcomeContext.status` literal `"rejected"` → `"blocked"`
+      and the pairing validator message/check
+- [ ] 3.3 Update the emission site in `internal/extraction.py` (the
+      `EXTRACTION_MEMBER_REJECTED` / `outcome="rejected"` branch)
+
+## 4. CLI
+
+- [ ] 4.1 Update `cli/extract_cmd.py` status branches/labels
+      (`skipped:` → `not overwritten:`; `rejected` → `blocked`); keep the
+      `superseded:` label from #154
+
+## 5. Specs & docs
+
+- [ ] 5.1 Sync main specs from this change’s deltas (`safe-extraction`,
+      `diagnostics`, `format-rar`)
+- [ ] 5.2 Sweep `error-handling` spec prose (`FAILED`/`REJECTED` → `FAILED`/`BLOCKED`)
+- [ ] 5.3 Grep `docs/` and `openspec/specs/` for stray `SKIPPED`/`REJECTED`
+      extraction references (exclude the unrelated pytest-job "SKIPPED" wording in
+      `testing-contract`); `docs/api.md` autodoc needs no manual edit
+
+## 6. Tests
+
+- [ ] 6.1 Rename assertions across the extraction/diagnostic suites; add a case
+      asserting filter-`None` produces **no** `ExtractionResult` (locks D1)
+- [ ] 6.2 Assert a `BLOCKED` result pairs with `EXTRACTION_MEMBER_BLOCKED` /
+      `status="blocked"`
+- [ ] 6.3 `uv run --no-sync pytest` for affected tests; `ruff format` / `ruff check`;
+      `uv run pyrefly check` and `uv run ty check` on touched paths
+
+## 7. Verify
+
+- [ ] 7.1 `openspec validate --strict clarify-extraction-status-names`


### PR DESCRIPTION
Proposal-only OpenSpec change (`openspec/changes/clarify-extraction-status-names/`) — no code yet. `openspec validate --strict` passes.

## Why

After the api-coherence Q1 follow-up added `ExtractionStatus.SUPERSEDED`, the enum has three "not written" outcomes and the two older names stopped carrying their own reason:

- `SKIPPED` now means exactly one thing — an existing destination kept under `OverwritePolicy.SKIP` — but the name still reads as "skipped for some reason."
- `REJECTED` doesn't signal that a **safety or policy gate** blocked the entry.

VISION's "honest signals" wants a status a caller can branch on without reading a docstring.

## What it proposes

- Rename `SKIPPED` → **`NOT_OVERWRITTEN`** (`"not_overwritten"`).
- Rename `REJECTED` → **`BLOCKED`** (`"blocked"`) — no `_BY_POLICY` suffix, because a universal path-safety block is safety, not policy.
- **Cascade** `BLOCKED` to its paired diagnostic: `DiagnosticCode.EXTRACTION_MEMBER_REJECTED` → `EXTRACTION_MEMBER_BLOCKED`, `ExtractionOutcomeContext.status` `"rejected"` → `"blocked"`.
- Keep `EXTRACTED`, `SUPERSEDED`, `FAILED`.

## Two spec/code drifts reconciled in the same area

- **filter-`None`:** the spec claimed it yields `SKIPPED`, but the coordinator records **no result** (like a selector exclusion). Spec corrected to match code — this is what makes `NOT_OVERWRITTEN` accurate.
- **`format-rar`:** history rows still documented as extracting `SKIPPED`; post-Q1 they're `SUPERSEDED`.

## Decisions captured (see `design.md`)

- D1 filter-`None` = no result · D2 `NOT_OVERWRITTEN` over `EXISTS`/`KEPT` · D3 `BLOCKED` over `REJECTED`/`*_BY_POLICY` · D4 cascade to the diagnostic.
- **Flagged, not bundled:** `ExtractionStatus` is `Enum` in code but the spec pseudocode says `str, Enum` — left for a separate call.

## Contents

`proposal.md` · `design.md` · `tasks.md` · `brief.md` · spec deltas for `safe-extraction`, `diagnostics`, `format-rar`.

## Notes

- **Breaking** public rename (no back-compat aliases; pre-1.0).
- **Stacks on #154** (`SUPERSEDED` + the shared last-entry-wins pass) — deltas edit the post-#154 enum and specs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017cszQZzxSsZMVoTwhpcc65

---
_Generated by [Claude Code](https://claude.ai/code/session_017cszQZzxSsZMVoTwhpcc65)_