### PR TITLE
Surface multi-member lzip CRC32 digests

### DIFF
--- a/docs/formats.md
+++ b/docs/formats.md
@@ -119,9 +119,13 @@ Third-party credits (deps, oracles, design refs): [Acknowledgements](acknowledge
 - `.gz` surfaces the trailer CRC-32 as `member.hashes["crc32"]` for a **single-member**
   file on a seekable/path source (omit for multi-member gzip — the trailer covers only
   the last member — and for non-seekable sources).
-- `.lz` surfaces the trailer CRC-32 the same way **size** is exposed: only when
-  `MemberStreams.SEEKABLE` is declared on a path source (seekable lzip backend).
-- `.bz2` / `.xz` / zlib / brotli / `.Z` have no cheap whole-member stored CRC.
+- `.lz` surfaces a whole-member CRC-32 the same way **size** is exposed: only when
+  `MemberStreams.SEEKABLE` is declared on a path source (seekable lzip backend). For
+  multi-member lzip the value is derived by combining per-trailer CRCs with each
+  member's uncompressed size so it equals `crc32` of the concatenated payloads.
+- Standalone zlib surfaces the RFC 1950 Adler-32 trailer as `member.hashes["adler32"]`
+  on a seekable/path complete single stream (omit when non-seekable).
+- `.bz2` / `.xz` / brotli / `.Z` have no cheap whole-member stored digest.
 - `.Z` (unix-compress) is core (native LZW). Truncation is best-effort: nonzero leftover
   bits after the last complete code raise `TruncatedError` on the next `read()` after
   delivering available bytes; zero-leftover cuts remain silent. Forward decode works on
@@ -131,11 +135,12 @@ Third-party credits (deps, oracles, design refs): [Acknowledgements](acknowledge
 
 ## Stored digests (cheap dedupe)
 
-`member.hashes` holds digests the archive **already stores**, keyed by
-:class:`~archivey.HashAlgorithm` (values always ``bytes`` — CRC-32 is four
-big-endian bytes via :func:`~archivey.crc32_digest`). They are readable without
-decompressing when the backend documents them. They are **not** computed digests —
-a full `read()` still verifies through the normal path.
+`member.hashes` holds digests the archive **already stores** (or, for multi-member
+lzip, derives via CRC combine from per-member stored CRCs), keyed by
+:class:`~archivey.HashAlgorithm` (values always ``bytes`` — CRC-32 / Adler-32 are four
+big-endian bytes via :func:`~archivey.crc32_digest` for CRC-32). They are readable
+without decompressing when the backend documents them. They are **not** computed digests
+— a full `read()` still verifies through the normal path.
 
 | Format | When present | Keys |
 | --- | --- | --- |
@@ -143,12 +148,11 @@ a full `read()` still verifies through the normal path.
 | 7z | FILE | `crc32` |
 | RAR5 | FILE with CRC32 and/or Blake2sp | `crc32` and/or `blake2sp` |
 | single-file `.gz` | single member, seekable/path | `crc32` |
-| single-file `.lz` | seekable path + `MemberStreams.SEEKABLE` | `crc32` |
-| `.bz2` / `.xz` / zlib / brotli / `.Z`, TAR, directory | — | none |
+| single-file `.lz` | seekable path + `MemberStreams.SEEKABLE` (one or many members; multi-member value is combined) | `crc32` |
+| single-file zlib | seekable/path single stream | `adler32` |
+| `.bz2` / `.xz` / brotli / `.Z`, TAR, directory | — | none |
 
 See [usage](usage.md#cheap-dedupe-with-stored-hashes) for the cheap→computed fallback recipe.
-(Zlib Adler-32 and multi-member lzip CRC combine are tracked in OpenSpec
-`surface-stored-stream-digests`.)
 
 ## Detection
 

--- a/docs/formats.md
+++ b/docs/formats.md
@@ -123,9 +123,10 @@ Third-party credits (deps, oracles, design refs): [Acknowledgements](acknowledge
   `MemberStreams.SEEKABLE` is declared on a path source (seekable lzip backend). For
   multi-member lzip the value is derived by combining per-trailer CRCs with each
   member's uncompressed size so it equals `crc32` of the concatenated payloads.
-- Standalone zlib surfaces the RFC 1950 Adler-32 trailer as `member.hashes["adler32"]`
-  on a seekable/path complete single stream (omit when non-seekable).
-- `.bz2` / `.xz` / brotli / `.Z` have no cheap whole-member stored digest.
+- `.bz2` / `.xz` / zlib / brotli / `.Z` have no cheap whole-member stored digest
+  (zlib's RFC 1950 Adler-32 is still verified by the decompressor on read; it is not
+  surfaced on `member.hashes` because the wrapper has no size fields for a reliable
+  single-stream trailer peek when concat/trailing junk is possible).
 - `.Z` (unix-compress) is core (native LZW). Truncation is best-effort: nonzero leftover
   bits after the last complete code raise `TruncatedError` on the next `read()` after
   delivering available bytes; zero-leftover cuts remain silent. Forward decode works on
@@ -137,10 +138,10 @@ Third-party credits (deps, oracles, design refs): [Acknowledgements](acknowledge
 
 `member.hashes` holds digests the archive **already stores** (or, for multi-member
 lzip, derives via CRC combine from per-member stored CRCs), keyed by
-:class:`~archivey.HashAlgorithm` (values always ``bytes`` — CRC-32 / Adler-32 are four
-big-endian bytes via :func:`~archivey.crc32_digest` for CRC-32). They are readable
-without decompressing when the backend documents them. They are **not** computed digests
-— a full `read()` still verifies through the normal path.
+:class:`~archivey.HashAlgorithm` (values always ``bytes`` — CRC-32 is four
+big-endian bytes via :func:`~archivey.crc32_digest`). They are readable without
+decompressing when the backend documents them. They are **not** computed digests —
+a full `read()` still verifies through the normal path.
 
 | Format | When present | Keys |
 | --- | --- | --- |
@@ -149,8 +150,7 @@ without decompressing when the backend documents them. They are **not** computed
 | RAR5 | FILE with CRC32 and/or Blake2sp | `crc32` and/or `blake2sp` |
 | single-file `.gz` | single member, seekable/path | `crc32` |
 | single-file `.lz` | seekable path + `MemberStreams.SEEKABLE` (one or many members; multi-member value is combined) | `crc32` |
-| single-file zlib | seekable/path single stream | `adler32` |
-| `.bz2` / `.xz` / brotli / `.Z`, TAR, directory | — | none |
+| `.bz2` / `.xz` / zlib / brotli / `.Z`, TAR, directory | — | none |
 
 See [usage](usage.md#cheap-dedupe-with-stored-hashes) for the cheap→computed fallback recipe.
 

--- a/openspec/changes/surface-stored-stream-digests/brief.md
+++ b/openspec/changes/surface-stored-stream-digests/brief.md
@@ -5,16 +5,31 @@ symbols — so text-to-speech reads cleanly. Aim for ~200–280 words. Derive it
 proposal.md / design.md / tasks.md; do not introduce new decisions here.
 -->
 
-# surface-stored-stream-digests — fill zlib Adler-32 and multi-member lzip CRC32 without decompressing
+# surface-stored-stream-digests — multi-member lzip CRC32 without decompressing
 
-**Status:** Ready to implement. Depends on the api-coherence hashes typing fix shipping HashAlgorithm with byte values first. Blocks nothing. Not breaking once that typing landed. Effort: medium.
+**Status:** Implemented (zlib Adler peek deliberately omitted). Depends on the
+api-coherence hashes typing fix shipping HashAlgorithm with byte values first.
+Blocks nothing. Not breaking once that typing landed. Effort: medium.
 
-**Why it matters:** VISION wants hashes without decompression for cheap dedupe. Docs still say zlib has no stored digest, but RFC 1950 puts Adler-32 at the end of every zlib stream. Lzip’s index already walks every member’s CRC and size, then throws the CRC away, so multi-member lzip stays blank for no good reason.
+**Why it matters:** VISION wants hashes without decompression for cheap dedupe.
+Lzip’s index already walks every member’s CRC and size, then previously threw the
+CRC away or only surfaced the single-member case, so multi-member lzip stayed blank
+for no good reason. Zlib’s Adler-32 trailer cannot be surfaced honestly the same
+way: the wrapper has no size fields, so a last-four-byte peek lies under concat or
+trailing junk. Adler stays decompressor-checked on read.
 
-**What it does:** Peeks zlib’s trailer into hashes as Adler-32 on seekable single streams. For lzip, keeps per-member CRCs from the backward index and combines them into one whole-member CRC32 that matches hashing the concatenated uncompressed payloads. Teaches the verify path to compute Adler-32. Updates specs, formats docs, and the corpus digest matrix.
+**What it does:** For lzip, keeps per-member CRCs from the backward index and
+combines them into one whole-member CRC32 that matches hashing the concatenated
+uncompressed payloads. Teaches the verify path to compute Adler-32 when an expected
+digest is installed. Updates specs, formats docs, and the corpus digest matrix.
+Does not put zlib Adler-32 on member hashes.
 
-**Decided:** Pure-Python crc32 and adler32 combine helpers because CPython only adds those in three point fifteen. Lzip always surfaces a combined CRC when the index exists. Gzip and xz multi-unit combine stay deferred. Derived combined digests are documented as derived, not as a single on-disk field.
+**Decided:** Pure-Python crc32 and adler32 combine helpers because CPython only
+adds those in three point fifteen. Lzip always surfaces a combined CRC when the
+index exists. Zlib omit on hashes. Gzip and xz multi-unit combine stay deferred.
+Derived combined digests are documented as derived, not as a single on-disk field.
 
 **Your call later:** None — the design is settled.
 
-**Bottom line:** Additive parity after the hashes type cleanup; do the typing PR first, then this.
+**Bottom line:** Additive lzip parity after the hashes type cleanup; zlib stays
+out of the cheap-digest matrix on purpose.

--- a/openspec/changes/surface-stored-stream-digests/design.md
+++ b/openspec/changes/surface-stored-stream-digests/design.md
@@ -7,8 +7,9 @@ api-coherence Q6 investigated stored-digest parity for single-file compressors
 - Lzip’s `_read_index_backwards` walks every trailer (`crc32`, `data_size`,
   `member_size`) but **discards** the CRC; metadata surfaces CRC only when the
   file is a single member (`member_size == compressed_size`).
-- Zlib is documented as “no cheap whole-member CRC” — wrong: RFC 1950 stores
-  Adler-32 of uncompressed data as the last 4 bytes (network order).
+- Zlib stores Adler-32 as the last 4 bytes (RFC 1950) but has **no** size fields,
+  so a cheap whole-member peek cannot be made honest under concat/trailing junk;
+  Adler remains decompressor-checked on read.
 - XZ index knows per-block sizes + check *type* but does not read check bytes;
   default check is CRC64; SHA-256 is not combinable.
 - `zlib.crc32_combine` / `adler32_combine` exist in CPython only from 3.15;
@@ -22,13 +23,13 @@ surface. This design assumes that typing is already landed.
 
 **Goals:**
 
-- Cheap zlib `ADLER32` on seekable single-stream sources.
 - Whole-member `CRC32` for multi-member lzip via combine over index trailers.
 - Verify path can check `adler32` when expected.
-- Spec/docs/sweep matrix match reality.
+- Spec/docs/sweep matrix match reality (including zlib omit).
 
 **Non-Goals:**
 
+- Surfacing zlib Adler-32 on `member.hashes` (no reliable cheap boundary).
 - Introducing `HashAlgorithm` / migrating crc32 `int`→`bytes` (review fix).
 - Gzip multi-member combine (mid-member trailers not cheap without decompress;
   ISIZE mod 2³²).
@@ -55,7 +56,7 @@ well-known zlib `crc32_combine_` (matrix powers of the zero operator).
 
 | Format | Single-unit peek | Multi-unit combine |
 |---|---|---|
-| zlib | Last 4 bytes = Adler-32 if complete single stream | Concatenated zlib rare; omit unless we detect splits |
+| zlib | **Omit** from `member.hashes` (no size fields; last-4 lies under concat/junk; Adler still decompressor-checked) | N/A |
 | lzip | Already | Index has every CRC + exact u64 size → **do it** |
 | gzip | Already | Blocked on finding mid trailers without decompress |
 | xz | Single-block CRC32 possible later | Default CRC64; SHA-256 no; out of scope |
@@ -81,13 +82,17 @@ Add `crc32_combine` and `adler32_combine` (and tests) rather than waiting for
 3.15 or adding a native dep. **Rejected:** soft-depend on 3.15-only stdlib;
 **Rejected:** shell out / copy entire zlib C.
 
-### 3. Zlib: peek last 4 bytes, gate like gzip
+### 3. Zlib: do **not** surface Adler-32 on `member.hashes`
 
-Seekable/path, file long enough for header+deflate+Adler, treat as single
-stream (no concat detector unless we already have one). Store
-`hashes[ADLER32]` as 4 bytes big-endian (matches wire + digest convention).
-Omit on non-seekable. **Rejected:** forcing a decompress pass to “confirm”
-Adler placement.
+RFC 1950 stores Adler-32 as the last 4 bytes, but the wrapper has **no** compressed
+or uncompressed size fields — unlike lzip’s trailer — so a backward index / honest
+whole-member peek is impossible without decompressing. A last-4-byte peek lies under
+concatenated streams or trailing junk (hashes ≠ `read()` payload). **Decision:** omit
+zlib from the stored-digest matrix; Adler-32 remains verified by the decompressor on
+read. Keep `adler32` in the verify hasher table for explicitly installed expectations.
+**Rejected:** last-4 peek “complete single stream” assumption; **Rejected:** forcing a
+decompress pass just to publish metadata digests.
+
 
 ### 4. Lzip: always surface combined CRC32 when index is available
 
@@ -99,8 +104,9 @@ multi-member empty forever.
 
 ### 5. Docs: call multi-member lzip digest “derived” where it matters
 
-`docs/formats.md` matrix: zlib → `adler32`; lzip → `crc32` (combined when
-multi-member). One sentence that multi-member lzip’s value equals
+`docs/formats.md` matrix: lzip → `crc32` (combined when multi-member); zlib stays
+with formats that have no cheap `member.hashes` digest, with a note that Adler is
+decompressor-checked. One sentence that multi-member lzip’s value equals
 `crc32(concat(parts))` derived from stored per-member CRCs. **Rejected:**
 hiding the derivation (VISION: no surprises as data/docs).
 
@@ -117,9 +123,6 @@ streams) verifies instead of `DIGEST_UNVERIFIABLE`.
 
 ## Risks / Trade-offs
 
-- **[Risk] Trailing junk after zlib stream** → last-4-byte peek is wrong.
-  **Mitigation:** same class of risk as trusting gzip EOF trailer; omit if we
-  later detect trailing bytes; document “complete single zlib file” assumption.
 - **[Risk] Combined lzip CRC used for dedupe across tools that hash only the
   last member** → mismatch with naive tools.
   **Mitigation:** document derivation; value matches full decompressed concat.

--- a/openspec/changes/surface-stored-stream-digests/design.md
+++ b/openspec/changes/surface-stored-stream-digests/design.md
@@ -96,11 +96,13 @@ decompress pass just to publish metadata digests.
 
 ### 4. Lzip: always surface combined CRC32 when index is available
 
-Whether one or many members: fold trailer CRCs with `crc32_combine` and exact
-`data_size`s. Single-member degenerates to the trailer CRC. SEEKABLE/path gate
+Whether one or many members: one backward index scan yields both total
+decompressed size and the folded trailer CRCs (`crc32_combine` + exact
+`data_size`s). Single-member degenerates to the trailer CRC. SEEKABLE/path gate
 unchanged (index already requires that). **Rejected:** exposing only the last
 member’s CRC (lies about whole synthetic member). **Rejected:** leaving
-multi-member empty forever.
+multi-member empty forever. **Rejected:** separate size probe + CRC probe (two
+I/O scans of the same trailers).
 
 ### 5. Docs: call multi-member lzip digest “derived” where it matters
 

--- a/openspec/changes/surface-stored-stream-digests/proposal.md
+++ b/openspec/changes/surface-stored-stream-digests/proposal.md
@@ -1,26 +1,29 @@
 ## Why
 
-VISION’s “hashes without decompression” path is incomplete for single-file
-compressors: docs/specs claim zlib has no cheap stored digest (false — RFC 1950
-Adler-32 trailer), and multi-member lzip already walks every trailer CRC+size in
-its index but discards the CRCs instead of combining them into one whole-member
-digest. Filling those gaps is additive parity work, separate from the
+VISION’s “hashes without decompression” path is incomplete for multi-member lzip:
+the seekable index already walks every trailer CRC+size but previously discarded the
+CRCs (or surfaced only the single-member case) instead of combining them into one
+whole-member digest. Filling that gap is additive parity work, separate from the
 api-coherence **type** cleanup (`HashAlgorithm` + `bytes` values).
+
+Standalone zlib’s RFC 1950 Adler-32 trailer is **not** surfaced on `member.hashes`:
+the wrapper has no size fields, so a last-4-byte peek cannot reliably mean “whole
+synthetic member” under concat/trailing junk. Adler-32 remains checked by the
+decompressor on read; the verify hasher table still recognizes `adler32` when an
+expected digest is installed explicitly.
 
 ## What Changes
 
-- Surface standalone **zlib** Adler-32 as `member.hashes[HashAlgorithm.ADLER32]`
-  when cheaply peekable (seekable/path, single complete stream).
 - Surface **lzip** whole-member `CRC32` for **multi-member** streams by combining
   per-trailer CRCs with known uncompressed lengths (`crc32_combine`), not only
   the single-member case.
-- Teach the shared verify hasher table to compute/compare `adler32` (stdlib
-  `zlib.adler32`) so surfaced values stay consistent with read-path checks.
+- Add pure-Python `crc32_combine` / `adler32_combine` helpers (3.11 has no stdlib
+  combine); register `adler32` in the verify hasher table.
 - Update `format-single-file-compressors` / formats docs / corpus assertions for
-  the new matrix rows.
-- **Out of scope here:** `HashAlgorithm` enum introduction and crc32 `int`→`bytes`
-  migration (api-coherence Q6 review fix). gzip/xz multi-unit combine (hard to
-  acquire mid-unit trailers / CRC64 default) — deferred; single-unit-only stays.
+  multi-member lzip; keep zlib in the “no cheap stored digest” row with an explicit
+  note that Adler is decompressor-checked only.
+- **Out of scope:** zlib Adler peek on `member.hashes`; `HashAlgorithm` enum /
+  crc32 `int`→`bytes` migration (api-coherence); gzip/xz multi-unit combine.
 
 ## Capabilities
 
@@ -30,22 +33,22 @@ api-coherence **type** cleanup (`HashAlgorithm` + `bytes` values).
 
 ### Modified Capabilities
 
-- `format-single-file-compressors` — stored-digest surfacing matrix (zlib Adler-32;
-  lzip multi-member combined CRC32)
+- `format-single-file-compressors` — stored-digest surfacing matrix (lzip
+  multi-member combined CRC32; zlib remains omit)
 - `compressed-streams` — verify path recognizes `adler32` as a computable digest
-- `testing-contract` — cross-format stored-digest expectations for zlib / multi-lzip
-- `documentation` — `docs/formats.md` stored-digests table (zlib / lzip rows)
+- `testing-contract` — cross-format stored-digest expectations for multi-lzip
+- `documentation` — `docs/formats.md` stored-digests table (lzip multi-member;
+  zlib omit + decompressor note)
 
 ## Impact
 
-- Modules: `codecs.py` (zlib/lzip `extract_metadata`), `single_file_reader.py`
-  (probes), `lzip.py` (retain trailer CRCs in index), new small
-  `crc32_combine`/`adler32_combine` helpers (3.11 has no stdlib combine),
-  `verify.py` hasher registry.
-- Public API: additive `hashes` keys/values only (after `HashAlgorithm` lands);
-  no signature breaks in this change.
+- Modules: `codecs.py` (lzip `extract_metadata`), `single_file_reader.py`
+  (lzip CRC probe), `lzip.py` (retain trailer CRCs in index),
+  `crc32_combine`/`adler32_combine` helpers, `verify.py` hasher registry.
+- Public API: additive `hashes` values for multi-member lzip only; no zlib
+  `ADLER32` key from this change.
 - Extras/deps: none (stdlib `zlib`).
-- Tests: unit tests for combine helpers; single-file metadata tests for zlib
-  Adler-32 and multi-member lzip; update formats matrix / sweep expectations.
+- Tests: unit tests for combine helpers; multi-member lzip metadata; corpus/docs
+  parity.
 - **Prerequisite:** api-coherence Q6 hashes typing (`Mapping[HashAlgorithm, bytes]`)
-  merged or stacked first so this change writes enum keys, not stringly `"crc32"`.
+  merged or stacked first.

--- a/openspec/changes/surface-stored-stream-digests/specs/compressed-streams/spec.md
+++ b/openspec/changes/surface-stored-stream-digests/specs/compressed-streams/spec.md
@@ -12,8 +12,9 @@ Supported computable algorithms SHALL include `crc32` (via `zlib.crc32`),
 `adler32` (via `zlib.adler32`), the `hashlib.algorithms_available` set, and
 `blake2sp` (the 8-way parallel BLAKE2s tree hash used by RAR5), computed via an
 internal zero-dependency hasher. A well-formed member carrying only a `blake2sp`
-digest SHALL therefore be verified, not skipped. A well-formed zlib member
-carrying only `adler32` SHALL likewise be verified, not skipped.
+digest SHALL therefore be verified, not skipped. When an expected `adler32` is
+installed on a verifying stream, it SHALL likewise be computed and checked (not
+skipped as unknown).
 
 When an expected digest cannot be computed because the algorithm is genuinely unknown
 or a backend is missing, the system SHALL emit `DIGEST_UNVERIFIABLE` with algorithm,
@@ -25,7 +26,7 @@ collection, logging/callback delivery, member attachment, and escalation.
 | Case | Expected |
 | --- | --- |
 | Expected `blake2sp` on a well-formed RAR5 member | Computed and verified; mismatch raises `CorruptionError` |
-| Expected `adler32` on a well-formed zlib member | Computed and verified; mismatch raises `CorruptionError` |
+| Expected `adler32` on a verifying stream | Computed and verified; mismatch raises `CorruptionError` |
 | Expected digest under a genuinely-unknown algorithm name | `DIGEST_UNVERIFIABLE` counted/retained/logged; bytes still returned without that check |
 | Full member read reaches EOF with computable digest mismatch | `CorruptionError` naming the algorithm |
 | Chunked read reaches EOF with mismatch | All valid chunks delivered; following terminal read raises |

--- a/openspec/changes/surface-stored-stream-digests/specs/documentation/spec.md
+++ b/openspec/changes/surface-stored-stream-digests/specs/documentation/spec.md
@@ -6,17 +6,17 @@ The end-user documentation SHALL include a stored-digest matrix stating, per for
 `member.hashes` keys are populated from data the archive already stores (or, for
 multi-member lzip, derived via CRC combine from per-member stored CRCs) without
 decompression, and under what conditions (e.g. single-member/seekable gzip; seekable
-zlib Adler-32; seekable lzip including multi-member). It SHALL include a cheap-dedupe
-recipe showing how to key on `member.hashes` for a first-pass dedupe and fall back to
-computing a digest while reading when no stored digest is present, and SHALL state the
-"best available digest + provenance (stored vs computed)" recommendation so an indexer
-can choose cheap-but-weak vs costly-but-strong uniformly. The matrix SHALL NOT claim
-zlib has no stored digest.
+lzip including multi-member). It SHALL include a cheap-dedupe recipe showing how to key
+on `member.hashes` for a first-pass dedupe and fall back to computing a digest while
+reading when no stored digest is present, and SHALL state the "best available digest +
+provenance (stored vs computed)" recommendation so an indexer can choose cheap-but-weak
+vs costly-but-strong uniformly. The matrix SHALL list zlib with formats that have no
+cheap whole-member stored digest on `member.hashes` (Adler-32 remains decompressor-checked).
 
 #### Scenario: stored-digest documentation
 
 | Case | Expected |
 | --- | --- |
 | Reader consults the guide for dedupe | Finds the per-format stored-digest matrix and the cheap→computed fallback recipe |
-| Format stores no cheap digest (e.g. bzip2, tar) | Matrix states so; recipe covers the computed-on-read fallback |
-| zlib / multi-member lzip | Matrix lists `adler32` / combined `crc32` respectively |
+| Format stores no cheap digest (e.g. bzip2, zlib, tar) | Matrix states so; recipe covers the computed-on-read fallback |
+| Multi-member lzip | Matrix lists combined `crc32` |

--- a/openspec/changes/surface-stored-stream-digests/specs/format-single-file-compressors/spec.md
+++ b/openspec/changes/surface-stored-stream-digests/specs/format-single-file-compressors/spec.md
@@ -24,11 +24,12 @@ the existing path; stored/derived values are metadata only.
   `crc32(concat(member payloads))` derived by combining per-trailer CRC-32 values with
   each member's exact uncompressed `data_size` (combine algebra). Single-member
   degenerates to the trailer CRC.
-- **ZLIB:** seekable/path complete single-stream file → surface trailer `ADLER32`
-  (RFC 1950, last 4 bytes, network order). Non-seekable or unrecognized layout → omit.
 - **Non-seekable source:** omit digests that require a trailer/index peek (no forced
   decode).
-- **BZ2, XZ, BR, `.Z`:** no cheap whole-member stored digest in this change — omit.
+- **BZ2, XZ, ZLIB, BR, `.Z`:** no cheap whole-member stored digest — omit. (Zlib's
+  RFC 1950 Adler-32 trailer is verified by the decompressor on read; it is not surfaced
+  on `member.hashes` because the wrapper has no size fields for a reliable
+  single-stream boundary when concat/trailing junk is possible.)
 
 #### Scenario: stored-digest surfacing by codec
 
@@ -40,7 +41,5 @@ the existing path; stored/derived values are metadata only.
 | Single-member `.lz`, seekable lzip index | `CRC32` present (= trailer) |
 | Multi-member `.lz`, seekable lzip index | `CRC32` present (= combine of per-member trailers) |
 | `.lz` without seekable index | no digest key |
-| Standalone zlib, seekable/path single stream | `ADLER32` present |
-| zlib non-seekable | no digest key |
-| `.bz2` / `.xz` / `.br` / `.Z` | no digest key |
+| `.bz2` / `.xz` / `.zlib` / `.br` / `.Z` | no digest key |
 | Any of the above, full `read()` | verification unchanged; hashes are metadata only |

--- a/openspec/changes/surface-stored-stream-digests/specs/testing-contract/spec.md
+++ b/openspec/changes/surface-stored-stream-digests/specs/testing-contract/spec.md
@@ -19,9 +19,7 @@ The asserted matrix SHALL match the documented policy:
 | single-file GZIP | multi-member or non-seekable | digest keys absent |
 | single-file LZIP | seekable lzip index (one or many members) | `crc32` present |
 | single-file LZIP | no seekable index | digest keys absent |
-| single-file ZLIB | seekable/path single stream | `adler32` present |
-| single-file ZLIB | non-seekable | digest keys absent |
-| single-file BZ2/XZ/BR/`.Z`, TAR, directory | any | no stored-digest key |
+| single-file BZ2/XZ/ZLIB/BR/`.Z`, TAR, directory | any | no stored-digest key |
 
 #### Scenario: parity sweep
 

--- a/openspec/changes/surface-stored-stream-digests/tasks.md
+++ b/openspec/changes/surface-stored-stream-digests/tasks.md
@@ -23,10 +23,11 @@
 ## 4. Lzip multi-member CRC32
 
 - [x] 4.1 Retain per-member CRC32 in lzip backward index entries
-- [x] 4.2 In `extract_metadata`, combine CRCs with `data_size` via
-      `crc32_combine`; surface `HashAlgorithm.CRC32` for one- and multi-member
+- [x] 4.2 One index scan surfaces size + combined `HashAlgorithm.CRC32` for
+      one- and multi-member (`peek_index_summary` / `probe_lzip_index`)
 - [x] 4.3 Test: multi-member fixture’s surfaced CRC equals CRC of full
-      decompressed concat; single-member still matches trailer
+      decompressed concat; single-member still matches trailer; metadata open
+      performs a single backward scan
 
 ## 5. Specs, docs, sweep
 

--- a/openspec/changes/surface-stored-stream-digests/tasks.md
+++ b/openspec/changes/surface-stored-stream-digests/tasks.md
@@ -12,13 +12,13 @@
 - [x] 2.2 Unit tests: combine equals `zlib.crc32` / `zlib.adler32` of
       concatenation for empty/short/multi-chunk cases
 
-## 3. Zlib Adler-32 surfacing
+## 3. Zlib Adler-32 (omit from `member.hashes`)
 
-- [x] 3.1 Add seekable probe for last-4-byte Adler-32 (single-file reader /
-      zlib codec `extract_metadata`)
-- [x] 3.2 Set `member.hashes[HashAlgorithm.ADLER32]` as 4-byte big-endian;
-      omit on non-seekable / too-short
-- [x] 3.3 Register `adler32` in `verify.py` hasher table (`zlib.adler32`)
+- [x] 3.1 Do **not** peek/surface zlib Adler-32 on `member.hashes` (no size
+      fields → unreliable under concat/trailing junk); document omit +
+      decompressor-checked Adler
+- [x] 3.2 Register `adler32` in `verify.py` hasher table (`zlib.adler32`) for
+      explicitly installed expectations
 
 ## 4. Lzip multi-member CRC32
 
@@ -32,13 +32,13 @@
 
 - [x] 5.1 Sync main specs from this change’s deltas (`format-single-file-compressors`,
       `compressed-streams`, `testing-contract`, `documentation`)
-- [x] 5.2 Update `docs/formats.md` stored-digests table (zlib `adler32`; lzip
-      multi-member combined `crc32`; note derivation)
-- [x] 5.3 Extend corpus / focused tests for zlib + multi-lzip parity rows
+- [x] 5.2 Update `docs/formats.md` stored-digests table (lzip multi-member
+      combined `crc32`; zlib omit + decompressor note)
+- [x] 5.3 Extend corpus / focused tests for multi-lzip parity rows
 
 ## 6. Verify
 
-- [x] 6.1 Targeted tests for combine helpers, zlib Adler peek, multi-lzip CRC
+- [x] 6.1 Targeted tests for combine helpers, multi-lzip CRC, verify `adler32`
 - [x] 6.2 `uv run --no-sync pytest` for affected tests; `ruff format` / check on
       touched paths
 - [x] 6.3 `openspec validate --strict surface-stored-stream-digests`

--- a/openspec/changes/surface-stored-stream-digests/tasks.md
+++ b/openspec/changes/surface-stored-stream-digests/tasks.md
@@ -38,7 +38,7 @@
 
 ## 6. Verify
 
-- [ ] 6.1 Targeted tests for combine helpers, zlib Adler peek, multi-lzip CRC
-- [ ] 6.2 `uv run --no-sync pytest` for affected tests; `ruff format` / check on
+- [x] 6.1 Targeted tests for combine helpers, zlib Adler peek, multi-lzip CRC
+- [x] 6.2 `uv run --no-sync pytest` for affected tests; `ruff format` / check on
       touched paths
-- [ ] 6.3 `openspec validate --strict surface-stored-stream-digests`
+- [x] 6.3 `openspec validate --strict surface-stored-stream-digests`

--- a/openspec/changes/surface-stored-stream-digests/tasks.md
+++ b/openspec/changes/surface-stored-stream-digests/tasks.md
@@ -1,40 +1,40 @@
 ## 1. Prerequisites
 
-- [ ] 1.1 Confirm api-coherence Q6 hashes typing is merged (`HashAlgorithm`,
+- [x] 1.1 Confirm api-coherence Q6 hashes typing is merged (`HashAlgorithm`,
       `Mapping[HashAlgorithm, bytes]`); stack or rebase this change on it
-- [ ] 1.2 Add `HashAlgorithm.ADLER32` if the typing PR only shipped `CRC32` /
+- [x] 1.2 Add `HashAlgorithm.ADLER32` if the typing PR only shipped `CRC32` /
       `BLAKE2SP`
 
 ## 2. Combine helpers
 
-- [ ] 2.1 Implement `crc32_combine` + `adler32_combine` under
+- [x] 2.1 Implement `crc32_combine` + `adler32_combine` under
       `archivey.internal.hashing` (pure Python; 3.11-compatible)
-- [ ] 2.2 Unit tests: combine equals `zlib.crc32` / `zlib.adler32` of
+- [x] 2.2 Unit tests: combine equals `zlib.crc32` / `zlib.adler32` of
       concatenation for empty/short/multi-chunk cases
 
 ## 3. Zlib Adler-32 surfacing
 
-- [ ] 3.1 Add seekable probe for last-4-byte Adler-32 (single-file reader /
+- [x] 3.1 Add seekable probe for last-4-byte Adler-32 (single-file reader /
       zlib codec `extract_metadata`)
-- [ ] 3.2 Set `member.hashes[HashAlgorithm.ADLER32]` as 4-byte big-endian;
+- [x] 3.2 Set `member.hashes[HashAlgorithm.ADLER32]` as 4-byte big-endian;
       omit on non-seekable / too-short
-- [ ] 3.3 Register `adler32` in `verify.py` hasher table (`zlib.adler32`)
+- [x] 3.3 Register `adler32` in `verify.py` hasher table (`zlib.adler32`)
 
 ## 4. Lzip multi-member CRC32
 
-- [ ] 4.1 Retain per-member CRC32 in lzip backward index entries
-- [ ] 4.2 In `extract_metadata`, combine CRCs with `data_size` via
+- [x] 4.1 Retain per-member CRC32 in lzip backward index entries
+- [x] 4.2 In `extract_metadata`, combine CRCs with `data_size` via
       `crc32_combine`; surface `HashAlgorithm.CRC32` for one- and multi-member
-- [ ] 4.3 Test: multi-member fixture’s surfaced CRC equals CRC of full
+- [x] 4.3 Test: multi-member fixture’s surfaced CRC equals CRC of full
       decompressed concat; single-member still matches trailer
 
 ## 5. Specs, docs, sweep
 
-- [ ] 5.1 Sync main specs from this change’s deltas (`format-single-file-compressors`,
+- [x] 5.1 Sync main specs from this change’s deltas (`format-single-file-compressors`,
       `compressed-streams`, `testing-contract`, `documentation`)
-- [ ] 5.2 Update `docs/formats.md` stored-digests table (zlib `adler32`; lzip
+- [x] 5.2 Update `docs/formats.md` stored-digests table (zlib `adler32`; lzip
       multi-member combined `crc32`; note derivation)
-- [ ] 5.3 Extend corpus / focused tests for zlib + multi-lzip parity rows
+- [x] 5.3 Extend corpus / focused tests for zlib + multi-lzip parity rows
 
 ## 6. Verify
 

--- a/openspec/specs/compressed-streams/spec.md
+++ b/openspec/specs/compressed-streams/spec.md
@@ -162,10 +162,12 @@ computable mismatch at clean EOF. A mismatch SHALL surface from the terminal rea
 after all data chunks have been delivered; a bytes-returning full read raises and
 returns no bytes. Partial/random-access reads SHALL NOT produce a digest verdict.
 
-Supported computable algorithms SHALL include `crc32` (via `zlib.crc32`), the
-`hashlib.algorithms_available` set, and `blake2sp` (the 8-way parallel BLAKE2s tree
-hash used by RAR5), computed via an internal zero-dependency hasher. A well-formed
-member carrying only a `blake2sp` digest SHALL therefore be verified, not skipped.
+Supported computable algorithms SHALL include `crc32` (via `zlib.crc32`),
+`adler32` (via `zlib.adler32`), the `hashlib.algorithms_available` set, and
+`blake2sp` (the 8-way parallel BLAKE2s tree hash used by RAR5), computed via an
+internal zero-dependency hasher. A well-formed member carrying only a `blake2sp`
+digest SHALL therefore be verified, not skipped. A well-formed zlib member
+carrying only `adler32` SHALL likewise be verified, not skipped.
 
 When an expected digest cannot be computed because the algorithm is genuinely unknown
 or a backend is missing, the system SHALL emit `DIGEST_UNVERIFIABLE` with algorithm,
@@ -177,6 +179,7 @@ collection, logging/callback delivery, member attachment, and escalation.
 | Case | Expected |
 | --- | --- |
 | Expected `blake2sp` on a well-formed RAR5 member | Computed and verified; mismatch raises `CorruptionError` |
+| Expected `adler32` on a well-formed zlib member | Computed and verified; mismatch raises `CorruptionError` |
 | Expected digest under a genuinely-unknown algorithm name | `DIGEST_UNVERIFIABLE` counted/retained/logged; bytes still returned without that check |
 | Full member read reaches EOF with computable digest mismatch | `CorruptionError` naming the algorithm |
 | Chunked read reaches EOF with mismatch | All valid chunks delivered; following terminal read raises |

--- a/openspec/specs/compressed-streams/spec.md
+++ b/openspec/specs/compressed-streams/spec.md
@@ -166,8 +166,9 @@ Supported computable algorithms SHALL include `crc32` (via `zlib.crc32`),
 `adler32` (via `zlib.adler32`), the `hashlib.algorithms_available` set, and
 `blake2sp` (the 8-way parallel BLAKE2s tree hash used by RAR5), computed via an
 internal zero-dependency hasher. A well-formed member carrying only a `blake2sp`
-digest SHALL therefore be verified, not skipped. A well-formed zlib member
-carrying only `adler32` SHALL likewise be verified, not skipped.
+digest SHALL therefore be verified, not skipped. When an expected `adler32` is
+installed on a verifying stream, it SHALL likewise be computed and checked (not
+skipped as unknown).
 
 When an expected digest cannot be computed because the algorithm is genuinely unknown
 or a backend is missing, the system SHALL emit `DIGEST_UNVERIFIABLE` with algorithm,
@@ -179,7 +180,7 @@ collection, logging/callback delivery, member attachment, and escalation.
 | Case | Expected |
 | --- | --- |
 | Expected `blake2sp` on a well-formed RAR5 member | Computed and verified; mismatch raises `CorruptionError` |
-| Expected `adler32` on a well-formed zlib member | Computed and verified; mismatch raises `CorruptionError` |
+| Expected `adler32` on a verifying stream | Computed and verified; mismatch raises `CorruptionError` |
 | Expected digest under a genuinely-unknown algorithm name | `DIGEST_UNVERIFIABLE` counted/retained/logged; bytes still returned without that check |
 | Full member read reaches EOF with computable digest mismatch | `CorruptionError` naming the algorithm |
 | Chunked read reaches EOF with mismatch | All valid chunks delivered; following terminal read raises |

--- a/openspec/specs/documentation/spec.md
+++ b/openspec/specs/documentation/spec.md
@@ -123,18 +123,18 @@ The end-user documentation SHALL include a stored-digest matrix stating, per for
 `member.hashes` keys are populated from data the archive already stores (or, for
 multi-member lzip, derived via CRC combine from per-member stored CRCs) without
 decompression, and under what conditions (e.g. single-member/seekable gzip; seekable
-zlib Adler-32; seekable lzip including multi-member). It SHALL include a cheap-dedupe
-recipe showing how to key on `member.hashes` for a first-pass dedupe and fall back to
-computing a digest while reading when no stored digest is present, and SHALL state the
-"best available digest + provenance (stored vs computed)" recommendation so an indexer
-can choose cheap-but-weak vs costly-but-strong uniformly. The matrix SHALL NOT claim
-zlib has no stored digest.
+lzip including multi-member). It SHALL include a cheap-dedupe recipe showing how to key
+on `member.hashes` for a first-pass dedupe and fall back to computing a digest while
+reading when no stored digest is present, and SHALL state the "best available digest +
+provenance (stored vs computed)" recommendation so an indexer can choose cheap-but-weak
+vs costly-but-strong uniformly. The matrix SHALL list zlib with formats that have no
+cheap whole-member stored digest on `member.hashes` (Adler-32 remains decompressor-checked).
 
 #### Scenario: stored-digest documentation
 
 | Case | Expected |
 | --- | --- |
 | Reader consults the guide for dedupe | Finds the per-format stored-digest matrix and the cheap→computed fallback recipe |
-| Format stores no cheap digest (e.g. bzip2, tar) | Matrix states so; recipe covers the computed-on-read fallback |
-| zlib / multi-member lzip | Matrix lists `adler32` / combined `crc32` respectively |
+| Format stores no cheap digest (e.g. bzip2, zlib, tar) | Matrix states so; recipe covers the computed-on-read fallback |
+| Multi-member lzip | Matrix lists combined `crc32` |
 

--- a/openspec/specs/documentation/spec.md
+++ b/openspec/specs/documentation/spec.md
@@ -120,12 +120,15 @@ archive). Salvage / `--salvage` remains out of scope and separately reserved.
 ### Requirement: Document the stored-digest matrix and cheap-dedupe recipe
 
 The end-user documentation SHALL include a stored-digest matrix stating, per format, which
-`member.hashes` keys are populated from data the archive already stores (readable without
-decompression) and under what conditions (e.g. single-member/seekable gzip). It SHALL
-include a cheap-dedupe recipe showing how to key on `member.hashes` for a first-pass
-dedupe and fall back to computing a digest while reading when no stored digest is present,
-and SHALL state the "best available digest + provenance (stored vs computed)"
-recommendation so an indexer can choose cheap-but-weak vs costly-but-strong uniformly.
+`member.hashes` keys are populated from data the archive already stores (or, for
+multi-member lzip, derived via CRC combine from per-member stored CRCs) without
+decompression, and under what conditions (e.g. single-member/seekable gzip; seekable
+zlib Adler-32; seekable lzip including multi-member). It SHALL include a cheap-dedupe
+recipe showing how to key on `member.hashes` for a first-pass dedupe and fall back to
+computing a digest while reading when no stored digest is present, and SHALL state the
+"best available digest + provenance (stored vs computed)" recommendation so an indexer
+can choose cheap-but-weak vs costly-but-strong uniformly. The matrix SHALL NOT claim
+zlib has no stored digest.
 
 #### Scenario: stored-digest documentation
 
@@ -133,4 +136,5 @@ recommendation so an indexer can choose cheap-but-weak vs costly-but-strong unif
 | --- | --- |
 | Reader consults the guide for dedupe | Finds the per-format stored-digest matrix and the cheap→computed fallback recipe |
 | Format stores no cheap digest (e.g. bzip2, tar) | Matrix states so; recipe covers the computed-on-read fallback |
+| zlib / multi-member lzip | Matrix lists `adler32` / combined `crc32` respectively |
 

--- a/openspec/specs/format-single-file-compressors/spec.md
+++ b/openspec/specs/format-single-file-compressors/spec.md
@@ -188,11 +188,12 @@ the existing path; stored/derived values are metadata only.
   `crc32(concat(member payloads))` derived by combining per-trailer CRC-32 values with
   each member's exact uncompressed `data_size` (combine algebra). Single-member
   degenerates to the trailer CRC.
-- **ZLIB:** seekable/path complete single-stream file → surface trailer `ADLER32`
-  (RFC 1950, last 4 bytes, network order). Non-seekable or unrecognized layout → omit.
 - **Non-seekable source:** omit digests that require a trailer/index peek (no forced
   decode).
-- **BZ2, XZ, BR, `.Z`:** no cheap whole-member stored digest in this change — omit.
+- **BZ2, XZ, ZLIB, BR, `.Z`:** no cheap whole-member stored digest — omit. (Zlib's
+  RFC 1950 Adler-32 trailer is verified by the decompressor on read; it is not surfaced
+  on `member.hashes` because the wrapper has no size fields for a reliable
+  single-stream boundary when concat/trailing junk is possible.)
 
 #### Scenario: stored-digest surfacing by codec
 
@@ -204,8 +205,6 @@ the existing path; stored/derived values are metadata only.
 | Single-member `.lz`, seekable lzip index | `CRC32` present (= trailer) |
 | Multi-member `.lz`, seekable lzip index | `CRC32` present (= combine of per-member trailers) |
 | `.lz` without seekable index | no digest key |
-| Standalone zlib, seekable/path single stream | `ADLER32` present |
-| zlib non-seekable | no digest key |
-| `.bz2` / `.xz` / `.br` / `.Z` | no digest key |
+| `.bz2` / `.xz` / `.zlib` / `.br` / `.Z` | no digest key |
 | Any of the above, full `read()` | verification unchanged; hashes are metadata only |
 

--- a/openspec/specs/format-single-file-compressors/spec.md
+++ b/openspec/specs/format-single-file-compressors/spec.md
@@ -169,35 +169,43 @@ readable without adding another `ReadBackend` subclass.
 | Register a new standalone codec descriptor | Existing backend reads it through the descriptor |
 | Required codec backend is missing | Format availability reports `NONE`, not a separate backend failure |
 
-### Requirement: Surface the stored decompressed CRC without decompression
+### Requirement: Surface stored decompressed digests without decompression
 
-The single-file backend SHALL surface a codec's stored decompressed-content CRC-32 as
-`member.hashes["crc32"]` when it is cheaply readable from the source without
-decompressing, and SHALL omit it otherwise. This serves cheap dedupe (`VISION.md`
-"hashes without decompression") and never triggers a decompression pass.
+The single-file backend SHALL surface a codec's stored (or cheaply derived-from-stored)
+decompressed-content digest(s) on `member.hashes` when readable without decompressing,
+and SHALL omit them otherwise. This serves cheap dedupe (`VISION.md` "hashes without
+decompression") and never triggers a decompression pass.
 
-- **GZIP:** the 8-byte trailer's CRC-32 SHALL be surfaced only when the stream contains
-  exactly one member and the source is seekable/path (peek the trailer). For concatenated
-  multi-member gzip the trailer CRC covers only the last member, so `crc32` SHALL be
-  omitted. Reuse the member-count detection already used by the truncation backstop.
-- **LZIP:** the per-member trailer CRC-32 SHALL be surfaced via the seekable lzip backend
-  (which already reads the trailer for size); omitted when that backend/source is
-  unavailable.
-- **Non-seekable source:** `crc32` SHALL be omitted (no forced decode); callers compute it
-  while reading.
-- **BZ2, XZ, ZLIB, BR, `.Z`:** no cheap whole-member stored CRC — `crc32` SHALL be absent.
+Keys and value types follow the public `HashAlgorithm` / `bytes` contract (api-coherence
+hashes typing). Surfacing SHALL NOT change read behavior: a full read still verifies via
+the existing path; stored/derived values are metadata only.
 
-Surfacing the stored CRC SHALL NOT change read behavior or verification: a full read still
-verifies via the existing path, and the stored value is metadata only.
+- **GZIP:** trailer `CRC32` only when exactly one member and the source is seekable/path.
+  Multi-member → omit (trailer covers only the last member; mid-member trailers are not
+  cheap without decompress).
+- **LZIP:** when the seekable lzip index is available, surface `CRC32` of the whole
+  synthetic member. For multi-member files, the value SHALL equal
+  `crc32(concat(member payloads))` derived by combining per-trailer CRC-32 values with
+  each member's exact uncompressed `data_size` (combine algebra). Single-member
+  degenerates to the trailer CRC.
+- **ZLIB:** seekable/path complete single-stream file → surface trailer `ADLER32`
+  (RFC 1950, last 4 bytes, network order). Non-seekable or unrecognized layout → omit.
+- **Non-seekable source:** omit digests that require a trailer/index peek (no forced
+  decode).
+- **BZ2, XZ, BR, `.Z`:** no cheap whole-member stored digest in this change — omit.
 
-#### Scenario: stored CRC surfacing by codec
+#### Scenario: stored-digest surfacing by codec
 
-| Case | `member.hashes["crc32"]` |
+| Case | `member.hashes` |
 | --- | --- |
-| Single-member `.gz`, seekable/path source | Present (trailer CRC-32) |
-| Multi-member `.gz` | Absent (trailer covers only last member) |
-| `.gz` on a non-seekable source | Absent (no forced decode) |
-| `.lz` via seekable lzip backend | Present (per-member trailer CRC-32) |
-| `.bz2` / `.xz` / `.zlib` / `.br` / `.Z` | Absent (no cheap whole-member stored CRC) |
-| Any of the above, full `read()` | Verification unchanged; stored value is metadata only |
+| Single-member `.gz`, seekable/path | `CRC32` present |
+| Multi-member `.gz` | no digest key |
+| `.gz` non-seekable | no digest key |
+| Single-member `.lz`, seekable lzip index | `CRC32` present (= trailer) |
+| Multi-member `.lz`, seekable lzip index | `CRC32` present (= combine of per-member trailers) |
+| `.lz` without seekable index | no digest key |
+| Standalone zlib, seekable/path single stream | `ADLER32` present |
+| zlib non-seekable | no digest key |
+| `.bz2` / `.xz` / `.br` / `.Z` | no digest key |
+| Any of the above, full `read()` | verification unchanged; hashes are metadata only |
 

--- a/openspec/specs/testing-contract/spec.md
+++ b/openspec/specs/testing-contract/spec.md
@@ -410,9 +410,12 @@ The asserted matrix SHALL match the documented policy:
 | RAR5 | FILE with CRC32 | `crc32` present |
 | RAR5 | FILE with Blake2sp only | `blake2sp` present, `crc32` absent |
 | single-file GZIP | single member, seekable | `crc32` present |
-| single-file GZIP | multi-member or non-seekable | `crc32` absent |
-| single-file LZIP | via seekable lzip backend | `crc32` present |
-| single-file BZ2/XZ/ZLIB/BR/`.Z`, TAR, directory | any | no stored-digest key |
+| single-file GZIP | multi-member or non-seekable | digest keys absent |
+| single-file LZIP | seekable lzip index (one or many members) | `crc32` present |
+| single-file LZIP | no seekable index | digest keys absent |
+| single-file ZLIB | seekable/path single stream | `adler32` present |
+| single-file ZLIB | non-seekable | digest keys absent |
+| single-file BZ2/XZ/BR/`.Z`, TAR, directory | any | no stored-digest key |
 
 #### Scenario: parity sweep
 
@@ -421,6 +424,7 @@ The asserted matrix SHALL match the documented policy:
 | Backend surfaces its documented stored digest for an applicable member | Sweep passes |
 | A backend stops populating a documented digest | Sweep fails |
 | A backend populates a digest the format does not store | Sweep fails |
+| Multi-member lzip combined `crc32` matches `crc32` of full decompressed concat | Sweep or focused unit test passes |
 
 
 ### Requirement: BLAKE2sp verification is tested with KATs and a RAR5 oracle

--- a/openspec/specs/testing-contract/spec.md
+++ b/openspec/specs/testing-contract/spec.md
@@ -413,9 +413,7 @@ The asserted matrix SHALL match the documented policy:
 | single-file GZIP | multi-member or non-seekable | digest keys absent |
 | single-file LZIP | seekable lzip index (one or many members) | `crc32` present |
 | single-file LZIP | no seekable index | digest keys absent |
-| single-file ZLIB | seekable/path single stream | `adler32` present |
-| single-file ZLIB | non-seekable | digest keys absent |
-| single-file BZ2/XZ/BR/`.Z`, TAR, directory | any | no stored-digest key |
+| single-file BZ2/XZ/ZLIB/BR/`.Z`, TAR, directory | any | no stored-digest key |
 
 #### Scenario: parity sweep
 

--- a/src/archivey/internal/backends/single_file_reader.py
+++ b/src/archivey/internal/backends/single_file_reader.py
@@ -41,6 +41,7 @@ from archivey.internal.registry import register_reader
 from archivey.internal.streams.archive_stream import ArchiveStream
 from archivey.internal.streams.codecs import (
     SINGLE_FILE_CODECS,
+    Codec,
     MetadataContext,
     gzip_has_additional_member,
     open_codec_stream,
@@ -48,6 +49,7 @@ from archivey.internal.streams.codecs import (
     stream_codec_for_format,
 )
 from archivey.internal.streams.decompressor_stream import DecompressorStream
+from archivey.internal.streams.lzip import peek_combined_crc32
 from archivey.internal.streams.streamtools import (
     SharedSource,
     is_seekable,
@@ -183,6 +185,7 @@ class SingleFileReader(BaseArchiveReader):
             peek_trailer=self._peek_trailer,
             probe_decompressed_size=self._probe_decompressed_size,
             probe_gzip_stored_crc32=self._probe_gzip_stored_crc32,
+            probe_lzip_stored_crc32=self._probe_lzip_stored_crc32,
         )
 
     def _peek_header(self, length: int) -> bytes:
@@ -273,6 +276,28 @@ class SingleFileReader(BaseArchiveReader):
             if len(trailer) < 8:
                 return None
             return struct.unpack_from("<I", trailer, 0)[0]
+
+        return self._with_seekable_source(probe)
+
+    def _probe_lzip_stored_crc32(self) -> int | None:
+        """Whole-member CRC-32 from the seekable lzip index (combined when multi-member).
+
+        Same gate as decompressed size: path source with declared SEEKABLE so the index
+        scan is enabled. Returns ``None`` when the index is unavailable or corrupt.
+        """
+        if self._codec is not Codec.LZIP:
+            return None
+        if not isinstance(self._source, Path) or not self._codec_config.seekable:
+            return None
+
+        def probe(f: BinaryIO) -> int | None:
+            size = f.seek(0, io.SEEK_END)
+            if size < 26:  # header(6) + trailer(20)
+                return None
+            try:
+                return peek_combined_crc32(f, size)
+            except ArchiveyError:
+                return None
 
         return self._with_seekable_source(probe)
 

--- a/src/archivey/internal/backends/single_file_reader.py
+++ b/src/archivey/internal/backends/single_file_reader.py
@@ -49,7 +49,7 @@ from archivey.internal.streams.codecs import (
     stream_codec_for_format,
 )
 from archivey.internal.streams.decompressor_stream import DecompressorStream
-from archivey.internal.streams.lzip import peek_combined_crc32
+from archivey.internal.streams.lzip import peek_index_summary
 from archivey.internal.streams.streamtools import (
     SharedSource,
     is_seekable,
@@ -185,7 +185,7 @@ class SingleFileReader(BaseArchiveReader):
             peek_trailer=self._peek_trailer,
             probe_decompressed_size=self._probe_decompressed_size,
             probe_gzip_stored_crc32=self._probe_gzip_stored_crc32,
-            probe_lzip_stored_crc32=self._probe_lzip_stored_crc32,
+            probe_lzip_index=self._probe_lzip_index,
         )
 
     def _peek_header(self, length: int) -> bytes:
@@ -279,10 +279,10 @@ class SingleFileReader(BaseArchiveReader):
 
         return self._with_seekable_source(probe)
 
-    def _probe_lzip_stored_crc32(self) -> int | None:
-        """Whole-member CRC-32 from the seekable lzip index (combined when multi-member).
+    def _probe_lzip_index(self) -> tuple[int, int] | None:
+        """Decompressed size + combined CRC-32 from one seekable lzip index scan.
 
-        Same gate as decompressed size: path source with declared SEEKABLE so the index
+        Same gate as size historically: path source with declared SEEKABLE so the index
         scan is enabled. Returns ``None`` when the index is unavailable or corrupt.
         """
         if self._codec is not Codec.LZIP:
@@ -290,12 +290,12 @@ class SingleFileReader(BaseArchiveReader):
         if not isinstance(self._source, Path) or not self._codec_config.seekable:
             return None
 
-        def probe(f: BinaryIO) -> int | None:
+        def probe(f: BinaryIO) -> tuple[int, int] | None:
             size = f.seek(0, io.SEEK_END)
             if size < 26:  # header(6) + trailer(20)
                 return None
             try:
-                return peek_combined_crc32(f, size)
+                return peek_index_summary(f, size)
             except ArchiveyError:
                 return None
 

--- a/src/archivey/internal/hashing/__init__.py
+++ b/src/archivey/internal/hashing/__init__.py
@@ -1,1 +1,5 @@
 """Internal hashing helpers (not part of the public API)."""
+
+from archivey.internal.hashing.combine import adler32_combine, crc32_combine
+
+__all__ = ["adler32_combine", "crc32_combine"]

--- a/src/archivey/internal/hashing/combine.py
+++ b/src/archivey/internal/hashing/combine.py
@@ -2,8 +2,9 @@
 
 These match zlib's ``crc32_combine_`` / ``adler32_combine_``: given digests of
 ``a`` and ``b`` plus ``len(b)``, return the digest of ``a + b`` without seeing the
-bytes. Used to surface whole-stream digests from per-unit trailers (multi-member
-lzip).
+bytes. ``crc32_combine`` surfaces whole-stream digests from per-unit trailers
+(multi-member lzip). ``adler32_combine`` is the paired helper (same algebra; no
+current production caller — kept so 3.11 has both without waiting on 3.15).
 """
 
 from __future__ import annotations

--- a/src/archivey/internal/hashing/combine.py
+++ b/src/archivey/internal/hashing/combine.py
@@ -1,0 +1,83 @@
+"""Pure-Python CRC-32 / Adler-32 combine (CPython adds stdlib helpers only in 3.15+).
+
+These match zlib's ``crc32_combine_`` / ``adler32_combine_``: given digests of
+``a`` and ``b`` plus ``len(b)``, return the digest of ``a + b`` without seeing the
+bytes. Used to surface whole-stream digests from per-unit trailers (multi-member
+lzip).
+"""
+
+from __future__ import annotations
+
+# ISO/zlib CRC-32 polynomial (reflected).
+_CRC32_POLY = 0xEDB88320
+_MOD_ADLER = 65521
+
+
+def _gf2_matrix_times(mat: list[int], vec: int) -> int:
+    summary = 0
+    i = 0
+    while vec:
+        if vec & 1:
+            summary ^= mat[i]
+        vec >>= 1
+        i += 1
+    return summary
+
+
+def _gf2_matrix_square(square: list[int], mat: list[int]) -> None:
+    for n in range(32):
+        square[n] = _gf2_matrix_times(mat, mat[n])
+
+
+def crc32_combine(crc1: int, crc2: int, len2: int) -> int:
+    """Return ``zlib.crc32(a + b)`` given ``crc32(a)``, ``crc32(b)``, and ``len(b)``."""
+    if len2 <= 0:
+        return crc1 & 0xFFFFFFFF
+
+    odd = [0] * 32
+    even = [0] * 32
+    odd[0] = _CRC32_POLY
+    row = 1
+    for n in range(1, 32):
+        odd[n] = row
+        row <<= 1
+    _gf2_matrix_square(even, odd)
+    _gf2_matrix_square(odd, even)
+
+    crc1 &= 0xFFFFFFFF
+    remaining = len2
+    while True:
+        _gf2_matrix_square(even, odd)
+        if remaining & 1:
+            crc1 = _gf2_matrix_times(even, crc1)
+        remaining >>= 1
+        if remaining == 0:
+            break
+        _gf2_matrix_square(odd, even)
+        if remaining & 1:
+            crc1 = _gf2_matrix_times(odd, crc1)
+        remaining >>= 1
+        if remaining == 0:
+            break
+    return (crc1 ^ (crc2 & 0xFFFFFFFF)) & 0xFFFFFFFF
+
+
+def adler32_combine(adler1: int, adler2: int, len2: int) -> int:
+    """Return ``zlib.adler32(a + b)`` given ``adler32(a)``, ``adler32(b)``, ``len(b)``."""
+    if len2 <= 0:
+        return adler1 & 0xFFFFFFFF
+
+    rem = len2 % _MOD_ADLER
+    sum1 = adler1 & 0xFFFF
+    sum2 = (rem * sum1) % _MOD_ADLER
+    sum1 += (adler2 & 0xFFFF) + _MOD_ADLER - 1
+    sum2 += ((adler1 >> 16) & 0xFFFF) + ((adler2 >> 16) & 0xFFFF) + _MOD_ADLER - rem
+    if sum1 >= _MOD_ADLER:
+        sum1 -= _MOD_ADLER
+    if sum1 >= _MOD_ADLER:
+        sum1 -= _MOD_ADLER
+    if sum2 >= (_MOD_ADLER << 1):
+        sum2 -= _MOD_ADLER << 1
+    if sum2 >= _MOD_ADLER:
+        sum2 -= _MOD_ADLER
+    return (sum1 | (sum2 << 16)) & 0xFFFFFFFF

--- a/src/archivey/internal/streams/codecs.py
+++ b/src/archivey/internal/streams/codecs.py
@@ -1089,26 +1089,6 @@ class ZlibCodec(_ZlibErrorCodec):
         """Recognize a zlib stream: a known CMF/FLG header (fail-fast) that then decodes."""
         return prefix[:2] in _ZLIB_HEADERS and self._decodes_sample(prefix)
 
-    def extract_metadata(self, ctx: MetadataContext, member: ArchiveMember) -> None:
-        """Surface RFC 1950 Adler-32 (last 4 bytes, network order) when cheaply peekable.
-
-        Seekable/path complete single-stream files only. Non-seekable sources and
-        unrecognized headers omit the digest (no forced decode).
-        """
-        header = ctx.peek_header(2)
-        if header[:2] not in _ZLIB_HEADERS:
-            return
-        # Minimum zlib stream: CMF/FLG (2) + empty deflate block (≥2) + Adler-32 (4).
-        trailer = ctx.peek_trailer(4)
-        if trailer is None or len(trailer) < 4:
-            return
-        # Need room for a header before the Adler trailer.
-        if member.compressed_size is not None and member.compressed_size < 8:
-            return
-        hashes = dict(member.hashes)
-        hashes[HashAlgorithm.ADLER32] = trailer
-        member.hashes = hashes
-
 
 class ZstdCodec(StreamCodec):
     codec = Codec.ZSTD

--- a/src/archivey/internal/streams/codecs.py
+++ b/src/archivey/internal/streams/codecs.py
@@ -514,13 +514,15 @@ class MetadataContext:
     ``probe_decompressed_size()`` returns the decompressed size from the stream
     index/trailer when cheaply available (else ``None``); ``probe_gzip_stored_crc32()``
     returns the single-member gzip trailer CRC when that is cheaply knowable (else
-    ``None``), in one seekable pass.
+    ``None``), in one seekable pass; ``probe_lzip_stored_crc32()`` returns the whole-member
+    CRC-32 derived from the seekable lzip index (combined across members) when available.
     """
 
     peek_header: Callable[[int], bytes]
     peek_trailer: Callable[[int], bytes | None]
     probe_decompressed_size: Callable[[], int | None]
     probe_gzip_stored_crc32: Callable[[], int | None]
+    probe_lzip_stored_crc32: Callable[[], int | None]
 
 
 # --- the codec descriptors -------------------------------------------------------------
@@ -895,21 +897,15 @@ class LzipCodec(_SizedLzmaCodec):
         return LzipDecompressorStream(source, seekable=config.seekable)
 
     def extract_metadata(self, ctx: MetadataContext, member: ArchiveMember) -> None:
-        """Surface decompressed size and the trailer CRC-32 under the same cheap gate.
+        """Surface decompressed size and whole-member CRC-32 from the seekable index.
 
-        Size comes from the seekable lzip index (``probe_decompressed_size``). The trailer
-        CRC is surfaced only when that probe succeeds *and* the file is a single lzip
-        member (``member_size`` equals the compressed source size) — a multi-member ``.lz``
-        has no single whole-stream stored CRC for the one synthetic archive member.
+        Size comes from the seekable lzip index (``probe_decompressed_size``). The CRC is
+        the combine of every per-member trailer CRC-32 with that member's uncompressed
+        ``data_size`` (single-member degenerates to the trailer CRC).
         """
         member.size = ctx.probe_decompressed_size()
-        if member.size is None or member.compressed_size is None:
-            return
-        trailer = ctx.peek_trailer(20)
-        if trailer is None or len(trailer) < 20:
-            return
-        crc32, _data_size, member_size = struct.unpack_from("<IQQ", trailer, 0)
-        if member_size == member.compressed_size:
+        crc32 = ctx.probe_lzip_stored_crc32()
+        if crc32 is not None:
             hashes = dict(member.hashes)
             hashes[HashAlgorithm.CRC32] = crc32_digest(crc32)
             member.hashes = hashes
@@ -1093,6 +1089,26 @@ class ZlibCodec(_ZlibErrorCodec):
         """Recognize a zlib stream: a known CMF/FLG header (fail-fast) that then decodes."""
         return prefix[:2] in _ZLIB_HEADERS and self._decodes_sample(prefix)
 
+    def extract_metadata(self, ctx: MetadataContext, member: ArchiveMember) -> None:
+        """Surface RFC 1950 Adler-32 (last 4 bytes, network order) when cheaply peekable.
+
+        Seekable/path complete single-stream files only. Non-seekable sources and
+        unrecognized headers omit the digest (no forced decode).
+        """
+        header = ctx.peek_header(2)
+        if header[:2] not in _ZLIB_HEADERS:
+            return
+        # Minimum zlib stream: CMF/FLG (2) + empty deflate block (≥2) + Adler-32 (4).
+        trailer = ctx.peek_trailer(4)
+        if trailer is None or len(trailer) < 4:
+            return
+        # Need room for a header before the Adler trailer.
+        if member.compressed_size is not None and member.compressed_size < 8:
+            return
+        hashes = dict(member.hashes)
+        hashes[HashAlgorithm.ADLER32] = trailer
+        member.hashes = hashes
+
 
 class ZstdCodec(StreamCodec):
     codec = Codec.ZSTD
@@ -1214,7 +1230,6 @@ class UnixCompressCodec(StreamCodec):
 
 def _parse_ppmd_var_h_properties(properties: bytes | None) -> tuple[int, int]:
     """Parse 7z PPMd var.H coder properties → ``(order, mem_size)``."""
-    import struct
 
     if properties is None:
         raise ValueError("PPMd requires coder properties (order + mem size)")

--- a/src/archivey/internal/streams/codecs.py
+++ b/src/archivey/internal/streams/codecs.py
@@ -514,15 +514,16 @@ class MetadataContext:
     ``probe_decompressed_size()`` returns the decompressed size from the stream
     index/trailer when cheaply available (else ``None``); ``probe_gzip_stored_crc32()``
     returns the single-member gzip trailer CRC when that is cheaply knowable (else
-    ``None``), in one seekable pass; ``probe_lzip_stored_crc32()`` returns the whole-member
-    CRC-32 derived from the seekable lzip index (combined across members) when available.
+    ``None``), in one seekable pass; ``probe_lzip_index()`` returns
+    ``(decompressed_size, combined_crc32)`` from one seekable lzip index scan when
+    available (else ``None``).
     """
 
     peek_header: Callable[[int], bytes]
     peek_trailer: Callable[[int], bytes | None]
     probe_decompressed_size: Callable[[], int | None]
     probe_gzip_stored_crc32: Callable[[], int | None]
-    probe_lzip_stored_crc32: Callable[[], int | None]
+    probe_lzip_index: Callable[[], tuple[int, int] | None]
 
 
 # --- the codec descriptors -------------------------------------------------------------
@@ -897,18 +898,19 @@ class LzipCodec(_SizedLzmaCodec):
         return LzipDecompressorStream(source, seekable=config.seekable)
 
     def extract_metadata(self, ctx: MetadataContext, member: ArchiveMember) -> None:
-        """Surface decompressed size and whole-member CRC-32 from the seekable index.
+        """Surface decompressed size and whole-member CRC-32 from one seekable index scan.
 
-        Size comes from the seekable lzip index (``probe_decompressed_size``). The CRC is
-        the combine of every per-member trailer CRC-32 with that member's uncompressed
-        ``data_size`` (single-member degenerates to the trailer CRC).
+        ``probe_lzip_index`` returns both values from a single backward trailer walk.
+        The CRC is the combine of every per-member trailer CRC-32 with that member's
+        uncompressed ``data_size`` (single-member degenerates to the trailer CRC).
         """
-        member.size = ctx.probe_decompressed_size()
-        crc32 = ctx.probe_lzip_stored_crc32()
-        if crc32 is not None:
-            hashes = dict(member.hashes)
-            hashes[HashAlgorithm.CRC32] = crc32_digest(crc32)
-            member.hashes = hashes
+        summary = ctx.probe_lzip_index()
+        if summary is None:
+            return
+        member.size, crc32 = summary
+        hashes = dict(member.hashes)
+        hashes[HashAlgorithm.CRC32] = crc32_digest(crc32)
+        member.hashes = hashes
 
 
 def _alone_props_plausible(props: int) -> bool:

--- a/src/archivey/internal/streams/lzip.py
+++ b/src/archivey/internal/streams/lzip.py
@@ -26,6 +26,7 @@ from typing import BinaryIO
 
 from archivey.exceptions import CorruptionError, TruncatedError
 from archivey.internal.diagnostics_collector import DiagnosticCollector
+from archivey.internal.hashing import crc32_combine
 from archivey.internal.streams.decompressor_stream import (
     BaseDecoder,
     DecodeOut,
@@ -50,6 +51,7 @@ class _MemberBounds:
     decompressed_start: int
     compressed_size: int
     decompressed_size: int
+    crc32: int
 
     @property
     def decompressed_end(self) -> int:
@@ -65,9 +67,10 @@ def _read_index_backwards(
     """Build the member index by scanning trailers backwards (no decompression).
 
     A 4-byte magic check at each computed member start catches a corrupt ``member_size``
-    before it cascades into wrong offsets for every earlier member.
+    before it cascades into wrong offsets for every earlier member. Each entry retains the
+    trailer CRC-32 so callers can combine a whole-stream digest without decompressing.
     """
-    entries: list[tuple[int, int, int]] = []
+    entries: list[tuple[int, int, int, int]] = []
     compressed_end = file_size
 
     while compressed_end > stop_at:
@@ -77,7 +80,7 @@ def _read_index_backwards(
         trailer = stream.read(_TRAILER_SIZE)
         if len(trailer) < _TRAILER_SIZE:
             raise CorruptionError("Lzip file truncated during backward index scan")
-        _, data_size, member_size = struct.unpack_from("<IQQ", trailer, 0)
+        crc32, data_size, member_size = struct.unpack_from("<IQQ", trailer, 0)
         if member_size < _HEADER_SIZE + _TRAILER_SIZE:
             raise CorruptionError(
                 f"Lzip member_size {member_size} in trailer is too small to be valid"
@@ -94,17 +97,32 @@ def _read_index_backwards(
                 f"Lzip magic not found at expected member start {compressed_start} "
                 f"(got {magic!r}); member_size in trailer may be corrupt"
             )
-        entries.append((compressed_start, int(data_size), int(member_size)))
+        entries.append((compressed_start, int(data_size), int(member_size), int(crc32)))
         compressed_end = compressed_start
 
     result: list[_MemberBounds] = []
     decompressed_offset = start_decompressed_offset
-    for comp_start, decomp_size, comp_size in reversed(entries):
+    for comp_start, decomp_size, comp_size, crc32 in reversed(entries):
         result.append(
-            _MemberBounds(comp_start, decompressed_offset, comp_size, decomp_size)
+            _MemberBounds(
+                comp_start, decompressed_offset, comp_size, decomp_size, crc32
+            )
         )
         decompressed_offset += decomp_size
     return result
+
+
+def combined_crc32_from_index(members: list[_MemberBounds]) -> int:
+    """Whole-stream CRC-32 = ``crc32(concat(payloads))`` via trailer combine."""
+    crc = 0
+    for member in members:
+        crc = crc32_combine(crc, member.crc32, member.decompressed_size)
+    return crc
+
+
+def peek_combined_crc32(stream: BinaryIO, file_size: int) -> int:
+    """Scan the lzip index and return the combined whole-stream CRC-32."""
+    return combined_crc32_from_index(_read_index_backwards(stream, file_size))
 
 
 class _LzipState:

--- a/src/archivey/internal/streams/lzip.py
+++ b/src/archivey/internal/streams/lzip.py
@@ -120,9 +120,12 @@ def combined_crc32_from_index(members: list[_MemberBounds]) -> int:
     return crc
 
 
-def peek_combined_crc32(stream: BinaryIO, file_size: int) -> int:
-    """Scan the lzip index and return the combined whole-stream CRC-32."""
-    return combined_crc32_from_index(_read_index_backwards(stream, file_size))
+def peek_index_summary(stream: BinaryIO, file_size: int) -> tuple[int, int]:
+    """One backward index scan → ``(total_decompressed_size, combined_crc32)``."""
+    members = _read_index_backwards(stream, file_size)
+    if not members:
+        return 0, 0
+    return members[-1].decompressed_end, combined_crc32_from_index(members)
 
 
 class _LzipState:

--- a/src/archivey/internal/streams/verify.py
+++ b/src/archivey/internal/streams/verify.py
@@ -83,11 +83,28 @@ class _Crc32Hasher:
         return (self._value & 0xFFFFFFFF).to_bytes(self.digest_size, "big")
 
 
+class _Adler32Hasher:
+    """A ``hashlib``-shaped wrapper over ``zlib.adler32`` (RFC 1950 / standalone zlib)."""
+
+    digest_size = 4
+
+    def __init__(self) -> None:
+        self._value = 1  # zlib.adler32(b"")
+
+    def update(self, data: bytes, /) -> None:
+        self._value = zlib.adler32(data, self._value)
+
+    def digest(self) -> bytes:
+        return (self._value & 0xFFFFFFFF).to_bytes(self.digest_size, "big")
+
+
 def _make_hasher(algorithm: Any) -> Callable[[], _IncrementalHasher] | None:
     """Return a zero-arg factory for an incremental hasher, or ``None`` if unavailable."""
     name = _algo_key(algorithm)
     if name == "crc32":
         return _Crc32Hasher
+    if name == "adler32":
+        return _Adler32Hasher
     if name == "blake2sp":
         # RAR5 BLAKE2sp — not in hashlib; zero-dep tree hash on blake2s (see hashing/).
         return Blake2sp

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -561,10 +561,11 @@ def test_verify_matching_adler32_passes() -> None:
 
 
 def test_verify_adler32_mismatch_raises() -> None:
-    bad = (zlib.adler32(CONTENT) ^ 0xFFFF).to_bytes(4, "big")
+    bad = ((zlib.adler32(CONTENT) & 0xFFFFFFFF) ^ 0xFFFF).to_bytes(4, "big")
     stream = VerifyingStream(io.BytesIO(CONTENT), {HashAlgorithm.ADLER32: bad})
+    assert stream.read() == CONTENT  # data delivered first
     with pytest.raises(CorruptionError, match="adler32"):
-        stream.read()
+        stream.read()  # terminal empty read verifies
 
 
 def test_verify_multiple_algorithms() -> None:

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -554,6 +554,19 @@ def test_verify_matching_crc32_passes() -> None:
     assert stream.read() == b""  # terminal read verifies; no error
 
 
+def test_verify_matching_adler32_passes() -> None:
+    expected = (zlib.adler32(CONTENT) & 0xFFFFFFFF).to_bytes(4, "big")
+    stream = VerifyingStream(io.BytesIO(CONTENT), {HashAlgorithm.ADLER32: expected})
+    assert stream.read() == CONTENT
+
+
+def test_verify_adler32_mismatch_raises() -> None:
+    bad = (zlib.adler32(CONTENT) ^ 0xFFFF).to_bytes(4, "big")
+    stream = VerifyingStream(io.BytesIO(CONTENT), {HashAlgorithm.ADLER32: bad})
+    with pytest.raises(CorruptionError, match="adler32"):
+        stream.read()
+
+
 def test_verify_multiple_algorithms() -> None:
     expected = {
         HashAlgorithm.CRC32: _crc32(CONTENT),

--- a/tests/test_corpus_sweep.py
+++ b/tests/test_corpus_sweep.py
@@ -280,13 +280,11 @@ def _check_single_file(entry: CorpusEntry, key: str, source: Path) -> None:
             assert member.modified is not None
             assert int(member.modified.timestamp()) == payload.mtime
         # Stored-digest parity: single-member gzip always (path source); lzip only with
-        # declared SEEKABLE (same gate as size); zlib Adler-32 on seekable/path; others omit.
+        # declared SEEKABLE (same gate as size); other codecs omit (zlib Adler-32 is
+        # checked by the decompressor, not surfaced on member.hashes).
         if key in ("gz", "gz-meta"):
             assert HashAlgorithm.CRC32 in member.hashes
         elif key == "lz":
-            assert HashAlgorithm.CRC32 not in member.hashes
-        elif key == "zz":
-            assert HashAlgorithm.ADLER32 in member.hashes
             assert HashAlgorithm.CRC32 not in member.hashes
         else:
             assert HashAlgorithm.CRC32 not in member.hashes

--- a/tests/test_corpus_sweep.py
+++ b/tests/test_corpus_sweep.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import importlib.util
 import os
 import shutil
+import zlib
 from pathlib import Path
 
 import pytest
@@ -30,7 +31,7 @@ from archivey import (
     format_availability,
     open_archive,
 )
-from archivey.types import HashAlgorithm
+from archivey.types import HashAlgorithm, crc32_digest
 from tests.conftest import _has_zstd_backend
 from tests.sample_archives import (
     BUILDER_BINARIES,
@@ -292,4 +293,7 @@ def _check_single_file(entry: CorpusEntry, key: str, source: Path) -> None:
             assert HashAlgorithm.ADLER32 not in member.hashes
     if key == "lz":
         with open_archive(source, member_streams=MemberStreams.SEEKABLE) as ar:
-            assert HashAlgorithm.CRC32 in ar.members()[0].hashes
+            member = ar.members()[0]
+            assert member.hashes[HashAlgorithm.CRC32] == crc32_digest(
+                zlib.crc32(payload.contents)
+            )

--- a/tests/test_corpus_sweep.py
+++ b/tests/test_corpus_sweep.py
@@ -140,7 +140,11 @@ def _check_listing(ar, entry: CorpusEntry, key: str) -> None:
 def _assert_stored_digest_parity(member, key: str) -> None:
     """Assert documented stored-digest keys are present/absent (testing-contract)."""
     keys = set(member.hashes)
-    digest_keys = keys & {HashAlgorithm.CRC32, HashAlgorithm.BLAKE2SP}
+    digest_keys = keys & {
+        HashAlgorithm.CRC32,
+        HashAlgorithm.BLAKE2SP,
+        HashAlgorithm.ADLER32,
+    }
     if key == "zip":
         if member.type in (MemberType.FILE, MemberType.SYMLINK):
             # AE-2 (WinZip AES) stores CRC as 0 and relies on the HMAC — no crc32 digest.
@@ -276,14 +280,18 @@ def _check_single_file(entry: CorpusEntry, key: str, source: Path) -> None:
             assert member.modified is not None
             assert int(member.modified.timestamp()) == payload.mtime
         # Stored-digest parity: single-member gzip always (path source); lzip only with
-        # declared SEEKABLE (same gate as size); other codecs omit.
+        # declared SEEKABLE (same gate as size); zlib Adler-32 on seekable/path; others omit.
         if key in ("gz", "gz-meta"):
             assert HashAlgorithm.CRC32 in member.hashes
         elif key == "lz":
             assert HashAlgorithm.CRC32 not in member.hashes
+        elif key == "zz":
+            assert HashAlgorithm.ADLER32 in member.hashes
+            assert HashAlgorithm.CRC32 not in member.hashes
         else:
             assert HashAlgorithm.CRC32 not in member.hashes
             assert HashAlgorithm.BLAKE2SP not in member.hashes
+            assert HashAlgorithm.ADLER32 not in member.hashes
     if key == "lz":
         with open_archive(source, member_streams=MemberStreams.SEEKABLE) as ar:
             assert HashAlgorithm.CRC32 in ar.members()[0].hashes

--- a/tests/test_hash_combine.py
+++ b/tests/test_hash_combine.py
@@ -1,0 +1,47 @@
+"""Unit tests for pure-Python crc32/adler32 combine helpers."""
+
+from __future__ import annotations
+
+import zlib
+
+import pytest
+
+from archivey.internal.hashing import adler32_combine, crc32_combine
+
+_CASES = [
+    (b"", b""),
+    (b"a", b""),
+    (b"", b"a"),
+    (b"hello", b"world"),
+    (b"x" * 100, b"y" * 50),
+    (b"abc", b"def" * 1000),
+    (bytes(range(256)), b"\xff" * 17),
+]
+
+
+@pytest.mark.parametrize(("left", "right"), _CASES)
+def test_crc32_combine_matches_zlib(left: bytes, right: bytes) -> None:
+    c1 = zlib.crc32(left) & 0xFFFFFFFF
+    c2 = zlib.crc32(right) & 0xFFFFFFFF
+    assert crc32_combine(c1, c2, len(right)) == (zlib.crc32(left + right) & 0xFFFFFFFF)
+
+
+@pytest.mark.parametrize(("left", "right"), _CASES)
+def test_adler32_combine_matches_zlib(left: bytes, right: bytes) -> None:
+    a1 = zlib.adler32(left) & 0xFFFFFFFF
+    a2 = zlib.adler32(right) & 0xFFFFFFFF
+    assert adler32_combine(a1, a2, len(right)) == (
+        zlib.adler32(left + right) & 0xFFFFFFFF
+    )
+
+
+def test_multi_chunk_fold_matches_full_digest() -> None:
+    parts = [b"one", b"two", b"three" * 10, b"", b"tail"]
+    crc = 0
+    adler = 1  # zlib.adler32(b"")
+    for part in parts:
+        crc = crc32_combine(crc, zlib.crc32(part) & 0xFFFFFFFF, len(part))
+        adler = adler32_combine(adler, zlib.adler32(part) & 0xFFFFFFFF, len(part))
+    full = b"".join(parts)
+    assert crc == (zlib.crc32(full) & 0xFFFFFFFF)
+    assert adler == (zlib.adler32(full) & 0xFFFFFFFF)

--- a/tests/test_single_file.py
+++ b/tests/test_single_file.py
@@ -261,6 +261,7 @@ def test_gzip_metadata_omits_crc_without_gzip_magic() -> None:
         peek_trailer=lambda _n: b"\x11\x22\x33\x44\x55\x66\x77\x88",
         probe_decompressed_size=lambda: None,
         probe_gzip_stored_crc32=boom,
+        probe_lzip_stored_crc32=lambda: None,
     )
     GzipCodec().extract_metadata(ctx, member)
     assert HashAlgorithm.CRC32 not in member.hashes
@@ -286,18 +287,50 @@ def test_lzip_exposes_stored_crc32(tmp_path: Path) -> None:
         assert HashAlgorithm.CRC32 not in ar.members()[0].hashes
 
 
+def test_multi_member_lzip_exposes_combined_crc32(tmp_path: Path) -> None:
+    from tests.streams_util import make_multi_member_lzip
+
+    parts = [b"alpha-payload", b"beta" * 20, b"gamma"]
+    path = tmp_path / "multi.lz"
+    path.write_bytes(make_multi_member_lzip(parts))
+    full = b"".join(parts)
+    with open_archive(path, member_streams=MemberStreams.SEEKABLE) as ar:
+        member = ar.members()[0]
+        assert member.hashes[HashAlgorithm.CRC32] == crc32_digest(zlib.crc32(full))
+        assert ar.read(member) == full
+
+
+def test_zlib_exposes_stored_adler32(tmp_path: Path) -> None:
+    payload = b"zlib-adler-payload" * 5
+    path = tmp_path / "data.zz"
+    path.write_bytes(zlib.compress(payload))
+    expected = (zlib.adler32(payload) & 0xFFFFFFFF).to_bytes(4, "big")
+    with open_archive(path) as ar:
+        member = ar.members()[0]
+        assert member.hashes[HashAlgorithm.ADLER32] == expected
+        assert HashAlgorithm.CRC32 not in member.hashes
+
+
+def test_zlib_omits_adler32_on_nonseekable_source() -> None:
+    data = zlib.compress(b"pipe-zlib")
+    with open_archive(NonSeekableBytesIO(data), streaming=True) as ar:
+        report = ar.members_report_if_available()
+        assert report is not None
+        assert HashAlgorithm.ADLER32 not in report[0].hashes
+
+
 def test_other_single_file_codecs_omit_stored_crc32(tmp_path: Path) -> None:
     payload = b"no-whole-member-crc"
     cases = {
         "data.bz2": bz2.compress(payload),
         "data.xz": lzma.compress(payload),
-        "data.zz": zlib.compress(payload),
     }
     for name, blob in cases.items():
         path = tmp_path / name
         path.write_bytes(blob)
         with open_archive(path) as ar:
             assert HashAlgorithm.CRC32 not in ar.members()[0].hashes, name
+            assert HashAlgorithm.ADLER32 not in ar.members()[0].hashes, name
 
 
 def test_stored_gzip_crc32_does_not_change_read_or_verification(tmp_path: Path) -> None:

--- a/tests/test_single_file.py
+++ b/tests/test_single_file.py
@@ -300,30 +300,12 @@ def test_multi_member_lzip_exposes_combined_crc32(tmp_path: Path) -> None:
         assert ar.read(member) == full
 
 
-def test_zlib_exposes_stored_adler32(tmp_path: Path) -> None:
-    payload = b"zlib-adler-payload" * 5
-    path = tmp_path / "data.zz"
-    path.write_bytes(zlib.compress(payload))
-    expected = (zlib.adler32(payload) & 0xFFFFFFFF).to_bytes(4, "big")
-    with open_archive(path) as ar:
-        member = ar.members()[0]
-        assert member.hashes[HashAlgorithm.ADLER32] == expected
-        assert HashAlgorithm.CRC32 not in member.hashes
-
-
-def test_zlib_omits_adler32_on_nonseekable_source() -> None:
-    data = zlib.compress(b"pipe-zlib")
-    with open_archive(NonSeekableBytesIO(data), streaming=True) as ar:
-        report = ar.members_report_if_available()
-        assert report is not None
-        assert HashAlgorithm.ADLER32 not in report[0].hashes
-
-
 def test_other_single_file_codecs_omit_stored_crc32(tmp_path: Path) -> None:
     payload = b"no-whole-member-crc"
     cases = {
         "data.bz2": bz2.compress(payload),
         "data.xz": lzma.compress(payload),
+        "data.zz": zlib.compress(payload),
     }
     for name, blob in cases.items():
         path = tmp_path / name

--- a/tests/test_single_file.py
+++ b/tests/test_single_file.py
@@ -329,6 +329,20 @@ def test_other_single_file_codecs_omit_stored_digests(tmp_path: Path) -> None:
             assert HashAlgorithm.ADLER32 not in ar.members()[0].hashes, name
 
 
+def test_zlib_omits_hashes_but_verifies_adler_on_read(tmp_path: Path) -> None:
+    """Adler-32 is not on member.hashes, but a corrupt trailer still fails on read."""
+    path = tmp_path / "bad-adler.zz"
+    blob = bytearray(zlib.compress(b"zlib-adler-payload" * 5))
+    blob[-1] ^= 0xFF
+    path.write_bytes(blob)
+    with open_archive(path) as ar:
+        member = ar.members()[0]
+        assert HashAlgorithm.ADLER32 not in member.hashes
+        assert HashAlgorithm.CRC32 not in member.hashes
+        with pytest.raises(CorruptionError):
+            ar.read(member)
+
+
 def test_stored_gzip_crc32_does_not_change_read_or_verification(tmp_path: Path) -> None:
     payload = b"verify-unchanged"
     path = tmp_path / "ok.gz"

--- a/tests/test_single_file.py
+++ b/tests/test_single_file.py
@@ -261,7 +261,7 @@ def test_gzip_metadata_omits_crc_without_gzip_magic() -> None:
         peek_trailer=lambda _n: b"\x11\x22\x33\x44\x55\x66\x77\x88",
         probe_decompressed_size=lambda: None,
         probe_gzip_stored_crc32=boom,
-        probe_lzip_stored_crc32=lambda: None,
+        probe_lzip_index=lambda: None,
     )
     GzipCodec().extract_metadata(ctx, member)
     assert HashAlgorithm.CRC32 not in member.hashes
@@ -281,26 +281,40 @@ def test_lzip_exposes_stored_crc32(tmp_path: Path) -> None:
     path.write_bytes(make_lzip_member(payload))
     with open_archive(path, member_streams=MemberStreams.SEEKABLE) as ar:
         member = ar.members()[0]
+        assert member.size == len(payload)
         assert member.hashes[HashAlgorithm.CRC32] == crc32_digest(zlib.crc32(payload))
-    # Same gate as size: without declared SEEKABLE, omit the trailer CRC.
+    # Same gate as size: without declared SEEKABLE, omit size and trailer CRC.
     with open_archive(path) as ar:
-        assert HashAlgorithm.CRC32 not in ar.members()[0].hashes
+        member = ar.members()[0]
+        assert member.size is None
+        assert HashAlgorithm.CRC32 not in member.hashes
 
 
 def test_multi_member_lzip_exposes_combined_crc32(tmp_path: Path) -> None:
+    from unittest.mock import patch
+
+    import archivey.internal.streams.lzip as lzip_mod
     from tests.streams_util import make_multi_member_lzip
 
     parts = [b"alpha-payload", b"beta" * 20, b"gamma"]
     path = tmp_path / "multi.lz"
     path.write_bytes(make_multi_member_lzip(parts))
     full = b"".join(parts)
-    with open_archive(path, member_streams=MemberStreams.SEEKABLE) as ar:
-        member = ar.members()[0]
-        assert member.hashes[HashAlgorithm.CRC32] == crc32_digest(zlib.crc32(full))
-        assert ar.read(member) == full
+
+    with patch.object(
+        lzip_mod, "_read_index_backwards", wraps=lzip_mod._read_index_backwards
+    ) as scanned:
+        with open_archive(path, member_streams=MemberStreams.SEEKABLE) as ar:
+            member = ar.members()[0]
+            assert scanned.call_count == 1, (
+                "size + CRC must share one backward index scan"
+            )
+            assert member.size == len(full)
+            assert member.hashes[HashAlgorithm.CRC32] == crc32_digest(zlib.crc32(full))
+            assert ar.read(member) == full
 
 
-def test_other_single_file_codecs_omit_stored_crc32(tmp_path: Path) -> None:
+def test_other_single_file_codecs_omit_stored_digests(tmp_path: Path) -> None:
     payload = b"no-whole-member-crc"
     cases = {
         "data.bz2": bz2.compress(payload),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to review of #159 / review notes on this PR.

## Changes

- **Omit zlib Adler-32 from `member.hashes`** — RFC 1950 has no size fields, so a last-4 peek cannot honestly mean the whole synthetic member under concat/trailing junk. Adler-32 remains verified by the decompressor on read (`test_zlib_omits_hashes_but_verifies_adler_on_read`).
- **One lzip backward index scan** — `probe_lzip_index` / `peek_index_summary` return `(size, combined_crc32)` together.
- Multi-member lzip whole-member `CRC32` via `crc32_combine`; corpus SEEKABLE lzip asserts digest **value** equals payload CRC.
- Specs/docs updates; `adler32_combine` kept as intentional 3.11 companion (documented; no production caller yet).

## Test plan

- [x] `test_zlib_omits_hashes_but_verifies_adler_on_read` — corrupt trailer, no hash keys, `read()` → `CorruptionError`
- [x] Multi-member lzip: one index scan; size + CRC match concat payload
- [x] Corpus SEEKABLE `.lz` CRC value match
- [x] Targeted pytest green; `openspec validate --strict surface-stored-stream-digests`

Supersedes the zlib-surfacing part of #159.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-43b28dc3-d473-4410-8ac8-0d8d4da0a53f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-43b28dc3-d473-4410-8ac8-0d8d4da0a53f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

