### PR TITLE
Propose: stop-on-failure-not-policy (OnError governs failures, not policy blocks)

### DIFF
--- a/openspec/changes/stop-on-failure-not-policy/.openspec.yaml
+++ b/openspec/changes/stop-on-failure-not-policy/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: library
+created: 2026-07-19

--- a/openspec/changes/stop-on-failure-not-policy/brief.md
+++ b/openspec/changes/stop-on-failure-not-policy/brief.md
@@ -1,0 +1,29 @@
+# Brief: stop-on-failure-not-policy
+
+**Status.** Ready to implement. The direction is decided — you endorsed it on pull request
+one-six-three — and the one thing left open, the name of a future strict-security mode, is
+deliberately out of scope and does not block this change.
+
+**Why it matters.** Today the library's error policy treats two very different things the
+same way. If you ask it to stop on error, it stops both when a member is genuinely broken
+and when the safe-extraction policy refuses an unsafe member. But refusing an unsafe member
+is the library doing its job, not an error. So stop-on-error aborts an otherwise-good
+archive the moment one entry looks dangerous — the opposite of "skip the bad one and keep
+going", which is the whole point of the library.
+
+**What it does.** It narrows the error policy so it governs member failures only. A policy
+block is always recorded and always lets extraction continue, whether or not stop-on-error
+is set. Genuine failures, like corrupt or truncated data, still stop the run under stop
+mode. All the hard safety limits — resource guards, bomb guards, keyboard interrupt — keep
+halting exactly as before. The change lives at a single spot in the extraction handler,
+with no new options and no signature change.
+
+**Decided.** Stop keys off failures, not policy. Aborting the whole archive on any unsafe
+member becomes a separate future opt-in, not part of the error policy.
+
+**Your call later.** Whether that future strict mode is a policy setting or a command-line
+flag — a separate change.
+
+**Bottom line.** This is a breaking change to the default stop behavior, and it also
+settles the command-line exit-code question on pull request one-six-three: because stop
+never halts on a block anymore, the awkward case simply disappears.

--- a/openspec/changes/stop-on-failure-not-policy/design.md
+++ b/openspec/changes/stop-on-failure-not-policy/design.md
@@ -1,0 +1,105 @@
+## Context
+
+`internal/extraction.py` handles every member that cannot be written normally at one
+site (~L448–459): it classifies the outcome as `BLOCKED` when the error is a
+`FilterRejectionError` (universal path-safety check or policy filter) and `FAILED`
+otherwise, appends an `ExtractionResult`, then — for **both** classes — does
+`if self._on_error is OnError.STOP: raise error`. So today `OnError.STOP` aborts on the
+first policy block just as it aborts on the first genuine failure.
+
+`OnError` (`internal/extraction_types.py`) is a two-value enum (`STOP` default,
+`CONTINUE`), and the library default is `STOP`. The CLI overrides to `CONTINUE` by
+default and adds `--stop-on-error` in PR #163 (branch `cursor/cli-product-findings-cefd`,
+not yet merged); `main` still passes the library `STOP` default and has no such flag.
+
+This change is the library-side follow-up that PR #163's Q8 comment points to. It was
+discussed on PR #163 and the maintainer endorsed "change STOP to stop only on failures,
+not policy."
+
+## Goals / Non-Goals
+
+**Goals:**
+- `OnError` governs member **failures** only; a policy `BLOCKED` is always recorded and
+  never halts extraction, under `STOP` or `CONTINUE`.
+- Preserve all existing always-stop guards (resource limits, `DiagnosticRaisedError`,
+  `KeyboardInterrupt`, `MemoryError`, programming errors) unchanged.
+- Give PR #163 a coherent target: `--stop-on-error` = stop on failures only, and the
+  Q8 exit-code map resolves to Option A structurally.
+
+**Non-Goals:**
+- A fail-closed "reject the whole archive if any member is unsafe" mode. That is a
+  distinct security posture and a **separate future opt-in** (a strict policy mode or a
+  `--reject-unsafe-archive` CLI flag), deliberately not folded into `OnError` here.
+- Re-speccing the `cli` capability's exit-code requirement — PR #163 owns that rewrite
+  (see Decision 3).
+- Changing what counts as a `BLOCKED` vs `FAILED` outcome; only the *stop/continue*
+  disposition of `BLOCKED` changes.
+
+## Decisions
+
+### 1. Split the stop disposition by outcome class, at the existing handler site
+The block/fail classification already exists two lines above the `raise`. The change is
+to make the `STOP` raise conditional on the outcome being `FAILED`: a `BLOCKED` result is
+recorded-and-continued regardless of `on_error`; a `FAILED` result raises under `STOP`
+and records-and-continues under `CONTINUE`. No new enum value, no signature change — the
+narrowing lives entirely in the per-member handler.
+
+**Rejected:** a third `OnError` value (e.g. `STOP_ON_FAILURE`). It would leave the old
+`STOP`-halts-on-block behavior reachable, which is exactly the conflation we are removing;
+callers who genuinely want abort-on-unsafe should reach for an explicit *policy* opt-in,
+not an error-handling mode. Keeping `OnError` two-valued keeps the axis clean: `OnError`
+is about failures, policy strictness is about blocks.
+
+### 2. This is a behavior change to the shipped library default (accepted)
+`extract_all(..., on_error=OnError.STOP)` previously raised `FilterRejectionError` on the
+first blocked member; it now completes and returns a report containing `BLOCKED` results.
+A caller that relied on STOP to fail-closed on unsafe members must switch to the
+forthcoming strict-policy opt-in (Non-Goal above). This is called out as **BREAKING** in
+the proposal. It is the right default for a safe-extraction library: skipping the unsafe
+member and continuing is the defining behavior, and a lone hostile entry should not deny
+the caller the archive's legitimate contents.
+
+**Rejected:** gating the new behavior behind a new default-off knob to preserve strict
+back-compat. That would keep the trap (STOP surprising callers into aborting) as the
+default and bury the fix behind opt-in — inverting the priority.
+
+### 3. Coordinate the CLI parts with PR #163 rather than re-speccing `cli` here
+PR #163 introduces CONTINUE-by-default, `--stop-on-error`, and lifts the `exit ≥3 is
+reserved` rule from `cli/spec.md`. This change supplies the two decision inputs #163
+should encode, and the `cli` spec delta lands wherever the two changes are sequenced:
+
+- **`--stop-on-error` narrows to failures only.** With Decision 1, passing library `STOP`
+  already means "stop on failures, continue on blocks", so the flag needs no special CLI
+  logic — it just maps to `OnError.STOP`.
+- **Exit codes follow Q8 Option A.** `0` clean; `3` reserved for a completed run with ≥1
+  `BLOCKED` and no `FAILED`; `1` for any abort/failure; `2` usage. Because STOP no longer
+  halts on a block, the "STOP + policy block" rows of the Q8 table cannot occur — Option A
+  becomes structural, not a convention. `cli/exit_codes.py` gains a named `EXIT_BLOCKED =
+  3` (or similar) constant.
+
+If #163 merges first, the implementer adds a `cli` delta MODIFYING the (by then rewritten)
+exit-code requirement here; if this merges first, #163 rebases onto the narrowed flag
+meaning. Either ordering is a rebase, not a conflict of intent.
+
+### 4. Leave the `BLOCKED` status/definition prose as-is
+`safe-extraction`'s "result/status matrix" already defines `BLOCKED` as a *continued*
+`FilterRejectionError`; that stays true (blocks are now always continued). Only the
+"Error Policy (OnError)" requirement, which currently subordinates blocks to `OnError`,
+is modified. Avoids a wider delta than the behavior change warrants.
+
+## Risks / Trade-offs
+
+- [Existing library callers using `OnError.STOP` for fail-closed security lose the abort]
+  → Documented as BREAKING; the strict-policy opt-in is the migration path. Until it
+  ships, such callers can inspect the returned report for `BLOCKED` results and raise
+  themselves.
+- [Spec delta on `safe-extraction` while PR #163 edits `cli` in parallel] → The two
+  capabilities are disjoint; only design/tasks reference the CLI, and Decision 3 spells
+  out the rebase either way.
+- [Tests currently assert STOP raises on a policy block] → Those assertions invert to
+  "STOP completes with a `BLOCKED` result"; enumerated in tasks.
+
+## Open Questions
+
+- Name and shape of the future fail-closed opt-in (strict policy mode vs. dedicated flag)
+  — out of scope here; tracked for a later change so this one is not blocked on it.

--- a/openspec/changes/stop-on-failure-not-policy/proposal.md
+++ b/openspec/changes/stop-on-failure-not-policy/proposal.md
@@ -1,0 +1,62 @@
+## Why
+
+`OnError.STOP` currently halts on **both** a member *failure* (corrupt / truncated /
+undecodable data) and a policy *block* (an unsafe member refused by a universal
+path-safety check or a policy filter). These are different in kind: a failure means
+the archive is broken; a block is the safe-extraction library working **as designed**.
+Conflating them means STOP aborts an otherwise-good archive the moment one member is
+unsafe — the opposite of "skip the unsafe member and keep going," which is the
+library's defining behavior. It also forces the CLI's `--stop-on-error` (PR #163) into
+an unwanted meaning and creates the unanswerable exit-code question in
+`review/cli-product/QUESTIONS.md` Q8.
+
+## What Changes
+
+- **BREAKING** (library default behavior): `OnError` governs **member failures only**.
+  A policy `BLOCKED` outcome (`FilterRejectionError` from a universal check or a policy
+  filter) is **always** recorded-and-continued and never halts extraction, under either
+  `OnError.STOP` or `OnError.CONTINUE`. `OnError.STOP` continues to raise on the first
+  genuine member failure.
+- Global always-stop guards are unchanged: cumulative-byte / archive-wide / live-ratio /
+  max-entries `ResourceLimitError`, `DiagnosticRaisedError` (diagnostic `RAISE`),
+  `KeyboardInterrupt`, `MemoryError`, and unexpected programming errors still halt under
+  any `OnError`.
+- CLI (depends on PR #163): `--stop-on-error` narrows to stop on **failures only**;
+  policy blocks are always reported-and-continued. Exit codes follow Q8 **Option A** —
+  the abort/STOP path exits `1`; exit `3` is reserved for a run that *completed* with
+  ≥1 policy `BLOCKED` and no `FAILED`. This makes the "STOP + policy block" row of the
+  Q8 table structurally impossible and resolves Q8.
+- "Abort the whole extraction on any unsafe member" (fail-closed strict-security
+  posture) is explicitly **out of scope** here and deferred to a future, separate opt-in
+  (e.g. a strict policy mode / `--reject-unsafe-archive`), not folded into `OnError`.
+
+## Capabilities
+
+### New Capabilities
+<!-- none -->
+
+### Modified Capabilities
+- `safe-extraction` — the "Error Policy (OnError) for extraction failures" requirement
+  changes so `OnError` no longer governs policy blocks; STOP no longer raises on a
+  `FilterRejectionError`.
+
+_(The CLI's `--stop-on-error` narrowing and the Option-A exit-code map live on the `cli`
+capability, whose exit-code requirement is being rewritten by PR #163. To avoid dueling
+deltas, this change does not re-spec `cli`; it supplies the decision inputs #163 encodes
+and is captured in design.md / tasks.md as coordinated-with-#163. If #163 has already
+merged when this is implemented, add the `cli` delta here instead.)_
+
+## Impact
+
+- **Public API / behavior**: `Reader.extract_all(..., on_error=OnError.STOP)` no longer
+  raises `FilterRejectionError` on the first blocked member; such runs now complete and
+  return an `ExtractionReport` containing `BLOCKED` results. Callers relying on STOP to
+  fail-closed on unsafe members must switch to the forthcoming strict-policy opt-in.
+- **Modules**: `internal/extraction.py` (the `OnError.STOP` raise site at the
+  per-member handler), `cli/extract_cmd.py` (stop path + exit codes), `cli/exit_codes.py`
+  (name the reserved `3`).
+- **Docs**: `docs/safe-extraction.md`, `docs/usage.md` (CLI stop/exit-code behavior);
+  `review/cli-product/QUESTIONS.md` Q8 recorded as resolved.
+- **Tests**: `OnError` matrix tests (STOP + policy block now continues), CLI exit-code
+  tests (STOP+policy → `1`, and the `3`-reserved-for-completed-with-blocks invariant).
+- **Extras/deps**: none.

--- a/openspec/changes/stop-on-failure-not-policy/specs/safe-extraction/spec.md
+++ b/openspec/changes/stop-on-failure-not-policy/specs/safe-extraction/spec.md
@@ -1,0 +1,39 @@
+## MODIFIED Requirements
+
+### Requirement: Error Policy (OnError) for extraction failures
+
+`OnError.STOP` and `OnError.CONTINUE` SHALL govern per-member **failures** only — a
+non-rejection member-scoped `ArchiveyError`, a permitted read/write `OSError`, or a
+per-member ratio violation. A policy **block** (a `FilterRejectionError` from a universal
+path-safety check or a policy filter) is NOT a failure: it SHALL always be recorded as a
+`BLOCKED` `ExtractionResult`, have its partial output removed, emit its
+`EXTRACTION_MEMBER_BLOCKED` diagnostic, and let extraction proceed — under **either**
+`OnError.STOP` or `OnError.CONTINUE`. `OnError.STOP` therefore never raises on a blocked
+member; a STOP run can complete and return an `ExtractionReport` whose results include
+`BLOCKED`. Aborting the whole extraction on the first unsafe member (fail-closed strict
+security) is a separate, future opt-in and is not expressed through `OnError`.
+
+Under `CONTINUE`, a member-scoped failure records `FAILED`, removes partial output, emits
+the matching diagnostic under the active diagnostic policy, and proceeds.
+
+Diagnostic disposition SHALL still be authoritative: `RAISE` emits `DiagnosticRaisedError`
+and halts immediately even under `OnError.CONTINUE`; logging-handler and
+diagnostic-callback exceptions propagate unchanged. Under `STOP`, a genuine member failure
+raises immediately and is not converted to an extraction advisory. Global resource guards
+(`ResourceLimitError` for cumulative bytes, archive-wide/live ratio, and max entries),
+`KeyboardInterrupt`, `MemoryError`, and unexpected programming exceptions are always-stop
+and are not swallowed.
+
+#### Scenario: OnError matrix
+
+| Case | Expected |
+| --- | --- |
+| Member blocked by policy/path-safety under `STOP` | `BLOCKED` result; partial output removed; `EXTRACTION_MEMBER_BLOCKED`; extraction does **not** halt; later members continue |
+| Member blocked by policy/path-safety under `CONTINUE` | `BLOCKED` result; partial output removed; `EXTRACTION_MEMBER_BLOCKED`; later members continue |
+| First member blocked, remaining members extractable, under `STOP` | Run completes; report contains `BLOCKED` + later `EXTRACTED`; no exception escapes |
+| Corrupt member under `CONTINUE` and default diagnostics | Partial output removed; `FAILED` result; `EXTRACTION_MEMBER_FAILED`; later members continue |
+| Default `STOP` member failure (e.g. `CorruptionError`) | Original error propagates immediately; failing partial file removed; earlier outputs remain; no continued-failure diagnostic |
+| Filesystem `OSError` while writing under `CONTINUE` | Partial output removed; `FAILED` result/diagnostic; extraction proceeds |
+| Extraction diagnostic resolves to `RAISE` under `CONTINUE` | `DiagnosticRaisedError` halts; no report returned |
+| Cumulative bytes/live ratio/max entries exceed limit under any `OnError` | `ResourceLimitError` propagates and halts; no later member processed |
+| Mixed good/corrupt/blocked archive under `CONTINUE` | Extractable members written; report includes `EXTRACTED` plus `FAILED`/`BLOCKED`; no per-member exception escapes |

--- a/openspec/changes/stop-on-failure-not-policy/tasks.md
+++ b/openspec/changes/stop-on-failure-not-policy/tasks.md
@@ -1,0 +1,60 @@
+## 1. Library: make OnError govern failures only
+
+- [ ] 1.1 In `internal/extraction.py`, at the per-member outcome handler (the site that
+      classifies `BLOCKED` vs `FAILED` and does `if on_error is OnError.STOP: raise`),
+      make the STOP raise conditional on the outcome being `FAILED`. A `BLOCKED` result
+      is always recorded-and-continued regardless of `on_error`.
+- [ ] 1.2 Confirm the always-stop guards are untouched: `ResourceLimitError` (cumulative
+      bytes / archive-wide / live ratio / max entries), `DiagnosticRaisedError`,
+      `KeyboardInterrupt`, `MemoryError`, and unexpected programming errors still halt
+      under any `OnError` — none of these are `FilterRejectionError`, so 1.1 must not
+      broaden or narrow them.
+- [ ] 1.3 Verify the hardlink-orphan and other secondary raise sites (e.g. the
+      `if self._on_error is OnError.STOP: raise` around orphan handling) only ever carry
+      `FAILED` outcomes; leave them as-is (they are failures, not blocks).
+- [ ] 1.4 Update the `OnError.STOP` docstring comment in `internal/extraction_types.py`
+      to say it stops on the first member *failure* (blocks are always continued).
+
+## 2. Spec + docs
+
+- [ ] 2.1 Land the `safe-extraction` delta (this change's
+      `specs/safe-extraction/spec.md`): STOP no longer raises on a `FilterRejectionError`;
+      a STOP run can complete with `BLOCKED` results.
+- [ ] 2.2 Update `docs/safe-extraction.md` (and any `docs/usage.md` note) to describe
+      STOP as failures-only, and that aborting on unsafe members is a separate future
+      opt-in.
+- [ ] 2.3 Record `review/cli-product/QUESTIONS.md` Q8 as **resolved by scoping** — STOP
+      never halts on policy, so the "STOP + policy block" rows are moot; exit codes are
+      Option A. Note the resolution supersedes the A/B framing.
+
+## 3. CLI (coordinate with PR #163 — see design Decision 3)
+
+- [ ] 3.1 After PR #163's `--stop-on-error` / CONTINUE-default plumbing is present, confirm
+      `--stop-on-error` maps to `OnError.STOP` and — via task 1.1 — stops on failures only
+      while blocks are reported-and-continued. No block-specific CLI logic should be needed.
+- [ ] 3.2 Implement Option-A exit codes in `cli/extract_cmd.py`: `0` clean; `3` when the
+      run completed with ≥1 `BLOCKED` and no `FAILED`; `1` on any abort/failure; `2` usage.
+- [ ] 3.3 Add a named constant for the reserved `3` in `cli/exit_codes.py`
+      (e.g. `EXIT_BLOCKED = 3`) with a one-line comment tying it to the Q8 decision.
+- [ ] 3.4 If PR #163 has merged, add a `cli` delta under this change MODIFYING the (then
+      rewritten) exit-code requirement to the Option-A map; otherwise leave the CLI spec
+      to #163 and cross-reference this change's decision.
+
+## 4. Tests
+
+- [ ] 4.1 Update/replace `OnError` matrix tests: STOP + first-member policy block now
+      *completes* with a `BLOCKED` result and continues to later `EXTRACTED` members
+      (was: raised `FilterRejectionError`).
+- [ ] 4.2 Add a regression test: STOP + a genuine member failure still raises immediately
+      (unchanged), and a mixed archive under STOP yields `BLOCKED` for unsafe members but
+      raises on the first real failure.
+- [ ] 4.3 Update CLI exit-code tests (once 3.x lands): STOP-path abort/failure → `1`;
+      a completed run with blocks and no failures → `3`; assert no test asserts `3` for a
+      STOP+policy abort.
+
+## 5. Verify
+
+- [ ] 5.1 `uv run pytest tests/ -k "extraction or on_error or cli"` (and the full suite
+      before push) across `[all]`, `[all-lowest]`, and `[core-only]` per CONTRIBUTING.
+- [ ] 5.2 `uv run pyrefly check` and `uv run ty check`; `uv run ruff format` + `ruff check`.
+- [ ] 5.3 `openspec validate --strict stop-on-failure-not-policy`.


### PR DESCRIPTION
## Summary

OpenSpec change proposal (`openspec/changes/stop-on-failure-not-policy/`) that separates
**policy blocks** from **member failures** in extraction stop semantics — the deeper issue
surfaced by PR #163's Q8.

Today `internal/extraction.py` classifies each un-writable member as `BLOCKED` (a
`FilterRejectionError` from a universal path-safety check or a policy filter) or `FAILED`
(broken/undecodable data), then halts on **both** under `OnError.STOP`. A block isn't an
error — it's the safe-extraction library working as designed — so STOP aborting an
otherwise-good archive on the first unsafe member is the opposite of "skip it and keep
going."

## What this proposes

- **BREAKING (library default):** `OnError` governs member **failures only**. A policy
  `BLOCKED` is always recorded-and-continued, under `STOP` or `CONTINUE`; STOP no longer
  raises on a `FilterRejectionError`. Always-stop guards (resource/bomb limits,
  `DiagnosticRaisedError`, `KeyboardInterrupt`, `MemoryError`) are unchanged.
- **CLI (coordinated with #163):** `--stop-on-error` narrows to failures only; exit codes
  follow Q8 **Option A** — abort/STOP → `1`, `3` reserved for a *completed* run with ≥1
  `BLOCKED` and no `FAILED`. This makes the "STOP + policy block" row of the Q8 table
  structurally impossible and **resolves Q8**.
- **Deferred:** "abort the whole archive on any unsafe member" (fail-closed strict
  security) → a separate future opt-in, not folded into `OnError`.

## Artifacts
- `proposal.md` — why/what/impact
- `design.md` — decisions, incl. how this coordinates with the in-flight PR #163 `cli` delta
- `specs/safe-extraction/spec.md` — MODIFIED "Error Policy (OnError)" delta
- `tasks.md` — implementation steps (library core is mergeable against `main`; CLI parts gated on #163)
- `brief.md` — one-minute spoken summary

`openspec validate --strict stop-on-failure-not-policy` passes.

## Notes
- This is a **proposal only** — no library/CLI code changes yet.
- The scoping decision (spec delta limited to `safe-extraction`, CLI left to #163 to avoid
  dueling deltas) is explained in design.md Decision 3.
- My Q8 recommendation (Option A) is posted on PR #163 for reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Jq6hWe8KrpcvR8hADCT3WN

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jq6hWe8KrpcvR8hADCT3WN)_