### PR TITLE
docs(review): refresh STATUS after #143–#157

### DIFF
--- a/review/README.md
+++ b/review/README.md
@@ -20,11 +20,11 @@ completed changes out of `changes/`.
 Round commissioned 2026-07-17 — the **non-security** pass toward the first public
 `0.2.0`, after the three security-adjacent reviews archived below. See each `brief.md`:
 
-| Dir | Review | Status (2026-07-18) |
+| Dir | Review | Status (2026-07-19) |
 |-----|--------|---------------------|
-| `api-coherence/` | Public API & member-model coherence / ergonomics (incl. cross-backend parity) | Findings in (#133); **Q1–Q6 decided + implemented**; digest fill → `surface-stored-stream-digests`; Q7 → next round |
-| `cli-product/` | The CLI as a **product** — UX, grammar, exit codes, output (not code correctness; #131 did that) | **Brief only** — review not run |
-| `performance/` | The ≤1.3× stdlib perf budget — benchmark-gate efficacy + the real traps | Findings + partial fixes (#134/#136/#137/#139/#140/#141); P1/P2/P6/P7 + Q2/Q4 remain |
+| `api-coherence/` | Public API & member-model coherence / ergonomics (incl. cross-backend parity) | **Q1–Q7 decided + implemented** (#153–#157); park Q5 + digest fill → archive |
+| `cli-product/` | The CLI as a **product** — UX, grammar, exit codes, output (not code correctness; #131 did that) | Findings in (#144); **no fixes yet** — Q1–Q7 open |
+| `performance/` | The ≤1.3× stdlib perf budget — benchmark-gate efficacy + the real traps | Listing L0–L3 + peers (#143/#146/#148); residual band miss; **Q2/Q4** still open |
 | `stream-layering/` | Stream wrapper stack — are the checks correct, and can slicing+verification collapse into one stream under `ArchiveStream`? | **Essentially done** (#137); park Q4 then archive |
 
 **Live triage of remaining action items / decisions / future copy-targets:**

--- a/review/STATUS.md
+++ b/review/STATUS.md
@@ -1,7 +1,7 @@
-# In-flight review status (2026-07-18)
+# In-flight review status (2026-07-19)
 
 Triage of the four top-level reviews after cross-checking findings against
-merged PRs (#120, #133–#141). Update this file when a finding is fixed or a
+merged PRs through **#157**. Update this file when a finding is fixed or a
 question is decided; archive a review directory only when every actionable
 item is fixed or consciously deferred here / in `backlog.md`.
 
@@ -10,125 +10,147 @@ item is fixed or consciously deferred here / in `backlog.md`.
 | Review | Findings delivered? | Code/docs follow-ups | Ready to archive? |
 |--------|---------------------|----------------------|-------------------|
 | `stream-layering/` | yes (#137) | **done** (F1/F2/D1/D2); Q4 parked → future | **almost** — park Q4 then archive |
-| `performance/` | yes (#134 + #139/#140/#143/#146) | partial (P3–P5 done; P7 listing L0–L2 done, L3 partial; P1/P2/P6 open) | no |
-| `api-coherence/` | yes (#133) | **Q1–Q6 decided + implemented**; digest fill → `surface-stored-stream-digests`; Q5 deferred; **Q7 → `partial-members-and-errors`** | **almost** — park digest fill / Q5 then archive |
-| `cli-product/` | **no** — brief only | review not run | no |
+| `performance/` | yes (#134 + follow-ups) | P3–P5 done; listing L0–L3 + peers (#143/#146/#148); residual band miss + **Q2/Q4 open** | no |
+| `api-coherence/` | yes (#133) | **Q1–Q7 decided + implemented** (#153–#157); Q5 deferred; digest *fill* → OpenSpec | **almost** — park Q5 + digest fill then archive |
+| `cli-product/` | yes (#144) | **none yet** — P1–P14 + Q1–Q7 all open | no |
 
 ---
 
 ## 1. Actionable right now
 
 Work that does not need a new maintainer decision (direction already recorded,
-or the finding is a clear proposed fix with no spec conflict).
+or a clear fix with no spec conflict).
 
-### From `performance/` (Q1 direction recorded 2026-07-18 in #140)
+### From `cli-product/` (findings in #144 — no code yet)
 
-| ID | Action |
-|----|--------|
-| **P7 / H3** | **partial** — #143 model-build + **#146** L1 (7z bulk UTF-16 names) / L2 (`ArchiveMember` slots + trimmed kwargs) / L3 volume fast-reject. ZIP many-small ~3.7×; 7z open+list probe ~2.0× (was ~3.4×). Still above Q1 bands; L3 large RAR fixture + L4 deferred; L5 needs OpenSpec. |
-| **P6 remainder** | **partial** — `py7zr` / `rarfile` / TAR `open_list` peers + Q1 band labels in harness. RAR/encrypted/accel *data* cases still missing. |
-| **P2 remainder** | Many-small `read_all` follows the listing story (same per-member machinery as P7). Large-member ZIP read already ≤1.25× after #139; realistic extract ~1.9× (inside ~2× band) — no further extract code pending Q2. |
-| **VISION/docs** | Re-word the ≤1.3× claim to match Q1 (decompression-dominated ≤1.3×; listing as peer ratios) once enforcement (Q2) is chosen. |
-
-### From `api-coherence/` (Q1–Q6 decided 2026-07-18 — implemented)
+Small / unambiguous blockers that don't wait on Q1–Q3:
 
 | ID | Action |
 |----|--------|
-| **P1 / Q1** | **implemented** — `_apply_last_entry_wins_is_current` in `base_reader.py`; ZIP/TAR/all RA formats now set `is_current`; `archive-data-model` spec updated; corpus sweep uses default ERROR policy. |
-| **Q2** | **implemented** — `docs/usage.md` duplicate-name section + filter recipe. |
-| **P2 / Q3** | **implemented** — `cost.py` docstrings fixed; RAR open-walk note in `docs/costs.md`; RAR row in `test_cost_receipt.py`. |
-| **S1 / S3 / Q4** | **implemented** — 13 `*Context` classes + `RAPIDGZIP_AUTO_MIN_COMPRESSED_SIZE` + `WriteError` demoted from `__all__`; `PasswordInput` / `OnDiagnostic` / `HashAlgorithm` / `crc32_digest` / `IoStats` / `enable_measurement` added; `source_name` dropped from `core.__all__`; `MemberSelector` used consistently. |
-| **S2 / Q6** | **implemented** — `ArchiveFormat.display_name` property; CLI `_format_label` uses it. |
-| **E1** | **implemented** — public `archivey.measurement` with `IoStats` + `enable_measurement`; `ArchiveReader.io_stats()` on the ABC; CLI `common.py` uses public API only. |
-| **E3 / Q6** | **implemented** — `ExtractionStatus.SUPERSEDED` for non-current skip; `SKIPPED` is overwrite-skip only. |
-| **Q6 hashes** | **typing done** (c7b88b5) — `HashAlgorithm` enum + `Mapping[HashAlgorithm, bytes]`; filling digests deferred to OpenSpec `surface-stored-stream-digests`. |
-| **Q6 WriteError / `[7z-write]`** | **implemented** — `WriteError` demoted from `__all__`; `[7z-write]` extra removed from pyproject.toml and `recommended-lite`; `py7zr` kept in dev. |
+| **P5** | Ctrl-D at password prompt → catch `EOFError`, treat as no password (tiny). |
+| **P3** | Escape control bytes in member names on all CLI output (style still Q4, but escaping itself is agreed-shape). |
+| **P6 (message)** | Replace raw errno reprs with prose for missing file / bad path; "did you mean a verb?" can wait. |
+| **P7 worst cases** | Library/CLI message cleanup: truncated-zip `BadZipFile` prose, enum-name leaks, zipcrypto "Wrong password" with no password (#131 D8 residue). Ownership confirmed in cli Q7. |
+| **P9** | Rapidgzip AUTO-gate warning text: distinguish "not installed" vs "not engaged". |
+| **P10–P13** | Help epilog examples; hoist/summary micro-copy; argparse `patterns` required wording; reserved-flag asymmetry. |
+
+### From `performance/` (Q1 direction + listing worklist)
+
+| ID | Action |
+|----|--------|
+| **P7 residual** | ZIP many-small still ~3.7× (above 2–3×); 7z open+list ~2.0–2.2× (above 1.25× native). Next levers: **L3** large RAR listing fixture; **L5** lazy derivation (needs OpenSpec). L4 deferred (no ≥10% lever). |
+| **P6 remainder** | RAR / encrypted / accelerator *data* harness cases still missing (listing peers done in #143). |
+| **VISION/docs** | Re-word ≤1.3× claim to match Q1 once **Q2** (enforcement) is chosen. |
 
 ### Process
 
 | Item | Action |
 |------|--------|
-| **`cli-product/`** | Run the product review (brief is ready; #120 is merged). |
-| **`stream-layering/`** | Mark Q4 deferred → archive the directory (see §3). |
+| **`stream-layering/`** | Park Q4 → archive the directory. |
+| **`api-coherence/`** | Park Q5 (`IDEAS.md` already) + digest fill (`surface-stored-stream-digests`) → archive. |
+| **`clarify-extraction-status-names`** | OpenSpec change tasks all `[x]` (#156) — archive the change when convenient. |
 
 ---
 
 ## 2. Still needs decisions
 
-Do not implement these until the maintainer answers (pause-and-ask).
+### `cli-product/QUESTIONS.md` (all open — blocks most of that review)
 
-### `api-coherence/QUESTIONS.md`
-
-| Q | Status |
-|---|--------|
-| **Q1–Q6** | **Decided** 2026-07-18 — see §1 and `api-coherence/QUESTIONS.md` |
-| **Q7** | **Decided** — OpenSpec `partial-members-and-errors` |
+| Q | Finding | Why blocked |
+|---|---------|-------------|
+| **Q1** | **P1** extract abort-on-first-error | Continue-on-reject/fail vs STOP; exit 3 vs 1; `--stop-on-error` timing. |
+| **Q2** | **P4** `--json` | 0.2.0 vs first 0.2.x vs wait for `hash` verb. |
+| **Q3** | **P2** no-match filters | Exit code on zero matches; `(did you mean -d?)` hint. |
+| **Q4** | **P3** control-byte quoting style | Backslash vs U+FFFD; TTY-only vs always. |
+| **Q5** | **P14** `info` cost/access line | In-scope for CLI now? |
+| **Q6** | **P14** install capability view | `--version -v` / `formats` / defer. |
+| **Q7** | P7/P9 library message owners | Confirm library vs CLI ownership (recommend fix in library). |
 
 ### `performance/QUESTIONS.md`
 
 | Q | Finding | Why blocked |
 |---|---------|-------------|
-| **Q2** | **P1** wall-budget enforcement | Nightly drift gate vs 2× band vs informational — flake vs honesty. Recommendation: (a)+(c). |
-| **Q4** | Verify-skip knob | Perf case now ~nil post-#137; still an API-design call (overlaps api-coherence). Leaning: leave as-is. |
+| **Q2** | **P1** wall-budget enforcement | Nightly drift vs 2× band vs informational. Recommendation: (a)+(c). |
+| **Q4** | Verify-skip knob | Perf case ~nil post-#137; lean leave-as-is. |
 
 ### `stream-layering/QUESTIONS.md`
 
 | Q | Status |
 |---|--------|
-| Q1–Q3 | **Decided / implemented** in #137 |
-| **Q4** | Open only as “park vs do now” — see §3 (recommend park) |
+| Q1–Q3 | **Done** (#137) |
+| **Q4** | Park (future) — see §3 |
+
+### `api-coherence/QUESTIONS.md`
+
+| Q | Status |
+|---|--------|
+| **Q1–Q6** | **Decided + implemented** (#153/#154); E3 rename polish in #156 |
+| **Q5** | **Decided: defer** past 0.2.0 — parked in `IDEAS.md` |
+| **Q7** | **Decided + implemented** (#157 / archived `partial-members-and-errors`) |
 
 ---
 
 ## 3. Future / archive-copy targets
 
 When archiving a review, copy these into `backlog.md`, `IDEAS.md`, or a
-dedicated follow-up brief — they are not 0.2.0 blockers from the current round.
+follow-up brief — not current-round 0.2.0 blockers unless noted.
 
-### From `performance/` (follow-ups)
+### From `performance/`
 
 | ID | Notes |
 |----|-------|
-| **P8** | rapidgzip AUTO threshold (1 MiB) may be conservative for seek workloads. |
-| **P9** | Measurement blind spots (7z password-confirm decode; RAR solid rewind via unrar pipe). |
-| Extract residual | Documented safety floor (`mkstemp`+rename / `lstat`); realistic ~1.9× already in band. |
-| Topic 6 | Decode-engine performance (`DecompressorStream` / accelerators) — already in `backlog.md`. |
+| **P8** | rapidgzip AUTO threshold (1 MiB) may be conservative for seek. |
+| **P9** | Measurement blind spots (7z password-confirm; RAR solid rewind via unrar pipe). |
+| Extract residual | Safety floor (`mkstemp`+rename); realistic ~1.9× already in band. |
+| **L5** | Lazy `ArchiveMember` derivation — OpenSpec; only path to ~1× many-small ZIP list. |
+| Topic 6 | Decode-engine performance — `backlog.md`. |
 
 ### From `stream-layering/`
 
 | ID | Notes |
 |----|-------|
-| **Q4** | Real `SlicingStream.readinto` — park until an extract path is shown `readinto`-bound. Optional cleanup: delete unused `VerifyingStream` later. |
+| **Q4** | Real `SlicingStream.readinto` — park until extract is shown `readinto`-bound. Optional: delete thin `VerifyingStream` later. |
 
 ### From `api-coherence/`
 
 | ID | Notes |
 |----|-------|
-| **D1** | CLI list marks for `ANTI` / non-current — belongs to **`cli-product/`** when that review runs. |
-| **E2 / Q5** | Library `verify` / `VerifyReport` — deferred past 0.2.0; uncertain whether callers verify without extracting often enough. Park in `IDEAS.md`. |
-| **Q7** | Partial members + honest error — **OpenSpec `partial-members-and-errors`** |
-| **Stored stream digests** | zlib Adler-32 + lzip multi-member combine — OpenSpec **`surface-stored-stream-digests`** (after hashes typing). |
+| **D1** | CLI list marks for `ANTI` / non-current — fold into **`cli-product/`** (still open there). |
+| **E2 / Q5** | Library `verify` / `VerifyReport` — already in `IDEAS.md`. |
+| **Stored stream digests** | zlib Adler-32 + lzip multi-member combine — OpenSpec **`surface-stored-stream-digests`** (typing done in #154). |
 
-### Already on `backlog.md` (not from this round’s findings)
+### From `cli-product/` (polish / later)
 
-Topics 4–5 (test strategy + debt ledger), Topic 6 (decode-engine perf), Topic 7
-(outside-in adoption capstone), plus salvage/best-effort mode as a feature gap.
+| ID | Notes |
+|----|-------|
+| **P4** | `--json` if Q2 chooses post-0.2.0. |
+| **P8** | `test` archive-wide failure counts honesty. |
+| **P14** | capability / cost views if Q5/Q6 defer. |
+
+### Already on `backlog.md`
+
+Topics 4–5 (test strategy + debt ledger), Topic 6 (decode-engine), Topic 7
+(outside-in adoption), salvage/best-effort mode. (Q7 partial-members entry is
+**done** — remove/strike when editing backlog.)
 
 ---
 
 ## Already addressed (do not re-open)
 
-Cross-check against merged PRs; statuses should also appear in each review’s
-`SUMMARY.md` / `QUESTIONS.md`.
-
 | Review | Item | Where |
 |--------|------|-------|
-| stream-layering | F1, F2, D1, D2; Q1–Q3 | #137 (+ #138 tidy) |
-| performance | P3 (selective solid) | #136 |
-| performance | P4, P5 (gate holes); decode-feed; Q3, Q6 | #139 |
-| performance | Q5 (H1 shape) | #136 |
-| performance | Q1 *direction* (listing = peer ratios) | #140 (implementation still open — §1) |
-| performance | O8 side-finding (empty wrong-password 7z) | #141 (threat-model mitigated) |
-| api-coherence | *(none)* | findings-only #133 |
-| cli-product | *(n/a)* | brief only |
-| archive/ | all five archived reviews | see `README.md` |
+| stream-layering | F1, F2, D1, D2; Q1–Q3 | #137 (+ #138) |
+| performance | P3 selective solid | #136 |
+| performance | P4, P5 gate holes; decode-feed; Q3, Q6 | #139 |
+| performance | Q5 H1 shape | #136 |
+| performance | Q1 direction (listing = peer ratios) | #140 |
+| performance | O8 empty wrong-password 7z | #141 |
+| performance | Listing peers + ZIP/TAR model-build (L0) | #143 |
+| performance | Listing L1/L2/L3 (bulk 7z names, slots, volume skip) | #146 |
+| performance | 7z byte-cursor header parse | #148 |
+| api-coherence | Q1–Q6 decisions recorded | #153 |
+| api-coherence | Q1–Q6 implementation (P1, P2, S1–S3, E1, E3, hashes typing, WriteError/`[7z-write]`) | #154 |
+| api-coherence | E3 rename polish `SKIPPED`→`NOT_OVERWRITTEN`, rejected→`BLOCKED` | #156 |
+| api-coherence | Q7 `members_report` / partial listing | #157 |
+| cli-product | Findings delivered (P1–P14, Q1–Q7) | #144 |
+| archive/ | five earlier reviews | see `README.md` |

--- a/review/api-coherence/QUESTIONS.md
+++ b/review/api-coherence/QUESTIONS.md
@@ -1,7 +1,9 @@
 # QUESTIONS — maintainer decisions
 
-> **Status (2026-07-18):** **Q1–Q6 decided** (recorded below). **Q7** deferred to a
-> next review round (not this freeze pass). Triage / follow-up work: `../STATUS.md`.
+> **Status (2026-07-19):** **Q1–Q7 decided and implemented** (#153–#157), except
+> **Q5** (verify primitive — deferred past 0.2.0, parked in `IDEAS.md`) and
+> digest *filling* (OpenSpec `surface-stored-stream-digests`). This review is
+> ready to archive once those two are parked. Triage: `../STATUS.md`.
 
 Per the pause-and-ask rule (`CLAUDE.md`, `CONTRIBUTING.md`): discrepancies and
 judgement calls surfaced, not silently resolved. Ordered by weight.
@@ -15,22 +17,16 @@ conformance sweep assert the uniform contract (drop the
 `REPLACE if has_duplicates` dodge). Streaming-mode caveat stays documented (forward
 pass cannot know supersession mid-yield).
 
-### Already done? (checked 2026-07-18)
+### Already done? (checked 2026-07-19)
 
-**No — not implemented for ZIP/TAR.** Current code:
+**Yes — implemented in #154.** Shared `_apply_last_entry_wins_is_current` in
+`base_reader.py` runs for all random-access materializations (ZIP/TAR included);
+`archive-data-model` / `safe-extraction` specs agree; corpus sweep asserts the
+uniform contract. Regression: `tests/test_duplicates_is_current.py`.
 
-| Backend | `is_current` |
-|---|---|
-| 7z | `compute_is_current(...)` in `sevenzip_reader` / `sevenzip_parser` |
-| RAR | history rows get distinct `path;n` names + `is_current=False` |
-| ZIP / TAR | never set — field defaults to `True` (`types.py`) |
-| `base_reader` | no shared last-entry-wins pass |
-
-So a duplicate-name ZIP/TAR still fails default extraction with `ExtractionError`
-(O2 / `OverwritePolicy.ERROR`). The impression that this was already done is
-understandable (7z has the helper; the specs already describe the skip) — but the
-ZIP/TAR materialization path never grew the equivalent. Tracking fix: P1 in
-`SUMMARY.md` / `parity.md`.
+*(Historical note from decision-recording day: before #154, only 7z/RAR set
+`is_current`; ZIP/TAR defaulted to `True` and failed default extraction under
+`OverwritePolicy.ERROR`.)*
 
 ---
 
@@ -139,7 +135,7 @@ a first-class API (CLI `test` can keep its hand-rolled loop for now). Park in
 | Item | Decision |
 |---|---|
 | **`WriteError`** | **Defer / remove from the read-only 0.2.0 surface.** v0.2.0 is read-only; writing is a later major release. Do not ship writing leftovers — demote/unexport `WriteError` for now. Same spirit: drop or stop advertising the `[7z-write]` extra/dep group until writing is real (py7zr stays a *dev* oracle as needed). |
-| **`ExtractionStatus.SKIPPED` split (E3)** | **Split into distinct statuses** (not a `reason` field). Overwrite-skip and non-current-skip are different caller concerns: most tools ignore superseded members but care that an expected extract hit a pre-existing path. Name at implement (`SUPERSEDED` / `NON_CURRENT` / …) — prefer a clear verb/noun over overloading `SKIPPED`. |
+| **`ExtractionStatus.SKIPPED` split (E3)** | **Split into distinct statuses** (not a `reason` field). **Implemented (#154 / #156):** non-current → `SUPERSEDED`; overwrite-skip → `NOT_OVERWRITTEN` (renamed from `SKIPPED`); safety-filter → `BLOCKED` (was rejected diagnostic). |
 | **`hashes` value convention** | **Type cleanup (immediate review fix):** all values `bytes`; keys become `HashAlgorithm` (`CRC32` / `BLAKE2SP` / `ADLER32` stub OK). Today: `Mapping[str, int \| bytes]`. Target: `Mapping[HashAlgorithm, bytes]` (crc32 as 4-byte digest). Prefer `HashAlgorithm(str, Enum)`. Endianness of 4-byte digests: fix at implement (big-endian usual). **Filling missing digests (zlib Adler-32, lzip multi-member combine, …):** **out of this review’s code follow-ups** — tracked as OpenSpec change `surface-stored-stream-digests` (depends on the typing fix). |
 
 ### Q6 hashes — what formats store today / Adler-32 parity
@@ -170,7 +166,7 @@ hard parts — deferred in that change.
 
 ---
 
-## Q7 — Partial members + honest error accessor (later-surfaced)
+## Q7 — Partial members + honest error accessor (later-surfaced) — DONE (#157)
 
 > **Surfaced later** (2026-07-18), during review of #149 (`decide-strict-archive-eof-default`
 > Option F) — not part of the original api-coherence finding set in #133. Adjacent to
@@ -183,20 +179,24 @@ surface: `members()` / `scan_members()` stay complete-or-raise; `members_report(
 `get_members_if_available` renamed to `members_report_if_available`. Exception-carried
 prefix rejected. Salvage / soft-extract / verify remain separate.
 
+**Implemented in #157** (change archived as
+`openspec/changes/archive/2026-07-18-partial-members-and-errors/`). CLI `list` uses
+`members_report()` so recovered members print with an honest error.
+
 ---
 
 ## Decision → implementation map
 
-| Decision | Follow-up (code/docs; not this PR unless noted) |
-|---|---|
-| Q1 (a) | Shared last-entry-wins on ZIP/TAR RA materialization; spec delta; sweep asserts |
-| Q2 | Docs / recipes only once Q1 lands |
-| Q3 | Fix `cost.py` docstring + receipt test + formats/costs prose |
-| Q4 | Surface PR (demote/export/docs) |
-| Q5 | `IDEAS.md` park only |
-| Q6 WriteError / `[7z-write]` | Demote exception; remove or un-advertise extra |
-| Q6 SKIPPED split | New `ExtractionStatus` value + CLI/report call sites |
-| Q6 hashes → `Mapping[HashAlgorithm, bytes]` | Review-fix PR: add enum (`CRC32` / `BLAKE2SP` / `ADLER32`); crc32 `int`→4-byte `bytes`; backends/verify/docs for type only |
-| Q6 hashes fill (zlib/lzip) | **Separate change:** `openspec/changes/surface-stored-stream-digests` |
-| Q6 `display_name` | Property on `ArchiveFormat` + CLI |
-| Q7 | **OpenSpec `partial-members-and-errors`** (this change) |
+| Decision | Follow-up | Status |
+|---|---|---|
+| Q1 (a) | Shared last-entry-wins on ZIP/TAR RA; spec delta; sweep asserts | **done #154** |
+| Q2 | Docs / recipes | **done #154** |
+| Q3 | Fix `cost.py` docstring + receipt test + formats/costs prose | **done #154** |
+| Q4 | Surface PR (demote/export/docs) | **done #154** |
+| Q5 | `IDEAS.md` park only | **parked** |
+| Q6 WriteError / `[7z-write]` | Demote exception; remove extra | **done #154** |
+| Q6 SKIPPED split | `SUPERSEDED` + later `NOT_OVERWRITTEN` / `BLOCKED` | **done #154/#156** |
+| Q6 hashes typing | `HashAlgorithm` + `Mapping[..., bytes]` | **done #154** |
+| Q6 hashes fill (zlib/lzip) | OpenSpec `surface-stored-stream-digests` | **open change** |
+| Q6 `display_name` | Property on `ArchiveFormat` + CLI | **done #154** |
+| Q7 | OpenSpec `partial-members-and-errors` | **done #157** |

--- a/review/api-coherence/SUMMARY.md
+++ b/review/api-coherence/SUMMARY.md
@@ -1,10 +1,10 @@
 # API-coherence review — SUMMARY
 
-> **Status (2026-07-18):** findings delivered in #133; **Q1–Q6 decided**
-> (`QUESTIONS.md`) — **Q1–Q6 code follow-ups implemented** on this branch (except
-> digest *filling*, which is OpenSpec `surface-stored-stream-digests`). **Q7** deferred to a next
-> review round. Mechanical surface work (S1/S2/S3/E1/E3) and P1/`is_current` are
-> now unblocked. Triage: `../STATUS.md`.
+> **Status (2026-07-19):** findings delivered in #133; **Q1–Q7 decided and
+> implemented** (#153–#157). Remaining park-before-archive: **Q5** (verify
+> primitive → `IDEAS.md`) and digest *filling* (OpenSpec
+> `surface-stored-stream-digests`). E3 rename polish (`NOT_OVERWRITTEN` /
+> `BLOCKED`) landed in #156. Triage: `../STATUS.md`.
 
 Reviewed at `main` + CLI (#120) merged (`7139c13`). Baseline (all captured before
 review, `[all]` config): pytest **1699 passed / 131 skipped / 3 deselected**, pyrefly
@@ -45,15 +45,16 @@ subtle generator semantics); and `ArchiveFormat` has no display name (the CLI pa
 
 | # | Severity | Finding | Where | Status |
 |---|----------|---------|-------|--------|
-| P1 | **High** | Duplicate-name members: `is_current` computed only by 7z/RAR; ZIP/TAR default extraction *errors* where 7z silently skips — same input, divergent outcome; `safe-extraction` scenario ("superseded by later same-name → SKIPPED") is format-silent and currently false for ZIP/TAR | `sevenzip_parser.py:331`, `extraction.py:351`, repro in `parity.md` | **implemented** — `_apply_last_entry_wins_is_current` in `base_reader.py`; `ExtractionStatus.SUPERSEDED` distinguishes non-current skip |
-| E1 | Medium | No public measurement/IO-stats API: CLI `--track-io` imports `enable_measurement` + `BaseArchiveReader` from `internal/` and reads three counters not on the `ArchiveReader` ABC | `cli/common.py:15-16,56-68`, `base_reader.py:557-1009` | **implemented** — public `archivey.measurement` module with `IoStats` + `enable_measurement`; `ArchiveReader.io_stats()` on the ABC |
-| E2 | Medium | No library "verify" primitive: `archivey test` hand-rolls manual `next()` loop; a mid-pass failure poisons the stream and loses remaining members | `cli/test_cmd.py:56-73` | **deferred** (Q5 — post-0.2.0 / maybe never) |
-| S1 | Medium | `__all__` = 90 names: 13 `*Context` classes + `RAPIDGZIP_AUTO_MIN_COMPRESSED_SIZE` should demote; `PasswordInput` / `OnDiagnostic` missing; `MemberSelector` vs internal `MemberSelectorArg` duplicate aliases used inconsistently in one class | `__init__.py:113-204`, `reader.py:27,148` | **implemented** — 13 concrete context classes demoted from `__all__`; `PasswordInput` / `OnDiagnostic` / `HashAlgorithm` / `crc32_digest` / `IoStats` / `enable_measurement` added; `MemberSelector` used consistently |
-| P2 | Low-Med | RAR `listing_cost=INDEXED` always, but `cost.py` docstring names "RAR with no quick-open record" as the canonical `REQUIRES_SCANNING` example — doc/impl conflict on an honest-cost axis | `rar_reader.py:773` vs `cost.py:24-27` | **implemented** — `cost.py` docstrings updated; `test_cost_receipt.py` RAR row added; `costs.md` RAR open-walk note added |
-| E3 | Low | `ExtractionStatus.SKIPPED` conflates overwrite-skip and non-current-skip; caller must infer reason via `member.is_current` | `extraction_types.py:80-87`, `extraction.py:351` | **implemented** — `ExtractionStatus.SUPERSEDED` added for non-current skip |
-| S2 | Low | `ArchiveFormat` has no display-name property; CLI string-parses `repr()` | `cli/info_cmd.py:16-23` | **implemented** — `ArchiveFormat.display_name` property; CLI uses it |
-| S3 | Low | `archivey.core.__all__` exports internal helper `source_name`; `docs/api.md` omits `open_stream`, `MemberStreams`, selectors, format-support queries | `core.py:78`, `docs/api.md` | **implemented** — `source_name` dropped from `core.__all__`; `WriteError` demoted from top-level `__all__`; `[7z-write]` extra removed |
-| D1 | Low | CLI list line has no mark for `ANTI` (falls to `"?"`, same as `OTHER`) and no non-current indicator — the member model's own distinctions are invisible in the first consumer | `cli/format.py:9-15` | **defer to `cli-product/`** |
+| P1 | **High** | Duplicate-name members: `is_current` computed only by 7z/RAR; ZIP/TAR default extraction *errors* where 7z silently skips — same input, divergent outcome; `safe-extraction` scenario ("superseded by later same-name → SKIPPED") is format-silent and currently false for ZIP/TAR | `sevenzip_parser.py:331`, `extraction.py:351`, repro in `parity.md` | **implemented** (#154) — `_apply_last_entry_wins_is_current`; `ExtractionStatus.SUPERSEDED` for non-current |
+| E1 | Medium | No public measurement/IO-stats API: CLI `--track-io` imports `enable_measurement` + `BaseArchiveReader` from `internal/` and reads three counters not on the `ArchiveReader` ABC | `cli/common.py:15-16,56-68`, `base_reader.py:557-1009` | **implemented** (#154) — public `archivey.measurement`; `ArchiveReader.io_stats()` |
+| E2 | Medium | No library "verify" primitive: `archivey test` hand-rolls manual `next()` loop; a mid-pass failure poisons the stream and loses remaining members | `cli/test_cmd.py:56-73` | **deferred** (Q5 — post-0.2.0 / maybe never; `IDEAS.md`) |
+| S1 | Medium | `__all__` = 90 names: 13 `*Context` classes + `RAPIDGZIP_AUTO_MIN_COMPRESSED_SIZE` should demote; `PasswordInput` / `OnDiagnostic` missing; `MemberSelector` vs internal `MemberSelectorArg` duplicate aliases used inconsistently in one class | `__init__.py:113-204`, `reader.py:27,148` | **implemented** (#154) |
+| P2 | Low-Med | RAR `listing_cost=INDEXED` always, but `cost.py` docstring names "RAR with no quick-open record" as the canonical `REQUIRES_SCANNING` example — doc/impl conflict on an honest-cost axis | `rar_reader.py:773` vs `cost.py:24-27` | **implemented** (#154) |
+| E3 | Low | `ExtractionStatus.SKIPPED` conflates overwrite-skip and non-current-skip; caller must infer reason via `member.is_current` | `extraction_types.py:80-87`, `extraction.py:351` | **implemented** (#154/#156) — `SUPERSEDED` / `NOT_OVERWRITTEN` / `BLOCKED` |
+| S2 | Low | `ArchiveFormat` has no display-name property; CLI string-parses `repr()` | `cli/info_cmd.py:16-23` | **implemented** (#154) — `ArchiveFormat.display_name` |
+| S3 | Low | `archivey.core.__all__` exports internal helper `source_name`; `docs/api.md` omits `open_stream`, `MemberStreams`, selectors, format-support queries | `core.py:78`, `docs/api.md` | **implemented** (#154) |
+| D1 | Low | CLI list line has no mark for `ANTI` (falls to `"?"`, same as `OTHER`) and no non-current indicator — the member model's own distinctions are invisible in the first consumer | `cli/format.py:9-15` | **defer to `cli-product/`** (still open) |
+| Q7 | — | Partial members + honest error (`members_report`) | `base_reader.py`, `diagnostics.py` | **implemented** (#157) |
 
 ## The maintainer's extra question (members scope)
 

--- a/review/backlog.md
+++ b/review/backlog.md
@@ -141,8 +141,8 @@ OpenSpec change), not something a review finds. Flagged here only so it doesn't 
 lost among the review topics — it likely outranks both topics above in product value,
 and `--salvage` is already reserved in the CLI grammar waiting for it.
 
-**Partial members + honest error accessor (api-coherence Q7)** — **decided / in
-progress** as OpenSpec change `partial-members-and-errors`: `members_report()` →
-`MemberListReport`, complete-or-raise `members()`/`scan_members()`, RA
-yield-then-raise, `members_report_if_available` rename. Adjacent to salvage but
-narrower (no resync past damage). See `api-coherence/QUESTIONS.md` §Q7.
+**Partial members + honest error accessor (api-coherence Q7)** — **done** in
+#157 / archived OpenSpec `partial-members-and-errors`
+(`members_report()` → `MemberListReport`, complete-or-raise
+`members()`/`scan_members()`, RA yield-then-raise). Salvage / best-effort
+resync past damage remains a separate feature gap above.

--- a/review/cli-product/QUESTIONS.md
+++ b/review/cli-product/QUESTIONS.md
@@ -1,5 +1,8 @@
 # Maintainer decisions — CLI product review
 
+> **Status (2026-07-19):** **Q1–Q7 all still open** — no decisions recorded
+> since findings landed in #144. Triage: `../STATUS.md`.
+
 Decisions this review surfaced that are not plain fixes. Q1–Q3 shape 0.2.0
 user-visible behavior; Q4–Q6 can land after. #131's D1–D8 are settled and not
 reopened.

--- a/review/cli-product/SUMMARY.md
+++ b/review/cli-product/SUMMARY.md
@@ -1,5 +1,10 @@
 # CLI-as-a-product review — SUMMARY
 
+> **Status (2026-07-19):** findings in #144; **no fixes landed yet.** Blockers
+> needing maintainer answers first: **Q1–Q3** (and Q4 for P3 style). Small
+> actionable items (P5, P6 prose, P7/P9 library messages, P10–P13 polish) are
+> listed in `../STATUS.md` §1.
+
 Deep review per `brief.md`: the merged `src/archivey/cli/` on `main` (post-#120,
 post-#131 fixes), judged as a **product** — muscle memory, output, errors, exit
 codes, discoverability — not re-reviewing implementation correctness.

--- a/review/cli-product/brief.md
+++ b/review/cli-product/brief.md
@@ -1,9 +1,9 @@
 # Brief — The `archivey` CLI as a product (UX / ergonomics)
 
-> **Status (2026-07-18):** brief only — **product review not yet run.**
-> Start condition (PR #120 merged) is met. Finding D1 from `api-coherence/`
-> (CLI list ANTI / non-current marks) should be folded into this review when
-> it runs. See `../STATUS.md`.
+> **Status (2026-07-19):** findings delivered in **#144** (`SUMMARY.md`, theme
+> files, `QUESTIONS.md`). **No code follow-ups yet** — P1–P14 + Q1–Q7 still
+> open. Api-coherence **D1** (ANTI / non-current list marks) remains a
+> fold-in for this review. Triage: `../STATUS.md`.
 
 Read `review/README.md` (conventions, VISION tie-breakers, deliverable shape). This
 is a **product** review — the CLI seen through a user's eyes — **not** a code-correctness

--- a/review/performance/QUESTIONS.md
+++ b/review/performance/QUESTIONS.md
@@ -2,11 +2,11 @@
 
 Decisions this review cannot make unilaterally (per the pause-and-ask rule).
 
-> **Status (2026-07-18):** Q3, Q5, Q6 **resolved** (#136 / #139). Q1 has a
-> **maintainer direction** (#140) — listing peers (#143) + L1/L2/L3 listing
-> fixes (#146) landed; ZIP open+list still above the 2–3× band. **Still need a
-> decision:** Q2 (wall enforcement), Q4 (verify-skip knob; perf case ~nil
-> post-#137). See `../STATUS.md`.
+> **Status (2026-07-19):** Q3, Q5, Q6 **resolved** (#136 / #139). Q1
+> **direction recorded** (#140) and largely **implemented** — listing peers
+> (#143) + L0–L3 (#143/#146) + 7z byte-cursor (#148). ZIP/7z listing still
+> above Q1 bands (residual). **Still need a decision:** Q2 (wall enforcement),
+> Q4 (verify-skip; lean leave-as-is). See `../STATUS.md`.
 
 ## Q1 — What does "≤1.3× on common paths" cover, exactly? — DIRECTION RECORDED
 

--- a/review/performance/SUMMARY.md
+++ b/review/performance/SUMMARY.md
@@ -109,18 +109,18 @@ suite green, gate green, probes re-run, before/after probe on shared fixtures):
 pipeline). Threat-model O8 marked mitigated; residual is only garbage that
 parses as a *non-empty* plausible header.
 
-## Remaining open (triage 2026-07-18 — see `../STATUS.md`)
+## Remaining open (triage 2026-07-19 — see `../STATUS.md`)
 
 | # | Status |
 |---|--------|
 | P1 | open — needs **Q2** (enforcement venue) |
-| P2 | **partial** — large-member ZIP read in budget; many-small / open+list improved (ZIP many-small ~3.7× after L2; 7z open+list ~2.0× after L1) but not yet inside Q1 bands; extract realistic in ~2× band |
+| P2 | **partial** — large-member ZIP read in budget; many-small / open+list improved (ZIP ~3.7× after L2; 7z ~2.0–2.2× after L1/#148) but not yet inside Q1 bands; extract realistic in ~2× band |
 | P3 | **fixed** (#136) |
 | P4 / P5 | **fixed** (#139) |
-| P6 | **partial** — ZIP peers in #139; **py7zr/rarfile + TAR open_list peers added** (#143); RAR/encrypted/accel data cases still missing |
-| P7 | **partial** — #143 model-build fast paths + #146 L1/L2/L3 listing fixes (`listing-attribution.md`); ZIP open+list still above 2–3×; 7z closer to native band |
+| P6 | **partial** — listing peers done (#139/#143); RAR/encrypted/accel *data* cases still missing |
+| P7 | **partial** — L0–L3 (#143/#146) + byte-cursor (#148); residual band miss → L3 large RAR fixture / L5 lazy derivation |
 | P8 / P9 | **follow-up** (future / archive-copy) |
-| Q1 | **direction recorded** (#140) — listing peers + ZIP model-build (#143) + L1/L2/L3 from attribution worklist (#146); residual band miss remains |
+| Q1 | **direction recorded + largely implemented** — residual band miss remains |
 | Q2 / Q4 | **need decision** |
 | Q3 / Q5 / Q6 | **resolved** |
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Docs-only refresh of [`review/STATUS.md`](./review/STATUS.md) and per-review banners after today's merges.

## What changed since #142

| PR | Effect on triage |
|----|------------------|
| #143 / #146 / #148 | Perf listing peers + L0–L3 + 7z byte-cursor — residual band miss remains |
| #144 | **cli-product findings delivered** (was brief-only) |
| #153–#154 | api-coherence Q1–Q6 decided + implemented |
| #156 | E3 rename polish (`NOT_OVERWRITTEN` / `BLOCKED`) |
| #157 | api-coherence Q7 `members_report` done |

## Updated buckets (see STATUS.md)

- **Actionable now:** cli-product small blockers (P5/P3/P6/P7/P9/P10–P13); perf listing residual (L3 RAR fixture / L5); archive stream-layering + api-coherence after parking leftovers
- **Needs decisions:** **cli-product Q1–Q7** (main new open set); perf Q2/Q4
- **Future / archive-copy:** unchanged theme (P8/P9, stream Q4, digest fill, L5, Topics 4–7)
- **Almost archiveable:** `api-coherence/` (park Q5 + digest fill), `stream-layering/` (park Q4)

No library code changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5a86e927-a4d7-4ef8-ba75-13fe6c3b7962"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5a86e927-a4d7-4ef8-ba75-13fe6c3b7962"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

