### PR TITLE
Surface zlib Adler-32 and multi-member lzip CRC32 digests

### DIFF
--- a/docs/formats.md
+++ b/docs/formats.md
@@ -119,9 +119,13 @@ Third-party credits (deps, oracles, design refs): [Acknowledgements](acknowledge
 - `.gz` surfaces the trailer CRC-32 as `member.hashes["crc32"]` for a **single-member**
   file on a seekable/path source (omit for multi-member gzip — the trailer covers only
   the last member — and for non-seekable sources).
-- `.lz` surfaces the trailer CRC-32 the same way **size** is exposed: only when
-  `MemberStreams.SEEKABLE` is declared on a path source (seekable lzip backend).
-- `.bz2` / `.xz` / zlib / brotli / `.Z` have no cheap whole-member stored CRC.
+- `.lz` surfaces a whole-member CRC-32 the same way **size** is exposed: only when
+  `MemberStreams.SEEKABLE` is declared on a path source (seekable lzip backend). For
+  multi-member lzip the value is derived by combining per-trailer CRCs with each
+  member's uncompressed size so it equals `crc32` of the concatenated payloads.
+- Standalone zlib surfaces the RFC 1950 Adler-32 trailer as `member.hashes["adler32"]`
+  on a seekable/path complete single stream (omit when non-seekable).
+- `.bz2` / `.xz` / brotli / `.Z` have no cheap whole-member stored digest.
 - `.Z` (unix-compress) is core (native LZW). Truncation is best-effort: nonzero leftover
   bits after the last complete code raise `TruncatedError` on the next `read()` after
   delivering available bytes; zero-leftover cuts remain silent. Forward decode works on
@@ -131,11 +135,12 @@ Third-party credits (deps, oracles, design refs): [Acknowledgements](acknowledge
 
 ## Stored digests (cheap dedupe)
 
-`member.hashes` holds digests the archive **already stores**, keyed by
-:class:`~archivey.HashAlgorithm` (values always ``bytes`` — CRC-32 is four
-big-endian bytes via :func:`~archivey.crc32_digest`). They are readable without
-decompressing when the backend documents them. They are **not** computed digests —
-a full `read()` still verifies through the normal path.
+`member.hashes` holds digests the archive **already stores** (or, for multi-member
+lzip, derives via CRC combine from per-member stored CRCs), keyed by
+:class:`~archivey.HashAlgorithm` (values always ``bytes`` — CRC-32 / Adler-32 are four
+big-endian bytes via :func:`~archivey.crc32_digest` for CRC-32). They are readable
+without decompressing when the backend documents them. They are **not** computed digests
+— a full `read()` still verifies through the normal path.
 
 | Format | When present | Keys |
 | --- | --- | --- |
@@ -143,12 +148,11 @@ a full `read()` still verifies through the normal path.
 | 7z | FILE | `crc32` |
 | RAR5 | FILE with CRC32 and/or Blake2sp | `crc32` and/or `blake2sp` |
 | single-file `.gz` | single member, seekable/path | `crc32` |
-| single-file `.lz` | seekable path + `MemberStreams.SEEKABLE` | `crc32` |
-| `.bz2` / `.xz` / zlib / brotli / `.Z`, TAR, directory | — | none |
+| single-file `.lz` | seekable path + `MemberStreams.SEEKABLE` (one or many members; multi-member value is combined) | `crc32` |
+| single-file zlib | seekable/path single stream | `adler32` |
+| `.bz2` / `.xz` / brotli / `.Z`, TAR, directory | — | none |
 
 See [usage](usage.md#cheap-dedupe-with-stored-hashes) for the cheap→computed fallback recipe.
-(Zlib Adler-32 and multi-member lzip CRC combine are tracked in OpenSpec
-`surface-stored-stream-digests`.)
 
 ## Detection
 

--- a/openspec/changes/surface-stored-stream-digests/tasks.md
+++ b/openspec/changes/surface-stored-stream-digests/tasks.md
@@ -38,7 +38,7 @@
 
 ## 6. Verify
 
-- [ ] 6.1 Targeted tests for combine helpers, zlib Adler peek, multi-lzip CRC
-- [ ] 6.2 `uv run --no-sync pytest` for affected tests; `ruff format` / check on
+- [x] 6.1 Targeted tests for combine helpers, zlib Adler peek, multi-lzip CRC
+- [x] 6.2 `uv run --no-sync pytest` for affected tests; `ruff format` / check on
       touched paths
-- [ ] 6.3 `openspec validate --strict surface-stored-stream-digests`
+- [x] 6.3 `openspec validate --strict surface-stored-stream-digests`

--- a/openspec/changes/surface-stored-stream-digests/tasks.md
+++ b/openspec/changes/surface-stored-stream-digests/tasks.md
@@ -1,40 +1,40 @@
 ## 1. Prerequisites
 
-- [ ] 1.1 Confirm api-coherence Q6 hashes typing is merged (`HashAlgorithm`,
+- [x] 1.1 Confirm api-coherence Q6 hashes typing is merged (`HashAlgorithm`,
       `Mapping[HashAlgorithm, bytes]`); stack or rebase this change on it
-- [ ] 1.2 Add `HashAlgorithm.ADLER32` if the typing PR only shipped `CRC32` /
+- [x] 1.2 Add `HashAlgorithm.ADLER32` if the typing PR only shipped `CRC32` /
       `BLAKE2SP`
 
 ## 2. Combine helpers
 
-- [ ] 2.1 Implement `crc32_combine` + `adler32_combine` under
+- [x] 2.1 Implement `crc32_combine` + `adler32_combine` under
       `archivey.internal.hashing` (pure Python; 3.11-compatible)
-- [ ] 2.2 Unit tests: combine equals `zlib.crc32` / `zlib.adler32` of
+- [x] 2.2 Unit tests: combine equals `zlib.crc32` / `zlib.adler32` of
       concatenation for empty/short/multi-chunk cases
 
 ## 3. Zlib Adler-32 surfacing
 
-- [ ] 3.1 Add seekable probe for last-4-byte Adler-32 (single-file reader /
+- [x] 3.1 Add seekable probe for last-4-byte Adler-32 (single-file reader /
       zlib codec `extract_metadata`)
-- [ ] 3.2 Set `member.hashes[HashAlgorithm.ADLER32]` as 4-byte big-endian;
+- [x] 3.2 Set `member.hashes[HashAlgorithm.ADLER32]` as 4-byte big-endian;
       omit on non-seekable / too-short
-- [ ] 3.3 Register `adler32` in `verify.py` hasher table (`zlib.adler32`)
+- [x] 3.3 Register `adler32` in `verify.py` hasher table (`zlib.adler32`)
 
 ## 4. Lzip multi-member CRC32
 
-- [ ] 4.1 Retain per-member CRC32 in lzip backward index entries
-- [ ] 4.2 In `extract_metadata`, combine CRCs with `data_size` via
+- [x] 4.1 Retain per-member CRC32 in lzip backward index entries
+- [x] 4.2 In `extract_metadata`, combine CRCs with `data_size` via
       `crc32_combine`; surface `HashAlgorithm.CRC32` for one- and multi-member
-- [ ] 4.3 Test: multi-member fixture’s surfaced CRC equals CRC of full
+- [x] 4.3 Test: multi-member fixture’s surfaced CRC equals CRC of full
       decompressed concat; single-member still matches trailer
 
 ## 5. Specs, docs, sweep
 
-- [ ] 5.1 Sync main specs from this change’s deltas (`format-single-file-compressors`,
+- [x] 5.1 Sync main specs from this change’s deltas (`format-single-file-compressors`,
       `compressed-streams`, `testing-contract`, `documentation`)
-- [ ] 5.2 Update `docs/formats.md` stored-digests table (zlib `adler32`; lzip
+- [x] 5.2 Update `docs/formats.md` stored-digests table (zlib `adler32`; lzip
       multi-member combined `crc32`; note derivation)
-- [ ] 5.3 Extend corpus / focused tests for zlib + multi-lzip parity rows
+- [x] 5.3 Extend corpus / focused tests for zlib + multi-lzip parity rows
 
 ## 6. Verify
 

--- a/openspec/specs/compressed-streams/spec.md
+++ b/openspec/specs/compressed-streams/spec.md
@@ -162,10 +162,12 @@ computable mismatch at clean EOF. A mismatch SHALL surface from the terminal rea
 after all data chunks have been delivered; a bytes-returning full read raises and
 returns no bytes. Partial/random-access reads SHALL NOT produce a digest verdict.
 
-Supported computable algorithms SHALL include `crc32` (via `zlib.crc32`), the
-`hashlib.algorithms_available` set, and `blake2sp` (the 8-way parallel BLAKE2s tree
-hash used by RAR5), computed via an internal zero-dependency hasher. A well-formed
-member carrying only a `blake2sp` digest SHALL therefore be verified, not skipped.
+Supported computable algorithms SHALL include `crc32` (via `zlib.crc32`),
+`adler32` (via `zlib.adler32`), the `hashlib.algorithms_available` set, and
+`blake2sp` (the 8-way parallel BLAKE2s tree hash used by RAR5), computed via an
+internal zero-dependency hasher. A well-formed member carrying only a `blake2sp`
+digest SHALL therefore be verified, not skipped. A well-formed zlib member
+carrying only `adler32` SHALL likewise be verified, not skipped.
 
 When an expected digest cannot be computed because the algorithm is genuinely unknown
 or a backend is missing, the system SHALL emit `DIGEST_UNVERIFIABLE` with algorithm,
@@ -177,6 +179,7 @@ collection, logging/callback delivery, member attachment, and escalation.
 | Case | Expected |
 | --- | --- |
 | Expected `blake2sp` on a well-formed RAR5 member | Computed and verified; mismatch raises `CorruptionError` |
+| Expected `adler32` on a well-formed zlib member | Computed and verified; mismatch raises `CorruptionError` |
 | Expected digest under a genuinely-unknown algorithm name | `DIGEST_UNVERIFIABLE` counted/retained/logged; bytes still returned without that check |
 | Full member read reaches EOF with computable digest mismatch | `CorruptionError` naming the algorithm |
 | Chunked read reaches EOF with mismatch | All valid chunks delivered; following terminal read raises |

--- a/openspec/specs/documentation/spec.md
+++ b/openspec/specs/documentation/spec.md
@@ -120,12 +120,15 @@ archive). Salvage / `--salvage` remains out of scope and separately reserved.
 ### Requirement: Document the stored-digest matrix and cheap-dedupe recipe
 
 The end-user documentation SHALL include a stored-digest matrix stating, per format, which
-`member.hashes` keys are populated from data the archive already stores (readable without
-decompression) and under what conditions (e.g. single-member/seekable gzip). It SHALL
-include a cheap-dedupe recipe showing how to key on `member.hashes` for a first-pass
-dedupe and fall back to computing a digest while reading when no stored digest is present,
-and SHALL state the "best available digest + provenance (stored vs computed)"
-recommendation so an indexer can choose cheap-but-weak vs costly-but-strong uniformly.
+`member.hashes` keys are populated from data the archive already stores (or, for
+multi-member lzip, derived via CRC combine from per-member stored CRCs) without
+decompression, and under what conditions (e.g. single-member/seekable gzip; seekable
+zlib Adler-32; seekable lzip including multi-member). It SHALL include a cheap-dedupe
+recipe showing how to key on `member.hashes` for a first-pass dedupe and fall back to
+computing a digest while reading when no stored digest is present, and SHALL state the
+"best available digest + provenance (stored vs computed)" recommendation so an indexer
+can choose cheap-but-weak vs costly-but-strong uniformly. The matrix SHALL NOT claim
+zlib has no stored digest.
 
 #### Scenario: stored-digest documentation
 
@@ -133,4 +136,5 @@ recommendation so an indexer can choose cheap-but-weak vs costly-but-strong unif
 | --- | --- |
 | Reader consults the guide for dedupe | Finds the per-format stored-digest matrix and the cheap→computed fallback recipe |
 | Format stores no cheap digest (e.g. bzip2, tar) | Matrix states so; recipe covers the computed-on-read fallback |
+| zlib / multi-member lzip | Matrix lists `adler32` / combined `crc32` respectively |
 

--- a/openspec/specs/format-single-file-compressors/spec.md
+++ b/openspec/specs/format-single-file-compressors/spec.md
@@ -169,35 +169,43 @@ readable without adding another `ReadBackend` subclass.
 | Register a new standalone codec descriptor | Existing backend reads it through the descriptor |
 | Required codec backend is missing | Format availability reports `NONE`, not a separate backend failure |
 
-### Requirement: Surface the stored decompressed CRC without decompression
+### Requirement: Surface stored decompressed digests without decompression
 
-The single-file backend SHALL surface a codec's stored decompressed-content CRC-32 as
-`member.hashes["crc32"]` when it is cheaply readable from the source without
-decompressing, and SHALL omit it otherwise. This serves cheap dedupe (`VISION.md`
-"hashes without decompression") and never triggers a decompression pass.
+The single-file backend SHALL surface a codec's stored (or cheaply derived-from-stored)
+decompressed-content digest(s) on `member.hashes` when readable without decompressing,
+and SHALL omit them otherwise. This serves cheap dedupe (`VISION.md` "hashes without
+decompression") and never triggers a decompression pass.
 
-- **GZIP:** the 8-byte trailer's CRC-32 SHALL be surfaced only when the stream contains
-  exactly one member and the source is seekable/path (peek the trailer). For concatenated
-  multi-member gzip the trailer CRC covers only the last member, so `crc32` SHALL be
-  omitted. Reuse the member-count detection already used by the truncation backstop.
-- **LZIP:** the per-member trailer CRC-32 SHALL be surfaced via the seekable lzip backend
-  (which already reads the trailer for size); omitted when that backend/source is
-  unavailable.
-- **Non-seekable source:** `crc32` SHALL be omitted (no forced decode); callers compute it
-  while reading.
-- **BZ2, XZ, ZLIB, BR, `.Z`:** no cheap whole-member stored CRC — `crc32` SHALL be absent.
+Keys and value types follow the public `HashAlgorithm` / `bytes` contract (api-coherence
+hashes typing). Surfacing SHALL NOT change read behavior: a full read still verifies via
+the existing path; stored/derived values are metadata only.
 
-Surfacing the stored CRC SHALL NOT change read behavior or verification: a full read still
-verifies via the existing path, and the stored value is metadata only.
+- **GZIP:** trailer `CRC32` only when exactly one member and the source is seekable/path.
+  Multi-member → omit (trailer covers only the last member; mid-member trailers are not
+  cheap without decompress).
+- **LZIP:** when the seekable lzip index is available, surface `CRC32` of the whole
+  synthetic member. For multi-member files, the value SHALL equal
+  `crc32(concat(member payloads))` derived by combining per-trailer CRC-32 values with
+  each member's exact uncompressed `data_size` (combine algebra). Single-member
+  degenerates to the trailer CRC.
+- **ZLIB:** seekable/path complete single-stream file → surface trailer `ADLER32`
+  (RFC 1950, last 4 bytes, network order). Non-seekable or unrecognized layout → omit.
+- **Non-seekable source:** omit digests that require a trailer/index peek (no forced
+  decode).
+- **BZ2, XZ, BR, `.Z`:** no cheap whole-member stored digest in this change — omit.
 
-#### Scenario: stored CRC surfacing by codec
+#### Scenario: stored-digest surfacing by codec
 
-| Case | `member.hashes["crc32"]` |
+| Case | `member.hashes` |
 | --- | --- |
-| Single-member `.gz`, seekable/path source | Present (trailer CRC-32) |
-| Multi-member `.gz` | Absent (trailer covers only last member) |
-| `.gz` on a non-seekable source | Absent (no forced decode) |
-| `.lz` via seekable lzip backend | Present (per-member trailer CRC-32) |
-| `.bz2` / `.xz` / `.zlib` / `.br` / `.Z` | Absent (no cheap whole-member stored CRC) |
-| Any of the above, full `read()` | Verification unchanged; stored value is metadata only |
+| Single-member `.gz`, seekable/path | `CRC32` present |
+| Multi-member `.gz` | no digest key |
+| `.gz` non-seekable | no digest key |
+| Single-member `.lz`, seekable lzip index | `CRC32` present (= trailer) |
+| Multi-member `.lz`, seekable lzip index | `CRC32` present (= combine of per-member trailers) |
+| `.lz` without seekable index | no digest key |
+| Standalone zlib, seekable/path single stream | `ADLER32` present |
+| zlib non-seekable | no digest key |
+| `.bz2` / `.xz` / `.br` / `.Z` | no digest key |
+| Any of the above, full `read()` | verification unchanged; hashes are metadata only |
 

--- a/openspec/specs/testing-contract/spec.md
+++ b/openspec/specs/testing-contract/spec.md
@@ -410,9 +410,12 @@ The asserted matrix SHALL match the documented policy:
 | RAR5 | FILE with CRC32 | `crc32` present |
 | RAR5 | FILE with Blake2sp only | `blake2sp` present, `crc32` absent |
 | single-file GZIP | single member, seekable | `crc32` present |
-| single-file GZIP | multi-member or non-seekable | `crc32` absent |
-| single-file LZIP | via seekable lzip backend | `crc32` present |
-| single-file BZ2/XZ/ZLIB/BR/`.Z`, TAR, directory | any | no stored-digest key |
+| single-file GZIP | multi-member or non-seekable | digest keys absent |
+| single-file LZIP | seekable lzip index (one or many members) | `crc32` present |
+| single-file LZIP | no seekable index | digest keys absent |
+| single-file ZLIB | seekable/path single stream | `adler32` present |
+| single-file ZLIB | non-seekable | digest keys absent |
+| single-file BZ2/XZ/BR/`.Z`, TAR, directory | any | no stored-digest key |
 
 #### Scenario: parity sweep
 
@@ -421,6 +424,7 @@ The asserted matrix SHALL match the documented policy:
 | Backend surfaces its documented stored digest for an applicable member | Sweep passes |
 | A backend stops populating a documented digest | Sweep fails |
 | A backend populates a digest the format does not store | Sweep fails |
+| Multi-member lzip combined `crc32` matches `crc32` of full decompressed concat | Sweep or focused unit test passes |
 
 
 ### Requirement: BLAKE2sp verification is tested with KATs and a RAR5 oracle

--- a/src/archivey/internal/backends/single_file_reader.py
+++ b/src/archivey/internal/backends/single_file_reader.py
@@ -41,6 +41,7 @@ from archivey.internal.registry import register_reader
 from archivey.internal.streams.archive_stream import ArchiveStream
 from archivey.internal.streams.codecs import (
     SINGLE_FILE_CODECS,
+    Codec,
     MetadataContext,
     gzip_has_additional_member,
     open_codec_stream,
@@ -48,6 +49,7 @@ from archivey.internal.streams.codecs import (
     stream_codec_for_format,
 )
 from archivey.internal.streams.decompressor_stream import DecompressorStream
+from archivey.internal.streams.lzip import peek_combined_crc32
 from archivey.internal.streams.streamtools import (
     SharedSource,
     is_seekable,
@@ -183,6 +185,7 @@ class SingleFileReader(BaseArchiveReader):
             peek_trailer=self._peek_trailer,
             probe_decompressed_size=self._probe_decompressed_size,
             probe_gzip_stored_crc32=self._probe_gzip_stored_crc32,
+            probe_lzip_stored_crc32=self._probe_lzip_stored_crc32,
         )
 
     def _peek_header(self, length: int) -> bytes:
@@ -273,6 +276,28 @@ class SingleFileReader(BaseArchiveReader):
             if len(trailer) < 8:
                 return None
             return struct.unpack_from("<I", trailer, 0)[0]
+
+        return self._with_seekable_source(probe)
+
+    def _probe_lzip_stored_crc32(self) -> int | None:
+        """Whole-member CRC-32 from the seekable lzip index (combined when multi-member).
+
+        Same gate as decompressed size: path source with declared SEEKABLE so the index
+        scan is enabled. Returns ``None`` when the index is unavailable or corrupt.
+        """
+        if self._codec is not Codec.LZIP:
+            return None
+        if not isinstance(self._source, Path) or not self._codec_config.seekable:
+            return None
+
+        def probe(f: BinaryIO) -> int | None:
+            size = f.seek(0, io.SEEK_END)
+            if size < 26:  # header(6) + trailer(20)
+                return None
+            try:
+                return peek_combined_crc32(f, size)
+            except ArchiveyError:
+                return None
 
         return self._with_seekable_source(probe)
 

--- a/src/archivey/internal/hashing/__init__.py
+++ b/src/archivey/internal/hashing/__init__.py
@@ -1,1 +1,5 @@
 """Internal hashing helpers (not part of the public API)."""
+
+from archivey.internal.hashing.combine import adler32_combine, crc32_combine
+
+__all__ = ["adler32_combine", "crc32_combine"]

--- a/src/archivey/internal/hashing/combine.py
+++ b/src/archivey/internal/hashing/combine.py
@@ -1,0 +1,83 @@
+"""Pure-Python CRC-32 / Adler-32 combine (CPython adds stdlib helpers only in 3.15+).
+
+These match zlib's ``crc32_combine_`` / ``adler32_combine_``: given digests of
+``a`` and ``b`` plus ``len(b)``, return the digest of ``a + b`` without seeing the
+bytes. Used to surface whole-stream digests from per-unit trailers (multi-member
+lzip).
+"""
+
+from __future__ import annotations
+
+# ISO/zlib CRC-32 polynomial (reflected).
+_CRC32_POLY = 0xEDB88320
+_MOD_ADLER = 65521
+
+
+def _gf2_matrix_times(mat: list[int], vec: int) -> int:
+    summary = 0
+    i = 0
+    while vec:
+        if vec & 1:
+            summary ^= mat[i]
+        vec >>= 1
+        i += 1
+    return summary
+
+
+def _gf2_matrix_square(square: list[int], mat: list[int]) -> None:
+    for n in range(32):
+        square[n] = _gf2_matrix_times(mat, mat[n])
+
+
+def crc32_combine(crc1: int, crc2: int, len2: int) -> int:
+    """Return ``zlib.crc32(a + b)`` given ``crc32(a)``, ``crc32(b)``, and ``len(b)``."""
+    if len2 <= 0:
+        return crc1 & 0xFFFFFFFF
+
+    odd = [0] * 32
+    even = [0] * 32
+    odd[0] = _CRC32_POLY
+    row = 1
+    for n in range(1, 32):
+        odd[n] = row
+        row <<= 1
+    _gf2_matrix_square(even, odd)
+    _gf2_matrix_square(odd, even)
+
+    crc1 &= 0xFFFFFFFF
+    remaining = len2
+    while True:
+        _gf2_matrix_square(even, odd)
+        if remaining & 1:
+            crc1 = _gf2_matrix_times(even, crc1)
+        remaining >>= 1
+        if remaining == 0:
+            break
+        _gf2_matrix_square(odd, even)
+        if remaining & 1:
+            crc1 = _gf2_matrix_times(odd, crc1)
+        remaining >>= 1
+        if remaining == 0:
+            break
+    return (crc1 ^ (crc2 & 0xFFFFFFFF)) & 0xFFFFFFFF
+
+
+def adler32_combine(adler1: int, adler2: int, len2: int) -> int:
+    """Return ``zlib.adler32(a + b)`` given ``adler32(a)``, ``adler32(b)``, ``len(b)``."""
+    if len2 <= 0:
+        return adler1 & 0xFFFFFFFF
+
+    rem = len2 % _MOD_ADLER
+    sum1 = adler1 & 0xFFFF
+    sum2 = (rem * sum1) % _MOD_ADLER
+    sum1 += (adler2 & 0xFFFF) + _MOD_ADLER - 1
+    sum2 += ((adler1 >> 16) & 0xFFFF) + ((adler2 >> 16) & 0xFFFF) + _MOD_ADLER - rem
+    if sum1 >= _MOD_ADLER:
+        sum1 -= _MOD_ADLER
+    if sum1 >= _MOD_ADLER:
+        sum1 -= _MOD_ADLER
+    if sum2 >= (_MOD_ADLER << 1):
+        sum2 -= _MOD_ADLER << 1
+    if sum2 >= _MOD_ADLER:
+        sum2 -= _MOD_ADLER
+    return (sum1 | (sum2 << 16)) & 0xFFFFFFFF

--- a/src/archivey/internal/streams/codecs.py
+++ b/src/archivey/internal/streams/codecs.py
@@ -514,13 +514,15 @@ class MetadataContext:
     ``probe_decompressed_size()`` returns the decompressed size from the stream
     index/trailer when cheaply available (else ``None``); ``probe_gzip_stored_crc32()``
     returns the single-member gzip trailer CRC when that is cheaply knowable (else
-    ``None``), in one seekable pass.
+    ``None``), in one seekable pass; ``probe_lzip_stored_crc32()`` returns the whole-member
+    CRC-32 derived from the seekable lzip index (combined across members) when available.
     """
 
     peek_header: Callable[[int], bytes]
     peek_trailer: Callable[[int], bytes | None]
     probe_decompressed_size: Callable[[], int | None]
     probe_gzip_stored_crc32: Callable[[], int | None]
+    probe_lzip_stored_crc32: Callable[[], int | None]
 
 
 # --- the codec descriptors -------------------------------------------------------------
@@ -895,21 +897,15 @@ class LzipCodec(_SizedLzmaCodec):
         return LzipDecompressorStream(source, seekable=config.seekable)
 
     def extract_metadata(self, ctx: MetadataContext, member: ArchiveMember) -> None:
-        """Surface decompressed size and the trailer CRC-32 under the same cheap gate.
+        """Surface decompressed size and whole-member CRC-32 from the seekable index.
 
-        Size comes from the seekable lzip index (``probe_decompressed_size``). The trailer
-        CRC is surfaced only when that probe succeeds *and* the file is a single lzip
-        member (``member_size`` equals the compressed source size) — a multi-member ``.lz``
-        has no single whole-stream stored CRC for the one synthetic archive member.
+        Size comes from the seekable lzip index (``probe_decompressed_size``). The CRC is
+        the combine of every per-member trailer CRC-32 with that member's uncompressed
+        ``data_size`` (single-member degenerates to the trailer CRC).
         """
         member.size = ctx.probe_decompressed_size()
-        if member.size is None or member.compressed_size is None:
-            return
-        trailer = ctx.peek_trailer(20)
-        if trailer is None or len(trailer) < 20:
-            return
-        crc32, _data_size, member_size = struct.unpack_from("<IQQ", trailer, 0)
-        if member_size == member.compressed_size:
+        crc32 = ctx.probe_lzip_stored_crc32()
+        if crc32 is not None:
             hashes = dict(member.hashes)
             hashes[HashAlgorithm.CRC32] = crc32_digest(crc32)
             member.hashes = hashes
@@ -1093,6 +1089,26 @@ class ZlibCodec(_ZlibErrorCodec):
         """Recognize a zlib stream: a known CMF/FLG header (fail-fast) that then decodes."""
         return prefix[:2] in _ZLIB_HEADERS and self._decodes_sample(prefix)
 
+    def extract_metadata(self, ctx: MetadataContext, member: ArchiveMember) -> None:
+        """Surface RFC 1950 Adler-32 (last 4 bytes, network order) when cheaply peekable.
+
+        Seekable/path complete single-stream files only. Non-seekable sources and
+        unrecognized headers omit the digest (no forced decode).
+        """
+        header = ctx.peek_header(2)
+        if header[:2] not in _ZLIB_HEADERS:
+            return
+        # Minimum zlib stream: CMF/FLG (2) + empty deflate block (≥2) + Adler-32 (4).
+        trailer = ctx.peek_trailer(4)
+        if trailer is None or len(trailer) < 4:
+            return
+        # Need room for a header before the Adler trailer.
+        if member.compressed_size is not None and member.compressed_size < 8:
+            return
+        hashes = dict(member.hashes)
+        hashes[HashAlgorithm.ADLER32] = trailer
+        member.hashes = hashes
+
 
 class ZstdCodec(StreamCodec):
     codec = Codec.ZSTD
@@ -1214,7 +1230,6 @@ class UnixCompressCodec(StreamCodec):
 
 def _parse_ppmd_var_h_properties(properties: bytes | None) -> tuple[int, int]:
     """Parse 7z PPMd var.H coder properties → ``(order, mem_size)``."""
-    import struct
 
     if properties is None:
         raise ValueError("PPMd requires coder properties (order + mem size)")

--- a/src/archivey/internal/streams/lzip.py
+++ b/src/archivey/internal/streams/lzip.py
@@ -26,6 +26,7 @@ from typing import BinaryIO
 
 from archivey.exceptions import CorruptionError, TruncatedError
 from archivey.internal.diagnostics_collector import DiagnosticCollector
+from archivey.internal.hashing import crc32_combine
 from archivey.internal.streams.decompressor_stream import (
     BaseDecoder,
     DecodeOut,
@@ -50,6 +51,7 @@ class _MemberBounds:
     decompressed_start: int
     compressed_size: int
     decompressed_size: int
+    crc32: int
 
     @property
     def decompressed_end(self) -> int:
@@ -65,9 +67,10 @@ def _read_index_backwards(
     """Build the member index by scanning trailers backwards (no decompression).
 
     A 4-byte magic check at each computed member start catches a corrupt ``member_size``
-    before it cascades into wrong offsets for every earlier member.
+    before it cascades into wrong offsets for every earlier member. Each entry retains the
+    trailer CRC-32 so callers can combine a whole-stream digest without decompressing.
     """
-    entries: list[tuple[int, int, int]] = []
+    entries: list[tuple[int, int, int, int]] = []
     compressed_end = file_size
 
     while compressed_end > stop_at:
@@ -77,7 +80,7 @@ def _read_index_backwards(
         trailer = stream.read(_TRAILER_SIZE)
         if len(trailer) < _TRAILER_SIZE:
             raise CorruptionError("Lzip file truncated during backward index scan")
-        _, data_size, member_size = struct.unpack_from("<IQQ", trailer, 0)
+        crc32, data_size, member_size = struct.unpack_from("<IQQ", trailer, 0)
         if member_size < _HEADER_SIZE + _TRAILER_SIZE:
             raise CorruptionError(
                 f"Lzip member_size {member_size} in trailer is too small to be valid"
@@ -94,17 +97,32 @@ def _read_index_backwards(
                 f"Lzip magic not found at expected member start {compressed_start} "
                 f"(got {magic!r}); member_size in trailer may be corrupt"
             )
-        entries.append((compressed_start, int(data_size), int(member_size)))
+        entries.append((compressed_start, int(data_size), int(member_size), int(crc32)))
         compressed_end = compressed_start
 
     result: list[_MemberBounds] = []
     decompressed_offset = start_decompressed_offset
-    for comp_start, decomp_size, comp_size in reversed(entries):
+    for comp_start, decomp_size, comp_size, crc32 in reversed(entries):
         result.append(
-            _MemberBounds(comp_start, decompressed_offset, comp_size, decomp_size)
+            _MemberBounds(
+                comp_start, decompressed_offset, comp_size, decomp_size, crc32
+            )
         )
         decompressed_offset += decomp_size
     return result
+
+
+def combined_crc32_from_index(members: list[_MemberBounds]) -> int:
+    """Whole-stream CRC-32 = ``crc32(concat(payloads))`` via trailer combine."""
+    crc = 0
+    for member in members:
+        crc = crc32_combine(crc, member.crc32, member.decompressed_size)
+    return crc
+
+
+def peek_combined_crc32(stream: BinaryIO, file_size: int) -> int:
+    """Scan the lzip index and return the combined whole-stream CRC-32."""
+    return combined_crc32_from_index(_read_index_backwards(stream, file_size))
 
 
 class _LzipState:

--- a/src/archivey/internal/streams/verify.py
+++ b/src/archivey/internal/streams/verify.py
@@ -83,11 +83,28 @@ class _Crc32Hasher:
         return (self._value & 0xFFFFFFFF).to_bytes(self.digest_size, "big")
 
 
+class _Adler32Hasher:
+    """A ``hashlib``-shaped wrapper over ``zlib.adler32`` (RFC 1950 / standalone zlib)."""
+
+    digest_size = 4
+
+    def __init__(self) -> None:
+        self._value = 1  # zlib.adler32(b"")
+
+    def update(self, data: bytes, /) -> None:
+        self._value = zlib.adler32(data, self._value)
+
+    def digest(self) -> bytes:
+        return (self._value & 0xFFFFFFFF).to_bytes(self.digest_size, "big")
+
+
 def _make_hasher(algorithm: Any) -> Callable[[], _IncrementalHasher] | None:
     """Return a zero-arg factory for an incremental hasher, or ``None`` if unavailable."""
     name = _algo_key(algorithm)
     if name == "crc32":
         return _Crc32Hasher
+    if name == "adler32":
+        return _Adler32Hasher
     if name == "blake2sp":
         # RAR5 BLAKE2sp — not in hashlib; zero-dep tree hash on blake2s (see hashing/).
         return Blake2sp

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -561,10 +561,11 @@ def test_verify_matching_adler32_passes() -> None:
 
 
 def test_verify_adler32_mismatch_raises() -> None:
-    bad = (zlib.adler32(CONTENT) ^ 0xFFFF).to_bytes(4, "big")
+    bad = ((zlib.adler32(CONTENT) & 0xFFFFFFFF) ^ 0xFFFF).to_bytes(4, "big")
     stream = VerifyingStream(io.BytesIO(CONTENT), {HashAlgorithm.ADLER32: bad})
+    assert stream.read() == CONTENT  # data delivered first
     with pytest.raises(CorruptionError, match="adler32"):
-        stream.read()
+        stream.read()  # terminal empty read verifies
 
 
 def test_verify_multiple_algorithms() -> None:

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -554,6 +554,19 @@ def test_verify_matching_crc32_passes() -> None:
     assert stream.read() == b""  # terminal read verifies; no error
 
 
+def test_verify_matching_adler32_passes() -> None:
+    expected = (zlib.adler32(CONTENT) & 0xFFFFFFFF).to_bytes(4, "big")
+    stream = VerifyingStream(io.BytesIO(CONTENT), {HashAlgorithm.ADLER32: expected})
+    assert stream.read() == CONTENT
+
+
+def test_verify_adler32_mismatch_raises() -> None:
+    bad = (zlib.adler32(CONTENT) ^ 0xFFFF).to_bytes(4, "big")
+    stream = VerifyingStream(io.BytesIO(CONTENT), {HashAlgorithm.ADLER32: bad})
+    with pytest.raises(CorruptionError, match="adler32"):
+        stream.read()
+
+
 def test_verify_multiple_algorithms() -> None:
     expected = {
         HashAlgorithm.CRC32: _crc32(CONTENT),

--- a/tests/test_corpus_sweep.py
+++ b/tests/test_corpus_sweep.py
@@ -140,7 +140,11 @@ def _check_listing(ar, entry: CorpusEntry, key: str) -> None:
 def _assert_stored_digest_parity(member, key: str) -> None:
     """Assert documented stored-digest keys are present/absent (testing-contract)."""
     keys = set(member.hashes)
-    digest_keys = keys & {HashAlgorithm.CRC32, HashAlgorithm.BLAKE2SP}
+    digest_keys = keys & {
+        HashAlgorithm.CRC32,
+        HashAlgorithm.BLAKE2SP,
+        HashAlgorithm.ADLER32,
+    }
     if key == "zip":
         if member.type in (MemberType.FILE, MemberType.SYMLINK):
             # AE-2 (WinZip AES) stores CRC as 0 and relies on the HMAC — no crc32 digest.
@@ -276,14 +280,18 @@ def _check_single_file(entry: CorpusEntry, key: str, source: Path) -> None:
             assert member.modified is not None
             assert int(member.modified.timestamp()) == payload.mtime
         # Stored-digest parity: single-member gzip always (path source); lzip only with
-        # declared SEEKABLE (same gate as size); other codecs omit.
+        # declared SEEKABLE (same gate as size); zlib Adler-32 on seekable/path; others omit.
         if key in ("gz", "gz-meta"):
             assert HashAlgorithm.CRC32 in member.hashes
         elif key == "lz":
             assert HashAlgorithm.CRC32 not in member.hashes
+        elif key == "zz":
+            assert HashAlgorithm.ADLER32 in member.hashes
+            assert HashAlgorithm.CRC32 not in member.hashes
         else:
             assert HashAlgorithm.CRC32 not in member.hashes
             assert HashAlgorithm.BLAKE2SP not in member.hashes
+            assert HashAlgorithm.ADLER32 not in member.hashes
     if key == "lz":
         with open_archive(source, member_streams=MemberStreams.SEEKABLE) as ar:
             assert HashAlgorithm.CRC32 in ar.members()[0].hashes

--- a/tests/test_hash_combine.py
+++ b/tests/test_hash_combine.py
@@ -1,0 +1,47 @@
+"""Unit tests for pure-Python crc32/adler32 combine helpers."""
+
+from __future__ import annotations
+
+import zlib
+
+import pytest
+
+from archivey.internal.hashing import adler32_combine, crc32_combine
+
+_CASES = [
+    (b"", b""),
+    (b"a", b""),
+    (b"", b"a"),
+    (b"hello", b"world"),
+    (b"x" * 100, b"y" * 50),
+    (b"abc", b"def" * 1000),
+    (bytes(range(256)), b"\xff" * 17),
+]
+
+
+@pytest.mark.parametrize(("left", "right"), _CASES)
+def test_crc32_combine_matches_zlib(left: bytes, right: bytes) -> None:
+    c1 = zlib.crc32(left) & 0xFFFFFFFF
+    c2 = zlib.crc32(right) & 0xFFFFFFFF
+    assert crc32_combine(c1, c2, len(right)) == (zlib.crc32(left + right) & 0xFFFFFFFF)
+
+
+@pytest.mark.parametrize(("left", "right"), _CASES)
+def test_adler32_combine_matches_zlib(left: bytes, right: bytes) -> None:
+    a1 = zlib.adler32(left) & 0xFFFFFFFF
+    a2 = zlib.adler32(right) & 0xFFFFFFFF
+    assert adler32_combine(a1, a2, len(right)) == (
+        zlib.adler32(left + right) & 0xFFFFFFFF
+    )
+
+
+def test_multi_chunk_fold_matches_full_digest() -> None:
+    parts = [b"one", b"two", b"three" * 10, b"", b"tail"]
+    crc = 0
+    adler = 1  # zlib.adler32(b"")
+    for part in parts:
+        crc = crc32_combine(crc, zlib.crc32(part) & 0xFFFFFFFF, len(part))
+        adler = adler32_combine(adler, zlib.adler32(part) & 0xFFFFFFFF, len(part))
+    full = b"".join(parts)
+    assert crc == (zlib.crc32(full) & 0xFFFFFFFF)
+    assert adler == (zlib.adler32(full) & 0xFFFFFFFF)

--- a/tests/test_single_file.py
+++ b/tests/test_single_file.py
@@ -261,6 +261,7 @@ def test_gzip_metadata_omits_crc_without_gzip_magic() -> None:
         peek_trailer=lambda _n: b"\x11\x22\x33\x44\x55\x66\x77\x88",
         probe_decompressed_size=lambda: None,
         probe_gzip_stored_crc32=boom,
+        probe_lzip_stored_crc32=lambda: None,
     )
     GzipCodec().extract_metadata(ctx, member)
     assert HashAlgorithm.CRC32 not in member.hashes
@@ -286,18 +287,50 @@ def test_lzip_exposes_stored_crc32(tmp_path: Path) -> None:
         assert HashAlgorithm.CRC32 not in ar.members()[0].hashes
 
 
+def test_multi_member_lzip_exposes_combined_crc32(tmp_path: Path) -> None:
+    from tests.streams_util import make_multi_member_lzip
+
+    parts = [b"alpha-payload", b"beta" * 20, b"gamma"]
+    path = tmp_path / "multi.lz"
+    path.write_bytes(make_multi_member_lzip(parts))
+    full = b"".join(parts)
+    with open_archive(path, member_streams=MemberStreams.SEEKABLE) as ar:
+        member = ar.members()[0]
+        assert member.hashes[HashAlgorithm.CRC32] == crc32_digest(zlib.crc32(full))
+        assert ar.read(member) == full
+
+
+def test_zlib_exposes_stored_adler32(tmp_path: Path) -> None:
+    payload = b"zlib-adler-payload" * 5
+    path = tmp_path / "data.zz"
+    path.write_bytes(zlib.compress(payload))
+    expected = (zlib.adler32(payload) & 0xFFFFFFFF).to_bytes(4, "big")
+    with open_archive(path) as ar:
+        member = ar.members()[0]
+        assert member.hashes[HashAlgorithm.ADLER32] == expected
+        assert HashAlgorithm.CRC32 not in member.hashes
+
+
+def test_zlib_omits_adler32_on_nonseekable_source() -> None:
+    data = zlib.compress(b"pipe-zlib")
+    with open_archive(NonSeekableBytesIO(data), streaming=True) as ar:
+        report = ar.members_report_if_available()
+        assert report is not None
+        assert HashAlgorithm.ADLER32 not in report[0].hashes
+
+
 def test_other_single_file_codecs_omit_stored_crc32(tmp_path: Path) -> None:
     payload = b"no-whole-member-crc"
     cases = {
         "data.bz2": bz2.compress(payload),
         "data.xz": lzma.compress(payload),
-        "data.zz": zlib.compress(payload),
     }
     for name, blob in cases.items():
         path = tmp_path / name
         path.write_bytes(blob)
         with open_archive(path) as ar:
             assert HashAlgorithm.CRC32 not in ar.members()[0].hashes, name
+            assert HashAlgorithm.ADLER32 not in ar.members()[0].hashes, name
 
 
 def test_stored_gzip_crc32_does_not_change_read_or_verification(tmp_path: Path) -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements OpenSpec change `surface-stored-stream-digests` (16/16 tasks).

## Summary

- Peek RFC 1950 Adler-32 (last 4 bytes) onto `member.hashes[ADLER32]` for seekable standalone zlib streams
- Retain per-member CRC32 in the lzip backward index and surface a whole-member `CRC32` via `crc32_combine` (one- and multi-member)
- Add pure-Python `crc32_combine` / `adler32_combine` helpers (3.11-compatible)
- Register `adler32` in the verify hasher table
- Sync main specs, `docs/formats.md`, and corpus/focused tests

## Test plan

- [x] Unit tests for combine helpers vs `zlib.crc32` / `zlib.adler32`
- [x] Targeted pytest (`test_hash_combine`, `test_single_file`, `test_codecs`, `test_corpus_sweep`): 179 passed, 14 skipped
- [x] `ruff format` / `ruff check` on touched paths
- [x] `openspec validate --strict surface-stored-stream-digests`
- [x] `pyrefly check` / `ty check` on touched modules
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8968cb75-1d2e-40dd-aa6c-e05e90862ef5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8968cb75-1d2e-40dd-aa6c-e05e90862ef5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

