### PR TITLE
Clarify ExtractionStatus names: NOT_OVERWRITTEN / BLOCKED

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -120,7 +120,7 @@ entries — `members()` / `__iter__` never hide anything — but marks which one
 - All earlier same-name entries have `is_current=False` (superseded).
 
 `extract_all` honours this automatically: non-current entries get
-`ExtractionStatus.SUPERSEDED` (distinct from overwrite `SKIPPED`) and are not written,
+`ExtractionStatus.SUPERSEDED` (distinct from overwrite `NOT_OVERWRITTEN`) and are not written,
 so the final on-disk state matches what you would get from a fresh write.
 
 To enumerate only the live state in your own code, filter with a one-liner:

--- a/openspec/changes/clarify-extraction-status-names/brief.md
+++ b/openspec/changes/clarify-extraction-status-names/brief.md
@@ -13,8 +13,6 @@ proposal.md / design.md / tasks.md; do not introduce new decisions here.
 
 **What it does:** Renames Skipped to Not Overwritten and Rejected to Blocked. Blocked stays honest for both a hardwired path-safety block and a policy filter, so no by-policy suffix, because a zip-slip block is safety, not policy. The rename cascades to the paired diagnostic, so the code becomes Extraction Member Blocked and its status field becomes blocked, keeping one vocabulary across the result and its diagnostic. Extracted, Superseded, and Failed keep their names.
 
-**Also fixes two drifts in the same area:** The spec claimed a filter returning None yields a skipped result, but the coordinator actually records no result at all, like a selector exclusion, so the spec is corrected. And the RAR file-version spec still said history rows extract as skipped, when they are now superseded.
-
-**Your call later:** Whether the enum should become a string enum to match the spec text and the hash algorithm enum. Flagged, not bundled.
+**Also fixes two drifts in the same area:** The spec claimed a filter returning None yields a skipped result, but the coordinator actually records no result at all, like a selector exclusion, so the spec is corrected. And the RAR file-version spec still said history rows extract as skipped, when they are now superseded. ExtractionStatus stays a string enum, matching the other public enums.
 
 **Bottom line:** Honest, self-documenting status names, plus two contract corrections, stacked on the Q1 follow-up.

--- a/openspec/changes/clarify-extraction-status-names/design.md
+++ b/openspec/changes/clarify-extraction-status-names/design.md
@@ -77,9 +77,8 @@ vocabulary split for a purely cosmetic diff saving.
 - No back-compat aliases: archivey is pre-1.0 and prefers an honest rename now
   over carrying a deprecated misnomer.
 
-## Adjacent drift noted, not fixed here
+## Adjacent drift resolved with this change
 
-`safe-extraction` pseudocode declares `class ExtractionStatus(str, Enum)` but the
-implementation is `class ExtractionStatus(Enum)`. Left for a separate decision
-(whether to make it `str, Enum` for serialization symmetry with `HashAlgorithm`,
-or correct the spec). Flagged so it is not silently bundled into a rename.
+`safe-extraction` pseudocode declares `class ExtractionStatus(str, Enum)`. The
+implementation already matches (`ExtractionStatus(str, Enum)`), keeping
+serialization symmetry with `HashAlgorithm` / `DiagnosticCode`.

--- a/openspec/changes/clarify-extraction-status-names/tasks.md
+++ b/openspec/changes/clarify-extraction-status-names/tasks.md
@@ -42,9 +42,9 @@
       asserting filter-`None` produces **no** `ExtractionResult` (locks D1)
 - [x] 6.2 Assert a `BLOCKED` result pairs with `EXTRACTION_MEMBER_BLOCKED` /
       `status="blocked"`
-- [ ] 6.3 `uv run --no-sync pytest` for affected tests; `ruff format` / `ruff check`;
+- [x] 6.3 `uv run --no-sync pytest` for affected tests; `ruff format` / `ruff check`;
       `uv run pyrefly check` and `uv run ty check` on touched paths
 
 ## 7. Verify
 
-- [ ] 7.1 `openspec validate --strict clarify-extraction-status-names`
+- [x] 7.1 `openspec validate --strict clarify-extraction-status-names`

--- a/openspec/changes/clarify-extraction-status-names/tasks.md
+++ b/openspec/changes/clarify-extraction-status-names/tasks.md
@@ -1,46 +1,46 @@
 ## 1. Prerequisites
 
-- [ ] 1.1 Confirm the api-coherence Q1 follow-up (PR #154 — `ExtractionStatus.SUPERSEDED`,
+- [x] 1.1 Confirm the api-coherence Q1 follow-up (PR #154 — `ExtractionStatus.SUPERSEDED`,
       shared last-entry-wins pass) is merged; rebase this change onto it
 
 ## 2. Enum rename (`ExtractionStatus`)
 
-- [ ] 2.1 Rename `SKIPPED` → `NOT_OVERWRITTEN` (`"skipped"` → `"not_overwritten"`)
+- [x] 2.1 Rename `SKIPPED` → `NOT_OVERWRITTEN` (`"skipped"` → `"not_overwritten"`)
       and `REJECTED` → `BLOCKED` (`"rejected"` → `"blocked"`) in
       `internal/extraction_types.py`; update the member docstring comments
-- [ ] 2.2 Sweep `internal/extraction.py` status emissions (overwrite/hardlink SKIP
+- [x] 2.2 Sweep `internal/extraction.py` status emissions (overwrite/hardlink SKIP
       → `NOT_OVERWRITTEN`; rejection → `BLOCKED`); confirm filter-`None` still
       appends **no** result (D1 — already correct, add/keep the covering comment)
 
 ## 3. Diagnostic cascade (D4)
 
-- [ ] 3.1 Rename `DiagnosticCode.EXTRACTION_MEMBER_REJECTED` → `EXTRACTION_MEMBER_BLOCKED`
+- [x] 3.1 Rename `DiagnosticCode.EXTRACTION_MEMBER_REJECTED` → `EXTRACTION_MEMBER_BLOCKED`
       (`"extraction_member_rejected"` → `"extraction_member_blocked"`) in `diagnostics.py`
-- [ ] 3.2 Change `ExtractionOutcomeContext.status` literal `"rejected"` → `"blocked"`
+- [x] 3.2 Change `ExtractionOutcomeContext.status` literal `"rejected"` → `"blocked"`
       and the pairing validator message/check
-- [ ] 3.3 Update the emission site in `internal/extraction.py` (the
+- [x] 3.3 Update the emission site in `internal/extraction.py` (the
       `EXTRACTION_MEMBER_REJECTED` / `outcome="rejected"` branch)
 
 ## 4. CLI
 
-- [ ] 4.1 Update `cli/extract_cmd.py` status branches/labels
+- [x] 4.1 Update `cli/extract_cmd.py` status branches/labels
       (`skipped:` → `not overwritten:`; `rejected` → `blocked`); keep the
       `superseded:` label from #154
 
 ## 5. Specs & docs
 
-- [ ] 5.1 Sync main specs from this change’s deltas (`safe-extraction`,
+- [x] 5.1 Sync main specs from this change’s deltas (`safe-extraction`,
       `diagnostics`, `format-rar`)
-- [ ] 5.2 Sweep `error-handling` spec prose (`FAILED`/`REJECTED` → `FAILED`/`BLOCKED`)
-- [ ] 5.3 Grep `docs/` and `openspec/specs/` for stray `SKIPPED`/`REJECTED`
+- [x] 5.2 Sweep `error-handling` spec prose (`FAILED`/`REJECTED` → `FAILED`/`BLOCKED`)
+- [x] 5.3 Grep `docs/` and `openspec/specs/` for stray `SKIPPED`/`REJECTED`
       extraction references (exclude the unrelated pytest-job "SKIPPED" wording in
       `testing-contract`); `docs/api.md` autodoc needs no manual edit
 
 ## 6. Tests
 
-- [ ] 6.1 Rename assertions across the extraction/diagnostic suites; add a case
+- [x] 6.1 Rename assertions across the extraction/diagnostic suites; add a case
       asserting filter-`None` produces **no** `ExtractionResult` (locks D1)
-- [ ] 6.2 Assert a `BLOCKED` result pairs with `EXTRACTION_MEMBER_BLOCKED` /
+- [x] 6.2 Assert a `BLOCKED` result pairs with `EXTRACTION_MEMBER_BLOCKED` /
       `status="blocked"`
 - [ ] 6.3 `uv run --no-sync pytest` for affected tests; `ruff format` / `ruff check`;
       `uv run pyrefly check` and `uv run ty check` on touched paths

--- a/openspec/specs/diagnostics/spec.md
+++ b/openspec/specs/diagnostics/spec.md
@@ -42,7 +42,7 @@ context SHALL be `json.dumps`-safe without a custom encoder.
 | `DIGEST_UNVERIFIABLE` | `DigestContext`: `kind="digest"`, `archive_name`, `member_name`, `member_id`, `algorithm`, `reason` |
 | `SEEK_INDEX_DEGRADED` | `SeekIndexContext`: `kind="seek_index"`, `archive_name`, `member_name`, `member_id`, `codec`, `scan`, `error_type` |
 | `STREAM_REWIND_REDECOMPRESSES` | `StreamRewindContext`: `kind="stream_rewind"`, `archive_name`, `member_name`, `member_id`, `codec`, `from_offset`, `to_offset`, `accelerator` |
-| `EXTRACTION_MEMBER_REJECTED` | `ExtractionOutcomeContext`: `kind="extraction_outcome"`, `…`, `status="rejected"`, `error_type`, `failure_group_id`, `failure_group_size` |
+| `EXTRACTION_MEMBER_BLOCKED` | `ExtractionOutcomeContext`: `kind="extraction_outcome"`, `…`, `status="blocked"`, `error_type`, `failure_group_id`, `failure_group_size` |
 | `EXTRACTION_MEMBER_FAILED` | `ExtractionOutcomeContext`: `kind="extraction_outcome"`, `…`, `status="failed"`, `error_type`, `failure_group_id`, `failure_group_size` |
 
 (`str | None` / `int | None` as in the typed variants.) `DiagnosticContext` is
@@ -50,7 +50,8 @@ exactly this union — no backend-defined variants. `observed_kind` ∈
 `{"absent","short","nonzero"}`. `expected_marker` is symbolic (e.g.
 `"two_zero_blocks"`). `member_id` MAY be `None` only before registration.
 `failure_group_id`/`failure_group_size` both set only when multiple hardlink
-results share one failed source; else both `None`.
+results share one failed source; else both `None`. `EXTRACTION_MEMBER_BLOCKED`
+pairs with `ExtractionStatus.BLOCKED`; the two share the `"blocked"` vocabulary.
 
 No diagnostic surface SHALL contain passwords, candidates, provider returns, keys,
 KDF material, or decrypted secrets.
@@ -65,6 +66,7 @@ and cross-run id stability are not promised.
 | Name normalization | `MEMBER_NAME_NORMALIZED` + typed JSON-safe context; no backend/mutable mapping |
 | Same occurrence on aggregate + member | Same `occurrence_id`; value equality; no object-identity promise |
 | Encrypted symlink unavailable | May use reason `"password_required"` + member name; no secret material |
+| Member blocked by a universal/policy check | `EXTRACTION_MEMBER_BLOCKED` with `status="blocked"`; pairs with a `BLOCKED` result |
 
 ### Requirement: Exact bounded diagnostic summaries
 

--- a/openspec/specs/error-handling/spec.md
+++ b/openspec/specs/error-handling/spec.md
@@ -159,7 +159,7 @@ central context mechanism. Escalation alone has no underlying exception, so
 | Case | Expected |
 | --- | --- |
 | Code resolves to `RAISE` and delivery succeeds | `DiagnosticRaisedError` carries the exact emitted diagnostic plus stamped context |
-| Member diagnostic escalates during `OnError.CONTINUE` | Error propagates immediately; extraction does not record `FAILED`/`REJECTED` or continue |
+| Member diagnostic escalates during `OnError.CONTINUE` | Error propagates immediately; extraction does not record `FAILED`/`BLOCKED` or continue |
 
 ### Requirement: Archive EOF strictness takes precedence
 

--- a/openspec/specs/format-rar/spec.md
+++ b/openspec/specs/format-rar/spec.md
@@ -108,8 +108,11 @@ member list contains any versioned payload FILE so the pipe includes history
 bytes in archive order; otherwise solid demux MAY omit `-ver`.
 
 Default `extract` / `extract_all` SHALL skip history rows through the existing
-`is_current=False` coordinator behavior (`safe-extraction`). History rows SHALL
-count toward listing / parser member ceilings like any other FILE.
+`is_current=False` coordinator behavior (`safe-extraction`), recording each as
+`ExtractionStatus.SUPERSEDED`. History rows have unique `path;n` presentation
+names, so the shared last-entry-wins pass leaves their backend `is_current=False`
+untouched. History rows SHALL count toward listing / parser member ceilings like
+any other FILE.
 
 #### Scenario: file-version matrix
 
@@ -118,7 +121,7 @@ count toward listing / parser member ceilings like any other FILE.
 | RAR5 `-ver` archive with revisions 1..k then live path | Members include `path;1`…`path;k` (`is_current=False`) and `path` (`is_current=True`) |
 | `read("path;1")` / `open` that member | Bytes of revision 1 |
 | `read("path")` | Bytes of the live revision |
-| `extract_all` default | Writes live `path` only; history rows `SKIPPED` |
+| `extract_all` default | Writes live `path` only; history rows `SUPERSEDED` |
 | Solid archive that includes versioned payload FILEs | ALL-pipe demux uses `-ver`; stream order stays aligned |
 | Nonsolid named `unrar p` of `path;n` | Exact member name; `-ver` not required |
 | Hostile archive with many version rows | Rows count toward member caps |

--- a/openspec/specs/safe-extraction/spec.md
+++ b/openspec/specs/safe-extraction/spec.md
@@ -209,7 +209,8 @@ is **hardwired coordinator behavior**, not the policy `filter` / `MemberFilter`
 pipeline: the skip happens after the optional user `filter` runs so callers can
 inspect or rewrite non-current members, then the coordinator still skips writing
 them unless a future explicit opt-in lands. `SUPERSEDED` is distinct from
-`ExtractionStatus.SKIPPED` (pre-existing destination under `OverwritePolicy.SKIP`).
+`ExtractionStatus.NOT_OVERWRITTEN` (an existing destination left in place under
+`OverwritePolicy.SKIP`).
 
 How surfaces interact:
 
@@ -283,10 +284,10 @@ When a selected HARDLINK's source was excluded by `members` or `filter`, the
 system MUST NOT materialize the excluded source at its own destination. It SHALL
 make the source content available only through selected link destinations: write
 the bytes to the first selected link path allowed by `OverwritePolicy`, record
-`SKIPPED` links under `SKIP`, link further selected links to the materialized
-path, and write nothing if every selected link is skipped. The materialized file
-gets the selected link's transformed metadata. An equivalent hidden temp inside
-`dest` is permitted.
+`NOT_OVERWRITTEN` links under `SKIP`, link further selected links to the
+materialized path, and write nothing if every selected link is skipped. The
+materialized file gets the selected link's transformed metadata. An equivalent
+hidden temp inside `dest` is permitted.
 
 The coordinator SHALL avoid wasted passes: if a free member list exists
 (`get_members_if_available()`), recovery is planned in one forward pass; otherwise
@@ -301,7 +302,7 @@ source is written, with one read and one bomb-limit count for the source bytes.
 | --- | --- |
 | HARDLINK reached after its source was extracted | Try `os.link()` against recorded source paths; fallback to copy on all-`EXDEV` |
 | Selected hardlink source was excluded but recoverable | Source content appears at selected link path(s); excluded source path is never created |
-| First selected link destination exists under `OverwritePolicy.SKIP` | That link result is `SKIPPED`; content moves to the next allowed link; all skipped means no write |
+| First selected link destination exists under `OverwritePolicy.SKIP` | That link result is `NOT_OVERWRITTEN`; content moves to the next allowed link; all skipped means no write |
 | Excluded source on a forward-only stream | Per-member failure: `STOP` raises; `CONTINUE` records `FAILED` and proceeds |
 | HARDLINK appears before its also-selected source | After the pass it links to the extracted source inode; source bytes read and counted once |
 
@@ -356,7 +357,7 @@ class OverwritePolicy(Enum):
 ```
 
 `ERROR` raises a per-member `ExtractionError` governed by `OnError`; `SKIP`
-records a `SKIPPED` result and is not a failure. Existence checks SHALL use
+records a `NOT_OVERWRITTEN` result and is not a failure. Existence checks SHALL use
 `lstat` semantics so dangling symlinks count as existing entries. `REPLACE` SHALL
 be atomic and never write through a symlink: FILE data streams to a temp file in
 the destination directory, metadata is applied, and `os.replace()` moves it onto
@@ -372,7 +373,7 @@ name-safety requirement.
 | Case | Expected |
 | --- | --- |
 | Existing path under `ERROR` | `ExtractionError`; existing entry unmodified |
-| Existing path under `SKIP` | `ExtractionResult.status == SKIPPED`, `path=None`, no exception |
+| Existing path under `SKIP` | `ExtractionResult.status == NOT_OVERWRITTEN`, `path=None`, no exception |
 | Existing file under `REPLACE` | Fresh file is written via temp file + `os.replace()` |
 | Existing symlink under `REPLACE` | Symlink entry itself is replaced; bytes never follow the old link |
 | `REPLACE` fails mid-stream | Existing file remains unchanged; temp is discarded |
@@ -514,8 +515,10 @@ frequency is bounded by the extraction copy chunk size; when `on_progress` is
 
 `ExtractionReport.results` SHALL contain one `ExtractionResult` for every
 selected member the coordinator processes when the operation completes, including
-members rejected by universal/policy checks before the user filter. Selector
-exclusions are outside the operation and have no result.
+members blocked by universal/policy checks before the user filter. Selector
+exclusions are outside the operation and have no result; a user `filter` that
+returns `None` likewise drops the member with **no** `ExtractionResult` (it is a
+caller-elected exclusion, not an extraction outcome).
 
 ```python
 @dataclass(frozen=True)
@@ -528,27 +531,27 @@ class ExtractionResult:
 
 class ExtractionStatus(str, Enum):
     EXTRACTED = "extracted"
-    SKIPPED = "skipped"
+    NOT_OVERWRITTEN = "not_overwritten"
     SUPERSEDED = "superseded"
-    REJECTED = "rejected"
+    BLOCKED = "blocked"
     FAILED = "failed"
 ```
 
 Statuses SHALL mean: `EXTRACTED` created an entry (`path` set, `error=None`);
-`SKIPPED` intentionally bypassed writing because the user filter returned `None`
-or `OverwritePolicy.SKIP` found an existing destination (`path=None`,
-`error=None`); `SUPERSEDED` is a non-current duplicate skipped by the hardwired
-last-entry-wins rule (`path=None`, `error=None`); `REJECTED` is a continued
-`FilterRejectionError`; `FAILED` is a continued non-rejection per-member
-`ArchiveyError` or permitted filesystem `OSError`. `SKIPPED` and `SUPERSEDED`
-are not failures and emit no diagnostic. `requested_path`
-carries the destination the coordinator intended before overwrite/rename
-resolution; it equals `path` for an ordinary write, and `requested_path != path
-and status == EXTRACTED` marks an `OverwritePolicy.RENAME` (see the cross-platform
-name-safety requirement).
+`NOT_OVERWRITTEN` left an existing destination in place because
+`OverwritePolicy.SKIP` found one (`path=None`, `error=None`); `SUPERSEDED` is a
+non-current duplicate skipped by the hardwired last-entry-wins rule (`path=None`,
+`error=None`); `BLOCKED` is a continued `FilterRejectionError` (a universal
+path-safety check or a policy filter blocked the member); `FAILED` is a continued
+non-rejection per-member `ArchiveyError` or permitted filesystem `OSError`.
+`NOT_OVERWRITTEN` and `SUPERSEDED` are not failures and emit no diagnostic.
+`requested_path` carries the destination the coordinator intended before
+overwrite/rename resolution; it equals `path` for an ordinary write, and
+`requested_path != path and status == EXTRACTED` marks an `OverwritePolicy.RENAME`
+(see the cross-platform name-safety requirement).
 
-Continued `REJECTED`/`FAILED` results SHALL emit exactly one matching
-`EXTRACTION_MEMBER_REJECTED` / `EXTRACTION_MEMBER_FAILED` occurrence per result.
+Continued `BLOCKED`/`FAILED` results SHALL emit exactly one matching
+`EXTRACTION_MEMBER_BLOCKED` / `EXTRACTION_MEMBER_FAILED` occurrence per result.
 `ExtractionResult` has no diagnostics field; `status` and `error` are the
 per-result outcome while diagnostics live in the report/reader aggregate. If one
 failed hardlink source causes `N` hardlink failures under `IGNORE` or `COLLECT`,
@@ -561,12 +564,12 @@ applies.
 
 | Case | Expected |
 | --- | --- |
-| User filter returns `None` | Result is `SKIPPED`, `path=None`, `error=None`, no skip diagnostic |
+| User filter returns `None` | No `ExtractionResult`; no result-count impact (like a selector exclusion) |
 | Selector excludes member | No `ExtractionResult`; no result-count impact |
-| Member blocked by `PathTraversalError` under `CONTINUE` | Result is `REJECTED` with matching error and diagnostic |
+| Member blocked by `PathTraversalError` under `CONTINUE` | Result is `BLOCKED` with matching error and diagnostic |
 | Member write raises `OSError` under `CONTINUE` | Result is `FAILED` with matching error and diagnostic |
 | Member written successfully | Result is `EXTRACTED`, `path` points to created entry |
-| Existing destination under `OverwritePolicy.SKIP` | Result is `SKIPPED`, `path=None` |
+| Existing destination under `OverwritePolicy.SKIP` | Result is `NOT_OVERWRITTEN`, `path=None` |
 | One failed source causes three hardlink results to fail | Failed count increases by three; retained contexts, if budget permits, share one failure group id/size |
 
 ### Requirement: Error Policy (OnError) for extraction failures
@@ -574,7 +577,7 @@ applies.
 `OnError.STOP` and `OnError.CONTINUE` SHALL govern per-member failures only.
 Under `CONTINUE`, a member-scoped `FilterRejectionError`, other member-scoped
 `ArchiveyError`, permitted read/write `OSError`, or per-member ratio violation
-records `REJECTED`/`FAILED`, removes partial output, emits the matching diagnostic
+records `BLOCKED`/`FAILED`, removes partial output, emits the matching diagnostic
 under the active diagnostic policy, and proceeds.
 
 Diagnostic disposition SHALL still be authoritative: `RAISE` emits
@@ -596,7 +599,7 @@ swallowed.
 | Filesystem `OSError` while writing under `CONTINUE` | Partial output removed; `FAILED` result/diagnostic; extraction proceeds |
 | Cumulative bytes/live ratio/max entries exceed limit under `CONTINUE` | `ResourceLimitError` propagates and halts; no later member processed |
 | Default `STOP` member failure | Exception raises immediately; failing partial file removed; earlier outputs remain |
-| Mixed good/corrupt archive under `CONTINUE` | Extractable members are written; report includes `EXTRACTED` plus `FAILED`/`REJECTED`; no per-member exception escapes |
+| Mixed good/corrupt archive under `CONTINUE` | Extractable members are written; report includes `EXTRACTED` plus `FAILED`/`BLOCKED`; no per-member exception escapes |
 
 ### Requirement: ExtractionReport is an immutable operation result
 

--- a/src/archivey/cli/extract_cmd.py
+++ b/src/archivey/cli/extract_cmd.py
@@ -287,7 +287,7 @@ def _report_extraction(
     extracted = 0
     renamed = extra_renamed
     skipped = extra_skipped
-    rejected = 0
+    blocked = 0
     failed = 0
     for result in report:
         status = result.status
@@ -307,19 +307,19 @@ def _report_extraction(
                 )
             elif verbose:
                 print(f"extracted: {result.member.name}", file=err)
-        elif status is ExtractionStatus.SKIPPED:
+        elif status is ExtractionStatus.NOT_OVERWRITTEN:
             skipped += 1
-            # Skips also change outcomes under --overwrite skip; always note.
+            # Overwrite-skips change outcomes under --overwrite skip; always note.
             where = result.requested_path or result.member.name
-            print(f"skipped: {where}", file=err)
+            print(f"not overwritten: {where}", file=err)
         elif status is ExtractionStatus.SUPERSEDED:
             skipped += 1  # count superseded entries alongside skipped in summary
             if verbose:
                 print(f"superseded: {result.member.name}", file=err)
-        elif status is ExtractionStatus.REJECTED:
-            rejected += 1
+        elif status is ExtractionStatus.BLOCKED:
+            blocked += 1
             detail = f": {result.error}" if result.error is not None else ""
-            print(f"rejected: {result.member.name}{detail}", file=err)
+            print(f"blocked: {result.member.name}{detail}", file=err)
         elif status is ExtractionStatus.FAILED:
             failed += 1
             detail = f": {result.error}" if result.error is not None else ""
@@ -333,7 +333,7 @@ def _report_extraction(
         dest_label = str(target)
     print(
         f"{extracted} extracted, {renamed} renamed, {skipped} skipped"
-        f"{f', {rejected} rejected' if rejected else ''}"
+        f"{f', {blocked} blocked' if blocked else ''}"
         f"{f', {failed} failed' if failed else ''}"
         f" → {dest_label}",
         file=err,

--- a/src/archivey/diagnostics.py
+++ b/src/archivey/diagnostics.py
@@ -56,7 +56,7 @@ class DiagnosticCode(str, Enum):
     DIGEST_UNVERIFIABLE = "digest_unverifiable"
     SEEK_INDEX_DEGRADED = "seek_index_degraded"
     STREAM_REWIND_REDECOMPRESSES = "stream_rewind_redecompresses"
-    EXTRACTION_MEMBER_REJECTED = "extraction_member_rejected"
+    EXTRACTION_MEMBER_BLOCKED = "extraction_member_blocked"
     EXTRACTION_MEMBER_FAILED = "extraction_member_failed"
     EXTRACTION_NAME_COLLISION = "extraction_name_collision"
     EXTRACTION_NAME_SANITIZED = "extraction_name_sanitized"
@@ -189,7 +189,7 @@ class ExtractionOutcomeContext(_JsonSafeContext):
     archive_name: str | None = None
     member_name: str = ""
     member_id: int | None = None
-    status: Literal["rejected", "failed"] = "failed"
+    status: Literal["blocked", "failed"] = "failed"
     error_type: str = ""
     failure_group_id: str | None = None
     failure_group_size: int | None = None
@@ -252,7 +252,7 @@ _CODE_CONTEXT_KINDS: Mapping[DiagnosticCode, str] = MappingProxyType(
         DiagnosticCode.DIGEST_UNVERIFIABLE: "digest",
         DiagnosticCode.SEEK_INDEX_DEGRADED: "seek_index",
         DiagnosticCode.STREAM_REWIND_REDECOMPRESSES: "stream_rewind",
-        DiagnosticCode.EXTRACTION_MEMBER_REJECTED: "extraction_outcome",
+        DiagnosticCode.EXTRACTION_MEMBER_BLOCKED: "extraction_outcome",
         DiagnosticCode.EXTRACTION_MEMBER_FAILED: "extraction_outcome",
         DiagnosticCode.EXTRACTION_NAME_COLLISION: "name_collision",
         DiagnosticCode.EXTRACTION_NAME_SANITIZED: "name_sanitized",
@@ -278,11 +278,10 @@ def validate_code_context(code: DiagnosticCode, context: DiagnosticContext) -> N
         not isinstance(context, ScanRaceContext) or context.entry_kind != "entry"
     ):
         raise ValueError("SCAN_ENTRY_VANISHED requires entry_kind='entry'")
-    if code is DiagnosticCode.EXTRACTION_MEMBER_REJECTED and (
-        not isinstance(context, ExtractionOutcomeContext)
-        or context.status != "rejected"
+    if code is DiagnosticCode.EXTRACTION_MEMBER_BLOCKED and (
+        not isinstance(context, ExtractionOutcomeContext) or context.status != "blocked"
     ):
-        raise ValueError("EXTRACTION_MEMBER_REJECTED requires status='rejected'")
+        raise ValueError("EXTRACTION_MEMBER_BLOCKED requires status='blocked'")
     if code is DiagnosticCode.EXTRACTION_MEMBER_FAILED and (
         not isinstance(context, ExtractionOutcomeContext) or context.status != "failed"
     ):

--- a/src/archivey/internal/extraction.py
+++ b/src/archivey/internal/extraction.py
@@ -356,7 +356,8 @@ class ExtractionCoordinator:
                 # even if the filter returns the member.
                 transformed = self._transform(original, dest_root)
                 if transformed is None:
-                    # Filter-skipped: no result; still counts as processed for progress.
+                    # Filter returned None: caller-elected exclusion — no ExtractionResult
+                    # (same as a selector exclusion). Still counts as processed for progress.
                     pass
                 elif not original.is_current:
                     results.append(
@@ -444,7 +445,7 @@ class ExtractionCoordinator:
                     )
                     error.__cause__ = exc
                 status = (
-                    ExtractionStatus.REJECTED
+                    ExtractionStatus.BLOCKED
                     if isinstance(error, FilterRejectionError)
                     else ExtractionStatus.FAILED
                 )
@@ -456,12 +457,12 @@ class ExtractionCoordinator:
                 if self._on_error is OnError.STOP:
                     raise error
                 code = (
-                    DiagnosticCode.EXTRACTION_MEMBER_REJECTED
-                    if status is ExtractionStatus.REJECTED
+                    DiagnosticCode.EXTRACTION_MEMBER_BLOCKED
+                    if status is ExtractionStatus.BLOCKED
                     else DiagnosticCode.EXTRACTION_MEMBER_FAILED
                 )
-                outcome: Literal["rejected", "failed"] = (
-                    "rejected" if status is ExtractionStatus.REJECTED else "failed"
+                outcome: Literal["blocked", "failed"] = (
+                    "blocked" if status is ExtractionStatus.BLOCKED else "failed"
                 )
                 self._diagnostics_collector.emit(
                     code=code,
@@ -598,7 +599,9 @@ class ExtractionCoordinator:
         if transformed.type == MemberType.DIRECTORY:
             existed = os.path.lexists(dest_path)
             if not self._prepare_destination(transformed, dest_path):
-                return ExtractionResult(original, None, ExtractionStatus.SKIPPED, None)
+                return ExtractionResult(
+                    original, None, ExtractionStatus.NOT_OVERWRITTEN, None
+                )
             os.makedirs(dest_path, exist_ok=True)
             self._apply_metadata(dest_path, transformed)
             if not existed:
@@ -804,7 +807,9 @@ class ExtractionCoordinator:
         source_paths: dict[int, list[Path]],
     ) -> ExtractionResult:
         if not self._prepare_destination(transformed, dest_path, atomic=True):
-            return ExtractionResult(original, None, ExtractionStatus.SKIPPED, None)
+            return ExtractionResult(
+                original, None, ExtractionStatus.NOT_OVERWRITTEN, None
+            )
 
         os.makedirs(dest_path.parent, exist_ok=True)
         self._write_file_atomic(stream, dest_path, transformed, tracker)
@@ -822,7 +827,9 @@ class ExtractionCoordinator:
         dest_path: Path,
     ) -> ExtractionResult:
         if not self._prepare_destination(transformed, dest_path):
-            return ExtractionResult(original, None, ExtractionStatus.SKIPPED, None)
+            return ExtractionResult(
+                original, None, ExtractionStatus.NOT_OVERWRITTEN, None
+            )
 
         target = transformed.link_target
         if target is None:
@@ -893,7 +900,9 @@ class ExtractionCoordinator:
 
         if source.member_id in source_paths:
             if not self._prepare_destination(transformed, dest_path):
-                return ExtractionResult(original, None, ExtractionStatus.SKIPPED, None)
+                return ExtractionResult(
+                    original, None, ExtractionStatus.NOT_OVERWRITTEN, None
+                )
             os.makedirs(dest_path.parent, exist_ok=True)
             self._place_link(source_paths, source.member_id, dest_path, transformed)
             return ExtractionResult(
@@ -1053,7 +1062,7 @@ class ExtractionCoordinator:
                 results[orphan.result_index] = ExtractionResult(
                     orphan.original,
                     None,
-                    ExtractionStatus.SKIPPED,
+                    ExtractionStatus.NOT_OVERWRITTEN,
                     None,
                     requested_path=orphan.dest_path,
                 )
@@ -1107,7 +1116,7 @@ class ExtractionCoordinator:
                     results[orphan.result_index] = ExtractionResult(
                         orphan.original,
                         None,
-                        ExtractionStatus.SKIPPED,
+                        ExtractionStatus.NOT_OVERWRITTEN,
                         None,
                         requested_path=orphan.dest_path,
                     )

--- a/src/archivey/internal/extraction_types.py
+++ b/src/archivey/internal/extraction_types.py
@@ -59,11 +59,11 @@ class OverwritePolicy(Enum):
     ``ERROR`` raises an ``ExtractionError`` for the member, which is then a per-member
     failure governed by the ``OnError`` policy — ``OnError.STOP`` re-raises and halts,
     ``OnError.CONTINUE`` records a ``FAILED`` ``ExtractionResult`` and proceeds. ``SKIP``
-    is not an error: it records a ``SKIPPED`` result regardless of ``OnError``.
+    is not an error: it records a ``NOT_OVERWRITTEN`` result regardless of ``OnError``.
     """
 
     ERROR = "error"  # existing entry -> ExtractionError (then handled per OnError)
-    SKIP = "skip"  # silently skip existing entries (records SKIPPED)
+    SKIP = "skip"  # silently skip existing entries (records NOT_OVERWRITTEN)
     REPLACE = (
         "replace"  # unlink the existing entry, then create fresh (never write-through)
     )
@@ -81,9 +81,9 @@ class ExtractionStatus(str, Enum):
     """The outcome recorded for a single member in its :class:`ExtractionResult`."""
 
     EXTRACTED = "extracted"
-    SKIPPED = "skipped"  # pre-existing destination under OverwritePolicy.SKIP
+    NOT_OVERWRITTEN = "not_overwritten"  # existing dest left under OverwritePolicy.SKIP
     SUPERSEDED = "superseded"  # non-current entry (a later same-name entry overwrites)
-    REJECTED = "rejected"  # blocked by a safety filter (universal or policy check)
+    BLOCKED = "blocked"  # blocked by a safety filter (universal or policy check)
     FAILED = "failed"  # error while extracting (corrupt data, ratio bomb, write error)
 
 
@@ -118,7 +118,7 @@ class ExtractionResult:
     member: ArchiveMember
     path: Path | None  # the written path, or None if the member was not written
     status: ExtractionStatus
-    # The failure, for FAILED/REJECTED under OnError.CONTINUE; an OSError when the failure
+    # The failure, for FAILED/BLOCKED under OnError.CONTINUE; an OSError when the failure
     # is a filesystem read/write error on this member (not translated to an ArchiveyError).
     error: ArchiveyError | OSError | None = None
     # The destination the coordinator intended before overwrite/rename resolution. For an

--- a/src/archivey/internal/filters.py
+++ b/src/archivey/internal/filters.py
@@ -278,7 +278,7 @@ def apply_name_policy(member: ArchiveMember, policy: ExtractionPolicy) -> Archiv
     non-representable bytes (O7). Rewriting (not rejecting) a legitimate-but-awkward name
     keeps extraction working; refusal is reserved for structures that cannot be safely
     written. Raises :class:`UnportableNameError` (a ``FilterRejectionError``, so the
-    coordinator records ``REJECTED``) on a rejected name; otherwise returns ``member`` or a
+    coordinator records ``BLOCKED``) on a rejected name; otherwise returns ``member`` or a
     rewritten ``.replace()`` copy.
     """
     if policy is ExtractionPolicy.TRUSTED:

--- a/tests/sample_archives.py
+++ b/tests/sample_archives.py
@@ -63,7 +63,7 @@ class Member:
     password: str | None = None
     zip_method: int | None = None  # per-member ZIP compress_type (compression entry)
     comment: str | None = None
-    # Expected to be REJECTED by safe extraction (adversarial name/link). Listing must
+    # Expected to be BLOCKED by safe extraction (adversarial name/link). Listing must
     # still be faithful — the danger is visible on the name/target, never hidden.
     unsafe: bool = False
 

--- a/tests/test_corpus_sweep.py
+++ b/tests/test_corpus_sweep.py
@@ -209,11 +209,11 @@ def _check_extraction(tmp_path: Path, source, entry: CorpusEntry, key: str) -> N
     for r in results:
         by_member_name.setdefault(r.member.name, []).append(r)
 
-    # Every adversarial member must be REJECTED; nothing may have been written for it.
+    # Every adversarial member must be BLOCKED; nothing may have been written for it.
     for m in entry.members:
         if m.unsafe:
             statuses = {r.status for r in by_member_name.get(m.name, [])}
-            assert statuses == {ExtractionStatus.REJECTED}, f"{m.name!r} not rejected"
+            assert statuses == {ExtractionStatus.BLOCKED}, f"{m.name!r} not blocked"
 
     # Safe FILE members: last occurrence per name wins on disk, contents must match.
     last_safe_file: dict[str, Member] = {}

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -416,7 +416,7 @@ def test_directory_scan_race_diagnostic(
         assert DiagnosticCode.SCAN_ENTRY_VANISHED in reader.diagnostics.counts
 
 
-def test_extraction_rejected_emits_diagnostic(tmp_path: Path) -> None:
+def test_extraction_blocked_emits_diagnostic(tmp_path: Path) -> None:
     buf = io.BytesIO()
     with zipfile.ZipFile(buf, "w") as zf:
         zf.writestr("../escape.txt", b"x")
@@ -427,8 +427,15 @@ def test_extraction_rejected_emits_diagnostic(tmp_path: Path) -> None:
         dest,
         on_error=OnError.CONTINUE,
     )
-    assert any(r.status is ExtractionStatus.REJECTED for r in report.results)
-    assert DiagnosticCode.EXTRACTION_MEMBER_REJECTED in report.diagnostics.counts
+    blocked = [r for r in report.results if r.status is ExtractionStatus.BLOCKED]
+    assert blocked
+    assert DiagnosticCode.EXTRACTION_MEMBER_BLOCKED in report.diagnostics.counts
+    outcome = next(
+        d
+        for d in report.diagnostics.retained
+        if d.code is DiagnosticCode.EXTRACTION_MEMBER_BLOCKED
+    )
+    assert outcome.context.status == "blocked"
 
 
 def test_raise_disposition_stops_despite_continue(tmp_path: Path) -> None:
@@ -440,7 +447,7 @@ def test_raise_disposition_stops_despite_continue(tmp_path: Path) -> None:
     dest.mkdir()
     policy = DiagnosticPolicy(
         overrides={
-            DiagnosticCode.EXTRACTION_MEMBER_REJECTED: DiagnosticDisposition.RAISE
+            DiagnosticCode.EXTRACTION_MEMBER_BLOCKED: DiagnosticDisposition.RAISE
         }
     )
     with pytest.raises(DiagnosticRaisedError) as ei:
@@ -450,7 +457,7 @@ def test_raise_disposition_stops_despite_continue(tmp_path: Path) -> None:
             on_error=OnError.CONTINUE,
             config=ArchiveyConfig(diagnostic_policy=policy),
         )
-    assert ei.value.diagnostic.code is DiagnosticCode.EXTRACTION_MEMBER_REJECTED
+    assert ei.value.diagnostic.code is DiagnosticCode.EXTRACTION_MEMBER_BLOCKED
 
 
 def test_strict_eof_precedence_over_raise() -> None:

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -478,9 +478,12 @@ def test_user_filter_skip(tmp_path: Path) -> None:
         return None if m.name == "b.txt" else m
 
     with open_archive(src) as r:
-        r.extract_all(dest, filter=skip_b)
+        report = r.extract_all(dest, filter=skip_b)
     assert (dest / "a.txt").exists()
     assert not (dest / "b.txt").exists()
+    # Filter returning None is a caller-elected exclusion: no ExtractionResult (D1).
+    assert [r.member.name for r in report.results] == ["a.txt"]
+    assert report.results[0].status is ExtractionStatus.EXTRACTED
 
 
 # ---------------------------------------------------------------------------
@@ -507,7 +510,7 @@ def test_overwrite_skip(tmp_path: Path) -> None:
     (dest / "a.txt").write_bytes(b"old")
     results = extract(src, dest, overwrite=OverwritePolicy.SKIP).results
     assert (dest / "a.txt").read_bytes() == b"old"
-    assert results[0].status is ExtractionStatus.SKIPPED
+    assert results[0].status is ExtractionStatus.NOT_OVERWRITTEN
 
 
 def test_overwrite_replace(tmp_path: Path) -> None:
@@ -651,7 +654,7 @@ def test_on_error_continue_records_rejected(tmp_path: Path) -> None:
     dest = tmp_path / "out"
     results = extract(src, dest, on_error=OnError.CONTINUE).results
     statuses = {r.member.name: r.status for r in results}
-    assert ExtractionStatus.REJECTED in statuses.values()
+    assert ExtractionStatus.BLOCKED in statuses.values()
     assert (dest / "good.txt").read_bytes() == b"good"
 
 
@@ -760,7 +763,7 @@ def test_rejected_members_do_not_count_toward_max_entries(tmp_path: Path) -> Non
     statuses = {res.member.name: res.status for res in results}
     assert statuses["good1.txt"] is ExtractionStatus.EXTRACTED
     assert statuses["good2.txt"] is ExtractionStatus.EXTRACTED
-    assert ExtractionStatus.REJECTED in statuses.values()
+    assert ExtractionStatus.BLOCKED in statuses.values()
 
 
 # ---------------------------------------------------------------------------
@@ -984,7 +987,7 @@ def test_tar_symlink_escape_continue_records_rejected(tmp_path: Path) -> None:
     dest = tmp_path / "out"
     results = extract(src, dest, on_error=OnError.CONTINUE).results
     statuses = {r.member.name: r.status for r in results}
-    assert statuses["evil"] is ExtractionStatus.REJECTED
+    assert statuses["evil"] is ExtractionStatus.BLOCKED
     assert (dest / "ok.txt").read_bytes() == b"ok"
 
 
@@ -1038,7 +1041,7 @@ def test_chained_symlink_attack_file_payload_rejected(tmp_path: Path) -> None:
     # proceeds, proving the FILE payload cannot follow it out of dest.
     results = extract(src, dest, on_error=OnError.CONTINUE).results
     statuses = {r.member.name: r.status for r in results}
-    assert statuses["sub"] is ExtractionStatus.REJECTED
+    assert statuses["sub"] is ExtractionStatus.BLOCKED
     assert not (outside / "leak.txt").exists()
     assert list(outside.iterdir()) == []
 
@@ -1375,7 +1378,7 @@ def test_orphan_first_link_skipped_writes_to_next(tmp_path: Path) -> None:
         ).results
 
     statuses = {res.member.name: res.status for res in results}
-    assert statuses["L1.txt"] is ExtractionStatus.SKIPPED
+    assert statuses["L1.txt"] is ExtractionStatus.NOT_OVERWRITTEN
     assert statuses["L2.txt"] is ExtractionStatus.EXTRACTED
     assert (dest / "L1.txt").read_bytes() == b"pre-existing"  # untouched under SKIP
     assert (
@@ -1386,7 +1389,7 @@ def test_orphan_first_link_skipped_writes_to_next(tmp_path: Path) -> None:
 
 def test_orphan_all_links_skipped_writes_nothing(tmp_path: Path) -> None:
     # Companion to the above: when EVERY selected link's destination already exists under
-    # SKIP, all links are recorded SKIPPED, existing files stay untouched, and no stray
+    # SKIP, all links are recorded NOT_OVERWRITTEN, existing files stay untouched, and no stray
     # content or temp file is written anywhere.
     src = _orphan_tar(tmp_path, ["L1.txt", "L2.txt"])
     dest = tmp_path / "out"
@@ -1401,7 +1404,7 @@ def test_orphan_all_links_skipped_writes_nothing(tmp_path: Path) -> None:
             overwrite=OverwritePolicy.SKIP,
         ).results
 
-    assert [res.status for res in results] == [ExtractionStatus.SKIPPED] * 2
+    assert [res.status for res in results] == [ExtractionStatus.NOT_OVERWRITTEN] * 2
     assert (dest / "L1.txt").read_bytes() == b"keep-1"
     assert (dest / "L2.txt").read_bytes() == b"keep-2"
     assert sorted(p.name for p in dest.iterdir()) == ["L1.txt", "L2.txt"]  # no strays
@@ -1649,7 +1652,7 @@ def test_o3_reserved_name_rejected(tmp_path: Path, name: str, policy) -> None:
     report = extract(
         io.BytesIO(archive), dest, policy=policy, on_error=OnError.CONTINUE
     )
-    assert report.results[0].status is ExtractionStatus.REJECTED
+    assert report.results[0].status is ExtractionStatus.BLOCKED
     assert isinstance(report.results[0].error, UnportableNameError)
 
 
@@ -1663,7 +1666,7 @@ def test_o3_reserved_name_written_under_trusted(tmp_path: Path) -> None:
     archive = _tar_bytes([("file", "NUL", b"x")])
     dest = tmp_path / "out"
     report = extract(io.BytesIO(archive), dest, policy=ExtractionPolicy.TRUSTED)
-    # TRUSTED does not apply the O3 name rejection — the member is not REJECTED by policy.
+    # TRUSTED does not apply the O3 name rejection — the member is not BLOCKED by policy.
     assert report.results[0].status is ExtractionStatus.EXTRACTED
     assert (dest / "NUL").read_bytes() == b"x"
 
@@ -1675,7 +1678,7 @@ def test_o4_colon_rejected_strict_and_standard(tmp_path: Path, policy) -> None:
     report = extract(
         io.BytesIO(archive), dest, policy=policy, on_error=OnError.CONTINUE
     )
-    assert report.results[0].status is ExtractionStatus.REJECTED
+    assert report.results[0].status is ExtractionStatus.BLOCKED
     assert isinstance(report.results[0].error, UnportableNameError)
 
 
@@ -1734,7 +1737,7 @@ def test_o3_all_dots_segment_rejected(tmp_path: Path) -> None:
         policy=ExtractionPolicy.STRICT,
         on_error=OnError.CONTINUE,
     )
-    assert report.results[0].status is ExtractionStatus.REJECTED
+    assert report.results[0].status is ExtractionStatus.BLOCKED
     assert isinstance(report.results[0].error, UnportableNameError)
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements OpenSpec change `clarify-extraction-status-names`.

## Summary

- Rename `ExtractionStatus.SKIPPED` → `NOT_OVERWRITTEN` (overwrite-skip under `OverwritePolicy.SKIP` only)
- Rename `ExtractionStatus.REJECTED` → `BLOCKED` (universal safety or policy filter gate)
- Cascade to `DiagnosticCode.EXTRACTION_MEMBER_BLOCKED` and `ExtractionOutcomeContext.status="blocked"`
- Spec corrections: filter returning `None` yields **no** `ExtractionResult`; RAR history rows extract as `SUPERSEDED`
- CLI labels: `not overwritten:` / `blocked:` (keep `superseded:`)
- `ExtractionStatus` remains `(str, Enum)` (already matched the other public enums)

## Verification

- 331 passed, 11 skipped on affected suites
- `ruff` / `pyrefly` / `ty` clean on touched paths
- `openspec validate --strict clarify-extraction-status-names` OK

Breaking rename, no back-compat aliases (pre-1.0). All 14 tasks complete — ready to archive.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3cc5db02-6735-4559-b513-82d819d5e57e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3cc5db02-6735-4559-b513-82d819d5e57e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

