### PR TITLE
fix(extraction): OnError.STOP governs failures only, not policy blocks

### DIFF
--- a/docs/gotchas.md
+++ b/docs/gotchas.md
@@ -113,6 +113,7 @@ unless you ask.
 | Collisions are first-class | Under `STRICT`/`STANDARD`, `README`/`readme` (and NFC/NFD twins) collide on **all** platforms. `OverwritePolicy` applies; `REPLACE` is not a silent merge — a collision diagnostic fires. Use `OverwritePolicy.RENAME` (`photo (1).jpg`) for intentional duplicates. |
 | Reserved names / `:` | Rejected under `STRICT`/`STANDARD` on every platform (`CON`, `NUL`, `file:ads`, …). |
 | `OnError.CONTINUE` ≠ ignore bombs | Per-member failures can continue; global bomb and listing guards still stop. |
+| `OnError.STOP` is failures-only | Policy blocks are always recorded and continued; inspect the report (or exit `3` on the CLI) for `BLOCKED`. Abort-on-unsafe is a separate future opt-in. |
 | `TRUSTED` still won’t traverse | Ownership / sticky bits only when allowed; path safety stays on. |
 | Hardlinks + filters | Excluding a hardlink’s source can orphan the link (especially on streaming sources); `OnError` decides fail vs continue. |
 | Symlink-hostile filesystems | Unlike `tarfile`, archivey does **not** copy target bytes through a symlink; you get a typed failure or skip. |

--- a/docs/safe-extraction.md
+++ b/docs/safe-extraction.md
@@ -37,7 +37,7 @@ archivey.extract(
     "out/",
     policy=ExtractionPolicy.STRICT,       # default
     overwrite=OverwritePolicy.ERROR,      # or REPLACE / SKIP
-    on_error=OnError.STOP,                # or CONTINUE
+    on_error=OnError.STOP,                # or CONTINUE — failures only
     limits=ExtractionLimits(...),         # or ExtractionLimits.UNLIMITED
 )
 
@@ -48,6 +48,14 @@ with archivey.open_archive(
     reader.members()  # ResourceLimitError if the central directory is larger
 
 ```
+
+`OnError` governs per-member **failures** (corrupt/truncated data, write errors,
+overwrite conflicts under `ERROR`). A policy **block** — an unsafe member refused by a
+universal path-safety check or a policy filter — is always recorded as `BLOCKED` and
+extraction continues, under either `STOP` or `CONTINUE`. Aborting the whole archive on
+the first unsafe member (fail-closed strict security) is a separate, future opt-in; until
+then, inspect the returned `ExtractionReport` for `BLOCKED` results if you need to raise
+yourself.
 
 | Policy | Intent |
 | --- | --- |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -231,7 +231,8 @@ archivey extract photos.zip
 # Classic unzip-into-cwd (opt-in):
 archivey extract photos.zip -d .
 
-# All-or-nothing (library STOP semantics) for scripts that need it:
+# All-or-nothing on member *failures* (library STOP). Policy blocks are still
+# reported and skipped; remaining members extract. Exit 3 if only blocks.
 archivey extract photos.zip --stop-on-error
 
 # Filters: positionals are includes; --exclude subtracts. Unmatched includes
@@ -246,10 +247,10 @@ archivey extract photos.zip --policy trusted -d /tmp/out
 - Verbs are bare words (`x`, `list`); dash-prefixed forms like `-x` are not mode selectors.
 - A file whose name is a verb word (e.g. `./x`) is reached with an explicit verb:
   `archivey list ./x`.
-- Exit codes: `0` success, `1` operation failed or extract aborted
-  (`--stop-on-error`), `2` usage error (argparse), `3` extract **completed**
-  with ≥1 safety-policy block and no member failure (safe members on disk).
-  Codes `≥4` are reserved.
+- Exit codes: `0` success, `1` operation failed or extract aborted on a member
+  failure (`--stop-on-error`), `2` usage error (argparse), `3` extract
+  **completed** with ≥1 safety-policy block and no member failure (safe members
+  on disk; under CONTINUE or STOP). Codes `≥4` are reserved.
 - `--salvage`, stdin (`-`), and `hash` / `create` / `convert` are reserved for later.
 
 ## Next

--- a/openspec/changes/stop-on-failure-not-policy/specs/cli/spec.md
+++ b/openspec/changes/stop-on-failure-not-policy/specs/cli/spec.md
@@ -1,0 +1,32 @@
+## MODIFIED Requirements
+
+### Requirement: exit codes are argparse-aligned with a policy-refusal code
+
+The system SHALL exit `0` on success and `2` on CLI usage errors (unknown
+verb/flag or bad arguments — the argparse default). Operational failures
+(unreadable, unsupported, or corrupt archive; read/integrity failure; member
+extraction `FAILED`; incomplete listing whose `MemberListReport.error` is set;
+an early abort under `--stop-on-error` on a member **failure**, or any
+always-stop / hoist failure) SHALL exit `1`. When `extract` **completes**
+(under CONTINUE or STOP) with one or more members `BLOCKED` by safety policy
+and no member `FAILED`, the system SHALL exit `3` (refused by safety policy —
+safe members are on disk). Because `OnError.STOP` / `--stop-on-error` never
+halts on a policy block, a STOP+policy abort cannot occur; exit `3` MUST NOT
+be used for an aborted STOP-path failure. Exit codes `≥4` SHALL remain
+reserved. Documentation SHALL direct callers to treat any nonzero code other
+than `2` as a failure and MUST NOT assume `1` is the only failure code.
+
+#### Scenario: exit codes
+
+| Case | Expected |
+| --- | --- |
+| `archivey list <valid-archive>` | Exit `0` |
+| `archivey --badflag` / unknown verb | Exit `2` (usage) |
+| `archivey list <corrupt-or-unreadable>` | Exit `1` |
+| `archivey list <archive-with-recoverable-prefix-and-terminal-error>` | Exit `1` (after printing recovered members) |
+| `archivey test <archive-with-failing-member>` | Exit `1` |
+| `archivey test <indexed-archive>` when the member stream aborts early | Summary includes `K not tested` for the untested remainder; exit `1` |
+| `archivey extract <archive-with-traversal-and-safe-members>` | Extracts safe members; prints `blocked:`; exit `3` |
+| `archivey extract --stop-on-error <archive-with-traversal-and-safe-members>` | Extracts safe members; prints `blocked:`; exit `3` (blocks always continue) |
+| `archivey extract <archive-with-corrupt-member>` | Extracts recoverable members; prints `failed:`; exit `1` |
+| `archivey extract --stop-on-error <archive-with-corrupt-member>` | Stops at first failure; exit `1` |

--- a/openspec/changes/stop-on-failure-not-policy/tasks.md
+++ b/openspec/changes/stop-on-failure-not-policy/tasks.md
@@ -1,54 +1,54 @@
 ## 1. Library: make OnError govern failures only
 
-- [ ] 1.1 In `internal/extraction.py`, at the per-member outcome handler (the site that
+- [x] 1.1 In `internal/extraction.py`, at the per-member outcome handler (the site that
       classifies `BLOCKED` vs `FAILED` and does `if on_error is OnError.STOP: raise`),
       make the STOP raise conditional on the outcome being `FAILED`. A `BLOCKED` result
       is always recorded-and-continued regardless of `on_error`.
-- [ ] 1.2 Confirm the always-stop guards are untouched: `ResourceLimitError` (cumulative
+- [x] 1.2 Confirm the always-stop guards are untouched: `ResourceLimitError` (cumulative
       bytes / archive-wide / live ratio / max entries), `DiagnosticRaisedError`,
       `KeyboardInterrupt`, `MemoryError`, and unexpected programming errors still halt
       under any `OnError` — none of these are `FilterRejectionError`, so 1.1 must not
       broaden or narrow them.
-- [ ] 1.3 Verify the hardlink-orphan and other secondary raise sites (e.g. the
+- [x] 1.3 Verify the hardlink-orphan and other secondary raise sites (e.g. the
       `if self._on_error is OnError.STOP: raise` around orphan handling) only ever carry
       `FAILED` outcomes; leave them as-is (they are failures, not blocks).
-- [ ] 1.4 Update the `OnError.STOP` docstring comment in `internal/extraction_types.py`
+- [x] 1.4 Update the `OnError.STOP` docstring comment in `internal/extraction_types.py`
       to say it stops on the first member *failure* (blocks are always continued).
 
 ## 2. Spec + docs
 
-- [ ] 2.1 Land the `safe-extraction` delta (this change's
+- [x] 2.1 Land the `safe-extraction` delta (this change's
       `specs/safe-extraction/spec.md`): STOP no longer raises on a `FilterRejectionError`;
       a STOP run can complete with `BLOCKED` results.
-- [ ] 2.2 Update `docs/safe-extraction.md` (and any `docs/usage.md` note) to describe
+- [x] 2.2 Update `docs/safe-extraction.md` (and any `docs/usage.md` note) to describe
       STOP as failures-only, and that aborting on unsafe members is a separate future
       opt-in.
-- [ ] 2.3 Record `review/cli-product/QUESTIONS.md` Q8 as **resolved by scoping** — STOP
+- [x] 2.3 Record `review/cli-product/QUESTIONS.md` Q8 as **resolved by scoping** — STOP
       never halts on policy, so the "STOP + policy block" rows are moot; exit codes are
       Option A. Note the resolution supersedes the A/B framing.
 
 ## 3. CLI (coordinate with PR #163 — see design Decision 3)
 
-- [ ] 3.1 After PR #163's `--stop-on-error` / CONTINUE-default plumbing is present, confirm
+- [x] 3.1 After PR #163's `--stop-on-error` / CONTINUE-default plumbing is present, confirm
       `--stop-on-error` maps to `OnError.STOP` and — via task 1.1 — stops on failures only
       while blocks are reported-and-continued. No block-specific CLI logic should be needed.
-- [ ] 3.2 Implement Option-A exit codes in `cli/extract_cmd.py`: `0` clean; `3` when the
+- [x] 3.2 Implement Option-A exit codes in `cli/extract_cmd.py`: `0` clean; `3` when the
       run completed with ≥1 `BLOCKED` and no `FAILED`; `1` on any abort/failure; `2` usage.
-- [ ] 3.3 Add a named constant for the reserved `3` in `cli/exit_codes.py`
+- [x] 3.3 Add a named constant for the reserved `3` in `cli/exit_codes.py`
       (e.g. `EXIT_BLOCKED = 3`) with a one-line comment tying it to the Q8 decision.
-- [ ] 3.4 If PR #163 has merged, add a `cli` delta under this change MODIFYING the (then
+- [x] 3.4 If PR #163 has merged, add a `cli` delta under this change MODIFYING the (then
       rewritten) exit-code requirement to the Option-A map; otherwise leave the CLI spec
       to #163 and cross-reference this change's decision.
 
 ## 4. Tests
 
-- [ ] 4.1 Update/replace `OnError` matrix tests: STOP + first-member policy block now
+- [x] 4.1 Update/replace `OnError` matrix tests: STOP + first-member policy block now
       *completes* with a `BLOCKED` result and continues to later `EXTRACTED` members
       (was: raised `FilterRejectionError`).
-- [ ] 4.2 Add a regression test: STOP + a genuine member failure still raises immediately
+- [x] 4.2 Add a regression test: STOP + a genuine member failure still raises immediately
       (unchanged), and a mixed archive under STOP yields `BLOCKED` for unsafe members but
       raises on the first real failure.
-- [ ] 4.3 Update CLI exit-code tests (once 3.x lands): STOP-path abort/failure → `1`;
+- [x] 4.3 Update CLI exit-code tests (once 3.x lands): STOP-path abort/failure → `1`;
       a completed run with blocks and no failures → `3`; assert no test asserts `3` for a
       STOP+policy abort.
 

--- a/openspec/changes/stop-on-failure-not-policy/tasks.md
+++ b/openspec/changes/stop-on-failure-not-policy/tasks.md
@@ -54,7 +54,7 @@
 
 ## 5. Verify
 
-- [ ] 5.1 `uv run pytest tests/ -k "extraction or on_error or cli"` (and the full suite
+- [x] 5.1 `uv run pytest tests/ -k "extraction or on_error or cli"` (and the full suite
       before push) across `[all]`, `[all-lowest]`, and `[core-only]` per CONTRIBUTING.
-- [ ] 5.2 `uv run pyrefly check` and `uv run ty check`; `uv run ruff format` + `ruff check`.
-- [ ] 5.3 `openspec validate --strict stop-on-failure-not-policy`.
+- [x] 5.2 `uv run pyrefly check` and `uv run ty check`; `uv run ruff format` + `ruff check`.
+- [x] 5.3 `openspec validate --strict stop-on-failure-not-policy`.

--- a/openspec/specs/cli/spec.md
+++ b/openspec/specs/cli/spec.md
@@ -122,9 +122,12 @@ Overwrite SHALL default to `rename` once `OverwritePolicy.RENAME` exists
 `extract` SHALL pass `OnError.CONTINUE` by default so policy rejections and
 per-member read failures are recorded (`blocked:` / `failed:` lines plus the
 closing summary) and remaining members are still extracted where the stream
-allows. `--stop-on-error` SHALL restore `OnError.STOP` for that invocation.
-On an early stop (STOP path or always-stop limit), the system SHALL still
-report how many members were written before the stop.
+allows. `--stop-on-error` SHALL restore `OnError.STOP` for that invocation —
+stopping on member **failures** only. Policy `BLOCKED` outcomes are always
+reported-and-continued (library `OnError` does not halt on blocks; see
+`stop-on-failure-not-policy`). On an early stop (STOP-path failure or
+always-stop limit), the system SHALL still report how many members were written
+before the stop.
 
 #### Scenario: CLI behavior matrix
 
@@ -148,7 +151,7 @@ report how many members were written before the stop.
 | `archivey extract <archive> -d .` | Extracts into cwd verbatim (classic splatter, opt-in) |
 | `archivey extract <archive> --policy trusted` | Maps to `ExtractionPolicy.TRUSTED` |
 | `archivey extract <archive-with-traversal-and-safe-members>` | Safe members extracted; `blocked:` lines; exit `3` |
-| `archivey extract --stop-on-error <archive-with-bad-member>` | Stops at first failure; reports members written before stop |
+| `archivey extract --stop-on-error <archive-with-bad-member>` | Stops at first **failure**; reports members written before stop; policy blocks alone do not stop |
 | Subcommand includes fnmatch pattern(s) after the archive | Operation limited to matching member names (positional = include) |
 | `archivey extract <archive> out` where `out/` exists and matches no member | stderr warning with `(did you mean -d out?)`; exit `1` |
 | `archivey extract <archive> '*.missing'` | stderr warning; exit `1` |
@@ -229,11 +232,13 @@ The system SHALL exit `0` on success and `2` on CLI usage errors (unknown
 verb/flag or bad arguments — the argparse default). Operational failures
 (unreadable, unsupported, or corrupt archive; read/integrity failure; member
 extraction `FAILED`; incomplete listing whose `MemberListReport.error` is set;
-an early abort under `--stop-on-error`, including a policy block that stops the
-run) SHALL exit `1`. When `extract` **completes** under continue-on-error with
-one or more members `BLOCKED` by safety policy and no member `FAILED`, the
-system SHALL exit `3` (refused by safety policy — safe members are on disk).
-Exit `3` MUST NOT be used for an aborted STOP run. Exit codes `≥4` SHALL remain
+an early abort under `--stop-on-error` on a member **failure**, or any
+always-stop / hoist failure) SHALL exit `1`. When `extract` **completes**
+(under CONTINUE or STOP) with one or more members `BLOCKED` by safety policy
+and no member `FAILED`, the system SHALL exit `3` (refused by safety policy —
+safe members are on disk). Because `OnError.STOP` / `--stop-on-error` never
+halts on a policy block, a STOP+policy abort cannot occur; exit `3` MUST NOT
+be used for an aborted STOP-path failure. Exit codes `≥4` SHALL remain
 reserved. Documentation SHALL direct callers to treat any nonzero code other
 than `2` as a failure and MUST NOT assume `1` is the only failure code.
 
@@ -248,8 +253,9 @@ than `2` as a failure and MUST NOT assume `1` is the only failure code.
 | `archivey test <archive-with-failing-member>` | Exit `1` |
 | `archivey test <indexed-archive>` when the member stream aborts early | Summary includes `K not tested` for the untested remainder; exit `1` |
 | `archivey extract <archive-with-traversal-and-safe-members>` | Extracts safe members; prints `blocked:`; exit `3` |
+| `archivey extract --stop-on-error <archive-with-traversal-and-safe-members>` | Extracts safe members; prints `blocked:`; exit `3` (blocks always continue) |
 | `archivey extract <archive-with-corrupt-member>` | Extracts recoverable members; prints `failed:`; exit `1` |
-| `archivey extract --stop-on-error <archive-with-bad-member>` | Stops at first bad member; exit `1` |
+| `archivey extract --stop-on-error <archive-with-corrupt-member>` | Stops at first failure; exit `1` |
 
 ### Requirement: stdin archives are reserved, not supported in v1
 

--- a/openspec/specs/cli/spec.md
+++ b/openspec/specs/cli/spec.md
@@ -126,8 +126,9 @@ allows. `--stop-on-error` SHALL restore `OnError.STOP` for that invocation —
 stopping on member **failures** only. Policy `BLOCKED` outcomes are always
 reported-and-continued (library `OnError` does not halt on blocks; see
 `stop-on-failure-not-policy`). On an early stop (STOP-path failure or
-always-stop limit), the system SHALL still report how many members were written
-before the stop.
+always-stop limit), the system SHALL still report how many members were
+**extracted** and how many were **blocked** before the stop (separate counts;
+other processed statuses are omitted from that line).
 
 #### Scenario: CLI behavior matrix
 
@@ -151,7 +152,7 @@ before the stop.
 | `archivey extract <archive> -d .` | Extracts into cwd verbatim (classic splatter, opt-in) |
 | `archivey extract <archive> --policy trusted` | Maps to `ExtractionPolicy.TRUSTED` |
 | `archivey extract <archive-with-traversal-and-safe-members>` | Safe members extracted; `blocked:` lines; exit `3` |
-| `archivey extract --stop-on-error <archive-with-bad-member>` | Stops at first **failure**; reports members written before stop; policy blocks alone do not stop |
+| `archivey extract --stop-on-error <archive-with-bad-member>` | Stops at first **failure**; reports extracted/blocked counts before stop; policy blocks alone do not stop |
 | Subcommand includes fnmatch pattern(s) after the archive | Operation limited to matching member names (positional = include) |
 | `archivey extract <archive> out` where `out/` exists and matches no member | stderr warning with `(did you mean -d out?)`; exit `1` |
 | `archivey extract <archive> '*.missing'` | stderr warning; exit `1` |

--- a/openspec/specs/safe-extraction/spec.md
+++ b/openspec/specs/safe-extraction/spec.md
@@ -574,32 +574,41 @@ applies.
 
 ### Requirement: Error Policy (OnError) for extraction failures
 
-`OnError.STOP` and `OnError.CONTINUE` SHALL govern per-member failures only.
-Under `CONTINUE`, a member-scoped `FilterRejectionError`, other member-scoped
-`ArchiveyError`, permitted read/write `OSError`, or per-member ratio violation
-records `BLOCKED`/`FAILED`, removes partial output, emits the matching diagnostic
-under the active diagnostic policy, and proceeds.
+`OnError.STOP` and `OnError.CONTINUE` SHALL govern per-member **failures** only — a
+non-rejection member-scoped `ArchiveyError`, a permitted read/write `OSError`, or a
+per-member ratio violation. A policy **block** (a `FilterRejectionError` from a universal
+path-safety check or a policy filter) is NOT a failure: it SHALL always be recorded as a
+`BLOCKED` `ExtractionResult`, have its partial output removed, emit its
+`EXTRACTION_MEMBER_BLOCKED` diagnostic, and let extraction proceed — under **either**
+`OnError.STOP` or `OnError.CONTINUE`. `OnError.STOP` therefore never raises on a blocked
+member; a STOP run can complete and return an `ExtractionReport` whose results include
+`BLOCKED`. Aborting the whole extraction on the first unsafe member (fail-closed strict
+security) is a separate, future opt-in and is not expressed through `OnError`.
 
-Diagnostic disposition SHALL still be authoritative: `RAISE` emits
-`DiagnosticRaisedError` and halts immediately even under `OnError.CONTINUE`;
-logging-handler and diagnostic-callback exceptions propagate unchanged. Under
-`STOP`, the genuine rejection/failure raises immediately and is not converted to
-an extraction advisory. Global resource guards (`ResourceLimitError` for
-cumulative bytes, archive-wide/live ratio, and max entries), `KeyboardInterrupt`,
-`MemoryError`, and unexpected programming exceptions are always-stop and are not
-swallowed.
+Under `CONTINUE`, a member-scoped failure records `FAILED`, removes partial output, emits
+the matching diagnostic under the active diagnostic policy, and proceeds.
+
+Diagnostic disposition SHALL still be authoritative: `RAISE` emits `DiagnosticRaisedError`
+and halts immediately even under `OnError.CONTINUE`; logging-handler and
+diagnostic-callback exceptions propagate unchanged. Under `STOP`, a genuine member failure
+raises immediately and is not converted to an extraction advisory. Global resource guards
+(`ResourceLimitError` for cumulative bytes, archive-wide/live ratio, and max entries),
+`KeyboardInterrupt`, `MemoryError`, and unexpected programming exceptions are always-stop
+and are not swallowed.
 
 #### Scenario: OnError matrix
 
 | Case | Expected |
 | --- | --- |
+| Member blocked by policy/path-safety under `STOP` | `BLOCKED` result; partial output removed; `EXTRACTION_MEMBER_BLOCKED`; extraction does **not** halt; later members continue |
+| Member blocked by policy/path-safety under `CONTINUE` | `BLOCKED` result; partial output removed; `EXTRACTION_MEMBER_BLOCKED`; later members continue |
+| First member blocked, remaining members extractable, under `STOP` | Run completes; report contains `BLOCKED` + later `EXTRACTED`; no exception escapes |
 | Corrupt member under `CONTINUE` and default diagnostics | Partial output removed; `FAILED` result; `EXTRACTION_MEMBER_FAILED`; later members continue |
-| Extraction diagnostic resolves to `RAISE` under `CONTINUE` | `DiagnosticRaisedError` halts; no report returned |
-| `CorruptionError` under `STOP` | Original `CorruptionError` propagates; no continued-failure diagnostic |
+| Default `STOP` member failure (e.g. `CorruptionError`) | Original error propagates immediately; failing partial file removed; earlier outputs remain; no continued-failure diagnostic |
 | Filesystem `OSError` while writing under `CONTINUE` | Partial output removed; `FAILED` result/diagnostic; extraction proceeds |
-| Cumulative bytes/live ratio/max entries exceed limit under `CONTINUE` | `ResourceLimitError` propagates and halts; no later member processed |
-| Default `STOP` member failure | Exception raises immediately; failing partial file removed; earlier outputs remain |
-| Mixed good/corrupt archive under `CONTINUE` | Extractable members are written; report includes `EXTRACTED` plus `FAILED`/`BLOCKED`; no per-member exception escapes |
+| Extraction diagnostic resolves to `RAISE` under `CONTINUE` | `DiagnosticRaisedError` halts; no report returned |
+| Cumulative bytes/live ratio/max entries exceed limit under any `OnError` | `ResourceLimitError` propagates and halts; no later member processed |
+| Mixed good/corrupt/blocked archive under `CONTINUE` | Extractable members written; report includes `EXTRACTED` plus `FAILED`/`BLOCKED`; no per-member exception escapes |
 
 ### Requirement: ExtractionReport is an immutable operation result
 

--- a/openspec/specs/safe-extraction/spec.md
+++ b/openspec/specs/safe-extraction/spec.md
@@ -474,6 +474,8 @@ class ExtractionProgress:
     members_done: int
     members_total: int | None
     member_bytes_written: int
+    members_extracted: int
+    members_blocked: int
 ```
 
 `bytes_written` is cumulative for the operation. `member_bytes_written` is the
@@ -483,8 +485,11 @@ is `None` when the format lacks uncompressed size information; `members_total` i
 free member list exists and a `members` selector is provided, totals SHALL cover
 only selected members. `members_done` counts every selected member processed,
 including user-filter skips and failures, so it reaches `members_total`;
-selector-excluded members are invisible. Predicate selectors evaluated against an
-upfront index MUST be pure functions of the member.
+selector-excluded members are invisible. `members_extracted` / `members_blocked`
+are completed-outcome tallies of `EXTRACTED` / `BLOCKED` results so far (on
+intra-member reports they exclude the in-flight member); other statuses advance
+`members_done` without incrementing either. Predicate selectors evaluated against
+an upfront index MUST be pure functions of the member.
 
 For a FILE member with a streamed body, the callback MAY be invoked **more than
 once** as bytes are written: intra-member reports carry `member` = the current
@@ -509,6 +514,7 @@ frequency is bounded by the extraction copy chunk size; when `on_progress` is
 | Member with unknown `size` (late-bound / streaming) | `member_bytes_written` still reported; terminal report equals final observed byte count |
 | Format cannot provide uncompressed sizes | `total_bytes_estimated is None` |
 | Free list + selector | Totals cover selected members only; filter skips/failures still advance `members_done` |
+| Terminal report after `EXTRACTED` / `BLOCKED` | `members_extracted` / `members_blocked` match completed outcome tallies |
 | `on_progress is None` | No callback; no extra per-chunk work beyond byte counting |
 
 ### Requirement: Per-ArchiveMember ExtractionResult with Status

--- a/review/STATUS.md
+++ b/review/STATUS.md
@@ -61,7 +61,7 @@ deferred by Q2).
 | **Q4** | **P3** control-byte quoting style | lean applied (escape everywhere / backslash); `--raw`/TTY-only still open |
 | **Q5 / Q6** | **P14** `info` cost line / install capability view | **decided** — `info` prints `access:` from `CostReceipt`; `--version -v` format matrix |
 | **Q7** | P7/P9 library vs CLI ownership | **done** (library) |
-| **Q8** | STOP+policy exit `3` vs `1` | **decided** — Option A: STOP always `1`; `3` only for completed CONTINUE + policy blocks |
+| **Q8** | STOP+policy exit `3` vs `1` | **resolved by scoping** — STOP never halts on policy; exit `3` for completed runs with blocks only (CONTINUE or STOP); abort/failure → `1` |
 
 ### `performance/QUESTIONS.md`
 

--- a/review/cli-product/QUESTIONS.md
+++ b/review/cli-product/QUESTIONS.md
@@ -12,7 +12,7 @@ reopened.
 |---|----------|
 | 1 Semantics | Record-and-continue for **policy rejections and per-member read failures** (digest/decode), continuing where the stream allows — same shape as `test` / VISION #3. |
 | 2 Mechanism | CLI passes `OnError.CONTINUE` by default; **library default stays `STOP`**. |
-| 3 Exit code | **`3`** when CONTINUE **completed** with ≥1 policy `BLOCKED` and no `FAILED`; **`1`** for any `FAILED`, hoist/always-stop, or **any `--stop-on-error` abort** (incl. policy) — refined in **Q8**. |
+| 3 Exit code | **`3`** when extract **completed** with ≥1 policy `BLOCKED` and no `FAILED`; **`1`** for any `FAILED`, hoist/always-stop, or `--stop-on-error` abort on a member failure — **Q8 resolved by scoping** (STOP never halts on policy). |
 | 4 Flag | **`--stop-on-error` now** — restores library `STOP` for that invocation (shell scripts cannot switch to the library API). |
 | 5 Stop-path reporting | Always report what was written before an early stop (count at minimum). |
 
@@ -89,22 +89,20 @@ distinguishes install-vs-not-engaged when it does fire.
 
 ## Q8 — `--stop-on-error` + policy block: exit `3` or `1`? (PR #163 review)
 
-**Decided (2026-07-19): Option A.** Abort/STOP always exits `1`. Exit `3` is
-reserved exclusively for a CONTINUE run that *completed* with ≥1 policy
-`BLOCKED` and no `FAILED` (safe members on disk). Maintainer + review agree:
-`3`'s useful script meaning is partial success with only policy gaps — a STOP
-abort leaves the output incomplete and must share `1` with other aborts.
-
-Forward-compat note (not in this PR): intended end-state is failures-only
-stopping (`OnError.STOP` / `--stop-on-error` ignore policy blocks; a separate
-opt-in would abort on unsafe members). Option A stays correct once that lands;
-the contested STOP+policy→`3` rows disappear structurally.
+**Resolved by scoping (2026-07-19, change `stop-on-failure-not-policy`).**
+Supersedes the A/B framing: `OnError.STOP` / `--stop-on-error` now stop on member
+**failures** only. A policy `BLOCKED` is always recorded-and-continued, so the
+"STOP + policy block abort" rows are structurally impossible. Exit codes follow
+**Option A**: abort/STOP-path failure always exits `1`; exit `3` is reserved for
+a run that *completed* with ≥1 policy `BLOCKED` and no `FAILED` (safe members on
+disk), under CONTINUE or STOP. Aborting the whole archive on any unsafe member
+is a separate future opt-in, not part of `OnError`.
 
 | Case | Mode | On disk | Exit |
 |------|------|---------|------|
-| Clean extract | CONTINUE | all OK | `0` |
-| ≥1 `BLOCKED`, no `FAILED` | CONTINUE | safe members extracted | `3` |
+| Clean extract | CONTINUE or STOP | all OK | `0` |
+| ≥1 `BLOCKED`, no `FAILED` | CONTINUE or STOP | safe members extracted | `3` |
 | ≥1 `FAILED` (± blocks) | CONTINUE | recoverable extracted | `1` |
-| Policy block or failure (abort) | `--stop-on-error` | incomplete | `1` |
+| Member failure (abort) | `--stop-on-error` | incomplete | `1` |
 | Always-stop / hoist failure / unmatched includes | — | — | `1` |
 | Usage | — | — | `2` |

--- a/src/archivey/cli/exit_codes.py
+++ b/src/archivey/cli/exit_codes.py
@@ -8,5 +8,4 @@ EXIT_USAGE = 2  # CLI usage error (argparse default)
 # Q8 Option A: completed extract with ≥1 policy BLOCKED and no FAILED (safe members on disk).
 # Applies under CONTINUE or STOP — STOP never aborts on a policy block.
 EXIT_POLICY = 3
-EXIT_BLOCKED = EXIT_POLICY  # alias; reserved exit 3 for policy-only completed runs
 # ≥4 reserved

--- a/src/archivey/cli/exit_codes.py
+++ b/src/archivey/cli/exit_codes.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 EXIT_OK = 0
-EXIT_FAIL = 1  # operational failure / aborted extract (incl. --stop-on-error)
+EXIT_FAIL = 1  # operational failure / aborted extract (STOP-path failure / always-stop)
 EXIT_USAGE = 2  # CLI usage error (argparse default)
-# CONTINUE completed with ≥1 policy BLOCKED and no FAILED (safe members on disk).
+# Q8 Option A: completed extract with ≥1 policy BLOCKED and no FAILED (safe members on disk).
+# Applies under CONTINUE or STOP — STOP never aborts on a policy block.
 EXIT_POLICY = 3
+EXIT_BLOCKED = EXIT_POLICY  # alias; reserved exit 3 for policy-only completed runs
 # ≥4 reserved

--- a/src/archivey/cli/extract_cmd.py
+++ b/src/archivey/cli/extract_cmd.py
@@ -387,7 +387,7 @@ def _report_extraction(
 
 
 def _exit_for_outcomes(*, blocked: int, failed: int, hoist_ok: bool) -> int:
-    """Map extract outcomes to exit codes (Q1): FAILED→1, policy-only BLOCKED→3."""
+    """Map extract outcomes to exit codes (Q8 Option A): FAILED→1, policy-only BLOCKED→3."""
     if not hoist_ok or failed:
         return EXIT_FAIL
     if blocked:
@@ -471,10 +471,11 @@ def run_extract(
                     on_progress=on_progress,
                 )
             except (ArchiveyError, OSError) as exc:
-                # STOP / always-stop (bomb guards, DiagnosticRaisedError): report
-                # what was already written, then the stop notice.
-                # Exit 1 always on abort (Q8): exit 3 is reserved for CONTINUE
-                # runs that *completed* with policy blocks and safe members on disk.
+                # STOP-path member failure / always-stop (bomb guards,
+                # DiagnosticRaisedError): report what was already written, then
+                # the stop notice. Exit 1 always on abort (Q8 Option A): exit 3
+                # is reserved for a *completed* run with policy blocks and safe
+                # members on disk (blocks never abort under STOP).
                 print(exc, file=err)
                 if members_completed:
                     print(

--- a/src/archivey/cli/extract_cmd.py
+++ b/src/archivey/cli/extract_cmd.py
@@ -451,12 +451,14 @@ def run_extract(
             hide_progress=hide_progress, stream=err
         )
         # Under STOP, extract_all raises without returning a report — track how
-        # many members completed before the stop via the progress callback (Q1.5).
-        members_completed = 0
+        # many members were extracted / blocked before the stop via progress (Q1.5).
+        members_extracted = 0
+        members_blocked = 0
 
         def on_progress(progress: ExtractionProgress) -> None:
-            nonlocal members_completed
-            members_completed = progress.members_done
+            nonlocal members_extracted, members_blocked
+            members_extracted = progress.members_extracted
+            members_blocked = progress.members_blocked
             if base_progress is not None:
                 base_progress(progress)
 
@@ -477,11 +479,13 @@ def run_extract(
                 # is reserved for a *completed* run with policy blocks and safe
                 # members on disk (blocks never abort under STOP).
                 print(exc, file=err)
-                if members_completed:
-                    print(
-                        f"{members_completed} member(s) written before the stop",
-                        file=err,
-                    )
+                parts: list[str] = []
+                if members_extracted:
+                    parts.append(f"{members_extracted} member(s) extracted")
+                if members_blocked:
+                    parts.append(f"{members_blocked} blocked")
+                if parts:
+                    print(f"{', '.join(parts)} before the stop", file=err)
                 print(
                     "extraction stopped; remaining members were not extracted",
                     file=err,

--- a/src/archivey/cli/main.py
+++ b/src/archivey/cli/main.py
@@ -276,8 +276,9 @@ def build_parser() -> argparse.ArgumentParser:
         "--stop-on-error",
         action="store_true",
         help=(
-            "stop at the first blocked or failed member "
-            "(default: continue and report; library OnError.STOP)"
+            "stop at the first member failure "
+            "(policy blocks are always reported and continued; "
+            "default: continue and report)"
         ),
     )
     _add_filter_args(p_extract)

--- a/src/archivey/cli/test_cmd.py
+++ b/src/archivey/cli/test_cmd.py
@@ -116,6 +116,8 @@ def run_test(
                                         members_done=files_done,
                                         members_total=members_total,
                                         member_bytes_written=member_written,
+                                        members_extracted=0,
+                                        members_blocked=0,
                                     )
                                 )
                     ok += 1
@@ -129,6 +131,8 @@ def run_test(
                                 members_done=files_done,
                                 members_total=members_total,
                                 member_bytes_written=member_written,
+                                members_extracted=0,
+                                members_blocked=0,
                             )
                         )
                     if verbose:

--- a/src/archivey/internal/extraction.py
+++ b/src/archivey/internal/extraction.py
@@ -455,7 +455,8 @@ class ExtractionCoordinator:
                     results[-1] = result
                 else:
                     results.append(result)
-                if self._on_error is OnError.STOP:
+                # OnError governs failures only; a policy BLOCKED is always continued.
+                if self._on_error is OnError.STOP and status is ExtractionStatus.FAILED:
                     raise error
                 code = (
                     DiagnosticCode.EXTRACTION_MEMBER_BLOCKED

--- a/src/archivey/internal/extraction.py
+++ b/src/archivey/internal/extraction.py
@@ -337,6 +337,8 @@ class ExtractionCoordinator:
         collision_map: dict[str, Path] = {}
         orphans: list[_Orphan] = []
         members_done = 0
+        members_extracted = 0
+        members_blocked = 0
         # Explicit selection with a free member list: once every selected member has
         # been seen, stop the forward pass. Solid backends otherwise keep walking the
         # rest of the archive (and would skip-decode unread tails if positioning were
@@ -399,6 +401,8 @@ class ExtractionCoordinator:
                             # Capture counters for intra-member reports: members_done is
                             # members fully completed *before* this one.
                             done_so_far = members_done
+                            extracted_so_far = members_extracted
+                            blocked_so_far = members_blocked
                             current = original
 
                             def emit_progress() -> None:
@@ -409,6 +413,8 @@ class ExtractionCoordinator:
                                     done_so_far,
                                     members_total,
                                     member_bytes_written=tracker.member_bytes,
+                                    members_extracted=extracted_so_far,
+                                    members_blocked=blocked_so_far,
                                 )
 
                             self._emit_progress = emit_progress
@@ -484,6 +490,12 @@ class ExtractionCoordinator:
                 self._emit_progress = None
                 self._close(stream)
 
+            if results and results[-1].member is original:
+                status = results[-1].status
+                if status is ExtractionStatus.EXTRACTED:
+                    members_extracted += 1
+                elif status is ExtractionStatus.BLOCKED:
+                    members_blocked += 1
             members_done += 1
             self._report_progress(
                 original,
@@ -492,6 +504,8 @@ class ExtractionCoordinator:
                 members_done,
                 members_total,
                 member_bytes_written=(tracker.member_bytes if member_started else 0),
+                members_extracted=members_extracted,
+                members_blocked=members_blocked,
             )
             if selected_total is not None and members_done >= selected_total:
                 break
@@ -1374,6 +1388,8 @@ class ExtractionCoordinator:
         members_total: int | None,
         *,
         member_bytes_written: int = 0,
+        members_extracted: int = 0,
+        members_blocked: int = 0,
     ) -> None:
         if self._on_progress is None:
             return
@@ -1385,6 +1401,8 @@ class ExtractionCoordinator:
                 members_done=members_done,
                 members_total=members_total,
                 member_bytes_written=member_bytes_written,
+                members_extracted=members_extracted,
+                members_blocked=members_blocked,
             )
         )
 

--- a/src/archivey/internal/extraction_types.py
+++ b/src/archivey/internal/extraction_types.py
@@ -111,6 +111,11 @@ class ExtractionProgress:
     members_done: int
     members_total: int | None  # None when the count would require a full scan
     member_bytes_written: int  # output bytes written for the current member so far
+    # Completed-outcome tallies so far (exclude the in-flight member on intra-member
+    # reports). ``members_done`` still counts every processed member; these split
+    # successful writes from policy blocks for stop-path reporting.
+    members_extracted: int
+    members_blocked: int
 
 
 @dataclass(frozen=True)
@@ -125,8 +130,9 @@ class ExtractionResult:
     member: ArchiveMember
     path: Path | None  # the written path, or None if the member was not written
     status: ExtractionStatus
-    # The failure, for FAILED/BLOCKED under OnError.CONTINUE; an OSError when the failure
-    # is a filesystem read/write error on this member (not translated to an ArchiveyError).
+    # Populated for FAILED/BLOCKED when the run continues past that member (including
+    # STOP + policy block). An OSError when the failure is a filesystem read/write
+    # error on this member (not translated to an ArchiveyError).
     error: ArchiveyError | OSError | None = None
     # The destination the coordinator intended before overwrite/rename resolution. For an
     # ordinary write it equals ``path``; under ``OverwritePolicy.RENAME`` a collided member

--- a/src/archivey/internal/extraction_types.py
+++ b/src/archivey/internal/extraction_types.py
@@ -71,9 +71,16 @@ class OverwritePolicy(Enum):
 
 
 class OnError(Enum):
-    """What to do when an individual member cannot be extracted."""
+    """What to do when an individual member cannot be extracted.
 
-    STOP = "stop"  # default: raise the first failure and halt
+    Governs per-member *failures* only (corrupt/truncated/undecodable data,
+    write ``OSError``, overwrite ``ERROR``, etc.). A policy ``BLOCKED`` outcome
+    (``FilterRejectionError`` from a universal path-safety check or a policy
+    filter) is always recorded and continued, under either value. Aborting the
+    whole extraction on the first unsafe member is a separate future opt-in.
+    """
+
+    STOP = "stop"  # default: raise the first member failure and halt
     CONTINUE = "continue"  # record the failure, clean up, proceed to the next member
 
 

--- a/tests/test_adversarial_corpus.py
+++ b/tests/test_adversarial_corpus.py
@@ -194,15 +194,19 @@ def test_adversarial_extract_has_exact_outcome(
         target = members[1] if entry.field == "link_target" else members[0]
 
         if entry.extract_outcome == "path_traversal":
-            with pytest.raises(PathTraversalError):
-                archive.extract_all(
-                    dest, members=[target], policy=ExtractionPolicy.TRUSTED
-                )
+            results = archive.extract_all(
+                dest, members=[target], policy=ExtractionPolicy.TRUSTED
+            ).results
+            assert len(results) == 1
+            assert results[0].status is ExtractionStatus.BLOCKED
+            assert isinstance(results[0].error, PathTraversalError)
         elif entry.extract_outcome == "symlink_escape":
-            with pytest.raises(SymlinkEscapeError):
-                archive.extract_all(
-                    dest, members=[target], policy=ExtractionPolicy.TRUSTED
-                )
+            results = archive.extract_all(
+                dest, members=[target], policy=ExtractionPolicy.TRUSTED
+            ).results
+            assert len(results) == 1
+            assert results[0].status is ExtractionStatus.BLOCKED
+            assert isinstance(results[0].error, SymlinkEscapeError)
         elif entry.extract_outcome == "filesystem_name_refusal":
             # A UTF-8-enforcing filesystem (e.g. APFS) refuses the surrogateescape
             # name with EILSEQ; the coordinator translates that to ExtractionError

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -285,9 +285,12 @@ def test_extract_strict_blocks_device_name_and_continues(
     assert (dest / "ok.txt").read_bytes() == b"y"
 
 
-def test_extract_strict_stop_on_error_aborts_on_device_name(
+def test_extract_strict_stop_on_error_continues_on_device_name(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
+    # --stop-on-error = library STOP = failures only; policy blocks continue.
+    from archivey.cli.exit_codes import EXIT_POLICY
+
     bad = _zip(tmp_path / "bad.zip", {"NUL": b"x", "ok.txt": b"y"})
     dest = tmp_path / "out"
     code = main(
@@ -301,12 +304,12 @@ def test_extract_strict_stop_on_error_aborts_on_device_name(
             "--stop-on-error",
         ]
     )
-    # Q8: STOP aborts → exit 1 (exit 3 only for completed CONTINUE + policy blocks).
-    assert code == EXIT_FAIL
+    assert code == EXIT_POLICY
     err = capsys.readouterr().err
     assert "NUL" in err
-    assert "extraction stopped" in err.lower()
-    assert not (dest / "ok.txt").exists()
+    assert "blocked:" in err
+    assert "extraction stopped" not in err.lower()
+    assert (dest / "ok.txt").read_bytes() == b"y"
 
 
 def test_extract_zip_root_slash_under_default_strict(tmp_path: Path) -> None:
@@ -1082,11 +1085,13 @@ def test_extract_continues_after_traversal(
     assert not (tmp_path / "escape.txt").exists()
 
 
-def test_extract_stop_on_error_aborts(
+def test_extract_stop_on_error_continues_on_policy_block(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
+    from archivey.cli.exit_codes import EXIT_POLICY
+
     monkeypatch.chdir(tmp_path)
-    # Put the traversal first so STOP aborts before safe members.
+    # Policy block under --stop-on-error: continue, extract safe members, exit 3.
     archive = _tar(
         tmp_path / "evil.tar",
         {
@@ -1095,11 +1100,45 @@ def test_extract_stop_on_error_aborts(
         },
     )
     code = main(["extract", str(archive), "-d", "out", "--stop-on-error"])
-    # Q8: incomplete extract under STOP → 1, not 3.
+    assert code == EXIT_POLICY
+    err = capsys.readouterr().err
+    assert "blocked:" in err
+    assert "extraction stopped" not in err
+    assert (tmp_path / "out" / "safe.txt").read_bytes() == b"ok"
+
+
+def test_extract_stop_on_error_aborts_on_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """--stop-on-error aborts on a genuine member failure (CRC), not a policy block."""
+    monkeypatch.chdir(tmp_path)
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("a.txt", b"hello")
+        zf.writestr("b.txt", b"world")
+        zf.writestr("c.txt", b"end")
+    data = bytearray(buf.getvalue())
+    pos = 0
+    while True:
+        i = data.find(b"PK\x01\x02", pos)
+        if i < 0:
+            break
+        name_len = int.from_bytes(data[i + 28 : i + 30], "little")
+        name = bytes(data[i + 46 : i + 46 + name_len])
+        if name == b"b.txt":
+            data[i + 16] ^= 0xFF
+            break
+        pos = i + 4
+    path = tmp_path / "badcrc.zip"
+    path.write_bytes(bytes(data))
+
+    code = main(["extract", str(path), "-d", "out", "--stop-on-error"])
     assert code == EXIT_FAIL
     err = capsys.readouterr().err
     assert "extraction stopped" in err
-    assert not (tmp_path / "out" / "safe.txt").exists()
+    assert (tmp_path / "out" / "a.txt").read_bytes() == b"hello"
+    assert not (tmp_path / "out" / "b.txt").exists()
+    assert not (tmp_path / "out" / "c.txt").exists()
 
 
 def test_extract_corrupt_member_continues_with_exit_fail(
@@ -1219,15 +1258,27 @@ def test_extract_stop_on_error_reports_members_written(
 ) -> None:
     """Q1.5: STOP after a successful member still reports how many were written."""
     monkeypatch.chdir(tmp_path)
-    archive = _tar(
-        tmp_path / "evil.tar",
-        {
-            "safe.txt": b"ok",
-            "../escape.txt": b"bad",
-            "later.txt": b"late",
-        },
-    )
-    code = main(["extract", str(archive), "-d", "out", "--stop-on-error"])
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("safe.txt", b"ok")
+        zf.writestr("corrupt.txt", b"bad")
+        zf.writestr("later.txt", b"late")
+    data = bytearray(buf.getvalue())
+    pos = 0
+    while True:
+        i = data.find(b"PK\x01\x02", pos)
+        if i < 0:
+            break
+        name_len = int.from_bytes(data[i + 28 : i + 30], "little")
+        name = bytes(data[i + 46 : i + 46 + name_len])
+        if name == b"corrupt.txt":
+            data[i + 16] ^= 0xFF
+            break
+        pos = i + 4
+    path = tmp_path / "partial.zip"
+    path.write_bytes(bytes(data))
+
+    code = main(["extract", str(path), "-d", "out", "--stop-on-error"])
     assert code == EXIT_FAIL  # Q8: abort → 1
     err = capsys.readouterr().err
     assert "1 member(s) written before the stop" in err

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -552,6 +552,8 @@ def test_progress_callback_on_tty_updates_bar(monkeypatch: pytest.MonkeyPatch) -
             members_done=0,
             members_total=1,
             member_bytes_written=40,
+            members_extracted=0,
+            members_blocked=0,
         )
     )
     cb(
@@ -562,6 +564,8 @@ def test_progress_callback_on_tty_updates_bar(monkeypatch: pytest.MonkeyPatch) -
             members_done=1,
             members_total=1,
             member_bytes_written=100,
+            members_extracted=1,
+            members_blocked=0,
         )
     )
     assert len(created) == 1
@@ -1112,30 +1116,19 @@ def test_extract_stop_on_error_aborts_on_failure(
 ) -> None:
     """--stop-on-error aborts on a genuine member failure (CRC), not a policy block."""
     monkeypatch.chdir(tmp_path)
-    buf = io.BytesIO()
-    with zipfile.ZipFile(buf, "w") as zf:
-        zf.writestr("a.txt", b"hello")
-        zf.writestr("b.txt", b"world")
-        zf.writestr("c.txt", b"end")
-    data = bytearray(buf.getvalue())
-    pos = 0
-    while True:
-        i = data.find(b"PK\x01\x02", pos)
-        if i < 0:
-            break
-        name_len = int.from_bytes(data[i + 28 : i + 30], "little")
-        name = bytes(data[i + 46 : i + 46 + name_len])
-        if name == b"b.txt":
-            data[i + 16] ^= 0xFF
-            break
-        pos = i + 4
-    path = tmp_path / "badcrc.zip"
-    path.write_bytes(bytes(data))
+    from tests.zip_corrupt import zip_with_flipped_cd_crc
+
+    path = zip_with_flipped_cd_crc(
+        tmp_path / "badcrc.zip",
+        {"a.txt": b"hello", "b.txt": b"world", "c.txt": b"end"},
+        corrupt_name="b.txt",
+    )
 
     code = main(["extract", str(path), "-d", "out", "--stop-on-error"])
     assert code == EXIT_FAIL
     err = capsys.readouterr().err
     assert "extraction stopped" in err
+    assert "1 member(s) extracted before the stop" in err
     assert (tmp_path / "out" / "a.txt").read_bytes() == b"hello"
     assert not (tmp_path / "out" / "b.txt").exists()
     assert not (tmp_path / "out" / "c.txt").exists()
@@ -1146,26 +1139,13 @@ def test_extract_corrupt_member_continues_with_exit_fail(
 ) -> None:
     """CRC mismatch: recoverable members extracted; exit 1 (FAILED, not policy)."""
     monkeypatch.chdir(tmp_path)
-    buf = io.BytesIO()
-    with zipfile.ZipFile(buf, "w") as zf:
-        zf.writestr("a.txt", b"hello")
-        zf.writestr("b.txt", b"world")
-        zf.writestr("c.txt", b"end")
-    data = bytearray(buf.getvalue())
-    # Flip the central-directory CRC for b.txt so open succeeds but extract fails.
-    pos = 0
-    while True:
-        i = data.find(b"PK\x01\x02", pos)
-        if i < 0:
-            break
-        name_len = int.from_bytes(data[i + 28 : i + 30], "little")
-        name = bytes(data[i + 46 : i + 46 + name_len])
-        if name == b"b.txt":
-            data[i + 16] ^= 0xFF
-            break
-        pos = i + 4
-    path = tmp_path / "badcrc.zip"
-    path.write_bytes(bytes(data))
+    from tests.zip_corrupt import zip_with_flipped_cd_crc
+
+    path = zip_with_flipped_cd_crc(
+        tmp_path / "badcrc.zip",
+        {"a.txt": b"hello", "b.txt": b"world", "c.txt": b"end"},
+        corrupt_name="b.txt",
+    )
 
     assert main(["extract", str(path), "-d", "out"]) == EXIT_FAIL
     err = capsys.readouterr().err
@@ -1253,35 +1233,51 @@ def test_extract_dest_before_dash_named_pattern(
     assert not (dest / "ok.txt").exists()
 
 
-def test_extract_stop_on_error_reports_members_written(
+def test_extract_stop_on_error_reports_extracted_and_blocked(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """Q1.5: STOP after a successful member still reports how many were written."""
+    """Q1.5: STOP abort reports extracted vs blocked counts separately."""
     monkeypatch.chdir(tmp_path)
-    buf = io.BytesIO()
-    with zipfile.ZipFile(buf, "w") as zf:
-        zf.writestr("safe.txt", b"ok")
-        zf.writestr("corrupt.txt", b"bad")
-        zf.writestr("later.txt", b"late")
-    data = bytearray(buf.getvalue())
-    pos = 0
-    while True:
-        i = data.find(b"PK\x01\x02", pos)
-        if i < 0:
-            break
-        name_len = int.from_bytes(data[i + 28 : i + 30], "little")
-        name = bytes(data[i + 46 : i + 46 + name_len])
-        if name == b"corrupt.txt":
-            data[i + 16] ^= 0xFF
-            break
-        pos = i + 4
-    path = tmp_path / "partial.zip"
-    path.write_bytes(bytes(data))
+    from tests.zip_corrupt import zip_with_flipped_cd_crc
+
+    path = zip_with_flipped_cd_crc(
+        tmp_path / "partial.zip",
+        {
+            "safe.txt": b"ok",
+            "../evil.txt": b"bad",
+            "corrupt.txt": b"payload",
+            "later.txt": b"late",
+        },
+        corrupt_name="corrupt.txt",
+    )
 
     code = main(["extract", str(path), "-d", "out", "--stop-on-error"])
     assert code == EXIT_FAIL  # Q8: abort → 1
     err = capsys.readouterr().err
-    assert "1 member(s) written before the stop" in err
+    assert "1 member(s) extracted, 1 blocked before the stop" in err
+    assert "extraction stopped" in err
+    assert (tmp_path / "out" / "safe.txt").read_bytes() == b"ok"
+    assert not (tmp_path / "out" / "later.txt").exists()
+
+
+def test_extract_stop_on_error_reports_members_extracted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Q1.5: STOP after a successful member still reports how many were extracted."""
+    monkeypatch.chdir(tmp_path)
+    from tests.zip_corrupt import zip_with_flipped_cd_crc
+
+    path = zip_with_flipped_cd_crc(
+        tmp_path / "partial.zip",
+        {"safe.txt": b"ok", "corrupt.txt": b"bad", "later.txt": b"late"},
+        corrupt_name="corrupt.txt",
+    )
+
+    code = main(["extract", str(path), "-d", "out", "--stop-on-error"])
+    assert code == EXIT_FAIL  # Q8: abort → 1
+    err = capsys.readouterr().err
+    assert "1 member(s) extracted before the stop" in err
+    assert "blocked" not in err.split("before the stop")[0]
     assert "extraction stopped" in err
     assert (tmp_path / "out" / "safe.txt").read_bytes() == b"ok"
     assert not (tmp_path / "out" / "later.txt").exists()

--- a/tests/test_crypto_findings.py
+++ b/tests/test_crypto_findings.py
@@ -544,6 +544,7 @@ def test_f5_check_rar5_password_accepts_and_rejects() -> None:
         _check_rar5_password(check_value, kdf_shift, salt, "nope")
 
 
+@requires("cryptography")
 @requires_binary("unrar")
 def test_f5_encrypted_header_fixture_still_opens() -> None:
     path = _rar_fixture("encrypted_header__.rar")

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -416,7 +416,8 @@ def test_directory_scan_race_diagnostic(
         assert DiagnosticCode.SCAN_ENTRY_VANISHED in reader.diagnostics.counts
 
 
-def test_extraction_blocked_emits_diagnostic(tmp_path: Path) -> None:
+@pytest.mark.parametrize("on_error", [OnError.CONTINUE, OnError.STOP])
+def test_extraction_blocked_emits_diagnostic(tmp_path: Path, on_error: OnError) -> None:
     buf = io.BytesIO()
     with zipfile.ZipFile(buf, "w") as zf:
         zf.writestr("../escape.txt", b"x")
@@ -425,7 +426,7 @@ def test_extraction_blocked_emits_diagnostic(tmp_path: Path) -> None:
     report = extract(
         io.BytesIO(buf.getvalue()),
         dest,
-        on_error=OnError.CONTINUE,
+        on_error=on_error,
     )
     blocked = [r for r in report.results if r.status is ExtractionStatus.BLOCKED]
     assert blocked

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -677,25 +677,13 @@ def test_on_error_stop_continues_on_policy_block(tmp_path: Path) -> None:
 def test_on_error_stop_raises_on_member_failure(tmp_path: Path) -> None:
     # Genuine member failure (CRC mismatch) still raises immediately under STOP.
     from archivey.exceptions import CorruptionError
+    from tests.zip_corrupt import zip_with_flipped_cd_crc
 
-    buf = io.BytesIO()
-    with zipfile.ZipFile(buf, "w") as zf:
-        zf.writestr("a.txt", b"hello")
-        zf.writestr("b.txt", b"world")
-    data = bytearray(buf.getvalue())
-    pos = 0
-    while True:
-        i = data.find(b"PK\x01\x02", pos)
-        if i < 0:
-            break
-        name_len = int.from_bytes(data[i + 28 : i + 30], "little")
-        name = bytes(data[i + 46 : i + 46 + name_len])
-        if name == b"b.txt":
-            data[i + 16] ^= 0xFF
-            break
-        pos = i + 4
-    src = tmp_path / "badcrc.zip"
-    src.write_bytes(bytes(data))
+    src = zip_with_flipped_cd_crc(
+        tmp_path / "badcrc.zip",
+        {"a.txt": b"hello", "b.txt": b"world"},
+        corrupt_name="b.txt",
+    )
     dest = tmp_path / "out"
     with pytest.raises(CorruptionError):
         extract(src, dest, on_error=OnError.STOP)
@@ -706,26 +694,17 @@ def test_on_error_stop_raises_on_member_failure(tmp_path: Path) -> None:
 def test_on_error_stop_blocks_then_raises_on_failure(tmp_path: Path) -> None:
     # Mixed archive under STOP: policy blocks continue; first real failure raises.
     from archivey.exceptions import CorruptionError
+    from tests.zip_corrupt import zip_with_flipped_cd_crc
 
-    buf = io.BytesIO()
-    with zipfile.ZipFile(buf, "w") as zf:
-        zf.writestr("../evil.txt", b"bad")
-        zf.writestr("good.txt", b"good")
-        zf.writestr("corrupt.txt", b"payload")
-    data = bytearray(buf.getvalue())
-    pos = 0
-    while True:
-        i = data.find(b"PK\x01\x02", pos)
-        if i < 0:
-            break
-        name_len = int.from_bytes(data[i + 28 : i + 30], "little")
-        name = bytes(data[i + 46 : i + 46 + name_len])
-        if name == b"corrupt.txt":
-            data[i + 16] ^= 0xFF
-            break
-        pos = i + 4
-    src = tmp_path / "mixed.zip"
-    src.write_bytes(bytes(data))
+    src = zip_with_flipped_cd_crc(
+        tmp_path / "mixed.zip",
+        {
+            "../evil.txt": b"bad",
+            "good.txt": b"good",
+            "corrupt.txt": b"payload",
+        },
+        corrupt_name="corrupt.txt",
+    )
     dest = tmp_path / "out"
     with pytest.raises(CorruptionError):
         extract(src, dest, on_error=OnError.STOP)

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -641,7 +641,7 @@ def test_no_temp_files_after_success(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
-# OnError policy (task 3.5)
+# OnError policy (failures-only; blocks always continue)
 # ---------------------------------------------------------------------------
 
 
@@ -658,13 +658,80 @@ def test_on_error_continue_records_rejected(tmp_path: Path) -> None:
     assert (dest / "good.txt").read_bytes() == b"good"
 
 
-def test_on_error_stop_raises(tmp_path: Path) -> None:
+def test_on_error_stop_continues_on_policy_block(tmp_path: Path) -> None:
+    # STOP governs failures only: a path-safety block is recorded and extraction
+    # continues to later members (does not raise FilterRejectionError).
     src = tmp_path / "a.zip"
     with zipfile.ZipFile(src, "w") as z:
         z.writestr("../evil.txt", b"bad")
+        z.writestr("good.txt", b"good")
     dest = tmp_path / "out"
-    with pytest.raises(PathTraversalError):
+    report = extract(src, dest, on_error=OnError.STOP)
+    statuses = {r.member.name: r.status for r in report.results}
+    assert ExtractionStatus.BLOCKED in statuses.values()
+    assert statuses["good.txt"] is ExtractionStatus.EXTRACTED
+    assert (dest / "good.txt").read_bytes() == b"good"
+    assert not any(p.name == "evil.txt" for p in dest.rglob("*"))
+
+
+def test_on_error_stop_raises_on_member_failure(tmp_path: Path) -> None:
+    # Genuine member failure (CRC mismatch) still raises immediately under STOP.
+    from archivey.exceptions import CorruptionError
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("a.txt", b"hello")
+        zf.writestr("b.txt", b"world")
+    data = bytearray(buf.getvalue())
+    pos = 0
+    while True:
+        i = data.find(b"PK\x01\x02", pos)
+        if i < 0:
+            break
+        name_len = int.from_bytes(data[i + 28 : i + 30], "little")
+        name = bytes(data[i + 46 : i + 46 + name_len])
+        if name == b"b.txt":
+            data[i + 16] ^= 0xFF
+            break
+        pos = i + 4
+    src = tmp_path / "badcrc.zip"
+    src.write_bytes(bytes(data))
+    dest = tmp_path / "out"
+    with pytest.raises(CorruptionError):
         extract(src, dest, on_error=OnError.STOP)
+    assert (dest / "a.txt").read_bytes() == b"hello"
+    assert not (dest / "b.txt").exists()
+
+
+def test_on_error_stop_blocks_then_raises_on_failure(tmp_path: Path) -> None:
+    # Mixed archive under STOP: policy blocks continue; first real failure raises.
+    from archivey.exceptions import CorruptionError
+
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("../evil.txt", b"bad")
+        zf.writestr("good.txt", b"good")
+        zf.writestr("corrupt.txt", b"payload")
+    data = bytearray(buf.getvalue())
+    pos = 0
+    while True:
+        i = data.find(b"PK\x01\x02", pos)
+        if i < 0:
+            break
+        name_len = int.from_bytes(data[i + 28 : i + 30], "little")
+        name = bytes(data[i + 46 : i + 46 + name_len])
+        if name == b"corrupt.txt":
+            data[i + 16] ^= 0xFF
+            break
+        pos = i + 4
+    src = tmp_path / "mixed.zip"
+    src.write_bytes(bytes(data))
+    dest = tmp_path / "out"
+    with pytest.raises(CorruptionError):
+        extract(src, dest, on_error=OnError.STOP)
+    assert (dest / "good.txt").read_bytes() == b"good"
+    assert not (dest / "corrupt.txt").exists()
+    assert not any(p.name == "evil.txt" for p in dest.rglob("*"))
 
 
 # ---------------------------------------------------------------------------
@@ -974,8 +1041,9 @@ def test_tar_symlink_escape_rejected(tmp_path: Path) -> None:
     src = tmp_path / "a.tar"
     src.write_bytes(_tar_bytes([("sym", "evil", "../../etc/passwd")]))
     dest = tmp_path / "out"
-    with pytest.raises(SymlinkEscapeError):
-        extract(src, dest)
+    report = extract(src, dest)  # default STOP; blocks always continue
+    assert report.results[0].status is ExtractionStatus.BLOCKED
+    assert isinstance(report.results[0].error, SymlinkEscapeError)
     assert not (dest / "evil").exists()
 
 
@@ -1019,8 +1087,12 @@ def test_chained_symlink_attack_symlink_payload_rejected(tmp_path: Path) -> None
         )
     )
     dest = tmp_path / "out"
-    with pytest.raises((SymlinkEscapeError, PathTraversalError)):
-        extract(src, dest)
+    report = extract(src, dest)  # default STOP; blocks always continue
+    assert all(r.status is ExtractionStatus.BLOCKED for r in report.results)
+    assert all(
+        isinstance(r.error, (SymlinkEscapeError, PathTraversalError))
+        for r in report.results
+    )
     assert list(outside.iterdir()) == []  # nothing leaked outside the destination
 
 
@@ -1063,8 +1135,9 @@ def test_file_payload_through_preexisting_parent_symlink_rejected(
     os.symlink(outside, dest / "sub", target_is_directory=True)
     src = tmp_path / "a.tar"
     src.write_bytes(_tar_bytes([("file", "sub/leak.txt", b"pwned")]))
-    with pytest.raises(PathTraversalError):
-        extract(src, dest)
+    report = extract(src, dest)  # default STOP; blocks always continue
+    assert report.results[0].status is ExtractionStatus.BLOCKED
+    assert isinstance(report.results[0].error, PathTraversalError)
     assert not (outside / "leak.txt").exists()
 
 
@@ -1082,8 +1155,9 @@ def test_symlink_payload_through_preexisting_parent_symlink_rejected(
     os.symlink(outside, dest / "sub", target_is_directory=True)
     src = tmp_path / "a.tar"
     src.write_bytes(_tar_bytes([("sym", "sub/leak", "x")]))
-    with pytest.raises(PathTraversalError):
-        extract(src, dest)
+    report = extract(src, dest)  # default STOP; blocks always continue
+    assert report.results[0].status is ExtractionStatus.BLOCKED
+    assert isinstance(report.results[0].error, PathTraversalError)
     assert not (outside / "leak").exists()
 
 

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -1088,12 +1088,15 @@ def test_chained_symlink_attack_symlink_payload_rejected(tmp_path: Path) -> None
     )
     dest = tmp_path / "out"
     report = extract(src, dest)  # default STOP; blocks always continue
-    assert all(r.status is ExtractionStatus.BLOCKED for r in report.results)
-    assert all(
-        isinstance(r.error, (SymlinkEscapeError, PathTraversalError))
-        for r in report.results
+    statuses = {r.member.name: r.status for r in report.results}
+    assert statuses["sub"] is ExtractionStatus.BLOCKED
+    assert isinstance(
+        next(r.error for r in report.results if r.member.name == "sub"),
+        SymlinkEscapeError,
     )
+    # Parent escape never planted, so the payload symlink resolves inside dest.
     assert list(outside.iterdir()) == []  # nothing leaked outside the destination
+    assert not (dest / "sub").is_symlink()
 
 
 def test_chained_symlink_attack_file_payload_rejected(tmp_path: Path) -> None:

--- a/tests/zip_corrupt.py
+++ b/tests/zip_corrupt.py
@@ -1,0 +1,39 @@
+"""Helpers for building ZIPs with a flipped central-directory CRC.
+
+Used by extraction / CLI tests that need a structurally openable archive whose
+named member fails integrity checks at extract/read time.
+"""
+
+from __future__ import annotations
+
+import io
+import zipfile
+from pathlib import Path
+
+
+def zip_with_flipped_cd_crc(
+    path: Path,
+    entries: dict[str, bytes],
+    *,
+    corrupt_name: str,
+) -> Path:
+    """Write ``entries`` to ``path``, flipping the CD CRC32 for ``corrupt_name``."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        for name, data in entries.items():
+            zf.writestr(name, data)
+    data = bytearray(buf.getvalue())
+    target = corrupt_name.encode("utf-8")
+    pos = 0
+    while True:
+        i = data.find(b"PK\x01\x02", pos)
+        if i < 0:
+            raise LookupError(f"central-directory entry not found for {corrupt_name!r}")
+        name_len = int.from_bytes(data[i + 28 : i + 30], "little")
+        name = bytes(data[i + 46 : i + 46 + name_len])
+        if name == target:
+            data[i + 16] ^= 0xFF
+            break
+        pos = i + 4
+    path.write_bytes(bytes(data))
+    return path


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements OpenSpec change `stop-on-failure-not-policy`.

## Summary

`OnError.STOP` previously halted on both genuine member failures and policy blocks (`FilterRejectionError`). These are different in kind: a block is safe-extraction working as designed. This change narrows `OnError` to **failures only**.

- Policy `BLOCKED` outcomes are always recorded-and-continued under `STOP` or `CONTINUE`
- Genuine failures still raise immediately under `STOP`
- Always-stop guards (resource limits, `DiagnosticRaisedError`, etc.) are unchanged
- CLI `--stop-on-error` maps to library `STOP` and inherits the narrowing
- Exit codes follow Q8 Option A: `3` for completed policy-only runs; `1` for abort/failure
- Abort-on-unsafe-member (fail-closed) remains a future separate opt-in

## Review follow-ups

- STOP abort reports **extracted** and **blocked** counts separately (`ExtractionProgress.members_extracted` / `members_blocked`)
- `review/STATUS.md` Q8 aligned with scoping resolution
- Stale `ExtractionResult.error` docstring fixed; unused `EXIT_BLOCKED` alias removed
- Shared `tests/zip_corrupt.py` helper; STOP+BLOCKED diagnostic coverage; gotchas note

## Verification

- Focused: `extraction or on_error or cli or adversarial` / review-fix suite — green
- `[all]` / `[all-lowest]` / `[core-only]` previously green on the behavior change; type-check clean
- `openspec validate --strict stop-on-failure-not-policy` OK

All 17/17 change tasks complete. Ready to archive.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-37ca4d64-8663-40f7-ba5f-f53d4d306dc4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-37ca4d64-8663-40f7-ba5f-f53d4d306dc4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

