### PR TITLE
fix(cli): unambiguous cli-product review findings

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -214,7 +214,8 @@ archivey photos.zip                 # same as: archivey list photos.zip
 archivey l photos.zip               # list (alias)
 archivey t photos.zip               # full-read integrity check
 archivey x photos.zip               # safe extract (alias for extract)
-archivey info photos.zip            # format / identity (alias: detect)
+archivey info photos.zip            # format / identity + access cost (alias: detect)
+archivey --version -v               # version + format availability for this install
 ```
 
 ### Safer extract demo

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -246,8 +246,9 @@ archivey extract photos.zip --policy trusted -d /tmp/out
 - Verbs are bare words (`x`, `list`); dash-prefixed forms like `-x` are not mode selectors.
 - A file whose name is a verb word (e.g. `./x`) is reached with an explicit verb:
   `archivey list ./x`.
-- Exit codes: `0` success, `1` operation failed, `2` usage error (argparse),
-  `3` extract completed with ≥1 safety-policy block and no member failure.
+- Exit codes: `0` success, `1` operation failed or extract aborted
+  (`--stop-on-error`), `2` usage error (argparse), `3` extract **completed**
+  with ≥1 safety-policy block and no member failure (safe members on disk).
   Codes `≥4` are reserved.
 - `--salvage`, stdin (`-`), and `hash` / `create` / `convert` are reserved for later.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -220,12 +220,18 @@ archivey info photos.zip            # format / identity (alias: detect)
 ### Safer extract demo
 
 ```bash
-# Default policy=strict, overwrite=rename. With no -d, a multi-entry archive lands in
-# ./photos/ instead of splattering the current directory (tarbomb-safe).
+# Default policy=strict, overwrite=rename, on_error=continue. With no -d, a
+# multi-entry archive lands in ./photos/ instead of splattering the current
+# directory (tarbomb-safe). Hostile/corrupt members are reported and skipped;
+# remaining members are still extracted. Exit 3 if only policy blocks; 1 if
+# any member failed.
 archivey extract photos.zip
 
 # Classic unzip-into-cwd (opt-in):
 archivey extract photos.zip -d .
+
+# All-or-nothing (library STOP semantics) for scripts that need it:
+archivey extract photos.zip --stop-on-error
 
 # Filters: positionals are includes; --exclude subtracts.
 archivey extract photos.zip -d out/ '*.py' --exclude '*_test.py'
@@ -237,8 +243,9 @@ archivey extract photos.zip --policy trusted -d /tmp/out
 - Verbs are bare words (`x`, `list`); dash-prefixed forms like `-x` are not mode selectors.
 - A file whose name is a verb word (e.g. `./x`) is reached with an explicit verb:
   `archivey list ./x`.
-- Exit codes: `0` success, `1` operation failed, `2` usage error (argparse). Codes `≥3`
-  are reserved.
+- Exit codes: `0` success, `1` operation failed, `2` usage error (argparse),
+  `3` extract completed with ≥1 safety-policy block and no member failure.
+  Codes `≥4` are reserved.
 - `--salvage`, stdin (`-`), and `hash` / `create` / `convert` are reserved for later.
 
 ## Next

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -233,7 +233,9 @@ archivey extract photos.zip -d .
 # All-or-nothing (library STOP semantics) for scripts that need it:
 archivey extract photos.zip --stop-on-error
 
-# Filters: positionals are includes; --exclude subtracts.
+# Filters: positionals are includes; --exclude subtracts. Unmatched includes
+# warn on stderr; extract/test exit 1 when nothing matched (list warns but
+# stays 0). A sole unmatched pattern that looks like a destination gets a -d hint.
 archivey extract photos.zip -d out/ '*.py' --exclude '*_test.py'
 archivey extract photos.zip --policy trusted -d /tmp/out
 ```

--- a/openspec/specs/cli/spec.md
+++ b/openspec/specs/cli/spec.md
@@ -84,7 +84,10 @@ Members with no stored digest SHALL count as OK when fully readable without
 error. `test` MUST NOT require emitting computed content hashes. By default
 `test` SHALL be quiet — printing only failures and a one-line summary
 (`N OK, M failed`) to stderr — and SHALL exit non-zero if any member fails;
-`-v` / `--verbose` SHALL add a per-member OK/FAIL line.
+`-v` / `--verbose` SHALL add a per-member OK/FAIL line. When a cheap member
+index is available and the stream ends before every selected file member has
+been counted OK or failed (archive-wide error or solid/poisoned abort), the
+summary SHALL append `, K not tested` where `K` is the untested remainder.
 
 `extract` SHALL use safe-extraction defaults and SHALL expose
 `--policy {strict,standard,trusted}` mapping to `ExtractionPolicy` (CLI default
@@ -241,6 +244,7 @@ than `2` as a failure and MUST NOT assume `1` is the only failure code.
 | `archivey list <corrupt-or-unreadable>` | Exit `1` |
 | `archivey list <archive-with-recoverable-prefix-and-terminal-error>` | Exit `1` (after printing recovered members) |
 | `archivey test <archive-with-failing-member>` | Exit `1` |
+| `archivey test <indexed-archive>` when the member stream aborts early | Summary includes `K not tested` for the untested remainder; exit `1` |
 | `archivey extract <archive-with-traversal-and-safe-members>` | Extracts safe members; prints `blocked:`; exit `3` |
 | `archivey extract <archive-with-corrupt-member>` | Extracts recoverable members; prints `failed:`; exit `1` |
 | `archivey extract --stop-on-error <archive-with-bad-member>` | Stops at first bad member; exit nonzero |

--- a/openspec/specs/cli/spec.md
+++ b/openspec/specs/cli/spec.md
@@ -228,10 +228,12 @@ member-to-stdout verb does not silently change the meaning of
 The system SHALL exit `0` on success and `2` on CLI usage errors (unknown
 verb/flag or bad arguments — the argparse default). Operational failures
 (unreadable, unsupported, or corrupt archive; read/integrity failure; member
-extraction `FAILED`; incomplete listing whose `MemberListReport.error` is set)
-SHALL exit `1`. When `extract` completes under continue-on-error with one or
-more members `BLOCKED` by safety policy and no member `FAILED`, the system
-SHALL exit `3` (refused by safety policy). Exit codes `≥4` SHALL remain
+extraction `FAILED`; incomplete listing whose `MemberListReport.error` is set;
+an early abort under `--stop-on-error`, including a policy block that stops the
+run) SHALL exit `1`. When `extract` **completes** under continue-on-error with
+one or more members `BLOCKED` by safety policy and no member `FAILED`, the
+system SHALL exit `3` (refused by safety policy — safe members are on disk).
+Exit `3` MUST NOT be used for an aborted STOP run. Exit codes `≥4` SHALL remain
 reserved. Documentation SHALL direct callers to treat any nonzero code other
 than `2` as a failure and MUST NOT assume `1` is the only failure code.
 
@@ -247,7 +249,7 @@ than `2` as a failure and MUST NOT assume `1` is the only failure code.
 | `archivey test <indexed-archive>` when the member stream aborts early | Summary includes `K not tested` for the untested remainder; exit `1` |
 | `archivey extract <archive-with-traversal-and-safe-members>` | Extracts safe members; prints `blocked:`; exit `3` |
 | `archivey extract <archive-with-corrupt-member>` | Extracts recoverable members; prints `failed:`; exit `1` |
-| `archivey extract --stop-on-error <archive-with-bad-member>` | Stops at first bad member; exit nonzero |
+| `archivey extract --stop-on-error <archive-with-bad-member>` | Stops at first bad member; exit `1` |
 
 ### Requirement: stdin archives are reserved, not supported in v1
 

--- a/openspec/specs/cli/spec.md
+++ b/openspec/specs/cli/spec.md
@@ -109,6 +109,12 @@ containing `src/`) SHALL be flattened in place, not treated as a collision.
 Container-name collisions SHALL be resolved by the overwrite policy.
 Overwrite SHALL default to `rename` once `OverwritePolicy.RENAME` exists
 (`--overwrite` may select `error` / `skip` / `replace` / `rename`).
+`extract` SHALL pass `OnError.CONTINUE` by default so policy rejections and
+per-member read failures are recorded (`blocked:` / `failed:` lines plus the
+closing summary) and remaining members are still extracted where the stream
+allows. `--stop-on-error` SHALL restore `OnError.STOP` for that invocation.
+On an early stop (STOP path or always-stop limit), the system SHALL still
+report how many members were written before the stop.
 
 #### Scenario: CLI behavior matrix
 
@@ -131,6 +137,8 @@ Overwrite SHALL default to `rename` once `OverwritePolicy.RENAME` exists
 | `archivey extract <archive> -d out/ '*.py'` | Dest is `out/` verbatim; `*.py` is a member filter |
 | `archivey extract <archive> -d .` | Extracts into cwd verbatim (classic splatter, opt-in) |
 | `archivey extract <archive> --policy trusted` | Maps to `ExtractionPolicy.TRUSTED` |
+| `archivey extract <archive-with-traversal-and-safe-members>` | Safe members extracted; `blocked:` lines; exit `3` |
+| `archivey extract --stop-on-error <archive-with-bad-member>` | Stops at first failure; reports members written before stop |
 | Subcommand includes fnmatch pattern(s) after the archive | Operation limited to matching member names (positional = include) |
 | `archivey extract <archive> '*.py' --exclude '*_test.py'` | Includes `*.py` minus `*_test.py`; exclude wins over include |
 | `archivey <verb> <archive> --include …` | Usage error — `--include` is not provided (use a positional) |
@@ -183,14 +191,16 @@ member-to-stdout verb does not silently change the meaning of
 | `t` | Means `test` (integrity), not create |
 | Unknown verb `hash` / `create` / `convert` / `cat` before implementation | Usage error naming the verb as unavailable (not a silent fallthrough to `list`) |
 
-### Requirement: exit codes are minimal and argparse-aligned
+### Requirement: exit codes are argparse-aligned with a policy-refusal code
 
 The system SHALL exit `0` on success and `2` on CLI usage errors (unknown
-verb/flag or bad arguments — the argparse default). All operational failures
-(unreadable, unsupported, or corrupt archive; read/integrity failure; extraction
-error; incomplete listing whose `MemberListReport.error` is set) SHALL exit `1`
-in this capability. Exit codes `≥3` SHALL be reserved and MUST NOT be emitted in
-this change; documentation SHALL direct callers to treat any nonzero code other
+verb/flag or bad arguments — the argparse default). Operational failures
+(unreadable, unsupported, or corrupt archive; read/integrity failure; member
+extraction `FAILED`; incomplete listing whose `MemberListReport.error` is set)
+SHALL exit `1`. When `extract` completes under continue-on-error with one or
+more members `BLOCKED` by safety policy and no member `FAILED`, the system
+SHALL exit `3` (refused by safety policy). Exit codes `≥4` SHALL remain
+reserved. Documentation SHALL direct callers to treat any nonzero code other
 than `2` as a failure and MUST NOT assume `1` is the only failure code.
 
 #### Scenario: exit codes
@@ -202,6 +212,9 @@ than `2` as a failure and MUST NOT assume `1` is the only failure code.
 | `archivey list <corrupt-or-unreadable>` | Exit `1` |
 | `archivey list <archive-with-recoverable-prefix-and-terminal-error>` | Exit `1` (after printing recovered members) |
 | `archivey test <archive-with-failing-member>` | Exit `1` |
+| `archivey extract <archive-with-traversal-and-safe-members>` | Extracts safe members; prints `blocked:`; exit `3` |
+| `archivey extract <archive-with-corrupt-member>` | Extracts recoverable members; prints `failed:`; exit `1` |
+| `archivey extract --stop-on-error <archive-with-bad-member>` | Stops at first bad member; exit nonzero |
 
 ### Requirement: stdin archives are reserved, not supported in v1
 

--- a/openspec/specs/cli/spec.md
+++ b/openspec/specs/cli/spec.md
@@ -161,15 +161,34 @@ report how many members were written before the stop.
 The system SHALL provide `archivey info` (alias `detect`) that reports detected
 and/or opened format identity for a path without listing every member. It SHALL
 be suitable for answering "what does archivey think this file is?" including
-failure cases with a typed/clear error.
+failure cases with a typed/clear error. After a successful open, `info` SHALL
+print an `access:` line summarizing the archive's `CostReceipt` (listing /
+member-access / stream axes) in human prose. With `-v` / `--verbose`, it SHALL
+also print the raw cost axes (`listing`, `access_cost`, `stream`,
+`solid_blocks`).
 
 #### Scenario: info vs list
 
 | Case | Expected |
 | --- | --- |
-| `archivey info <archive>` / `archivey detect <archive>` | Prints format/identity summary; does not dump full member listing |
+| `archivey info <archive>` / `archivey detect <archive>` | Prints format/identity summary including `access:`; does not dump full member listing |
+| `archivey info -v <indexed-zip>` | Includes `access: random (indexed)` and raw cost axes |
 | Unreadable/unknown file | Non-zero exit; clear error (no stack trace by default) |
 | `archivey list <archive>` | Member listing; not a substitute for info's format summary |
+
+### Requirement: version reports package identity and optional format matrix
+
+`--version` SHALL print `archivey <version>` and exit. With `-v` / `--verbose`,
+it SHALL also print a `formats:` matrix from the registry availability API
+(`list_known_formats` / `format_availability`), including missing-component
+install hints when support is not full.
+
+#### Scenario: version
+
+| Case | Expected |
+| --- | --- |
+| `archivey --version` | One line: `archivey <version>`; exit `0` |
+| `archivey --version -v` / `archivey -v --version` | Version line plus `formats:` availability matrix |
 
 ### Requirement: salvage flag reserved without behavior
 

--- a/openspec/specs/cli/spec.md
+++ b/openspec/specs/cli/spec.md
@@ -48,11 +48,18 @@ selected when it matches any positional, or when no positional is given).
 `--exclude PATTERN` (repeatable, long-form only — no short flag) SHALL remove
 matching members; a member SHALL be processed when it matches an include (or none
 is given) AND matches no `--exclude`. The system SHALL NOT provide a redundant
-`--include` flag. Each invocation SHALL accept exactly **one** archive positional
-(multi-archive is out of scope for this capability). `--password` SHALL be
-accepted for encrypted archives; when an encrypted archive is opened, no
-`--password` was supplied, and stdin is a TTY, the system SHALL prompt for the
-password without echoing it.
+`--include` flag. When one or more include patterns are given, each pattern that
+matches no member SHALL produce a stderr warning
+(`warning: pattern matched no members: '…'`). When every include misses on
+`extract` or `test`, the command SHALL exit `1` after the warning(s). On `list`,
+the same warnings SHALL be emitted but the exit code SHALL remain `0` when the
+archive otherwise listed successfully. On `extract`, when there is exactly one
+unmatched include that names an existing directory or ends with `/`, the warning
+SHALL include a hint `(did you mean -d PATTERN?)`. Each invocation SHALL accept
+exactly **one** archive positional (multi-archive is out of scope for this
+capability). `--password` SHALL be accepted for encrypted archives; when an
+encrypted archive is opened, no `--password` was supplied, and stdin is a TTY,
+the system SHALL prompt for the password without echoing it.
 
 Command data output (member listings, info summaries) SHALL be written to
 **stdout**; progress bars, human summaries, prompts, and diagnostics SHALL be
@@ -140,6 +147,9 @@ report how many members were written before the stop.
 | `archivey extract <archive-with-traversal-and-safe-members>` | Safe members extracted; `blocked:` lines; exit `3` |
 | `archivey extract --stop-on-error <archive-with-bad-member>` | Stops at first failure; reports members written before stop |
 | Subcommand includes fnmatch pattern(s) after the archive | Operation limited to matching member names (positional = include) |
+| `archivey extract <archive> out` where `out/` exists and matches no member | stderr warning with `(did you mean -d out?)`; exit `1` |
+| `archivey extract <archive> '*.missing'` | stderr warning; exit `1` |
+| `archivey list <archive> '*.missing'` | stderr warning; exit `0` |
 | `archivey extract <archive> '*.py' --exclude '*_test.py'` | Includes `*.py` minus `*_test.py`; exclude wins over include |
 | `archivey <verb> <archive> --include …` | Usage error — `--include` is not provided (use a positional) |
 | `[cli]` extra absent / `tqdm` missing | Progress suppressed; command and library API remain functional |

--- a/review/README.md
+++ b/review/README.md
@@ -23,7 +23,7 @@ recorded (see `backlog.md` / `IDEAS.md`). Remaining:
 
 | Dir | Review | Status (2026-07-19) |
 |-----|--------|---------------------|
-| `cli-product/` | The CLI as a **product** — UX, grammar, exit codes, output (not code correctness; #131 did that) | Findings in (#144); **no fixes yet** — Q1–Q7 open; D1 folded from api-coherence |
+| `cli-product/` | The CLI as a **product** — UX, grammar, exit codes, output (not code correctness; #131 did that) | Findings in (#144); **P3/P5–P7/P9–P13/D1 done**; Q1–Q6 / P1/P2/P4/P8/P14 still open |
 | `performance/` | The ≤1.3× stdlib perf budget — benchmark-gate efficacy + the real traps | Listing L0–L3 + peers (#143/#146/#148); residual band miss; **Q2/Q4** still open |
 
 **Live triage:** [`STATUS.md`](STATUS.md).

--- a/review/STATUS.md
+++ b/review/STATUS.md
@@ -10,7 +10,7 @@ a finding is fixed or a question is decided.
 | Review | Findings delivered? | Code/docs follow-ups | Ready to archive? |
 |--------|---------------------|----------------------|-------------------|
 | `performance/` | yes (#134 + follow-ups) | P3–P5 done; listing L0–L3 + peers (#143/#146/#148); residual band miss; **Q2/Q4 open** | no |
-| `cli-product/` | yes (#144) | **P1–P3/P5–P7/P9–P14/D1 done** (Q1–Q3/Q5–Q6 decided; P4 deferred); **P8** polish remains | no |
+| `cli-product/` | yes (#144) | **P1–P3/P5–P14/D1 done** (Q1–Q3/Q5–Q6 decided; P4 deferred) | yes (after merge) |
 
 Archived this pass: `archive/2026-07-19-api-coherence/`,
 `archive/2026-07-19-stream-layering/`.
@@ -33,8 +33,10 @@ Archived this pass: `archive/2026-07-19-api-coherence/`,
 | **P2** | No-match include warnings + extract/test exit 1 + `-d` hint (Q3). | **done** |
 | **P4** | `--json` for scripting audience. | **deferred** (Q2) — wait for `hash` / member schema |
 | **P14** | `info` access/cost line + `--version -v` capability matrix (Q5/Q6). | **done** |
+| **P8** | `test` summary reports `K not tested` when an indexed stream aborts early. | **done** |
 
-Still waiting: **P8** polish remains.
+cli-product code/docs follow-ups from #144 are complete for this pass (**P4**
+deferred by Q2).
 
 ### From `performance/`
 

--- a/review/STATUS.md
+++ b/review/STATUS.md
@@ -10,7 +10,7 @@ a finding is fixed or a question is decided.
 | Review | Findings delivered? | Code/docs follow-ups | Ready to archive? |
 |--------|---------------------|----------------------|-------------------|
 | `performance/` | yes (#134 + follow-ups) | P3–P5 done; listing L0–L3 + peers (#143/#146/#148); residual band miss; **Q2/Q4 open** | no |
-| `cli-product/` | yes (#144) | **P1/P3/P5–P7/P9–P13/D1 done** (Q1 decided); still open: P2/P4/P8/P14 + Q2–Q6 | no |
+| `cli-product/` | yes (#144) | **P1–P3/P5–P7/P9–P13/D1 done** (Q1/Q3 decided); still open: P4/P8/P14 + Q2/Q5–Q6 | no |
 
 Archived this pass: `archive/2026-07-19-api-coherence/`,
 `archive/2026-07-19-stream-layering/`.
@@ -30,8 +30,9 @@ Archived this pass: `archive/2026-07-19-api-coherence/`,
 | **P10–P13** | Help examples; hoist micro-copy; argparse `patterns` wording; reserved-flag asymmetry. | **done** |
 | **D1** | List marks for `ANTI` / non-current (from archived api-coherence). | **done** |
 | **P1** | Extract CONTINUE + `--stop-on-error` + exit 3 (Q1). | **done** |
+| **P2** | No-match include warnings + extract/test exit 1 + `-d` hint (Q3). | **done** |
 
-Still waiting on Q2–Q3 / Q5–Q6: **P2**, **P4**, **P14**. **P8** polish remains.
+Still waiting on Q2 / Q5–Q6: **P4**, **P14**. **P8** polish remains.
 
 ### From `performance/`
 
@@ -51,7 +52,7 @@ Still waiting on Q2–Q3 / Q5–Q6: **P2**, **P4**, **P14**. **P8** polish remai
 |---|---------|--------|
 | **Q1** | **P1** extract abort-on-first-error | **decided** — CONTINUE (+ `--stop-on-error`); exit 3 for policy-only blocks |
 | **Q2** | **P4** `--json` timing | open |
-| **Q3** | **P2** no-match filters exit code | open |
+| **Q3** | **P2** no-match filters exit code | **decided** — warn; extract/test exit 1; list exit 0; `-d` hint |
 | **Q4** | **P3** control-byte quoting style | lean applied (escape everywhere / backslash); `--raw`/TTY-only still open |
 | **Q5 / Q6** | **P14** `info` cost line / install capability view | open |
 | **Q7** | P7/P9 library vs CLI ownership | **done** (library) |

--- a/review/STATUS.md
+++ b/review/STATUS.md
@@ -60,7 +60,7 @@ deferred by Q2).
 | **Q4** | **P3** control-byte quoting style | lean applied (escape everywhere / backslash); `--raw`/TTY-only still open |
 | **Q5 / Q6** | **P14** `info` cost line / install capability view | **decided** — `info` prints `access:` from `CostReceipt`; `--version -v` format matrix |
 | **Q7** | P7/P9 library vs CLI ownership | **done** (library) |
-| **Q8** | STOP+policy exit `3` vs `1` | **open** — see `cli-product/QUESTIONS.md` Q8 table |
+| **Q8** | STOP+policy exit `3` vs `1` | **decided** — Option A: STOP always `1`; `3` only for completed CONTINUE + policy blocks |
 
 ### `performance/QUESTIONS.md`
 

--- a/review/STATUS.md
+++ b/review/STATUS.md
@@ -60,6 +60,7 @@ deferred by Q2).
 | **Q4** | **P3** control-byte quoting style | lean applied (escape everywhere / backslash); `--raw`/TTY-only still open |
 | **Q5 / Q6** | **P14** `info` cost line / install capability view | **decided** — `info` prints `access:` from `CostReceipt`; `--version -v` format matrix |
 | **Q7** | P7/P9 library vs CLI ownership | **done** (library) |
+| **Q8** | STOP+policy exit `3` vs `1` | **open** — see `cli-product/QUESTIONS.md` Q8 table |
 
 ### `performance/QUESTIONS.md`
 

--- a/review/STATUS.md
+++ b/review/STATUS.md
@@ -10,7 +10,7 @@ a finding is fixed or a question is decided.
 | Review | Findings delivered? | Code/docs follow-ups | Ready to archive? |
 |--------|---------------------|----------------------|-------------------|
 | `performance/` | yes (#134 + follow-ups) | P3–P5 done; listing L0–L3 + peers (#143/#146/#148); residual band miss; **Q2/Q4 open** | no |
-| `cli-product/` | yes (#144) | **P3/P5–P7/P9–P13/D1 done**; still open: P1/P2/P4/P8/P14 + Q1–Q6 | no |
+| `cli-product/` | yes (#144) | **P1/P3/P5–P7/P9–P13/D1 done** (Q1 decided); still open: P2/P4/P8/P14 + Q2–Q6 | no |
 
 Archived this pass: `archive/2026-07-19-api-coherence/`,
 `archive/2026-07-19-stream-layering/`.
@@ -29,8 +29,9 @@ Archived this pass: `archive/2026-07-19-api-coherence/`,
 | **P7 / P9** | Library/CLI message cleanup (truncated-zip prose, enum leaks, zipcrypto no-password; rapidgzip AUTO-gate warning text). | **done** |
 | **P10–P13** | Help examples; hoist micro-copy; argparse `patterns` wording; reserved-flag asymmetry. | **done** |
 | **D1** | List marks for `ANTI` / non-current (from archived api-coherence). | **done** |
+| **P1** | Extract CONTINUE + `--stop-on-error` + exit 3 (Q1). | **done** |
 
-Still waiting on Q1–Q3 / Q5–Q6: **P1**, **P2**, **P4**, **P14**. **P8** polish remains.
+Still waiting on Q2–Q3 / Q5–Q6: **P2**, **P4**, **P14**. **P8** polish remains.
 
 ### From `performance/`
 
@@ -44,16 +45,16 @@ Still waiting on Q1–Q3 / Q5–Q6: **P1**, **P2**, **P4**, **P14**. **P8** poli
 
 ## 2. Still needs decisions
 
-### `cli-product/QUESTIONS.md` (all open)
+### `cli-product/QUESTIONS.md`
 
-| Q | Finding |
-|---|---------|
-| **Q1** | **P1** extract abort-on-first-error (continue vs STOP; exit codes) |
-| **Q2** | **P4** `--json` timing |
-| **Q3** | **P2** no-match filters exit code |
-| **Q4** | **P3** control-byte quoting style |
-| **Q5 / Q6** | **P14** `info` cost line / install capability view |
-| **Q7** | P7/P9 library vs CLI ownership |
+| Q | Finding | Status |
+|---|---------|--------|
+| **Q1** | **P1** extract abort-on-first-error | **decided** — CONTINUE (+ `--stop-on-error`); exit 3 for policy-only blocks |
+| **Q2** | **P4** `--json` timing | open |
+| **Q3** | **P2** no-match filters exit code | open |
+| **Q4** | **P3** control-byte quoting style | lean applied (escape everywhere / backslash); `--raw`/TTY-only still open |
+| **Q5 / Q6** | **P14** `info` cost line / install capability view | open |
+| **Q7** | P7/P9 library vs CLI ownership | **done** (library) |
 
 ### `performance/QUESTIONS.md`
 

--- a/review/STATUS.md
+++ b/review/STATUS.md
@@ -10,7 +10,7 @@ a finding is fixed or a question is decided.
 | Review | Findings delivered? | Code/docs follow-ups | Ready to archive? |
 |--------|---------------------|----------------------|-------------------|
 | `performance/` | yes (#134 + follow-ups) | P3–P5 done; listing L0–L3 + peers (#143/#146/#148); residual band miss; **Q2/Q4 open** | no |
-| `cli-product/` | yes (#144) | **P1–P3/P5–P7/P9–P13/D1 done** (Q1/Q3 decided); still open: P4/P8/P14 + Q2/Q5–Q6 | no |
+| `cli-product/` | yes (#144) | **P1–P3/P5–P7/P9–P13/D1 done** (Q1–Q3 decided; P4 deferred); still open: P8/P14 + Q5–Q6 | no |
 
 Archived this pass: `archive/2026-07-19-api-coherence/`,
 `archive/2026-07-19-stream-layering/`.
@@ -31,8 +31,9 @@ Archived this pass: `archive/2026-07-19-api-coherence/`,
 | **D1** | List marks for `ANTI` / non-current (from archived api-coherence). | **done** |
 | **P1** | Extract CONTINUE + `--stop-on-error` + exit 3 (Q1). | **done** |
 | **P2** | No-match include warnings + extract/test exit 1 + `-d` hint (Q3). | **done** |
+| **P4** | `--json` for scripting audience. | **deferred** (Q2) — wait for `hash` / member schema |
 
-Still waiting on Q2 / Q5–Q6: **P4**, **P14**. **P8** polish remains.
+Still waiting on Q5–Q6: **P14**. **P8** polish remains.
 
 ### From `performance/`
 
@@ -51,7 +52,7 @@ Still waiting on Q2 / Q5–Q6: **P4**, **P14**. **P8** polish remains.
 | Q | Finding | Status |
 |---|---------|--------|
 | **Q1** | **P1** extract abort-on-first-error | **decided** — CONTINUE (+ `--stop-on-error`); exit 3 for policy-only blocks |
-| **Q2** | **P4** `--json` timing | open |
+| **Q2** | **P4** `--json` timing | **decided** — wait for `hash` / member schema (no minimal JSON in 0.2.0) |
 | **Q3** | **P2** no-match filters exit code | **decided** — warn; extract/test exit 1; list exit 0; `-d` hint |
 | **Q4** | **P3** control-byte quoting style | lean applied (escape everywhere / backslash); `--raw`/TTY-only still open |
 | **Q5 / Q6** | **P14** `info` cost line / install capability view | open |

--- a/review/STATUS.md
+++ b/review/STATUS.md
@@ -10,7 +10,7 @@ a finding is fixed or a question is decided.
 | Review | Findings delivered? | Code/docs follow-ups | Ready to archive? |
 |--------|---------------------|----------------------|-------------------|
 | `performance/` | yes (#134 + follow-ups) | P3–P5 done; listing L0–L3 + peers (#143/#146/#148); residual band miss; **Q2/Q4 open** | no |
-| `cli-product/` | yes (#144) | **P1–P3/P5–P7/P9–P13/D1 done** (Q1–Q3 decided; P4 deferred); still open: P8/P14 + Q5–Q6 | no |
+| `cli-product/` | yes (#144) | **P1–P3/P5–P7/P9–P14/D1 done** (Q1–Q3/Q5–Q6 decided; P4 deferred); **P8** polish remains | no |
 
 Archived this pass: `archive/2026-07-19-api-coherence/`,
 `archive/2026-07-19-stream-layering/`.
@@ -32,8 +32,9 @@ Archived this pass: `archive/2026-07-19-api-coherence/`,
 | **P1** | Extract CONTINUE + `--stop-on-error` + exit 3 (Q1). | **done** |
 | **P2** | No-match include warnings + extract/test exit 1 + `-d` hint (Q3). | **done** |
 | **P4** | `--json` for scripting audience. | **deferred** (Q2) — wait for `hash` / member schema |
+| **P14** | `info` access/cost line + `--version -v` capability matrix (Q5/Q6). | **done** |
 
-Still waiting on Q5–Q6: **P14**. **P8** polish remains.
+Still waiting: **P8** polish remains.
 
 ### From `performance/`
 
@@ -55,7 +56,7 @@ Still waiting on Q5–Q6: **P14**. **P8** polish remains.
 | **Q2** | **P4** `--json` timing | **decided** — wait for `hash` / member schema (no minimal JSON in 0.2.0) |
 | **Q3** | **P2** no-match filters exit code | **decided** — warn; extract/test exit 1; list exit 0; `-d` hint |
 | **Q4** | **P3** control-byte quoting style | lean applied (escape everywhere / backslash); `--raw`/TTY-only still open |
-| **Q5 / Q6** | **P14** `info` cost line / install capability view | open |
+| **Q5 / Q6** | **P14** `info` cost line / install capability view | **decided** — `info` prints `access:` from `CostReceipt`; `--version -v` format matrix |
 | **Q7** | P7/P9 library vs CLI ownership | **done** (library) |
 
 ### `performance/QUESTIONS.md`

--- a/review/STATUS.md
+++ b/review/STATUS.md
@@ -10,7 +10,7 @@ a finding is fixed or a question is decided.
 | Review | Findings delivered? | Code/docs follow-ups | Ready to archive? |
 |--------|---------------------|----------------------|-------------------|
 | `performance/` | yes (#134 + follow-ups) | P3–P5 done; listing L0–L3 + peers (#143/#146/#148); residual band miss; **Q2/Q4 open** | no |
-| `cli-product/` | yes (#144) | **none yet** — P1–P14 + Q1–Q7 open; D1 folded in from api-coherence | no |
+| `cli-product/` | yes (#144) | **P3/P5–P7/P9–P13/D1 done**; still open: P1/P2/P4/P8/P14 + Q1–Q6 | no |
 
 Archived this pass: `archive/2026-07-19-api-coherence/`,
 `archive/2026-07-19-stream-layering/`.
@@ -19,18 +19,18 @@ Archived this pass: `archive/2026-07-19-api-coherence/`,
 
 ## 1. Actionable right now
 
-### From `cli-product/` (findings in #144 — no code yet)
+### From `cli-product/` (findings in #144)
 
-Small / unambiguous items that don't wait on Q1–Q3:
+| ID | Action | Status |
+|----|--------|--------|
+| **P5** | Ctrl-D at password prompt → catch `EOFError`. | **done** |
+| **P3** | Escape control bytes in member names (backslash style; Q4 style still open for `--raw`/TTY-only). | **done** (recommended style) |
+| **P6 (message)** | Prose instead of raw errno for missing file / bad path. | **done** |
+| **P7 / P9** | Library/CLI message cleanup (truncated-zip prose, enum leaks, zipcrypto no-password; rapidgzip AUTO-gate warning text). | **done** |
+| **P10–P13** | Help examples; hoist micro-copy; argparse `patterns` wording; reserved-flag asymmetry. | **done** |
+| **D1** | List marks for `ANTI` / non-current (from archived api-coherence). | **done** |
 
-| ID | Action |
-|----|--------|
-| **P5** | Ctrl-D at password prompt → catch `EOFError`. |
-| **P3** | Escape control bytes in member names (style still Q4). |
-| **P6 (message)** | Prose instead of raw errno for missing file / bad path. |
-| **P7 / P9** | Library/CLI message cleanup (truncated-zip prose, enum leaks, zipcrypto no-password; rapidgzip AUTO-gate warning text). |
-| **P10–P13** | Help examples; hoist micro-copy; argparse `patterns` wording; reserved-flag asymmetry. |
-| **D1** | List marks for `ANTI` / non-current (from archived api-coherence). |
+Still waiting on Q1–Q3 / Q5–Q6: **P1**, **P2**, **P4**, **P14**. **P8** polish remains.
 
 ### From `performance/`
 

--- a/review/cli-product/QUESTIONS.md
+++ b/review/cli-product/QUESTIONS.md
@@ -84,6 +84,11 @@ messages ("install the 'crypto' extra") are excellent but reactive. Options:
 formats`/`doctor`. Any preference, or defer entirely? (Cheap and high-demo
 value: the maintainer's own "why can't I open this" debugging tool.)
 
+**Lean (2026-07-19):** prefer **`--version -v`** (or equivalent verbose
+version). Bare `archivey info` (no archive) feels unintuitive. Still open:
+ship in this pass vs defer; exact matrix shape (formats via
+`format_availability` / extras / both).
+
 ## Q7 — Two library-side message fixes surfaced here (P7, P9) — confirm owners
 
 **Done (library-owned, as recommended):** truncated/corrupt zip prose (no

--- a/review/cli-product/QUESTIONS.md
+++ b/review/cli-product/QUESTIONS.md
@@ -27,20 +27,15 @@ only fire under CONTINUE.
 
 ## Q2 — `--json` timing and minimal schema (drives P4)
 
-Design (Open Question 7) deferred `--json` pending a stable member schema —
-correctly, for the *full* `ArchiveMember` model. But the CLI needs only the
-fields it already prints: name, type, size, mtime, mode, encrypted,
-link_target, hashes. Options:
+**Decided (2026-07-19):** option **3** — wait for the `hash` verb / a designed
+member schema. Do **not** ship a minimal `--json` in 0.2.0 or as a quick
+0.2.x follow-up. Scripting remains human-column only until that design lands;
+prefer designing the stable contract once over an additive-but-provisional
+JSON-lines surface. Flag name when it lands: **`--json`** (not `--porcelain`).
 
-1. Ship minimal `--json` (JSON-lines) on `list` + `info` in 0.2.0 with an
-   additive-only promise on those fields.
-2. First 0.2.x follow-up (recommended if 0.2.0 is time-boxed — but then say
-   so in docs so the scripting audience knows it's coming and doesn't
-   scrape).
-3. Wait for the `hash` verb / full schema work.
-
-Recommend 1 if any slack exists, else 2. Naming: `--json` (tool-standard) vs
-`--porcelain` (git-ism) — recommend `--json`.
+Context (options considered): (1) minimal JSON-lines on `list`/`info` in
+0.2.0; (2) first 0.2.x with a "coming" note in docs; (3) wait for full schema.
+Rationale: lower priority than Q1/Q3 product traps; worth designing right.
 
 ## Q3 — No-match filters: warning + which exit code? (drives P2)
 
@@ -65,8 +60,9 @@ naturally safe)? Recommend: escape everywhere, backslash style, no `--raw`
 until someone asks — scripts get exact names via `--json` (Q2).
 
 **Partial lean (P3 landed):** escape everywhere, backslash style, no `--raw`
-yet — matching the recommendation. Q4 remains open only if we later want
-TTY-only or a `--raw` hatch.
+yet — matching the recommendation. With Q2 deferred (no `--json` until
+`hash`/schema), Q4 remains open only if we later want TTY-only or a `--raw`
+hatch for scripts that need exact names before machine output exists.
 
 ## Q5 — Should `info` tell the cost/access story? (drives P14)
 

--- a/review/cli-product/QUESTIONS.md
+++ b/review/cli-product/QUESTIONS.md
@@ -12,7 +12,7 @@ reopened.
 |---|----------|
 | 1 Semantics | Record-and-continue for **policy rejections and per-member read failures** (digest/decode), continuing where the stream allows — same shape as `test` / VISION #3. |
 | 2 Mechanism | CLI passes `OnError.CONTINUE` by default; **library default stays `STOP`**. |
-| 3 Exit code | **`3`** when the run completed with ≥1 policy `BLOCKED` and no `FAILED`; **`1`** when any member `FAILED` (or hoist/always-stop); **`0`** when clean. |
+| 3 Exit code | **`3`** when CONTINUE **completed** with ≥1 policy `BLOCKED` and no `FAILED`; **`1`** for any `FAILED`, hoist/always-stop, or **any `--stop-on-error` abort** (incl. policy) — refined in **Q8**. |
 | 4 Flag | **`--stop-on-error` now** — restores library `STOP` for that invocation (shell scripts cannot switch to the library API). |
 | 5 Stop-path reporting | Always report what was written before an early stop (count at minimum). |
 
@@ -89,28 +89,22 @@ distinguishes install-vs-not-engaged when it does fire.
 
 ## Q8 — `--stop-on-error` + policy block: exit `3` or `1`? (PR #163 review)
 
-**Open.** Q1 decided exit `3` when extract *completed* under CONTINUE with
-≥1 `BLOCKED` and no `FAILED`. The STOP path currently also returns `3` for a
-`FilterRejectionError` (first blocked member aborts). Spec only requires STOP
-→ “exit nonzero”; tests lock in `3`.
+**Decided (2026-07-19): Option A.** Abort/STOP always exits `1`. Exit `3` is
+reserved exclusively for a CONTINUE run that *completed* with ≥1 policy
+`BLOCKED` and no `FAILED` (safe members on disk). Maintainer + review agree:
+`3`'s useful script meaning is partial success with only policy gaps — a STOP
+abort leaves the output incomplete and must share `1` with other aborts.
 
-| Case | Mode | Outcome on disk | Current exit | Suggested (option A) | Suggested (option B: keep) |
-|------|------|-----------------|--------------|----------------------|----------------------------|
-| Clean extract | CONTINUE (default) | all OK | `0` | `0` | `0` |
-| ≥1 `BLOCKED`, no `FAILED` | CONTINUE | safe members extracted; blocked reported | `3` | `3` | `3` |
-| ≥1 `FAILED` (and any blocks) | CONTINUE | recoverable extracted; failures reported | `1` | `1` | `1` |
-| First member policy-blocked | `--stop-on-error` | nothing after the block; 0+ earlier OK | `3` | **`1`** | `3` |
-| First member read/failed | `--stop-on-error` | nothing after the failure | `1` | `1` | `1` |
-| Policy block after N OK | `--stop-on-error` | N written; remainder skipped | `3` | **`1`** | `3` |
-| Always-stop (bomb / diagnostic raise) | either | partial; hard stop | `1` | `1` | `1` |
-| Hoist collision failure | CONTINUE | partial layout | `1` | `1` | `1` |
-| Unmatched includes / nothing selected | — | nothing extracted | `1` | `1` | `1` |
-| Usage / argparse | — | — | `2` | `2` | `2` |
+Forward-compat note (not in this PR): intended end-state is failures-only
+stopping (`OnError.STOP` / `--stop-on-error` ignore policy blocks; a separate
+opt-in would abort on unsafe members). Option A stays correct once that lands;
+the contested STOP+policy→`3` rows disappear structurally.
 
-**Option A (review lean):** reserve `3` for “finished with policy refusals”
-(CONTINUE completed). STOP is always `1` — scripts can treat `3` as partial
-success with blocks, and `1` as aborted/failed.
-
-**Option B (status quo):** `3` means “a policy refusal was involved” whether
-or not the run completed; STOP+policy stays `3`. Simpler message (“policy
-touched the run”) but `3` no longer implies remaining members were extracted.
+| Case | Mode | On disk | Exit |
+|------|------|---------|------|
+| Clean extract | CONTINUE | all OK | `0` |
+| ≥1 `BLOCKED`, no `FAILED` | CONTINUE | safe members extracted | `3` |
+| ≥1 `FAILED` (± blocks) | CONTINUE | recoverable extracted | `1` |
+| Policy block or failure (abort) | `--stop-on-error` | incomplete | `1` |
+| Always-stop / hoist failure / unmatched includes | — | — | `1` |
+| Usage | — | — | `2` |

--- a/review/cli-product/QUESTIONS.md
+++ b/review/cli-product/QUESTIONS.md
@@ -102,15 +102,8 @@ value: the maintainer's own "why can't I open this" debugging tool.)
 
 ## Q7 — Two library-side message fixes surfaced here (P7, P9) — confirm owners
 
-Not CLI decisions, but they land in library code and deserve issues/changes:
-
-1. Truncated/corrupt zip: `BadZipFile('File is not a zip file')` repr (and
-   the misleading "not a zip file" for a magic-matched truncated file);
-   enum-name leaks (`ArchiveFormat.TAR_ZST`, `SEVEN_Z` label in `info`,
-   `format=ArchiveFormat.ZIP` suffixes); zipcrypto "Wrong password" when no
-   password was supplied (#131 D8 residue).
-2. The backward-seek warning firing with rapidgzip installed but size-gated
-   off, telling the user to install what they have
-   (`archive_stream.py:408` + `codecs.py:239-251`) — text should
-   distinguish "not installed" from "not engaged", and arguably not fire
-   below the size threshold at all.
+**Done (library-owned, as recommended):** truncated/corrupt zip prose (no
+`BadZipFile` repr); `format=` / registry messages use `display_name`; `info`
+uses `file_extension()` labels; STORED zipcrypto + provider-None → "Password
+required"; rewind warning stays quiet below the rapidgzip AUTO size gate and
+distinguishes install-vs-not-engaged when it does fire.

--- a/review/cli-product/QUESTIONS.md
+++ b/review/cli-product/QUESTIONS.md
@@ -44,21 +44,16 @@ Recommend 1 if any slack exists, else 2. Naming: `--json` (tool-standard) vs
 
 ## Q3 — No-match filters: warning + which exit code? (drives P2)
 
-Agreed shape (P2): stderr warning per unmatched include pattern; the open
-question is the exit code when zero members matched on `extract`/`test`:
+**Decided (2026-07-19):**
 
-1. Warn, exit 0 (gentlest; scripts still blind).
-2. Warn, exit 1 (recommended — "the operation did not do what was asked";
-   matches `tar`'s nonzero).
-3. Warn, dedicated code in the reserved ≥3 space (unzip's 11-style
-   "no files matched"); most script-friendly, spends a reserved code.
+| Piece | Decision |
+|-------|----------|
+| Warning | stderr per unmatched include pattern: `warning: pattern matched no members: '…'` |
+| `extract` / `test` zero matches | warn + exit **1** (not a dedicated ≥4 code — exit 11 is unzip/PKWARE-only, not a broader convention) |
+| `list` zero matches | warn + exit **0** (listing nothing is a valid answer) |
+| Dest hint | When a sole unmatched extract pattern names an existing directory or ends with `/`, add `(did you mean -d PATTERN?)` |
 
-And for `list` with no matches: silent-0 (grep-like it is not), or the same
-warning with exit 0? Recommend warning + exit 0 for `list` (listing nothing
-is an answer), warning + nonzero for `extract`/`test`.
-
-Also: adopt the `(did you mean -d out?)` hint when a sole unmatched extract
-pattern names an existing directory / ends with `/`?
+Rationale: silence-as-success on `x a.zip out` / `x a.zip project` is the muscle-memory trap; exit 1 matches `tar`'s nonzero. Spending another reserved code on unzip's 11 would be ZIP-specific mimicry next to our `0/1/2/3` map.
 
 ## Q4 — Control-byte quoting style for member names (drives P3)
 

--- a/review/cli-product/QUESTIONS.md
+++ b/review/cli-product/QUESTIONS.md
@@ -66,28 +66,18 @@ hatch for scripts that need exact names before machine output exists.
 
 ## Q5 — Should `info` tell the cost/access story? (drives P14)
 
-`info` answers "what is this file" but not the library's signature "what
-will it cost" claim. Minimal version: one derived `access:` line (e.g.
-`random (indexed central directory)` / `sequential-only (solid; reading one
-member decodes its folder prefix)` / `sequential (no gzip index; install
-[seekable] for random access)`). Is that in-scope for the CLI, or does it
-wait for a `CostReceipt`-shaped public surface in the library? The CLI can
-derive today's version from `info.is_solid` + format + accelerator presence
-without new public API.
+**Decided (2026-07-19):** ship now. `archivey info` prints an `access:` line
+derived from the existing `ArchiveInfo.cost` / `CostReceipt` (no new library
+API). With `-v`, also print the raw axes (`listing`, `access_cost`, `stream`,
+`solid_blocks`). Accelerator install/AUTO-gate state stays out of this line
+(not on the frozen receipt; can extend later).
 
 ## Q6 — A "what can this install read" view (drives P14)
 
-Design Decision 10 listed `--version` as "version + optional dependency
-matrix"; shipped `--version` prints only the version string. The per-failure
-messages ("install the 'crypto' extra") are excellent but reactive. Options:
-`--version -v`, `archivey info` with no argument, or a future `archivey
-formats`/`doctor`. Any preference, or defer entirely? (Cheap and high-demo
-value: the maintainer's own "why can't I open this" debugging tool.)
-
-**Lean (2026-07-19):** prefer **`--version -v`** (or equivalent verbose
-version). Bare `archivey info` (no archive) feels unintuitive. Still open:
-ship in this pass vs defer; exact matrix shape (formats via
-`format_availability` / extras / both).
+**Decided (2026-07-19):** **`--version -v`** (not bare `info`). Prints
+`archivey <version>` then a `formats:` matrix from `list_known_formats()` /
+`format_availability()` (support level + missing install hints). Plain
+`--version` stays one line.
 
 ## Q7 — Two library-side message fixes surfaced here (P7, P9) — confirm owners
 

--- a/review/cli-product/QUESTIONS.md
+++ b/review/cli-product/QUESTIONS.md
@@ -86,3 +86,31 @@ API). With `-v`, also print the raw axes (`listing`, `access_cost`, `stream`,
 uses `file_extension()` labels; STORED zipcrypto + provider-None → "Password
 required"; rewind warning stays quiet below the rapidgzip AUTO size gate and
 distinguishes install-vs-not-engaged when it does fire.
+
+## Q8 — `--stop-on-error` + policy block: exit `3` or `1`? (PR #163 review)
+
+**Open.** Q1 decided exit `3` when extract *completed* under CONTINUE with
+≥1 `BLOCKED` and no `FAILED`. The STOP path currently also returns `3` for a
+`FilterRejectionError` (first blocked member aborts). Spec only requires STOP
+→ “exit nonzero”; tests lock in `3`.
+
+| Case | Mode | Outcome on disk | Current exit | Suggested (option A) | Suggested (option B: keep) |
+|------|------|-----------------|--------------|----------------------|----------------------------|
+| Clean extract | CONTINUE (default) | all OK | `0` | `0` | `0` |
+| ≥1 `BLOCKED`, no `FAILED` | CONTINUE | safe members extracted; blocked reported | `3` | `3` | `3` |
+| ≥1 `FAILED` (and any blocks) | CONTINUE | recoverable extracted; failures reported | `1` | `1` | `1` |
+| First member policy-blocked | `--stop-on-error` | nothing after the block; 0+ earlier OK | `3` | **`1`** | `3` |
+| First member read/failed | `--stop-on-error` | nothing after the failure | `1` | `1` | `1` |
+| Policy block after N OK | `--stop-on-error` | N written; remainder skipped | `3` | **`1`** | `3` |
+| Always-stop (bomb / diagnostic raise) | either | partial; hard stop | `1` | `1` | `1` |
+| Hoist collision failure | CONTINUE | partial layout | `1` | `1` | `1` |
+| Unmatched includes / nothing selected | — | nothing extracted | `1` | `1` | `1` |
+| Usage / argparse | — | — | `2` | `2` | `2` |
+
+**Option A (review lean):** reserve `3` for “finished with policy refusals”
+(CONTINUE completed). STOP is always `1` — scripts can treat `3` as partial
+success with blocks, and `1` as aborted/failed.
+
+**Option B (status quo):** `3` means “a policy refusal was involved” whether
+or not the run completed; STOP+policy stays `3`. Simpler message (“policy
+touched the run”) but `3` no longer implies remaining members were extracted.

--- a/review/cli-product/QUESTIONS.md
+++ b/review/cli-product/QUESTIONS.md
@@ -6,35 +6,24 @@ reopened.
 
 ## Q1 — Extraction continuation: reject-and-continue for the CLI? (drives P1)
 
-Today `extract` inherits the library's `OnError.STOP`: the first rejected or
-failed member raises, nothing after it is extracted, and the already-written
-members are never reported. A traversal member means zero files extracted
-under every `--policy` — `unzip` extracts the safe files and warns, so the
-"safer unzip" is currently also the *less useful* unzip on exactly the input
-the pitch is about. The CLI already has dead plumbing for the better story
-(`rejected:`/`failed:` lines + summary counts, `cli/extract_cmd.py:315-336`).
+**Decided (2026-07-19):**
 
-Sub-decisions:
+| # | Decision |
+|---|----------|
+| 1 Semantics | Record-and-continue for **policy rejections and per-member read failures** (digest/decode), continuing where the stream allows — same shape as `test` / VISION #3. |
+| 2 Mechanism | CLI passes `OnError.CONTINUE` by default; **library default stays `STOP`**. |
+| 3 Exit code | **`3`** when the run completed with ≥1 policy `BLOCKED` and no `FAILED`; **`1`** when any member `FAILED` (or hoist/always-stop); **`0`** when clean. |
+| 4 Flag | **`--stop-on-error` now** — restores library `STOP` for that invocation (shell scripts cannot switch to the library API). |
+| 5 Stop-path reporting | Always report what was written before an early stop (count at minimum). |
 
-1. **Semantics**: should the CLI extract with record-and-continue for (a)
-   policy rejections only, or (b) rejections *and* per-member read failures
-   (digest mismatch, decode error), continuing where the stream allows?
-   Recommend (b) — it is `test`'s semantics applied to extraction, and it is
-   the VISION #3 claim.
-2. **Mechanism**: CLI passes an `OnError`-style argument (library gains/
-   exposes it), or the library default changes? Recommend: CLI-side opt-in
-   via the existing library knob if it exists/is cheap; the library default
-   staying STOP is fine for programmatic callers.
-3. **Exit code**: completed-with-rejections = 1, or break out the reserved
-   `3` ("refused by safety policy") now? The design already argued 3 is "a
-   genuinely useful distinction for the safer-unzip story" and callers were
-   told not to assume 1 is exhaustive, so it's compatible. Recommend: 3 for
-   "completed but ≥1 member rejected by policy", 1 for other failures.
-4. **Flag**: is a `--stop-on-error` opt-back needed at the same time, or
-   later on demand? Recommend later.
-5. Either way (even if STOP stays): on the stop path, report what *was*
-   extracted before the stop (count at minimum). Today even `-v` says
-   nothing.
+Rationale: without CONTINUE, `x evil.tar` extracts nothing while `unzip` delivers
+the safe members — the safer-unzip demo loses. Exit `3` was reserved in cli-v1
+Decision 12 for exactly this distinction. `--stop-on-error` keeps all-or-nothing
+available at the shell.
+
+Context that drove the call: today `extract` inherits `OnError.STOP`; the CLI
+already has dead plumbing for `blocked:`/`failed:` lines + summary counts that
+only fire under CONTINUE.
 
 ## Q2 — `--json` timing and minimal schema (drives P4)
 
@@ -79,6 +68,10 @@ replacement (prettier, lossy)? Is a `--raw` escape hatch needed for the
 pipe-to-script case, or does that wait for `--json` (where raw names are
 naturally safe)? Recommend: escape everywhere, backslash style, no `--raw`
 until someone asks — scripts get exact names via `--json` (Q2).
+
+**Partial lean (P3 landed):** escape everywhere, backslash style, no `--raw`
+yet — matching the recommendation. Q4 remains open only if we later want
+TTY-only or a `--raw` hatch.
 
 ## Q5 — Should `info` tell the cost/access story? (drives P14)
 

--- a/review/cli-product/SUMMARY.md
+++ b/review/cli-product/SUMMARY.md
@@ -1,8 +1,8 @@
 # CLI-as-a-product review — SUMMARY
 
-> **Status (2026-07-19):** findings in #144; **unambiguous fixes + Q1/P1 landed**
-> (P1/P3/P5–P7/P9–P13/D1). Still need maintainer answers for **Q2–Q3** (and Q5–Q6
-> for P14). See `../STATUS.md` §1.
+> **Status (2026-07-19):** findings in #144; **P1–P3/P5–P7/P9–P13/D1 landed**
+> (Q1/Q3 decided). Still need **Q2** (P4 `--json`) and **Q5–Q6** (P14). See
+> `../STATUS.md` §1.
 
 Deep review per `brief.md`: the merged `src/archivey/cli/` on `main` (post-#120,
 post-#131 fixes), judged as a **product** — muscle memory, output, errors, exit
@@ -76,7 +76,7 @@ public 0.2.0; polish = after.
 | # | Sev | Where | One-liner | 0.2.0 |
 |---|-----|-------|-----------|-------|
 | P1 | **H** | `cli/extract_cmd.py` (+ library `OnError`) | One bad/hostile member aborts the whole extraction under STOP. | **done** — CLI defaults to `CONTINUE`; `--stop-on-error`; exit 3 for policy-only blocks (Q1) |
-| P2 | **H** | `cli/filters.py:11`, `cli/extract_cmd.py:406`, `cli/list_cmd.py:36` | Include patterns that match nothing succeed **silently with exit 0** — and this is exactly what the `unzip a.zip out` positional-dest reflex and the `tar`-style bare-dir-name reflex (`x a.zip project` vs `project/*`) produce. `unzip` prints "filename not matched" and exits 11. | blocker |
+| P2 | **H** | `cli/filters.py`, extract/list/test | Include patterns that match nothing succeed silently with exit 0. | **done** — warn per pattern; extract/test exit 1; list exit 0; `-d` hint (Q3) |
 | P3 | **M** | `cli/format.py:52-85`, `cli/test_cmd.py`, `cli/extract_cmd.py` notices, tqdm desc | Member names print raw to the terminal: ANSI escapes render (demo'd red text) and `\r` rewrites the line (`line1\rOK  everything fine.txt`). A safety-branded tool should quote control bytes like `ls`/GNU `tar` do. | blocker |
 | P4 | **M** | (absent) | No `--json`/`--porcelain` anywhere; the "iterate members and hash" scripting audience must parse aligned human columns with no stability promise. Deliberately deferred in `cli-v1` design (needs a member schema) — but it is the wedge gap for one of VISION's two named audiences. | Q2 (recommend: first 0.2.x) |
 | P5 | **M** | `cli/password.py:19` | Ctrl-D (EOF) at the `Password:` prompt → uncaught `EOFError`, full traceback, exit 1. Catch → treat as "no password given". | blocker (small) |

--- a/review/cli-product/SUMMARY.md
+++ b/review/cli-product/SUMMARY.md
@@ -1,8 +1,8 @@
 # CLI-as-a-product review — SUMMARY
 
-> **Status (2026-07-19):** findings in #144; **P1–P3/P5–P7/P9–P13/D1 landed**
-> (Q1–Q3 decided; **P4/`--json` deferred** until `hash`/schema). Still need
-> **Q5–Q6** (P14) and **P8** polish. See `../STATUS.md` §1.
+> **Status (2026-07-19):** findings in #144; **P1–P3/P5–P7/P9–P14/D1 landed**
+> (Q1–Q3/Q5–Q6 decided; **P4/`--json` deferred** until `hash`/schema). **P8**
+> polish remains. See `../STATUS.md` §1.
 
 Deep review per `brief.md`: the merged `src/archivey/cli/` on `main` (post-#120,
 post-#131 fixes), judged as a **product** — muscle memory, output, errors, exit
@@ -88,7 +88,7 @@ public 0.2.0; polish = after.
 | P11 | **L** | `cli/extract_cmd.py:268,324-336` | Hoist/summary micro-copy: `extracting into src/` … `moved to src/` reads as a no-op; single-root reuse says `→ .` when everything actually landed in `./project/`. | polish |
 | P12 | **L** | argparse positionals | `archivey x` → "the following arguments are required: archive, patterns" — `patterns` is not required. | polish |
 | P13 | **L** | `cli/main.py:134-139` | Reserved-surface asymmetry: `--salvage` pre-verb is `unrecognized arguments` (globals otherwise work pre-verb); `-x`/`-l` get no "verbs are bare words — did you mean `x`?" hint. | polish |
-| P14 | **L** | `cli/main.py:158-162`, `cli/info_cmd.py` | No capability/dependency view: `--version` prints only the version (design Decision 10 mentioned a dependency matrix); `info` answers "what is this file" but not "can *this install* read it / what will it cost" (no `CostReceipt` story). | Q5/Q6 |
+| P14 | **L** | `cli/main.py:158-162`, `cli/info_cmd.py` | No capability/dependency view: `--version` prints only the version (design Decision 10 mentioned a dependency matrix); `info` answers "what is this file" but not "can *this install* read it / what will it cost" (no `CostReceipt` story). | **done** — `access:` from CostReceipt; `--version -v` format matrix (Q5/Q6) |
 | D1 | **L** | `cli/format.py` (from api-coherence) | List line has no mark for `ANTI` (falls to `"?"`, same as `OTHER`) and no non-current / superseded indicator — the member model's own distinctions are invisible in the first consumer. Folded here from api-coherence when that review archived. | polish |
 
 ## What is actually fine

--- a/review/cli-product/SUMMARY.md
+++ b/review/cli-product/SUMMARY.md
@@ -1,8 +1,8 @@
 # CLI-as-a-product review — SUMMARY
 
 > **Status (2026-07-19):** findings in #144; **P1–P3/P5–P7/P9–P13/D1 landed**
-> (Q1/Q3 decided). Still need **Q2** (P4 `--json`) and **Q5–Q6** (P14). See
-> `../STATUS.md` §1.
+> (Q1–Q3 decided; **P4/`--json` deferred** until `hash`/schema). Still need
+> **Q5–Q6** (P14) and **P8** polish. See `../STATUS.md` §1.
 
 Deep review per `brief.md`: the merged `src/archivey/cli/` on `main` (post-#120,
 post-#131 fixes), judged as a **product** — muscle memory, output, errors, exit
@@ -78,7 +78,7 @@ public 0.2.0; polish = after.
 | P1 | **H** | `cli/extract_cmd.py` (+ library `OnError`) | One bad/hostile member aborts the whole extraction under STOP. | **done** — CLI defaults to `CONTINUE`; `--stop-on-error`; exit 3 for policy-only blocks (Q1) |
 | P2 | **H** | `cli/filters.py`, extract/list/test | Include patterns that match nothing succeed silently with exit 0. | **done** — warn per pattern; extract/test exit 1; list exit 0; `-d` hint (Q3) |
 | P3 | **M** | `cli/format.py:52-85`, `cli/test_cmd.py`, `cli/extract_cmd.py` notices, tqdm desc | Member names print raw to the terminal: ANSI escapes render (demo'd red text) and `\r` rewrites the line (`line1\rOK  everything fine.txt`). A safety-branded tool should quote control bytes like `ls`/GNU `tar` do. | blocker |
-| P4 | **M** | (absent) | No `--json`/`--porcelain` anywhere; the "iterate members and hash" scripting audience must parse aligned human columns with no stability promise. Deliberately deferred in `cli-v1` design (needs a member schema) — but it is the wedge gap for one of VISION's two named audiences. | Q2 (recommend: first 0.2.x) |
+| P4 | **M** | (absent) | No `--json`/`--porcelain` anywhere; the "iterate members and hash" scripting audience must parse aligned human columns with no stability promise. Deliberately deferred in `cli-v1` design (needs a member schema) — but it is the wedge gap for one of VISION's two named audiences. | **deferred** (Q2) — wait for `hash` / full schema |
 | P5 | **M** | `cli/password.py:19` | Ctrl-D (EOF) at the `Password:` prompt → uncaught `EOFError`, full traceback, exit 1. Catch → treat as "no password given". | blocker (small) |
 | P6 | **M** | `cli/main.py:362-364` | Missing file and verb typos surface as raw errno reprs: `archivey lsit a.zip` → `[Errno 2] No such file or directory: 'lsit'`. No prose, no "did you mean a verb?" even though the signature (open failed + leftover pattern args) is detectable. | blocker (message), hint = polish |
 | P7 | **M** | library messages, `cli/info_cmd.py:16` | Exception/enum reprs leak into user prose: truncated zip → `Could not open ZIP archive: BadZipFile('File is not a zip file')` (misleading *and* repr-y); suffixes like `format=ArchiveFormat.ZIP`; `info` prints `SEVEN_Z`; zstd message says `Format ArchiveFormat.TAR_ZST is not available`; zipcrypto with **no** password says "Wrong password" (#131 D8 residue). | partial (worst cases) |

--- a/review/cli-product/SUMMARY.md
+++ b/review/cli-product/SUMMARY.md
@@ -1,9 +1,8 @@
 # CLI-as-a-product review — SUMMARY
 
-> **Status (2026-07-19):** findings in #144; **no fixes landed yet.** Blockers
-> needing maintainer answers first: **Q1–Q3** (and Q4 for P3 style). Small
-> actionable items + folded **D1** (ANTI / non-current list marks) listed in
-> `../STATUS.md` §1.
+> **Status (2026-07-19):** findings in #144; **unambiguous fixes landed**
+> (P3/P5–P7/P9–P13/D1). Still need maintainer answers for **Q1–Q3** (and Q4
+> polish / Q5–Q6 for P14). See `../STATUS.md` §1.
 
 Deep review per `brief.md`: the merged `src/archivey/cli/` on `main` (post-#120,
 post-#131 fixes), judged as a **product** — muscle memory, output, errors, exit

--- a/review/cli-product/SUMMARY.md
+++ b/review/cli-product/SUMMARY.md
@@ -1,8 +1,8 @@
 # CLI-as-a-product review — SUMMARY
 
-> **Status (2026-07-19):** findings in #144; **unambiguous fixes landed**
-> (P3/P5–P7/P9–P13/D1). Still need maintainer answers for **Q1–Q3** (and Q4
-> polish / Q5–Q6 for P14). See `../STATUS.md` §1.
+> **Status (2026-07-19):** findings in #144; **unambiguous fixes + Q1/P1 landed**
+> (P1/P3/P5–P7/P9–P13/D1). Still need maintainer answers for **Q2–Q3** (and Q5–Q6
+> for P14). See `../STATUS.md` §1.
 
 Deep review per `brief.md`: the merged `src/archivey/cli/` on `main` (post-#120,
 post-#131 fixes), judged as a **product** — muscle memory, output, errors, exit
@@ -75,7 +75,7 @@ public 0.2.0; polish = after.
 
 | # | Sev | Where | One-liner | 0.2.0 |
 |---|-----|-------|-----------|-------|
-| P1 | **H** | `cli/extract_cmd.py:384-400` (+ library `OnError` default) | One bad/hostile member aborts the whole extraction: `x evil.tar` (traversal) extracts **0** files under every `--policy`; `x badcrc.zip` stops mid-archive and never says which files *were* written. VISION #3's "recoverable members + honest error" fails at the shell; the CLI's own `rejected:`/`failed:` reporting (`_report_extraction`) is unreachable on this path. | blocker (needs Q1 decision) |
+| P1 | **H** | `cli/extract_cmd.py` (+ library `OnError`) | One bad/hostile member aborts the whole extraction under STOP. | **done** — CLI defaults to `CONTINUE`; `--stop-on-error`; exit 3 for policy-only blocks (Q1) |
 | P2 | **H** | `cli/filters.py:11`, `cli/extract_cmd.py:406`, `cli/list_cmd.py:36` | Include patterns that match nothing succeed **silently with exit 0** — and this is exactly what the `unzip a.zip out` positional-dest reflex and the `tar`-style bare-dir-name reflex (`x a.zip project` vs `project/*`) produce. `unzip` prints "filename not matched" and exits 11. | blocker |
 | P3 | **M** | `cli/format.py:52-85`, `cli/test_cmd.py`, `cli/extract_cmd.py` notices, tqdm desc | Member names print raw to the terminal: ANSI escapes render (demo'd red text) and `\r` rewrites the line (`line1\rOK  everything fine.txt`). A safety-branded tool should quote control bytes like `ls`/GNU `tar` do. | blocker |
 | P4 | **M** | (absent) | No `--json`/`--porcelain` anywhere; the "iterate members and hash" scripting audience must parse aligned human columns with no stability promise. Deliberately deferred in `cli-v1` design (needs a member schema) — but it is the wedge gap for one of VISION's two named audiences. | Q2 (recommend: first 0.2.x) |

--- a/review/cli-product/SUMMARY.md
+++ b/review/cli-product/SUMMARY.md
@@ -1,8 +1,8 @@
 # CLI-as-a-product review — SUMMARY
 
-> **Status (2026-07-19):** findings in #144; **P1–P3/P5–P7/P9–P14/D1 landed**
-> (Q1–Q3/Q5–Q6 decided; **P4/`--json` deferred** until `hash`/schema). **P8**
-> polish remains. See `../STATUS.md` §1.
+> **Status (2026-07-19):** findings in #144; **P1–P3/P5–P14/D1 landed**
+> (Q1–Q3/Q5–Q6 decided; **P4/`--json` deferred** until `hash`/schema). See
+> `../STATUS.md` §1.
 
 Deep review per `brief.md`: the merged `src/archivey/cli/` on `main` (post-#120,
 post-#131 fixes), judged as a **product** — muscle memory, output, errors, exit
@@ -82,7 +82,7 @@ public 0.2.0; polish = after.
 | P5 | **M** | `cli/password.py:19` | Ctrl-D (EOF) at the `Password:` prompt → uncaught `EOFError`, full traceback, exit 1. Catch → treat as "no password given". | blocker (small) |
 | P6 | **M** | `cli/main.py:362-364` | Missing file and verb typos surface as raw errno reprs: `archivey lsit a.zip` → `[Errno 2] No such file or directory: 'lsit'`. No prose, no "did you mean a verb?" even though the signature (open failed + leftover pattern args) is detectable. | blocker (message), hint = polish |
 | P7 | **M** | library messages, `cli/info_cmd.py:16` | Exception/enum reprs leak into user prose: truncated zip → `Could not open ZIP archive: BadZipFile('File is not a zip file')` (misleading *and* repr-y); suffixes like `format=ArchiveFormat.ZIP`; `info` prints `SEVEN_Z`; zstd message says `Format ArchiveFormat.TAR_ZST is not available`; zipcrypto with **no** password says "Wrong password" (#131 D8 residue). | partial (worst cases) |
-| P8 | **M** | `cli/test_cmd.py:56-73,127` | Archive-wide failures under-report: missing `unrar` on a 4-member RAR → `0 OK, 1 failed` (one FAIL line for a whole-archive condition; solid-abort loses the remaining members with no "N not tested" note). The pass/fail exit contract is right; the *counts* aren't honest. | polish |
+| P8 | **M** | `cli/test_cmd.py:56-73,127` | Archive-wide failures under-report: missing `unrar` on a 4-member RAR → `0 OK, 1 failed` (one FAIL line for a whole-archive condition; solid-abort loses the remaining members with no "N not tested" note). The pass/fail exit contract is right; the *counts* aren't honest. | **done** — append `, K not tested` when indexed remainder known |
 | P9 | **L** | `internal/streams/archive_stream.py:408` (library, CLI-visible) | Tripped bug: `[all]` install, `x src.tar.gz` warns "Install the 'seekable' extra (rapidgzip)" — rapidgzip **is** installed; the AUTO size-gate declined it, and the warning text doesn't know that. Misleading advice on the flagship demo path. | polish (fix text) |
 | P10 | **L** | `cli/main.py` help | `--help` is clean but example-free: smart-dest, `-d .`, filter grammar, `--exclude` are invisible until the man-page moment. One epilog with 4 examples fixes it. | polish |
 | P11 | **L** | `cli/extract_cmd.py:268,324-336` | Hoist/summary micro-copy: `extracting into src/` … `moved to src/` reads as a no-op; single-root reuse says `→ .` when everything actually landed in `./project/`. | polish |

--- a/review/cli-product/brief.md
+++ b/review/cli-product/brief.md
@@ -1,8 +1,7 @@
 # Brief — The `archivey` CLI as a product (UX / ergonomics)
 
-> **Status (2026-07-19):** findings delivered in **#144**. **No code follow-ups
-> yet** — P1–P14 + Q1–Q7 still open. Api-coherence **D1** (ANTI / non-current
-> list marks) folded into this review's SUMMARY when api-coherence archived.
+> **Status (2026-07-19):** findings delivered in **#144**. Unambiguous fixes
+> (P3/P5–P7/P9–P13/D1) implemented; **Q1–Q6** (and P1/P2/P4/P8/P14) still open.
 > Triage: `../STATUS.md`.
 
 Read `review/README.md` (conventions, VISION tie-breakers, deliverable shape). This

--- a/review/cli-product/brief.md
+++ b/review/cli-product/brief.md
@@ -1,8 +1,8 @@
 # Brief — The `archivey` CLI as a product (UX / ergonomics)
 
 > **Status (2026-07-19):** findings delivered in **#144**. Unambiguous fixes
-> (P3/P5–P7/P9–P13/D1) implemented; **Q1–Q6** (and P1/P2/P4/P8/P14) still open.
-> Triage: `../STATUS.md`.
+> (P3/P5–P7/P9–P13/D1) + **Q1/P1** + **Q3/P2** implemented; still open:
+> **Q2/P4**, **Q5–Q6/P14**, **P8**. Triage: `../STATUS.md`.
 
 Read `review/README.md` (conventions, VISION tie-breakers, deliverable shape). This
 is a **product** review — the CLI seen through a user's eyes — **not** a code-correctness

--- a/review/cli-product/brief.md
+++ b/review/cli-product/brief.md
@@ -1,8 +1,8 @@
 # Brief — The `archivey` CLI as a product (UX / ergonomics)
 
-> **Status (2026-07-19):** findings delivered in **#144**. Unambiguous fixes
-> (P3/P5–P7/P9–P13/D1) + **Q1/P1** + **Q3/P2** + **Q5–Q6/P14** implemented;
-> **Q2/P4** deferred (`hash`/schema). Still open: **P8**. Triage: `../STATUS.md`.
+> **Status (2026-07-19):** findings delivered in **#144**. Follow-ups
+> implemented except **Q2/P4** (`--json` deferred until `hash`/schema). Triage:
+> `../STATUS.md`.
 
 Read `review/README.md` (conventions, VISION tie-breakers, deliverable shape). This
 is a **product** review — the CLI seen through a user's eyes — **not** a code-correctness

--- a/review/cli-product/brief.md
+++ b/review/cli-product/brief.md
@@ -1,8 +1,8 @@
 # Brief — The `archivey` CLI as a product (UX / ergonomics)
 
 > **Status (2026-07-19):** findings delivered in **#144**. Unambiguous fixes
-> (P3/P5–P7/P9–P13/D1) + **Q1/P1** + **Q3/P2** implemented; still open:
-> **Q2/P4**, **Q5–Q6/P14**, **P8**. Triage: `../STATUS.md`.
+> (P3/P5–P7/P9–P13/D1) + **Q1/P1** + **Q3/P2** implemented; **Q2/P4** deferred
+> (`hash`/schema). Still open: **Q5–Q6/P14**, **P8**. Triage: `../STATUS.md`.
 
 Read `review/README.md` (conventions, VISION tie-breakers, deliverable shape). This
 is a **product** review — the CLI seen through a user's eyes — **not** a code-correctness

--- a/review/cli-product/brief.md
+++ b/review/cli-product/brief.md
@@ -1,8 +1,8 @@
 # Brief — The `archivey` CLI as a product (UX / ergonomics)
 
 > **Status (2026-07-19):** findings delivered in **#144**. Unambiguous fixes
-> (P3/P5–P7/P9–P13/D1) + **Q1/P1** + **Q3/P2** implemented; **Q2/P4** deferred
-> (`hash`/schema). Still open: **Q5–Q6/P14**, **P8**. Triage: `../STATUS.md`.
+> (P3/P5–P7/P9–P13/D1) + **Q1/P1** + **Q3/P2** + **Q5–Q6/P14** implemented;
+> **Q2/P4** deferred (`hash`/schema). Still open: **P8**. Triage: `../STATUS.md`.
 
 Read `review/README.md` (conventions, VISION tie-breakers, deliverable shape). This
 is a **product** review — the CLI seen through a user's eyes — **not** a code-correctness

--- a/review/cli-product/output.md
+++ b/review/cli-product/output.md
@@ -84,7 +84,9 @@ a display format. A minimal contract — `--json` on `list`/`info` emitting one
 object per line (name, type, size, mtime, mode, encrypted, link_target,
 hashes) with a documented "fields may be added, not renamed" promise — is
 cheap (stdlib json, the CLI already has every value in hand) and doesn't
-block on the full `ArchiveMember` schema question. Timing decision at Q2.
+block on the full `ArchiveMember` schema question. **Q2 decided:** wait for
+`hash` / full schema (no minimal JSON in 0.2.0); flag name when it lands:
+`--json`.
 
 ## `info`: answers "what is it", not yet "can I read it / what will it cost"
 

--- a/src/archivey/cli/exit_codes.py
+++ b/src/archivey/cli/exit_codes.py
@@ -4,4 +4,6 @@ from __future__ import annotations
 
 EXIT_OK = 0
 EXIT_FAIL = 1  # operational failure (open/read/extract/integrity)
-EXIT_USAGE = 2  # CLI usage error (argparse default); ≥3 reserved
+EXIT_USAGE = 2  # CLI usage error (argparse default)
+EXIT_POLICY = 3  # extract completed with ≥1 safety-policy block, no FAILED
+# ≥4 reserved

--- a/src/archivey/cli/exit_codes.py
+++ b/src/archivey/cli/exit_codes.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 EXIT_OK = 0
-EXIT_FAIL = 1  # operational failure (open/read/extract/integrity)
+EXIT_FAIL = 1  # operational failure / aborted extract (incl. --stop-on-error)
 EXIT_USAGE = 2  # CLI usage error (argparse default)
-EXIT_POLICY = 3  # extract completed with ≥1 safety-policy block, no FAILED
+# CONTINUE completed with ≥1 policy BLOCKED and no FAILED (safe members on disk).
+EXIT_POLICY = 3
 # ≥4 reserved

--- a/src/archivey/cli/extract_cmd.py
+++ b/src/archivey/cli/extract_cmd.py
@@ -11,18 +11,20 @@ from typing import TextIO
 
 from archivey import (
     ExtractionPolicy,
+    ExtractionProgress,
     ExtractionReport,
     ExtractionStatus,
+    OnError,
     OverwritePolicy,
 )
 from archivey.cli.common import open_for_cli, reject_salvage
-from archivey.cli.exit_codes import EXIT_FAIL, EXIT_OK
+from archivey.cli.exit_codes import EXIT_FAIL, EXIT_OK, EXIT_POLICY
 from archivey.cli.filters import member_predicate
 from archivey.cli.format import escape_member_name
 from archivey.cli.password import resolve_password
 from archivey.cli.progress import ProgressCallback, make_progress_callback
 from archivey.config import PasswordInput
-from archivey.exceptions import ArchiveyError
+from archivey.exceptions import ArchiveyError, FilterRejectionError
 from archivey.reader import ArchiveReader
 from archivey.types import ArchiveFormat, ArchiveMember, ContainerFormat
 
@@ -305,12 +307,14 @@ def _report_extraction(
     err: TextIO,
     extra_renamed: int = 0,
     extra_skipped: int = 0,
-) -> None:
+) -> tuple[int, int]:
     """Print rename notices + a closing summary from the library report (F3/D2).
 
     ``extra_renamed`` / ``extra_skipped`` fold in collisions resolved during the
     post-extract hoist (the library report covers only the wrapper extraction,
     which is collision-free by construction).
+
+    Returns ``(blocked_count, failed_count)`` for exit-code selection (Q1).
     """
     extracted = 0
     renamed = extra_renamed
@@ -373,6 +377,16 @@ def _report_extraction(
         f" → {dest_label}",
         file=err,
     )
+    return blocked, failed
+
+
+def _exit_for_outcomes(*, blocked: int, failed: int, hoist_ok: bool) -> int:
+    """Map extract outcomes to exit codes (Q1): FAILED→1, policy-only BLOCKED→3."""
+    if not hoist_ok or failed:
+        return EXIT_FAIL
+    if blocked:
+        return EXIT_POLICY
+    return EXIT_OK
 
 
 def run_extract(
@@ -388,6 +402,7 @@ def run_extract(
     track_io: bool,
     hide_progress: bool,
     verbose: bool,
+    stop_on_error: bool = False,
     out: TextIO | None = None,
     err: TextIO | None = None,
 ) -> int:
@@ -398,6 +413,7 @@ def run_extract(
     pred = member_predicate(patterns, exclude)
     policy_enum = ExtractionPolicy(policy)
     overwrite_enum = OverwritePolicy(overwrite)
+    on_error = OnError.STOP if stop_on_error else OnError.CONTINUE
     archive_path = Path(archive)
 
     with open_for_cli(archive_path, password=pwd, track_io=track_io, err=err) as reader:
@@ -416,9 +432,19 @@ def run_extract(
             if target != Path("."):
                 print(f"extracting into {target}/", file=err)
 
-        on_progress: ProgressCallback | None = make_progress_callback(
+        base_progress: ProgressCallback | None = make_progress_callback(
             hide_progress=hide_progress, stream=err
         )
+        # Under STOP, extract_all raises without returning a report — track how
+        # many members completed before the stop via the progress callback (Q1.5).
+        members_completed = 0
+
+        def on_progress(progress: ExtractionProgress) -> None:
+            nonlocal members_completed
+            members_completed = progress.members_done
+            if base_progress is not None:
+                base_progress(progress)
+
         try:
             try:
                 report = reader.extract_all(
@@ -426,23 +452,31 @@ def run_extract(
                     members=pred,
                     policy=policy_enum,
                     overwrite=overwrite_enum,
+                    on_error=on_error,
                     on_progress=on_progress,
                 )
             except (ArchiveyError, OSError) as exc:
-                # OnError.STOP (library default) re-raises the first member failure.
-                # OSError (disk full, perms) must get the same stop notice (F10).
+                # STOP / always-stop (bomb guards, DiagnosticRaisedError): report
+                # what was already written, then the stop notice.
                 print(exc, file=err)
+                if members_completed:
+                    print(
+                        f"{members_completed} member(s) written before the stop",
+                        file=err,
+                    )
                 print(
                     "extraction stopped; remaining members were not extracted",
                     file=err,
                 )
+                if isinstance(exc, FilterRejectionError):
+                    return EXIT_POLICY
                 return EXIT_FAIL
             hoist = _HoistResult(target)
             if may_hoist:
                 hoist = maybe_hoist_single_root(
                     target, overwrite=overwrite_enum, err=err
                 )
-            _report_extraction(
+            blocked, failed = _report_extraction(
                 report,
                 target=hoist.target,
                 verbose=verbose,
@@ -450,9 +484,7 @@ def run_extract(
                 extra_renamed=hoist.renamed,
                 extra_skipped=hoist.skipped,
             )
-            if not hoist.ok:
-                return EXIT_FAIL
+            return _exit_for_outcomes(blocked=blocked, failed=failed, hoist_ok=hoist.ok)
         finally:
-            if on_progress is not None:
-                on_progress.close()
-    return EXIT_OK
+            if base_progress is not None:
+                base_progress.close()

--- a/src/archivey/cli/extract_cmd.py
+++ b/src/archivey/cli/extract_cmd.py
@@ -19,7 +19,12 @@ from archivey import (
 )
 from archivey.cli.common import open_for_cli, reject_salvage
 from archivey.cli.exit_codes import EXIT_FAIL, EXIT_OK, EXIT_POLICY
-from archivey.cli.filters import member_predicate
+from archivey.cli.filters import (
+    count_selected,
+    member_predicate,
+    unmatched_include_patterns,
+    warn_unmatched_includes,
+)
 from archivey.cli.format import escape_member_name
 from archivey.cli.password import resolve_password
 from archivey.cli.progress import ProgressCallback, make_progress_callback
@@ -417,6 +422,17 @@ def run_extract(
     archive_path = Path(archive)
 
     with open_for_cli(archive_path, password=pwd, track_io=track_io, err=err) as reader:
+        if patterns:
+            indexed = reader.members_report_if_available()
+            members_for_filter = (
+                list(indexed) if indexed is not None else list(reader.members_report())
+            )
+            unmatched = unmatched_include_patterns(patterns, members_for_filter)
+            if unmatched:
+                warn_unmatched_includes(unmatched, err=err, dest_hint=True)
+            if count_selected(members_for_filter, pred) == 0:
+                return EXIT_FAIL
+
         may_hoist = False
         if dest is not None:
             target = Path(dest)

--- a/src/archivey/cli/extract_cmd.py
+++ b/src/archivey/cli/extract_cmd.py
@@ -22,6 +22,7 @@ from archivey.cli.exit_codes import EXIT_FAIL, EXIT_OK, EXIT_POLICY
 from archivey.cli.filters import (
     count_selected,
     member_predicate,
+    members_for_include_check,
     unmatched_include_patterns,
     warn_unmatched_includes,
 )
@@ -422,11 +423,9 @@ def run_extract(
     archive_path = Path(archive)
 
     with open_for_cli(archive_path, password=pwd, track_io=track_io, err=err) as reader:
-        if patterns:
-            indexed = reader.members_report_if_available()
-            members_for_filter = (
-                list(indexed) if indexed is not None else list(reader.members_report())
-            )
+        # None on forward-only readers: do not consume the sole pass before extract.
+        members_for_filter = members_for_include_check(reader) if patterns else None
+        if patterns and members_for_filter is not None:
             unmatched = unmatched_include_patterns(patterns, members_for_filter)
             if unmatched:
                 warn_unmatched_includes(unmatched, err=err, dest_hint=True)
@@ -486,6 +485,10 @@ def run_extract(
                 )
                 if isinstance(exc, FilterRejectionError):
                     return EXIT_POLICY
+                return EXIT_FAIL
+            # Streaming + patterns: empty report means nothing matched (no pre-scan).
+            if patterns and members_for_filter is None and len(report) == 0:
+                warn_unmatched_includes(patterns, err=err, dest_hint=True)
                 return EXIT_FAIL
             hoist = _HoistResult(target)
             if may_hoist:

--- a/src/archivey/cli/extract_cmd.py
+++ b/src/archivey/cli/extract_cmd.py
@@ -18,6 +18,7 @@ from archivey import (
 from archivey.cli.common import open_for_cli, reject_salvage
 from archivey.cli.exit_codes import EXIT_FAIL, EXIT_OK
 from archivey.cli.filters import member_predicate
+from archivey.cli.format import escape_member_name
 from archivey.cli.password import resolve_password
 from archivey.cli.progress import ProgressCallback, make_progress_callback
 from archivey.config import PasswordInput
@@ -265,8 +266,35 @@ def maybe_hoist_single_root(
             wrapper, ok=False, renamed=result.renamed, skipped=result.skipped
         )
     is_dir = result.target.is_dir() and not result.target.is_symlink()
-    print(f"moved to {result.target}{'/' if is_dir else ''}", file=err)
+    label = f"{result.target}{'/' if is_dir else ''}"
+    if result.target == wrapper:
+        # In-place flatten (src.tar → src/ containing src/): name unchanged.
+        print(f"removed wrapper; content at {label}", file=err)
+    else:
+        print(f"moved to {label}", file=err)
     return result
+
+
+def _summary_dest_label(target: Path, report: ExtractionReport) -> str:
+    """Closing summary destination; prefer the single extracted top when dest is cwd."""
+    if target != Path("."):
+        if target.is_dir():
+            return f"{target}/"
+        return str(target)
+    tops: set[str] = set()
+    for result in report:
+        if result.status is not ExtractionStatus.EXTRACTED:
+            continue
+        name = result.member.name.strip("/")
+        if name:
+            tops.add(name.split("/", 1)[0])
+    if len(tops) == 1:
+        only = next(iter(tops))
+        on_disk = Path(only)
+        if on_disk.is_dir() and not on_disk.is_symlink():
+            return f"{only}/"
+        return only
+    return "."
 
 
 def _report_extraction(
@@ -306,31 +334,38 @@ def _report_extraction(
                     file=err,
                 )
             elif verbose:
-                print(f"extracted: {result.member.name}", file=err)
+                print(
+                    f"extracted: {escape_member_name(result.member.name)}",
+                    file=err,
+                )
         elif status is ExtractionStatus.NOT_OVERWRITTEN:
             skipped += 1
             # Overwrite-skips change outcomes under --overwrite skip; always note.
-            where = result.requested_path or result.member.name
+            where = result.requested_path or escape_member_name(result.member.name)
             print(f"not overwritten: {where}", file=err)
         elif status is ExtractionStatus.SUPERSEDED:
             skipped += 1  # count superseded entries alongside skipped in summary
             if verbose:
-                print(f"superseded: {result.member.name}", file=err)
+                print(
+                    f"superseded: {escape_member_name(result.member.name)}",
+                    file=err,
+                )
         elif status is ExtractionStatus.BLOCKED:
             blocked += 1
             detail = f": {result.error}" if result.error is not None else ""
-            print(f"blocked: {result.member.name}{detail}", file=err)
+            print(
+                f"blocked: {escape_member_name(result.member.name)}{detail}",
+                file=err,
+            )
         elif status is ExtractionStatus.FAILED:
             failed += 1
             detail = f": {result.error}" if result.error is not None else ""
-            print(f"failed: {result.member.name}{detail}", file=err)
+            print(
+                f"failed: {escape_member_name(result.member.name)}{detail}",
+                file=err,
+            )
 
-    if target == Path("."):
-        dest_label = "."
-    elif target.is_dir():
-        dest_label = f"{target}/"
-    else:
-        dest_label = str(target)
+    dest_label = _summary_dest_label(target, report)
     print(
         f"{extracted} extracted, {renamed} renamed, {skipped} skipped"
         f"{f', {blocked} blocked' if blocked else ''}"

--- a/src/archivey/cli/extract_cmd.py
+++ b/src/archivey/cli/extract_cmd.py
@@ -30,7 +30,7 @@ from archivey.cli.format import escape_member_name
 from archivey.cli.password import resolve_password
 from archivey.cli.progress import ProgressCallback, make_progress_callback
 from archivey.config import PasswordInput
-from archivey.exceptions import ArchiveyError, FilterRejectionError
+from archivey.exceptions import ArchiveyError
 from archivey.reader import ArchiveReader
 from archivey.types import ArchiveFormat, ArchiveMember, ContainerFormat
 
@@ -473,6 +473,8 @@ def run_extract(
             except (ArchiveyError, OSError) as exc:
                 # STOP / always-stop (bomb guards, DiagnosticRaisedError): report
                 # what was already written, then the stop notice.
+                # Exit 1 always on abort (Q8): exit 3 is reserved for CONTINUE
+                # runs that *completed* with policy blocks and safe members on disk.
                 print(exc, file=err)
                 if members_completed:
                     print(
@@ -483,8 +485,6 @@ def run_extract(
                     "extraction stopped; remaining members were not extracted",
                     file=err,
                 )
-                if isinstance(exc, FilterRejectionError):
-                    return EXIT_POLICY
                 return EXIT_FAIL
             # Streaming + patterns: empty report means nothing matched (no pre-scan).
             if patterns and members_for_filter is None and len(report) == 0:

--- a/src/archivey/cli/filters.py
+++ b/src/archivey/cli/filters.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import fnmatch
+import os
 from collections.abc import Callable, Sequence
+from typing import TextIO
 
 from archivey.types import ArchiveMember
 
@@ -32,3 +34,59 @@ def member_predicate(
         return True
 
     return matches
+
+
+def unmatched_include_patterns(
+    includes: Sequence[str],
+    members: Sequence[ArchiveMember],
+) -> list[str]:
+    """Return include patterns that match no member names (order preserved)."""
+    if not includes:
+        return []
+    hit = dict.fromkeys(includes, False)
+    for member in members:
+        name = member.name
+        for pattern, matched in hit.items():
+            if not matched and fnmatch.fnmatchcase(name, pattern):
+                hit[pattern] = True
+        if all(hit.values()):
+            break
+    return [pattern for pattern, matched in hit.items() if not matched]
+
+
+def warn_unmatched_includes(
+    unmatched: Sequence[str],
+    *,
+    err: TextIO,
+    dest_hint: bool = False,
+) -> None:
+    """Print stderr warnings for unmatched include patterns (cli-product P2 / Q3).
+
+    When ``dest_hint`` is true and there is exactly one unmatched pattern that
+    names an existing directory or ends with ``/``, append a ``-d`` suggestion
+    (the unzip/7z positional-dest reflex).
+    """
+    for pattern in unmatched:
+        extra = ""
+        if (
+            dest_hint
+            and len(unmatched) == 1
+            and (pattern.endswith("/") or os.path.isdir(pattern))
+        ):
+            # Strip a trailing slash for the suggested -d argument display.
+            suggested = pattern.rstrip("/") or pattern
+            extra = f" (did you mean -d {suggested}?)"
+        print(
+            f"warning: pattern matched no members: {pattern!r}{extra}",
+            file=err,
+        )
+
+
+def count_selected(
+    members: Sequence[ArchiveMember],
+    pred: Callable[[ArchiveMember], bool] | None,
+) -> int:
+    """How many members the include/exclude predicate selects."""
+    if pred is None:
+        return len(members)
+    return sum(1 for member in members if pred(member))

--- a/src/archivey/cli/filters.py
+++ b/src/archivey/cli/filters.py
@@ -5,9 +5,13 @@ from __future__ import annotations
 import fnmatch
 import os
 from collections.abc import Callable, Sequence
-from typing import TextIO
+from typing import TYPE_CHECKING, TextIO
 
+from archivey.cost import StreamCapability
 from archivey.types import ArchiveMember
+
+if TYPE_CHECKING:
+    from archivey.reader import ArchiveReader
 
 
 def member_predicate(
@@ -90,3 +94,20 @@ def count_selected(
     if pred is None:
         return len(members)
     return sum(1 for member in members if pred(member))
+
+
+def members_for_include_check(reader: ArchiveReader) -> list[ArchiveMember] | None:
+    """Member list for unmatched-include / empty-selection checks, if safe.
+
+    Prefer a cheap index. On a forward-only (streaming) reader, return ``None``
+    instead of calling :meth:`~archivey.reader.ArchiveReader.members_report` —
+    that would consume the sole forward pass and break a following
+    ``extract_all`` / ``stream_members``. Callers then defer empty-selection
+    handling to the operation outcome.
+    """
+    indexed = reader.members_report_if_available()
+    if indexed is not None:
+        return list(indexed)
+    if reader.cost.stream_capability is StreamCapability.FORWARD_ONLY:
+        return None
+    return list(reader.members_report())

--- a/src/archivey/cli/format.py
+++ b/src/archivey/cli/format.py
@@ -11,8 +11,44 @@ _TYPE_MARK = {
     MemberType.DIRECTORY: "d",
     MemberType.SYMLINK: "l",
     MemberType.HARDLINK: "h",
+    MemberType.ANTI: "A",
     MemberType.OTHER: "?",
 }
+
+# C0 controls, DEL, and C1 controls — never emit raw into a terminal.
+_CONTROL_ESCAPE = {
+    "\n": "\\n",
+    "\r": "\\r",
+    "\t": "\\t",
+    "\\": "\\\\",
+}
+
+
+def escape_member_name(name: str) -> str:
+    """Backslash-escape control bytes in a member name for safe terminal display.
+
+    Archive member names are attacker-controlled; raw ANSI / ``\\r`` would let a
+    hostile archive spoof listing lines. GNU ``ls`` / ``tar`` quote for the same
+    reason. Style follows the cli-product recommendation (Q4 lean): escape
+    everywhere, lossless backslash form, no ``--raw`` yet.
+    """
+    out: list[str] = []
+    for ch in name:
+        if ch in _CONTROL_ESCAPE:
+            out.append(_CONTROL_ESCAPE[ch])
+            continue
+        if ch.isprintable():
+            out.append(ch)
+            continue
+        code = ord(ch)
+        if 0xDC00 <= code <= 0xDFFF:
+            # surrogateescape of a single byte — show the underlying octet.
+            out.append(f"\\x{code & 0xFF:02x}")
+        elif code <= 0xFF:
+            out.append(f"\\x{code:02x}")
+        else:
+            out.append(f"\\u{code:04x}")
+    return "".join(out)
 
 
 def format_mode(mode: int | None) -> str:
@@ -58,15 +94,20 @@ def format_member_line(
 ) -> str:
     """Layer-1 listing line; optional stored digests and verbose extras."""
     mark = _TYPE_MARK.get(member.type, "?")
-    enc = "E" if member.is_encrypted else "-"
+    if member.is_encrypted:
+        status = "E"
+    elif not member.is_current:
+        status = "~"  # superseded / non-current revision
+    else:
+        status = "-"
     mode = format_mode(member.mode)
     size = format_size(member.size)
     mtime = format_mtime(member.modified)
-    name = member.name
+    name = escape_member_name(member.name)
     if member.is_link and member.link_target is not None:
-        name = f"{name} -> {member.link_target}"
+        name = f"{name} -> {escape_member_name(member.link_target)}"
 
-    parts = [f"{mark}{enc}", mode, f"{size:>10}", mtime, name]
+    parts = [f"{mark}{status}", mode, f"{size:>10}", mtime, name]
     line = "  ".join(parts)
 
     if digests and member.hashes:

--- a/src/archivey/cli/format.py
+++ b/src/archivey/cli/format.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from archivey.types import ArchiveMember, MemberType
+from archivey.cost import AccessCost, CostReceipt, ListingCost, StreamCapability
+from archivey.types import ArchiveFormat, ArchiveMember, MemberType
 
 _TYPE_MARK = {
     MemberType.FILE: "f",
@@ -22,6 +23,14 @@ _CONTROL_ESCAPE = {
     "\t": "\\t",
     "\\": "\\\\",
 }
+
+
+def format_format_label(fmt: ArchiveFormat) -> str:
+    """Human format name (``zip``, ``7z``, ``tar.gz``) rather than enum spellings."""
+    ext = fmt.file_extension()
+    if ext:
+        return ext
+    return fmt.display_name.lower().replace("_", "-")
 
 
 def escape_member_name(name: str) -> str:
@@ -125,3 +134,36 @@ def format_member_line(
             line = f"{line}  ({diag})"
 
     return line
+
+
+def format_access_summary(cost: CostReceipt) -> str:
+    """One-line human summary of ``CostReceipt`` for ``archivey info`` (Q5 / P14).
+
+    Derived from the public open-time axes only — not accelerator install state
+    (that lives in config / diagnostics, not the frozen receipt).
+    """
+    if cost.access_cost is AccessCost.SOLID:
+        bits: list[str] = []
+        if cost.listing_cost is ListingCost.REQUIRES_DECOMPRESSION:
+            bits.append("listing requires decompression")
+        elif cost.listing_cost is ListingCost.REQUIRES_SCANNING:
+            bits.append("listing requires scan")
+        elif cost.listing_cost is ListingCost.INDEXED:
+            bits.append("reading one member may decode earlier members in its block")
+        if cost.solid_block_count is not None:
+            n = cost.solid_block_count
+            bits.append(f"{n} solid block{'s' if n != 1 else ''}")
+        if cost.stream_capability is StreamCapability.FORWARD_ONLY:
+            bits.append("forward-only source")
+        return f"solid ({'; '.join(bits)})" if bits else "solid"
+
+    if cost.listing_cost is ListingCost.INDEXED:
+        head = "random (indexed)"
+    elif cost.listing_cost is ListingCost.REQUIRES_SCANNING:
+        head = "random (listing requires scan)"
+    else:
+        head = "random (listing requires decompression)"
+
+    if cost.stream_capability is StreamCapability.FORWARD_ONLY:
+        return f"{head}; forward-only source"
+    return head

--- a/src/archivey/cli/info_cmd.py
+++ b/src/archivey/cli/info_cmd.py
@@ -14,8 +14,11 @@ from archivey.types import ArchiveFormat
 
 
 def _format_label(fmt: ArchiveFormat) -> str:
-    """Human format name (``ZIP``) rather than ``ArchiveFormat.ZIP``."""
-    return fmt.display_name
+    """Human format name (``zip``, ``7z``, ``tar.gz``) rather than enum spellings."""
+    ext = fmt.file_extension()
+    if ext:
+        return ext
+    return fmt.display_name.lower().replace("_", "-")
 
 
 def _line(key: str, value: object, out: TextIO) -> None:

--- a/src/archivey/cli/info_cmd.py
+++ b/src/archivey/cli/info_cmd.py
@@ -7,22 +7,31 @@ from typing import TextIO
 
 from archivey import detect_format, open_archive
 from archivey.cli.common import reject_stdin_token
+from archivey.cli.format import format_access_summary, format_format_label
 from archivey.cli.password import resolve_password
 from archivey.config import PasswordInput
+from archivey.cost import CostReceipt
 from archivey.exceptions import ArchiveyError
 from archivey.types import ArchiveFormat
 
 
 def _format_label(fmt: ArchiveFormat) -> str:
-    """Human format name (``zip``, ``7z``, ``tar.gz``) rather than enum spellings."""
-    ext = fmt.file_extension()
-    if ext:
-        return ext
-    return fmt.display_name.lower().replace("_", "-")
+    return format_format_label(fmt)
 
 
 def _line(key: str, value: object, out: TextIO) -> None:
     print(f"{key + ':':<12} {value}", file=out)
+
+
+def _print_cost_axes(cost: CostReceipt, out: TextIO) -> None:
+    """Verbose breakdown of the three CostReceipt axes (plus solid_block_count)."""
+    _line("listing", cost.listing_cost.value, out)
+    _line("access_cost", cost.access_cost.value, out)
+    _line("stream", cost.stream_capability.value, out)
+    blocks = cost.solid_block_count
+    _line("solid_blocks", blocks if blocks is not None else "-", out)
+    for note in cost.notes:
+        _line("cost_note", note, out)
 
 
 def run_info(
@@ -54,6 +63,9 @@ def run_info(
             info = reader.info
             _line("version", info.format_version or "-", out)
             _line("solid", info.is_solid, out)
+            _line("access", format_access_summary(info.cost), out)
+            if verbose:
+                _print_cost_axes(info.cost, out)
             _line("encrypted", info.is_encrypted, out)
             _line("multivolume", info.is_multivolume, out)
             _line(

--- a/src/archivey/cli/list_cmd.py
+++ b/src/archivey/cli/list_cmd.py
@@ -7,7 +7,11 @@ from typing import TextIO
 
 from archivey.cli.common import open_for_cli, reject_salvage
 from archivey.cli.exit_codes import EXIT_FAIL, EXIT_OK
-from archivey.cli.filters import member_predicate
+from archivey.cli.filters import (
+    member_predicate,
+    unmatched_include_patterns,
+    warn_unmatched_includes,
+)
 from archivey.cli.format import format_member_line
 from archivey.cli.password import resolve_password
 from archivey.config import PasswordInput
@@ -34,7 +38,11 @@ def run_list(
 
     with open_for_cli(archive, password=pwd, track_io=track_io, err=err) as reader:
         report = reader.members_report()
-        for member in report:
+        members = list(report)
+        if patterns:
+            unmatched = unmatched_include_patterns(patterns, members)
+            warn_unmatched_includes(unmatched, err=err)
+        for member in members:
             if pred is not None and not pred(member):
                 continue
             print(

--- a/src/archivey/cli/main.py
+++ b/src/archivey/cli/main.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import argparse
+import errno
 import sys
 from collections.abc import Sequence
-from typing import TextIO
+from typing import NoReturn, TextIO
 
 import archivey
 from archivey.cli.errors import CliError
@@ -48,6 +49,30 @@ _VALUE_OPTIONS = frozenset(
     }
 )
 
+_TOP_EPILOG = """\
+examples:
+  archivey archive.zip                  list members
+  archivey x archive.zip                extract safely (into ./archive/ if needed)
+  archivey x archive.zip -d out '*.py'  extract *.py into out/
+  archivey t archive.zip                verify integrity
+"""
+
+_EXTRACT_EPILOG = """\
+examples:
+  archivey x archive.zip                extract safely (into ./archive/ if needed)
+  archivey x archive.zip -d out         extract into out/ (use -d . for cwd)
+  archivey x archive.zip '*.py'         extract matching members only
+  archivey x archive.zip --exclude 't*' extract all except exclude patterns
+"""
+
+# Classic tar-style flag spellings that are not options here (verbs are bare words).
+_VERB_FLAG_HINTS = {
+    "-x": "x",
+    "-l": "l",
+    "-t": "t",
+    "-i": "i",
+}
+
 
 def _inject_default_list(argv: list[str]) -> list[str]:
     """If the first positional is not a known verb, insert ``list`` (known-verb-wins)."""
@@ -76,14 +101,31 @@ def _inject_default_list(argv: list[str]) -> list[str]:
     return argv
 
 
-def _common_parent(*, suppress_defaults: bool) -> argparse.ArgumentParser:
+class _ArchiveyArgumentParser(argparse.ArgumentParser):
+    """argparse tweaks for product-facing error messages (P12 / P13)."""
+
+    def error(self, message: str) -> NoReturn:
+        # bpo-26240: nargs='*' positionals are wrongly listed as required.
+        if "the following arguments are required:" in message:
+            message = message.replace(", patterns", "").replace("patterns, ", "")
+        # Tar users type -x/-l/-t; verbs here are bare words.
+        for flag, verb in _VERB_FLAG_HINTS.items():
+            if flag in message and "unrecognized arguments" in message:
+                message = (
+                    f"{message} (verbs are bare words — try 'archivey {verb} ARCHIVE')"
+                )
+                break
+        super().error(message)
+
+
+def _common_parent(*, suppress_defaults: bool) -> _ArchiveyArgumentParser:
     """Shared flags available before or after the verb.
 
     Build *two* instances (see ``build_parser``): the top-level copy carries real
     defaults; the subparser copy uses ``SUPPRESS`` so an absent post-verb flag cannot
     clobber a value the main parser already set (argparse shared-parents pitfall).
     """
-    p = argparse.ArgumentParser(add_help=False, allow_abbrev=False)
+    p = _ArchiveyArgumentParser(add_help=False, allow_abbrev=False)
     default_none: object = argparse.SUPPRESS if suppress_defaults else None
     default_false: object = argparse.SUPPRESS if suppress_defaults else False
     p.add_argument(
@@ -113,6 +155,14 @@ def _common_parent(*, suppress_defaults: bool) -> argparse.ArgumentParser:
             "(bytes decompressed, compressed consumed, seeks)"
         ),
     )
+    # Pre-verb globals include reserved --salvage so it gets the same "not yet"
+    # message as post-verb (P13), not argparse's "unrecognized arguments".
+    p.add_argument(
+        "--salvage",
+        action="store_true",
+        default=default_false,
+        help="reserved: best-effort reads (not implemented yet)",
+    )
     return p
 
 
@@ -120,6 +170,7 @@ def _add_filter_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "patterns",
         nargs="*",
+        metavar="pattern",
         help="fnmatch include patterns (omit to select all members)",
     )
     parser.add_argument(
@@ -131,26 +182,20 @@ def _add_filter_args(parser: argparse.ArgumentParser) -> None:
     )
 
 
-def _add_salvage_arg(parser: argparse.ArgumentParser) -> None:
-    parser.add_argument(
-        "--salvage",
-        action="store_true",
-        help="reserved: best-effort reads (not implemented yet)",
-    )
-
-
 def build_parser() -> argparse.ArgumentParser:
     # Two parent instances: action objects are shared if the same instance is reused,
     # so SUPPRESS on a single parent would also wipe the main parser's defaults.
     common = _common_parent(suppress_defaults=False)
     common_sub = _common_parent(suppress_defaults=True)
-    parser = argparse.ArgumentParser(
+    parser = _ArchiveyArgumentParser(
         prog="archivey",
         description=(
             "Inspect, verify, and safely extract archives. "
             "Bare invocation defaults to list. "
             "Forthcoming: hash, create, convert, cat."
         ),
+        epilog=_TOP_EPILOG,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
         parents=[common],
         conflict_handler="resolve",
         allow_abbrev=False,
@@ -161,7 +206,11 @@ def build_parser() -> argparse.ArgumentParser:
         version=f"archivey {archivey.__version__}",
     )
 
-    sub = parser.add_subparsers(dest="verb", metavar="VERB")
+    sub = parser.add_subparsers(
+        dest="verb",
+        metavar="VERB",
+        parser_class=_ArchiveyArgumentParser,
+    )
 
     p_list = sub.add_parser(
         "list",
@@ -178,7 +227,6 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="show stored member digests (no body read)",
     )
-    _add_salvage_arg(p_list)
     p_list.set_defaults(_run="list")
 
     p_test = sub.add_parser(
@@ -191,7 +239,6 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p_test.add_argument("archive", help="archive path")
     _add_filter_args(p_test)
-    _add_salvage_arg(p_test)
     p_test.set_defaults(_run="test")
 
     p_extract = sub.add_parser(
@@ -200,6 +247,8 @@ def build_parser() -> argparse.ArgumentParser:
         parents=[common_sub],
         conflict_handler="resolve",
         allow_abbrev=False,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=_EXTRACT_EPILOG,
         help="safely extract members",
     )
     p_extract.add_argument("archive", help="archive path")
@@ -222,7 +271,6 @@ def build_parser() -> argparse.ArgumentParser:
         help="collision policy (CLI default: rename; library default remains error)",
     )
     _add_filter_args(p_extract)
-    _add_salvage_arg(p_extract)
     p_extract.set_defaults(_run="extract")
 
     p_info = sub.add_parser(
@@ -255,6 +303,9 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def _dispatch(args: argparse.Namespace, *, out: TextIO, err: TextIO) -> int:
+    if bool(getattr(args, "salvage", False)):
+        raise CliError("--salvage is not implemented yet", code=EXIT_USAGE)
+
     run = getattr(args, "_run", None)
     if run is None:
         build_parser().print_help(err)
@@ -272,7 +323,7 @@ def _dispatch(args: argparse.Namespace, *, out: TextIO, err: TextIO) -> int:
             patterns=list(args.patterns),
             exclude=list(args.exclude),
             digests=bool(args.digests),
-            salvage=bool(args.salvage),
+            salvage=False,
             out=out,
             err=err,
         )
@@ -284,7 +335,7 @@ def _dispatch(args: argparse.Namespace, *, out: TextIO, err: TextIO) -> int:
             verbose=bool(args.verbose),
             patterns=list(args.patterns),
             exclude=list(args.exclude),
-            salvage=bool(args.salvage),
+            salvage=False,
             hide_progress=bool(args.hide_progress),
             out=out,
             err=err,
@@ -300,7 +351,7 @@ def _dispatch(args: argparse.Namespace, *, out: TextIO, err: TextIO) -> int:
             exclude=list(args.exclude),
             policy=args.policy,
             overwrite=args.overwrite,
-            salvage=bool(args.salvage),
+            salvage=False,
             hide_progress=bool(args.hide_progress),
             out=out,
             err=err,
@@ -316,6 +367,17 @@ def _dispatch(args: argparse.Namespace, *, out: TextIO, err: TextIO) -> int:
         )
 
     raise CliError(f"unknown verb {run!r}", code=EXIT_USAGE)
+
+
+def _format_os_error(exc: OSError) -> str:
+    """Human prose for missing paths / I/O errors (cli-product P6)."""
+    path = exc.filename
+    detail = exc.strerror or str(exc)
+    if path is not None:
+        if exc.errno == errno.ENOENT:
+            return f"archivey: cannot open {path!r}: no such file or directory"
+        return f"archivey: cannot open {path!r}: {detail}"
+    return f"archivey: {detail}"
 
 
 def main(
@@ -360,7 +422,7 @@ def main(
         _silence_broken_pipe()
         return EXIT_OK
     except OSError as exc:
-        print(exc, file=err_stream)
+        print(_format_os_error(exc), file=err_stream)
         return EXIT_FAIL
     except KeyboardInterrupt:
         print("interrupted", file=err_stream)

--- a/src/archivey/cli/main.py
+++ b/src/archivey/cli/main.py
@@ -389,6 +389,30 @@ def _format_os_error(exc: OSError) -> str:
     return f"archivey: {detail}"
 
 
+def _parse_cli_args(
+    parser: argparse.ArgumentParser, argv_list: list[str]
+) -> argparse.Namespace:
+    """Parse argv, folding leftover positionals into ``patterns``.
+
+    argparse leaves include patterns in the "unknown" remainder when optional
+    flags like ``-d`` appear before a ``nargs='*'`` patterns positional
+    (``archivey x a.zip -d out '*.py'``). Fold those tokens back so the
+    documented flag/pattern order works.
+    """
+    args, rest = parser.parse_known_args(argv_list)
+    if rest and rest[0] == "--":
+        rest = rest[1:]
+    if not rest:
+        return args
+    unknown_opts = [tok for tok in rest if tok.startswith("-") and tok != "-"]
+    if unknown_opts:
+        parser.error(f"unrecognized arguments: {' '.join(unknown_opts)}")
+    if not hasattr(args, "patterns"):
+        parser.error(f"unrecognized arguments: {' '.join(rest)}")
+    args.patterns = list(args.patterns or ()) + list(rest)
+    return args
+
+
 def main(
     argv: Sequence[str] | None = None,
     *,
@@ -407,7 +431,7 @@ def main(
     argv_list = _inject_default_list(raw)
     parser = build_parser()
     try:
-        args = parser.parse_args(argv_list)
+        args = _parse_cli_args(parser, argv_list)
     except SystemExit as exc:
         code = exc.code
         if code is None:

--- a/src/archivey/cli/main.py
+++ b/src/archivey/cli/main.py
@@ -270,6 +270,14 @@ def build_parser() -> argparse.ArgumentParser:
         default="rename",
         help="collision policy (CLI default: rename; library default remains error)",
     )
+    p_extract.add_argument(
+        "--stop-on-error",
+        action="store_true",
+        help=(
+            "stop at the first blocked or failed member "
+            "(default: continue and report; library OnError.STOP)"
+        ),
+    )
     _add_filter_args(p_extract)
     p_extract.set_defaults(_run="extract")
 
@@ -353,6 +361,7 @@ def _dispatch(args: argparse.Namespace, *, out: TextIO, err: TextIO) -> int:
             overwrite=args.overwrite,
             salvage=False,
             hide_progress=bool(args.hide_progress),
+            stop_on_error=bool(getattr(args, "stop_on_error", False)),
             out=out,
             err=err,
         )

--- a/src/archivey/cli/main.py
+++ b/src/archivey/cli/main.py
@@ -9,9 +9,11 @@ from collections.abc import Sequence
 from typing import NoReturn, TextIO
 
 import archivey
+from archivey import format_availability, list_known_formats
 from archivey.cli.errors import CliError
 from archivey.cli.exit_codes import EXIT_FAIL, EXIT_OK, EXIT_USAGE
 from archivey.cli.extract_cmd import run_extract
+from archivey.cli.format import format_format_label
 from archivey.cli.info_cmd import run_info
 from archivey.cli.list_cmd import run_list
 from archivey.cli.logging_config import cli_logging
@@ -202,8 +204,8 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--version",
-        action="version",
-        version=f"archivey {archivey.__version__}",
+        action="store_true",
+        help="print version and exit (-v adds format availability)",
     )
 
     sub = parser.add_subparsers(
@@ -310,7 +312,28 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def _print_version(*, verbose: bool, out: TextIO) -> None:
+    """``--version`` / ``--version -v`` (Q6 / P14)."""
+    print(f"archivey {archivey.__version__}", file=out)
+    if not verbose:
+        return
+    print(file=out)
+    print("formats:", file=out)
+    for fmt in list_known_formats():
+        avail = format_availability(fmt)
+        label = format_format_label(fmt)
+        if avail.missing:
+            missing = "; ".join(f"{m.name} ({m.install_hint})" for m in avail.missing)
+            print(f"  {label}: {avail.support.value} — missing {missing}", file=out)
+        else:
+            print(f"  {label}: {avail.support.value}", file=out)
+
+
 def _dispatch(args: argparse.Namespace, *, out: TextIO, err: TextIO) -> int:
+    if bool(getattr(args, "version", False)):
+        _print_version(verbose=bool(getattr(args, "verbose", False)), out=out)
+        return EXIT_OK
+
     if bool(getattr(args, "salvage", False)):
         raise CliError("--salvage is not implemented yet", code=EXIT_USAGE)
 

--- a/src/archivey/cli/main.py
+++ b/src/archivey/cli/main.py
@@ -421,15 +421,21 @@ def _parse_cli_args(
     flags like ``-d`` appear before a ``nargs='*'`` patterns positional
     (``archivey x a.zip -d out '*.py'``). Fold those tokens back so the
     documented flag/pattern order works.
+
+    Tokens after an explicit ``--`` are always positionals — including names
+    that start with ``-`` (``x ARCHIVE -d out -- -file.txt``).
     """
     args, rest = parser.parse_known_args(argv_list)
-    if rest and rest[0] == "--":
+    after_double_dash = bool(rest and rest[0] == "--")
+    if after_double_dash:
         rest = rest[1:]
     if not rest:
         return args
-    unknown_opts = [tok for tok in rest if tok.startswith("-") and tok != "-"]
-    if unknown_opts:
-        parser.error(f"unrecognized arguments: {' '.join(unknown_opts)}")
+    if not after_double_dash:
+        # Without ``--``, dash-prefixed leftovers are unknown options (not patterns).
+        unknown_opts = [tok for tok in rest if tok.startswith("-") and tok != "-"]
+        if unknown_opts:
+            parser.error(f"unrecognized arguments: {' '.join(unknown_opts)}")
     if not hasattr(args, "patterns"):
         parser.error(f"unrecognized arguments: {' '.join(rest)}")
     args.patterns = list(args.patterns or ()) + list(rest)

--- a/src/archivey/cli/password.py
+++ b/src/archivey/cli/password.py
@@ -16,6 +16,10 @@ def resolve_password(cli_password: str | None) -> PasswordInput:
     def provider(_request: PasswordRequest) -> str | None:
         if not sys.stdin.isatty():
             return None
-        return getpass.getpass("Password: ")
+        try:
+            return getpass.getpass("Password: ")
+        except EOFError:
+            # Ctrl-D / end-of-input at the prompt → treat as "no password given".
+            return None
 
     return provider

--- a/src/archivey/cli/progress.py
+++ b/src/archivey/cli/progress.py
@@ -6,6 +6,7 @@ import sys
 from collections.abc import Callable
 from typing import Protocol, TextIO, cast
 
+from archivey.cli.format import escape_member_name
 from archivey.internal.extraction_types import ExtractionProgress
 
 
@@ -41,15 +42,16 @@ class ProgressCallback:
                 unit_divisor=1024,
                 file=self._display,
                 leave=True,
-                desc=progress.member.name,
+                desc=escape_member_name(progress.member.name),
                 mininterval=0,
                 miniters=1,
                 dynamic_ncols=True,
                 disable=False,
             )
             self._bar = bar
-        if bar.desc != progress.member.name:
-            bar.set_description(progress.member.name, refresh=False)
+        safe_name = escape_member_name(progress.member.name)
+        if bar.desc != safe_name:
+            bar.set_description(safe_name, refresh=False)
         if total is not None and bar.total != total:
             bar.total = total
         delta = progress.bytes_written - int(bar.n)

--- a/src/archivey/cli/test_cmd.py
+++ b/src/archivey/cli/test_cmd.py
@@ -7,6 +7,7 @@ from typing import TextIO
 
 from archivey.cli.common import open_for_cli, reject_salvage
 from archivey.cli.filters import member_predicate
+from archivey.cli.format import escape_member_name
 from archivey.cli.password import resolve_password
 from archivey.cli.progress import ProgressCallback, make_progress_callback
 from archivey.config import PasswordInput
@@ -76,7 +77,7 @@ def run_test(
                     # Directories / links / non-file: no body to verify — omit from counts
                     # so "N OK" matches unzip -t style (files only).
                     if verbose:
-                        print(f"skip {member.name}", file=err)
+                        print(f"skip {escape_member_name(member.name)}", file=err)
                     continue
                 member_written = 0
                 try:
@@ -113,13 +114,13 @@ def run_test(
                             )
                         )
                     if verbose:
-                        print(f"OK   {member.name}", file=err)
+                        print(f"OK   {escape_member_name(member.name)}", file=err)
                 except ArchiveyError as exc:
                     failed += 1
-                    print(f"FAIL {member.name}: {exc}", file=err)
+                    print(f"FAIL {escape_member_name(member.name)}: {exc}", file=err)
                 except OSError as exc:
                     failed += 1
-                    print(f"FAIL {member.name}: {exc}", file=err)
+                    print(f"FAIL {escape_member_name(member.name)}: {exc}", file=err)
         finally:
             if on_progress is not None:
                 on_progress.close()

--- a/src/archivey/cli/test_cmd.py
+++ b/src/archivey/cli/test_cmd.py
@@ -6,7 +6,13 @@ import sys
 from typing import TextIO
 
 from archivey.cli.common import open_for_cli, reject_salvage
-from archivey.cli.filters import member_predicate
+from archivey.cli.exit_codes import EXIT_FAIL, EXIT_OK
+from archivey.cli.filters import (
+    count_selected,
+    member_predicate,
+    unmatched_include_patterns,
+    warn_unmatched_includes,
+)
 from archivey.cli.format import escape_member_name
 from archivey.cli.password import resolve_password
 from archivey.cli.progress import ProgressCallback, make_progress_callback
@@ -38,6 +44,16 @@ def run_test(
     failed = 0
     with open_for_cli(archive, password=pwd, track_io=track_io, err=err) as reader:
         indexed = reader.members_report_if_available()
+        if patterns:
+            members_for_filter = (
+                list(indexed) if indexed is not None else list(reader.members_report())
+            )
+            unmatched = unmatched_include_patterns(patterns, members_for_filter)
+            if unmatched:
+                warn_unmatched_includes(unmatched, err=err)
+            if count_selected(members_for_filter, pred) == 0:
+                return EXIT_FAIL
+
         total_bytes: int | None = None
         members_total: int | None = None
         if indexed is not None:
@@ -126,4 +142,4 @@ def run_test(
                 on_progress.close()
 
     print(f"{ok} OK, {failed} failed", file=err)
-    return 1 if failed else 0
+    return EXIT_FAIL if failed else EXIT_OK

--- a/src/archivey/cli/test_cmd.py
+++ b/src/archivey/cli/test_cmd.py
@@ -10,6 +10,7 @@ from archivey.cli.exit_codes import EXIT_FAIL, EXIT_OK
 from archivey.cli.filters import (
     count_selected,
     member_predicate,
+    members_for_include_check,
     unmatched_include_patterns,
     warn_unmatched_includes,
 )
@@ -45,10 +46,9 @@ def run_test(
     members_total: int | None = None
     with open_for_cli(archive, password=pwd, track_io=track_io, err=err) as reader:
         indexed = reader.members_report_if_available()
-        if patterns:
-            members_for_filter = (
-                list(indexed) if indexed is not None else list(reader.members_report())
-            )
+        # None on forward-only readers: do not consume the sole pass before streaming.
+        members_for_filter = members_for_include_check(reader) if patterns else None
+        if patterns and members_for_filter is not None:
             unmatched = unmatched_include_patterns(patterns, members_for_filter)
             if unmatched:
                 warn_unmatched_includes(unmatched, err=err)
@@ -69,6 +69,7 @@ def run_test(
         )
         bytes_done = 0
         files_done = 0
+        saw_selected = False
         try:
             # Manual iteration so open-time failures (wrong password, corrupt header)
             # count as FAIL and still reach the summary (F4). Once the generator raises,
@@ -89,6 +90,7 @@ def run_test(
                     print(f"FAIL: {exc}", file=err)
                     continue
 
+                saw_selected = True
                 if stream is None:
                     # Directories / links / non-file: no body to verify — omit from counts
                     # so "N OK" matches unzip -t style (files only).
@@ -140,6 +142,11 @@ def run_test(
         finally:
             if on_progress is not None:
                 on_progress.close()
+
+        # Streaming + patterns: no pre-scan — empty selection if nothing was yielded.
+        if patterns and members_for_filter is None and not saw_selected:
+            warn_unmatched_includes(patterns, err=err)
+            return EXIT_FAIL
 
     print(_test_summary(ok=ok, failed=failed, members_total=members_total), file=err)
     return EXIT_FAIL if failed else EXIT_OK

--- a/src/archivey/cli/test_cmd.py
+++ b/src/archivey/cli/test_cmd.py
@@ -42,6 +42,7 @@ def run_test(
 
     ok = 0
     failed = 0
+    members_total: int | None = None
     with open_for_cli(archive, password=pwd, track_io=track_io, err=err) as reader:
         indexed = reader.members_report_if_available()
         if patterns:
@@ -55,7 +56,6 @@ def run_test(
                 return EXIT_FAIL
 
         total_bytes: int | None = None
-        members_total: int | None = None
         if indexed is not None:
             selected = [m for m in indexed if pred is None or pred(m)]
             file_members = [m for m in selected if m.is_file]
@@ -73,7 +73,7 @@ def run_test(
             # Manual iteration so open-time failures (wrong password, corrupt header)
             # count as FAIL and still reach the summary (F4). Once the generator raises,
             # further next() yields StopIteration — remaining members are lost (library
-            # limitation for solid / poisoned streams).
+            # limitation for solid / poisoned streams); report them as "not tested" (P8).
             it = iter(reader.stream_members(pred))
             while True:
                 try:
@@ -141,5 +141,16 @@ def run_test(
             if on_progress is not None:
                 on_progress.close()
 
-    print(f"{ok} OK, {failed} failed", file=err)
+    print(_test_summary(ok=ok, failed=failed, members_total=members_total), file=err)
     return EXIT_FAIL if failed else EXIT_OK
+
+
+def _test_summary(*, ok: int, failed: int, members_total: int | None) -> str:
+    """Format the quiet test summary, including untested remainder when known (P8)."""
+    base = f"{ok} OK, {failed} failed"
+    if members_total is None:
+        return base
+    not_tested = members_total - ok - failed
+    if not_tested <= 0:
+        return base
+    return f"{base}, {not_tested} not tested"

--- a/src/archivey/exceptions.py
+++ b/src/archivey/exceptions.py
@@ -33,7 +33,8 @@ class ArchiveyError(Exception):
         if self.member_name:
             parts.append(f"member={self.member_name!r}")
         if self.source_format:
-            parts.append(f"format={self.source_format!r}")
+            # Human label (ZIP / TAR_GZ / SEVEN_Z), not ArchiveFormat.ZIP repr.
+            parts.append(f"format={self.source_format.display_name}")
         if len(parts) == 1:
             return self.message
         return f"{self.message} ({', '.join(parts[1:])})"

--- a/src/archivey/internal/backends/zip_reader.py
+++ b/src/archivey/internal/backends/zip_reader.py
@@ -438,8 +438,13 @@ class ZipReader(BaseArchiveReader):
                     archive_name=archive_name,
                     source_format=ArchiveFormat.ZIP,
                 ) from exc
+            # stdlib often says "File is not a zip file" for truncated/corrupt
+            # archives that already matched ZIP magic — prefer actionable prose.
+            detail = str(exc).strip() or exc.__class__.__name__
+            if "not a zip file" in detail.lower():
+                detail = "truncated or corrupt ZIP (central directory unreadable)"
             raise CorruptionError(
-                f"Could not open ZIP archive: {exc!r}",
+                f"Could not open ZIP archive: {detail}",
                 archive_name=archive_name,
                 source_format=ArchiveFormat.ZIP,
             ) from exc
@@ -1258,7 +1263,9 @@ class ZipReader(BaseArchiveReader):
             self._stamp_error_context(ambiguous, member_name)
             raise ambiguous from ambiguous_failure
 
-        if not self._passwords.has_passwords():
+        # A provider that exists but returned None without yielding a candidate
+        # must not read as "wrong password" (cli-product P7 / #131 D8 residue).
+        if not tried:
             required = EncryptionError("Password required to read this ZIP member")
             self._stamp_error_context(required, member_name)
             raise required

--- a/src/archivey/internal/registry.py
+++ b/src/archivey/internal/registry.py
@@ -226,14 +226,14 @@ class BackendRegistry:
             backend_cls = self._readers.get(fmt)
             if backend_cls is None:
                 raise UnsupportedFormatError(
-                    f"No read backend registered for format {fmt!r}",
+                    f"No read backend registered for format {fmt.display_name}",
                     source_format=fmt,
                 )
             hints = "; ".join(
                 f"{m.name} ({m.install_hint})" for m in availability.missing
             )
             raise UnsupportedFormatError(
-                f"Format {fmt!r} is not available: missing {hints}",
+                f"Format {fmt.display_name} is not available: missing {hints}",
                 source_format=fmt,
             )
         return self._readers[fmt]
@@ -241,7 +241,7 @@ class BackendRegistry:
     def writer_for_format(self, fmt: ArchiveFormat) -> type[WriteBackend]:
         if fmt not in self._writers:
             raise UnsupportedOperationError(
-                f"No write backend registered for format {fmt!r}",
+                f"No write backend registered for format {fmt.display_name}",
                 source_format=fmt,
             )
         return self._writers[fmt]

--- a/src/archivey/internal/streams/archive_stream.py
+++ b/src/archivey/internal/streams/archive_stream.py
@@ -54,12 +54,14 @@ class RewindWarning:
     Carried by :class:`ArchiveStream` so the public stream handle can warn once, on the first
     rewinding seek, that random access is O(n) here. ``codec_name`` names the format; when an
     ``accelerator`` package (the ``[seekable]`` extra) would provide indexed random access, the
-    warning names it. Codecs with a native random-access index (or an active accelerator) carry
-    no ``RewindWarning``.
+    warning names it. ``suggest_install`` is True when that package is absent (tell the user to
+    install it) and False when it is present but was not engaged for this stream. Codecs with a
+    native random-access index (or an active accelerator) carry no ``RewindWarning``.
     """
 
     codec_name: str
     accelerator: str | None = None
+    suggest_install: bool = True
 
 
 def _noop_stamp(_exc: ArchiveyError) -> None:
@@ -406,12 +408,20 @@ class ArchiveStream(ReadOnlyIOStream):
             return
         self._rewind_warned = True
         if warning.accelerator is not None:
-            message = (
-                f"Seeking backward in a {warning.codec_name} stream without a "
-                f"random-access accelerator re-decompresses from the start "
-                f"(O(n) per rewind). Install the 'seekable' extra "
-                f"({warning.accelerator}) for indexed random access."
-            )
+            if warning.suggest_install:
+                message = (
+                    f"Seeking backward in a {warning.codec_name} stream without a "
+                    f"random-access accelerator re-decompresses from the start "
+                    f"(O(n) per rewind). Install the 'seekable' extra "
+                    f"({warning.accelerator}) for indexed random access."
+                )
+            else:
+                message = (
+                    f"Seeking backward in a {warning.codec_name} stream without "
+                    f"indexed random access re-decompresses from the start "
+                    f"(O(n) per rewind). The '{warning.accelerator}' accelerator "
+                    f"is installed but was not engaged for this stream."
+                )
         else:
             message = (
                 f"Seeking backward in a {warning.codec_name} stream re-decompresses "

--- a/src/archivey/internal/streams/codecs.py
+++ b/src/archivey/internal/streams/codecs.py
@@ -258,6 +258,32 @@ def _rapidgzip_enabled(config: StreamConfig, *, available: bool) -> bool:
     )
 
 
+def _rapidgzip_rewind_warning(
+    codec_name: str, config: StreamConfig
+) -> RewindWarning | None:
+    """Rewind diagnostic for DEFLATE-family codecs that rapidgzip can accelerate.
+
+    Below the AUTO size threshold the rewind is cheap enough that warning (and
+    especially telling the user to install an already-present package) is noise —
+    stay quiet. Otherwise name the accelerator and say whether to install it or
+    that it was present but not engaged.
+    """
+    if _deflate_family_uses_accelerator(config):
+        return None
+    size = config.compressed_input_size
+    if (
+        config.use_rapidgzip is AcceleratorMode.AUTO
+        and size is not None
+        and size < RAPIDGZIP_AUTO_MIN_COMPRESSED_SIZE
+    ):
+        return None
+    return RewindWarning(
+        codec_name,
+        accelerator="rapidgzip",
+        suggest_install=_rapidgzip is None,
+    )
+
+
 def _wrap_accelerated_length(stream: BinaryIO, config: StreamConfig) -> BinaryIO:
     """Bound accelerated output to ``expected_decompressed_size`` when known.
 
@@ -725,9 +751,7 @@ class GzipCodec(StreamCodec):
 
     def rewind_warning(self, config: StreamConfig) -> RewindWarning | None:
         # The accelerator gives indexed random access; only the stdlib fallback rewinds slowly.
-        if _deflate_family_uses_accelerator(config):
-            return None
-        return RewindWarning("gzip", accelerator="rapidgzip")
+        return _rapidgzip_rewind_warning("gzip", config)
 
     def _translate_accelerator(self, exc: Exception) -> ArchiveyError | None:
         """Translate the rapidgzip accelerator's exceptions to the library's error types."""
@@ -813,7 +837,11 @@ class Bzip2Codec(StreamCodec):
     def rewind_warning(self, config: StreamConfig) -> RewindWarning | None:
         if _bzip2_uses_accelerator(config):
             return None
-        return RewindWarning("bzip2", accelerator="rapidgzip")
+        return RewindWarning(
+            "bzip2",
+            accelerator="rapidgzip",
+            suggest_install=_rapidgzip_bzip2 is None,
+        )
 
     def _translate_accelerator(self, exc: Exception) -> ArchiveyError | None:
         """Translate the indexed_bzip2 accelerator's exceptions to the library's error types."""
@@ -1046,9 +1074,7 @@ class DeflateCodec(_ZlibErrorCodec):
         return self.translate
 
     def rewind_warning(self, config: StreamConfig) -> RewindWarning | None:
-        if _deflate_family_uses_accelerator(config):
-            return None
-        return RewindWarning("deflate", accelerator="rapidgzip")
+        return _rapidgzip_rewind_warning("deflate", config)
 
     def _translate_accelerator(self, exc: Exception) -> ArchiveyError | None:
         return _translate_rapidgzip(exc, "deflate")
@@ -1080,9 +1106,7 @@ class ZlibCodec(_ZlibErrorCodec):
         return self.translate
 
     def rewind_warning(self, config: StreamConfig) -> RewindWarning | None:
-        if _deflate_family_uses_accelerator(config):
-            return None
-        return RewindWarning("zlib", accelerator="rapidgzip")
+        return _rapidgzip_rewind_warning("zlib", config)
 
     def _translate_accelerator(self, exc: Exception) -> ArchiveyError | None:
         return _translate_rapidgzip(exc, "zlib")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1203,3 +1203,74 @@ def test_test_unmatched_include_exits_one(
     err = capsys.readouterr().err
     assert "warning: pattern matched no members: 'missing'" in err
     assert "OK," not in err
+
+
+def test_extract_dest_before_dash_named_pattern(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``-d`` before patterns must still accept ``-- -file.txt`` (fold + ``--``)."""
+    monkeypatch.chdir(tmp_path)
+    z = _zip(tmp_path / "dash.zip", {"-file.txt": b"x", "ok.txt": b"y"})
+    dest = tmp_path / "out"
+    assert main(["x", str(z), "-d", str(dest), "--", "-file.txt"]) == EXIT_OK
+    assert (dest / "-file.txt").read_bytes() == b"x"
+    assert not (dest / "ok.txt").exists()
+
+
+def test_extract_stop_on_error_reports_members_written(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Q1.5: STOP after a successful member still reports how many were written."""
+    from archivey.cli.exit_codes import EXIT_POLICY
+
+    monkeypatch.chdir(tmp_path)
+    archive = _tar(
+        tmp_path / "evil.tar",
+        {
+            "safe.txt": b"ok",
+            "../escape.txt": b"bad",
+            "later.txt": b"late",
+        },
+    )
+    code = main(["extract", str(archive), "-d", "out", "--stop-on-error"])
+    assert code == EXIT_POLICY
+    err = capsys.readouterr().err
+    assert "1 member(s) written before the stop" in err
+    assert "extraction stopped" in err
+    assert (tmp_path / "out" / "safe.txt").read_bytes() == b"ok"
+    assert not (tmp_path / "out" / "later.txt").exists()
+
+
+def test_members_for_include_check_skips_forward_only(
+    tmp_path: Path,
+) -> None:
+    """Forward-only readers must not be pre-scanned (would burn the sole pass)."""
+    import io
+    import tarfile
+
+    from archivey import open_archive
+    from archivey.cli.filters import members_for_include_check
+    from archivey.cost import StreamCapability
+
+    tar_path = tmp_path / "a.tar"
+    with tarfile.open(tar_path, "w") as tf:
+        info = tarfile.TarInfo("a.txt")
+        info.size = 1
+        tf.addfile(info, io.BytesIO(b"x"))
+
+    class _NonSeekable(io.BytesIO):
+        def seekable(self) -> bool:
+            return False
+
+        def seek(self, *args: object, **kwargs: object) -> int:
+            raise OSError("not seekable")
+
+        def tell(self) -> int:
+            raise OSError("not seekable")
+
+    with open_archive(_NonSeekable(tar_path.read_bytes()), streaming=True) as reader:
+        assert reader.cost.stream_capability is StreamCapability.FORWARD_ONLY
+        assert members_for_include_check(reader) is None
+        # Sole pass still available for extract/test.
+        pairs = list(reader.stream_members())
+        assert [m.name for m, _ in pairs] == ["a.txt"]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -288,8 +288,6 @@ def test_extract_strict_blocks_device_name_and_continues(
 def test_extract_strict_stop_on_error_aborts_on_device_name(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    from archivey.cli.exit_codes import EXIT_POLICY
-
     bad = _zip(tmp_path / "bad.zip", {"NUL": b"x", "ok.txt": b"y"})
     dest = tmp_path / "out"
     code = main(
@@ -303,11 +301,11 @@ def test_extract_strict_stop_on_error_aborts_on_device_name(
             "--stop-on-error",
         ]
     )
-    assert code == EXIT_POLICY
+    # Q8: STOP aborts → exit 1 (exit 3 only for completed CONTINUE + policy blocks).
+    assert code == EXIT_FAIL
     err = capsys.readouterr().err
     assert "NUL" in err
     assert "extraction stopped" in err.lower()
-    assert "remaining members" in err.lower()
     assert not (dest / "ok.txt").exists()
 
 
@@ -1087,8 +1085,6 @@ def test_extract_continues_after_traversal(
 def test_extract_stop_on_error_aborts(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    from archivey.cli.exit_codes import EXIT_POLICY
-
     monkeypatch.chdir(tmp_path)
     # Put the traversal first so STOP aborts before safe members.
     archive = _tar(
@@ -1099,7 +1095,8 @@ def test_extract_stop_on_error_aborts(
         },
     )
     code = main(["extract", str(archive), "-d", "out", "--stop-on-error"])
-    assert code == EXIT_POLICY
+    # Q8: incomplete extract under STOP → 1, not 3.
+    assert code == EXIT_FAIL
     err = capsys.readouterr().err
     assert "extraction stopped" in err
     assert not (tmp_path / "out" / "safe.txt").exists()
@@ -1221,8 +1218,6 @@ def test_extract_stop_on_error_reports_members_written(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
     """Q1.5: STOP after a successful member still reports how many were written."""
-    from archivey.cli.exit_codes import EXIT_POLICY
-
     monkeypatch.chdir(tmp_path)
     archive = _tar(
         tmp_path / "evil.tar",
@@ -1233,7 +1228,7 @@ def test_extract_stop_on_error_reports_members_written(
         },
     )
     code = main(["extract", str(archive), "-d", "out", "--stop-on-error"])
-    assert code == EXIT_POLICY
+    assert code == EXIT_FAIL  # Q8: abort → 1
     err = capsys.readouterr().err
     assert "1 member(s) written before the stop" in err
     assert "extraction stopped" in err

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -189,6 +189,7 @@ def test_reserved_verbs(sample_zip: Path) -> None:
 
 def test_salvage_reserved(sample_zip: Path) -> None:
     assert main(["list", str(sample_zip), "--salvage"]) == EXIT_USAGE
+    assert main(["--salvage", "list", str(sample_zip)]) == EXIT_USAGE
     assert (
         main(
             [
@@ -314,9 +315,9 @@ def test_extract_dest_dot_splatter(
 def test_info_and_detect(sample_zip: Path, capsys: pytest.CaptureFixture[str]) -> None:
     assert main(["info", str(sample_zip)]) == EXIT_OK
     out = capsys.readouterr().out
-    assert "ZIP" in out
-    assert "format:" in out
+    assert "format:      zip" in out or "format:" in out and "zip" in out
     assert "ArchiveFormat.ZIP" not in out
+    assert "SEVEN_Z" not in out
     assert main(["detect", str(sample_zip)]) == EXIT_OK
 
 
@@ -633,7 +634,7 @@ def _tar(path: Path, entries: dict[str, bytes]) -> Path:
 
 
 def test_hoist_root_named_like_wrapper(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
     # src.tar containing src/ — the "collision" is the wrapper itself; flatten in
     # place instead of renaming away (H2) or deleting extracted data (H1).
@@ -641,6 +642,9 @@ def test_hoist_root_named_like_wrapper(
     archive = _tar(tmp_path / "src.tar", {"src/f.txt": b"data"})
     for overwrite in ("rename", "replace", "error", "skip"):
         assert main(["extract", str(archive), "--overwrite", overwrite]) == EXIT_OK
+        err = capsys.readouterr().err
+        assert "removed wrapper; content at src/" in err
+        assert "moved to src/" not in err
         assert (tmp_path / "src" / "f.txt").read_bytes() == b"data"
         assert not (tmp_path / "src (1)").exists()
         import shutil
@@ -759,3 +763,171 @@ def test_cli_logging_leaves_no_global_state(sample_zip: Path) -> None:
     assert root.handlers == []
     assert root.propagate is True
     assert root.level == logging.NOTSET
+
+
+# --- cli-product review follow-ups (P3 / P5 / P6 / P10–P13 / D1) -------------------------
+
+
+def test_missing_archive_uses_prose_not_errno_repr(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    missing = tmp_path / "nope.zip"
+    assert main(["list", str(missing)]) == EXIT_FAIL
+    err = capsys.readouterr().err
+    assert "cannot open" in err
+    assert "no such file or directory" in err.lower()
+    assert "[Errno" not in err
+
+
+def test_extract_missing_archive_only_requires_archive(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    assert main(["x"]) == EXIT_USAGE
+    err = capsys.readouterr().err
+    assert "required: archive" in err
+    assert "patterns" not in err.split("required:")[-1]
+
+
+def test_dash_x_hints_bare_verb(capsys: pytest.CaptureFixture[str]) -> None:
+    assert main(["-x", "a.zip"]) == EXIT_USAGE
+    err = capsys.readouterr().err
+    assert "unrecognized arguments: -x" in err
+    assert "bare words" in err
+    assert "archivey x ARCHIVE" in err
+
+
+def test_help_includes_examples(capsys: pytest.CaptureFixture[str]) -> None:
+    assert main(["--help"]) == EXIT_OK
+    out = capsys.readouterr().out
+    assert "examples:" in out
+    assert "archivey x archive.zip" in out
+
+
+def test_password_eof_treated_as_no_password(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from archivey.cli import password as password_mod
+    from archivey.config import PasswordRequest
+    from tests.zipcrypto import build_zipcrypto_zip
+
+    blob = build_zipcrypto_zip(b"secret", b"zc.txt", b"hello")
+    path = tmp_path / "zc.zip"
+    path.write_bytes(blob)
+
+    monkeypatch.setattr(password_mod.sys.stdin, "isatty", lambda: True)
+
+    def _eof(_prompt: str = "") -> str:
+        raise EOFError
+
+    monkeypatch.setattr(password_mod.getpass, "getpass", _eof)
+    provider = password_mod.resolve_password(None)
+    assert callable(provider)
+    assert provider(PasswordRequest(member=None, attempt=1)) is None
+
+    # End-to-end: EOF at prompt must not dump a traceback (P5).
+    err = io.StringIO()
+    assert main(["t", str(path)], out=io.StringIO(), err=err) == EXIT_FAIL
+    text = err.getvalue()
+    assert "Traceback" not in text
+    assert "EOFError" not in text
+    assert "Password required" in text
+
+
+def test_escape_member_name_controls() -> None:
+    from archivey.cli.format import escape_member_name
+
+    assert escape_member_name("ok.txt") == "ok.txt"
+    assert "\\x1b" in escape_member_name("evil\x1b[31mRED\x1b[0m.txt")
+    assert "\\r" in escape_member_name("line1\rOK  fine.txt")
+    assert "\\\\" in escape_member_name("a\\b")
+
+
+def test_list_escapes_control_bytes_in_names(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    z = _zip(
+        tmp_path / "hostile.zip", {"evil\x1b[31m.txt": b"x", "line1\rok.txt": b"y"}
+    )
+    assert main(["list", str(z)]) == EXIT_OK
+    out = capsys.readouterr().out
+    assert "\x1b" not in out
+    assert "\\x1b" in out
+    assert "\\r" in out
+
+
+def test_list_marks_anti_and_non_current() -> None:
+    from datetime import datetime
+
+    from archivey.cli.format import format_member_line
+    from archivey.types import ArchiveMember, MemberType
+
+    anti = ArchiveMember(type=MemberType.ANTI, name="gone.txt")
+    assert format_member_line(anti).startswith("A-")
+
+    old = ArchiveMember(
+        type=MemberType.FILE,
+        name="a.txt",
+        size=1,
+        modified=datetime(2026, 1, 1),
+        is_current=False,
+    )
+    assert format_member_line(old).startswith("f~")
+
+    enc = ArchiveMember(
+        type=MemberType.FILE,
+        name="a.txt",
+        size=1,
+        is_encrypted=True,
+        is_current=False,
+    )
+    assert format_member_line(enc).startswith("fE")
+
+
+def test_extract_summary_names_single_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    z = _zip(tmp_path / "one.zip", {"root/a.txt": b"a", "root/b.txt": b"b"})
+    assert main(["extract", str(z)]) == EXIT_OK
+    err = capsys.readouterr().err
+    assert "→ root/" in err
+    assert "→ ." not in err
+
+
+def test_truncated_zip_message_is_prose_not_repr(tmp_path: Path) -> None:
+    import zipfile as zf
+
+    from archivey import open_archive
+    from archivey.exceptions import CorruptionError
+
+    buf = io.BytesIO()
+    with zf.ZipFile(buf, "w") as archive:
+        archive.writestr("a.txt", "hello")
+    path = tmp_path / "truncated.zip"
+    path.write_bytes(buf.getvalue()[:20])
+    with pytest.raises(CorruptionError) as caught:
+        open_archive(path)
+    msg = str(caught.value)
+    assert "BadZipFile" not in msg
+    assert "ArchiveFormat.ZIP" not in msg
+    assert "format=ZIP" in msg
+    assert "truncated" in msg.lower() or "corrupt" in msg.lower()
+
+
+def test_stored_zipcrypto_provider_none_is_password_required(tmp_path: Path) -> None:
+    import zipfile as zf
+
+    from archivey import open_archive
+    from archivey.exceptions import EncryptionError
+    from tests.zipcrypto import build_zipcrypto_zip
+
+    blob = build_zipcrypto_zip(
+        b"secret", b"zc.txt", b"hello world", compression=zf.ZIP_STORED
+    )
+    path = tmp_path / "zc_stored.zip"
+    path.write_bytes(blob)
+
+    with pytest.raises(EncryptionError, match="Password required") as caught:
+        with open_archive(path, password=lambda _r: None) as ar:
+            ar.read(next(m for m in ar.members() if m.is_file))
+    assert "Wrong password" not in caught.value.message

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -598,6 +598,7 @@ def test_test_open_failure_still_prints_summary(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     # Open-time failures must count as FAIL and still reach the summary (F4).
+    # Indexed archives also report untested remainder (P8).
     from archivey.exceptions import ReadError
     from archivey.internal.base_reader import BaseArchiveReader
 
@@ -609,7 +610,43 @@ def test_test_open_failure_still_prints_summary(
     assert main(["test", str(sample_zip)]) == EXIT_FAIL
     err = capsys.readouterr().err
     assert "FAIL:" in err
-    assert "0 OK, 1 failed" in err
+    # sample_zip has 3 file members; archive-wide FAIL consumes one slot.
+    assert "0 OK, 1 failed, 2 not tested" in err
+
+
+def test_test_early_abort_reports_not_tested(
+    sample_zip: Path,
+    capsys: pytest.CaptureFixture[str],
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """After one OK, a poisoned stream leaves remaining indexed files as not tested."""
+    from archivey.exceptions import ReadError
+    from archivey.internal.base_reader import BaseArchiveReader
+
+    real = BaseArchiveReader.stream_members
+
+    def _one_then_die(self: BaseArchiveReader, members: object = None) -> object:
+        yielded = False
+        for item in real(self, members):
+            if yielded:
+                raise ReadError("simulated solid abort")
+            yielded = True
+            yield item
+
+    monkeypatch.setattr(BaseArchiveReader, "stream_members", _one_then_die)
+    assert main(["test", str(sample_zip)]) == EXIT_FAIL
+    err = capsys.readouterr().err
+    assert "1 OK, 1 failed, 1 not tested" in err
+
+
+def test_test_summary_helper() -> None:
+    from archivey.cli.test_cmd import _test_summary
+
+    assert _test_summary(ok=4, failed=0, members_total=4) == "4 OK, 0 failed"
+    assert (
+        _test_summary(ok=0, failed=1, members_total=4) == "0 OK, 1 failed, 3 not tested"
+    )
+    assert _test_summary(ok=0, failed=1, members_total=None) == "0 OK, 1 failed"
 
 
 def test_archive_stem_uses_format_extension() -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -91,8 +91,19 @@ def test_bare_invocation_is_usage() -> None:
     assert main([]) == EXIT_USAGE
 
 
-def test_version() -> None:
+def test_version(capsys: pytest.CaptureFixture[str]) -> None:
     assert main(["--version"]) == EXIT_OK
+    assert capsys.readouterr().out.strip().startswith("archivey ")
+
+
+def test_version_verbose_lists_formats(capsys: pytest.CaptureFixture[str]) -> None:
+    assert main(["--version", "-v"]) == EXIT_OK
+    out = capsys.readouterr().out
+    assert out.startswith("archivey ")
+    assert "formats:" in out
+    assert "zip:" in out
+    assert main(["-v", "--version"]) == EXIT_OK
+    assert "formats:" in capsys.readouterr().out
 
 
 def test_default_list_dispatch(
@@ -347,7 +358,40 @@ def test_info_and_detect(sample_zip: Path, capsys: pytest.CaptureFixture[str]) -
     assert "format:      zip" in out or "format:" in out and "zip" in out
     assert "ArchiveFormat.ZIP" not in out
     assert "SEVEN_Z" not in out
+    assert "access:      random (indexed)" in out
     assert main(["detect", str(sample_zip)]) == EXIT_OK
+
+
+def test_info_verbose_prints_cost_axes(
+    sample_zip: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    assert main(["info", "-v", str(sample_zip)]) == EXIT_OK
+    out = capsys.readouterr().out
+    assert "access:      random (indexed)" in out
+    assert "listing:     indexed" in out
+    assert "access_cost: direct" in out
+    assert "stream:      seekable" in out
+
+
+def test_info_access_solid_for_tar_gz(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    import gzip
+    import io
+    import tarfile
+
+    tar_path = tmp_path / "a.tar"
+    with tarfile.open(tar_path, "w") as tf:
+        info = tarfile.TarInfo("hello.txt")
+        info.size = 5
+        tf.addfile(info, io.BytesIO(b"hello"))
+    gz_path = tmp_path / "a.tar.gz"
+    gz_path.write_bytes(gzip.compress(tar_path.read_bytes()))
+
+    assert main(["info", str(gz_path)]) == EXIT_OK
+    out = capsys.readouterr().out
+    assert "access:      solid (" in out
+    assert "listing requires decompression" in out
 
 
 def test_info_track_io_is_explicit_na(
@@ -862,13 +906,25 @@ def test_password_eof_treated_as_no_password(
     assert "Password required" in text
 
 
-def test_escape_member_name_controls() -> None:
-    from archivey.cli.format import escape_member_name
+def test_format_access_summary() -> None:
+    from archivey.cli.format import format_access_summary
+    from archivey.cost import AccessCost, CostReceipt, ListingCost, StreamCapability
 
-    assert escape_member_name("ok.txt") == "ok.txt"
-    assert "\\x1b" in escape_member_name("evil\x1b[31mRED\x1b[0m.txt")
-    assert "\\r" in escape_member_name("line1\rOK  fine.txt")
-    assert "\\\\" in escape_member_name("a\\b")
+    indexed = CostReceipt(
+        listing_cost=ListingCost.INDEXED,
+        access_cost=AccessCost.DIRECT,
+        stream_capability=StreamCapability.SEEKABLE,
+    )
+    assert format_access_summary(indexed) == "random (indexed)"
+
+    solid = CostReceipt(
+        listing_cost=ListingCost.REQUIRES_DECOMPRESSION,
+        access_cost=AccessCost.SOLID,
+        stream_capability=StreamCapability.SEEKABLE,
+        solid_block_count=1,
+    )
+    assert "solid (" in format_access_summary(solid)
+    assert "1 solid block" in format_access_summary(solid)
 
 
 def test_list_escapes_control_bytes_in_names(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -255,15 +255,44 @@ def test_extract_policy_and_dest(sample_zip: Path, tmp_path: Path) -> None:
     assert (dest / "a.txt").read_bytes() == b"hello"
 
 
-def test_extract_strict_abort_explains_stop(
+def test_extract_strict_blocks_device_name_and_continues(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    # Windows-reserved device names are still rejected under STRICT; OnError.STOP must
-    # say so clearly (trailing-dot names are stripped, not rejected — see #123).
+    # Windows-reserved device names are rejected under STRICT; default CONTINUE
+    # still extracts the remaining members (Q1). Trailing-dot names are stripped,
+    # not rejected — see #123.
+    from archivey.cli.exit_codes import EXIT_POLICY
+
     bad = _zip(tmp_path / "bad.zip", {"NUL": b"x", "ok.txt": b"y"})
     dest = tmp_path / "out"
     code = main(["extract", str(bad), "-d", str(dest), "--policy", "strict"])
-    assert code == EXIT_FAIL
+    assert code == EXIT_POLICY
+    err = capsys.readouterr().err
+    assert "NUL" in err
+    assert "blocked:" in err
+    assert "extraction stopped" not in err.lower()
+    assert (dest / "ok.txt").read_bytes() == b"y"
+
+
+def test_extract_strict_stop_on_error_aborts_on_device_name(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from archivey.cli.exit_codes import EXIT_POLICY
+
+    bad = _zip(tmp_path / "bad.zip", {"NUL": b"x", "ok.txt": b"y"})
+    dest = tmp_path / "out"
+    code = main(
+        [
+            "extract",
+            str(bad),
+            "-d",
+            str(dest),
+            "--policy",
+            "strict",
+            "--stop-on-error",
+        ]
+    )
+    assert code == EXIT_POLICY
     err = capsys.readouterr().err
     assert "NUL" in err
     assert "extraction stopped" in err.lower()
@@ -931,3 +960,89 @@ def test_stored_zipcrypto_provider_none_is_password_required(tmp_path: Path) -> 
         with open_archive(path, password=lambda _r: None) as ar:
             ar.read(next(m for m in ar.members() if m.is_file))
     assert "Wrong password" not in caught.value.message
+
+
+# --- Q1 / P1: extract continue-on-error + exit 3 + --stop-on-error -----------------------
+
+
+def test_extract_continues_after_traversal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from archivey.cli.exit_codes import EXIT_POLICY
+
+    monkeypatch.chdir(tmp_path)
+    archive = _tar(
+        tmp_path / "evil.tar",
+        {
+            "../escape.txt": b"bad",
+            "safe1.txt": b"ok1",
+            "safe2.txt": b"ok2",
+            "dir/nested.txt": b"ok3",
+        },
+    )
+    assert main(["extract", str(archive), "-d", "out"]) == EXIT_POLICY
+    err = capsys.readouterr().err
+    assert "blocked:" in err
+    assert "escape.txt" in err or "../escape" in err
+    assert "blocked" in err.split("→")[0]  # summary mentions blocked
+    assert (tmp_path / "out" / "safe1.txt").read_bytes() == b"ok1"
+    assert (tmp_path / "out" / "safe2.txt").read_bytes() == b"ok2"
+    assert (tmp_path / "out" / "dir" / "nested.txt").read_bytes() == b"ok3"
+    assert not (tmp_path / "escape.txt").exists()
+
+
+def test_extract_stop_on_error_aborts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    from archivey.cli.exit_codes import EXIT_POLICY
+
+    monkeypatch.chdir(tmp_path)
+    # Put the traversal first so STOP aborts before safe members.
+    archive = _tar(
+        tmp_path / "evil.tar",
+        {
+            "../escape.txt": b"bad",
+            "safe.txt": b"ok",
+        },
+    )
+    code = main(["extract", str(archive), "-d", "out", "--stop-on-error"])
+    assert code == EXIT_POLICY
+    err = capsys.readouterr().err
+    assert "extraction stopped" in err
+    assert not (tmp_path / "out" / "safe.txt").exists()
+
+
+def test_extract_corrupt_member_continues_with_exit_fail(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """CRC mismatch: recoverable members extracted; exit 1 (FAILED, not policy)."""
+    monkeypatch.chdir(tmp_path)
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("a.txt", b"hello")
+        zf.writestr("b.txt", b"world")
+        zf.writestr("c.txt", b"end")
+    data = bytearray(buf.getvalue())
+    # Flip the central-directory CRC for b.txt so open succeeds but extract fails.
+    pos = 0
+    while True:
+        i = data.find(b"PK\x01\x02", pos)
+        if i < 0:
+            break
+        name_len = int.from_bytes(data[i + 28 : i + 30], "little")
+        name = bytes(data[i + 46 : i + 46 + name_len])
+        if name == b"b.txt":
+            data[i + 16] ^= 0xFF
+            break
+        pos = i + 4
+    path = tmp_path / "badcrc.zip"
+    path.write_bytes(bytes(data))
+
+    assert main(["extract", str(path), "-d", "out"]) == EXIT_FAIL
+    err = capsys.readouterr().err
+    assert "failed:" in err
+    assert "b.txt" in err
+    assert "extraction stopped" not in err
+    assert (tmp_path / "out" / "a.txt").read_bytes() == b"hello"
+    assert (tmp_path / "out" / "c.txt").read_bytes() == b"end"
+    assert not (tmp_path / "out" / "b.txt").exists()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1046,3 +1046,67 @@ def test_extract_corrupt_member_continues_with_exit_fail(
     assert (tmp_path / "out" / "a.txt").read_bytes() == b"hello"
     assert (tmp_path / "out" / "c.txt").read_bytes() == b"end"
     assert not (tmp_path / "out" / "b.txt").exists()
+
+
+def test_extract_dest_before_patterns_still_filters(
+    sample_zip: Path, tmp_path: Path
+) -> None:
+    """Documented ``x ARCHIVE -d DEST PATTERN`` must not drop the pattern (argparse)."""
+    dest = tmp_path / "dest"
+    assert main(["x", str(sample_zip), "-d", str(dest), "a.txt"]) == EXIT_OK
+    assert (dest / "a.txt").read_bytes() == b"hello"
+    assert not (dest / "b").exists()
+
+
+def test_extract_unmatched_include_exits_one(
+    sample_zip: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    dest = tmp_path / "dest"
+    dest.mkdir()
+    assert main(["x", str(sample_zip), "-d", str(dest), "*.missing"]) == EXIT_FAIL
+    err = capsys.readouterr().err
+    assert "warning: pattern matched no members: '*.missing'" in err
+    assert list(dest.iterdir()) == []
+
+
+def test_extract_unmatched_dir_pattern_hints_dash_d(
+    sample_zip: Path,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    out = tmp_path / "out"
+    out.mkdir()
+    assert main(["x", str(sample_zip), "out"]) == EXIT_FAIL
+    err = capsys.readouterr().err
+    assert "warning: pattern matched no members: 'out'" in err
+    assert "(did you mean -d out?)" in err
+
+
+def test_extract_partial_unmatched_still_extracts(
+    sample_zip: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    dest = tmp_path / "dest"
+    assert main(["x", str(sample_zip), "-d", str(dest), "a.txt", "nope.txt"]) == EXIT_OK
+    err = capsys.readouterr().err
+    assert "warning: pattern matched no members: 'nope.txt'" in err
+    assert (dest / "a.txt").read_bytes() == b"hello"
+
+
+def test_list_unmatched_include_warns_exit_zero(
+    sample_zip: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    assert main(["list", str(sample_zip), "*.rs"]) == EXIT_OK
+    captured = capsys.readouterr()
+    assert "warning: pattern matched no members: '*.rs'" in captured.err
+    assert captured.out == ""
+
+
+def test_test_unmatched_include_exits_one(
+    sample_zip: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    assert main(["t", str(sample_zip), "missing"]) == EXIT_FAIL
+    err = capsys.readouterr().err
+    assert "warning: pattern matched no members: 'missing'" in err
+    assert "OK," not in err

--- a/tests/test_seekable_streams.py
+++ b/tests/test_seekable_streams.py
@@ -341,7 +341,8 @@ def test_gzip_accelerator_off_warns_on_rewind_but_still_seeks(
         with caplog.at_level("WARNING", logger="archivey.streams"):
             assert stream.seek(0) == 0  # rewind → slow re-decompression
             assert stream.read(10) == CONTENT[:10]  # still returns correct data
-    assert sum("seekable" in r.getMessage() for r in caplog.records) == 1
+    assert sum("re-decompresses" in r.getMessage() for r in caplog.records) == 1
+    assert any("rapidgzip" in r.getMessage() for r in caplog.records)
 
 
 def test_bzip2_accelerator_off_warns_on_rewind(
@@ -380,11 +381,11 @@ def test_zlib_warns_on_rewind(caplog: pytest.LogCaptureFixture) -> None:
             assert stream.seek(0) == 0  # rewind → re-decode from start
             assert stream.read(10) == CONTENT[:10]  # still correct
     msgs = [r.getMessage() for r in caplog.records]
-    assert sum("seekable" in m and "rapidgzip" in m for m in msgs) == 1
+    assert sum("rapidgzip" in m and "re-decompresses" in m for m in msgs) == 1
 
 
 def test_deflate_warns_on_rewind(caplog: pytest.LogCaptureFixture) -> None:
-    """Stdlib-fallback raw deflate names the ``[seekable]`` accelerator on rewind."""
+    """Stdlib-fallback raw deflate names the rapidgzip accelerator on rewind."""
     co = zlib.compressobj(wbits=-15)
     compressed = co.compress(CONTENT) + co.flush()
     config = StreamConfig(use_rapidgzip=AcceleratorMode.OFF, seekable=True)
@@ -397,7 +398,7 @@ def test_deflate_warns_on_rewind(caplog: pytest.LogCaptureFixture) -> None:
             assert stream.read(10) == CONTENT[:10]
     assert (
         sum(
-            "seekable" in r.getMessage() and "rapidgzip" in r.getMessage()
+            "rapidgzip" in r.getMessage() and "re-decompresses" in r.getMessage()
             for r in caplog.records
         )
         == 1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **cli-product** review findings on branch `cursor/cli-product-findings-cefd`.

### Done
- Unambiguous fixes (P3/P5–P7/P9–P13/D1)
- **Q1/P1** — extract `CONTINUE` by default; `--stop-on-error`; exit `3` for policy-only blocks on **completed** CONTINUE runs
- **Q3/P2** — unmatched include warnings; extract/test exit `1` when nothing selected; list warns + exit `0`; `-d` hint; argparse fold for `-d` before patterns
- **Q5–Q6/P14** — `info` prints `access:` from `CostReceipt` (`-v` adds raw axes); `--version -v` format availability matrix
- **P8** — `test` summary appends `K not tested` when an indexed member stream aborts early
- **Q8** — **Option A**: `--stop-on-error` always exits `1`; exit `3` only when CONTINUE completed with policy blocks (safe members on disk)

### Review follow-ups (#163)
- Fold tokens after `--` into patterns even when dash-prefixed (`-d out -- -file.txt`)
- Skip unmatched-include pre-scan on forward-only/streaming readers (defer empty-selection check)
- Test for STOP “N member(s) written before the stop”

### Deferred (decided)
- **Q2/P4** — no `--json` until `hash` / member schema is designed
- Failures-only `OnError` / `--stop-on-error` narrowing (separate OpenSpec; not this PR)

## Test plan
- [x] `pytest tests/test_cli.py` (80 passed)
- [x] ruff format/check on touched CLI paths
- [x] pyrefly + ty on changed CLI modules

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-68edf182-9b33-40e4-a929-61544654cefd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-68edf182-9b33-40e4-a929-61544654cefd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

