### PR TITLE
Clarify public archivey modules for ease of understanding

### DIFF
--- a/src/archivey/__init__.py
+++ b/src/archivey/__init__.py
@@ -1,4 +1,20 @@
-"""Archivey — Python library for reading, streaming, and safely extracting archives."""
+"""Archivey — Python library for reading, streaming, and safely extracting archives.
+
+Public surface layout (this package root only — not ``internal`` / ``cli``):
+
+- :mod:`archivey.core` — ``open_archive`` / ``open_stream`` / ``extract`` / detection
+- :mod:`archivey.reader` — ``ArchiveReader`` ABC
+- :mod:`archivey.types` — formats, members, compression
+- :mod:`archivey.config` — ``ArchiveyConfig``, limits, passwords, accelerators
+- :mod:`archivey.cost` — listing/access cost receipt
+- :mod:`archivey.diagnostics` — advisory codes, summaries, extraction reports
+- :mod:`archivey.exceptions` — error hierarchy
+- :mod:`archivey.measurement` — optional I/O counters
+
+Names in ``__all__`` are the documented API. A few advanced types are also imported
+here (so ``from archivey import …`` keeps working) but omitted from ``__all__`` so
+they do not crowd the generated API reference — see the ``# noqa: F401`` imports.
+"""
 
 from importlib.metadata import PackageNotFoundError, version
 
@@ -9,7 +25,7 @@ except PackageNotFoundError:
 
 from archivey.config import (
     DEFAULT_ARCHIVEY_CONFIG,
-    RAPIDGZIP_AUTO_MIN_COMPRESSED_SIZE,  # noqa: F401 — not in __all__ but kept importable
+    RAPIDGZIP_AUTO_MIN_COMPRESSED_SIZE,  # noqa: F401 — advanced; not in __all__
     AcceleratorMode,
     ArchiveyConfig,
     ExtractionLimits,
@@ -39,7 +55,8 @@ from archivey.cost import (
     StreamCapability,
 )
 from archivey.diagnostics import (
-    ArchiveEofContext,  # noqa: F401 — not in __all__ but kept importable
+    # Context payloads: importable for isinstance/match; omitted from __all__.
+    ArchiveEofContext,  # noqa: F401
     Diagnostic,
     DiagnosticCode,
     DiagnosticContext,
@@ -87,7 +104,7 @@ from archivey.exceptions import (
     UnsupportedFeatureError,
     UnsupportedFormatError,
     UnsupportedOperationError,
-    WriteError,  # noqa: F401 — not in __all__ but kept importable
+    WriteError,  # noqa: F401 — write API not shipped yet; kept importable
 )
 from archivey.internal.extraction_types import (
     ExtractionPolicy,
@@ -201,11 +218,9 @@ __all__ = [
     "UnsupportedOperationError",
 ]
 
-# Register the bundled backends eagerly (each module self-registers on import), so the
-# availability queries (list_supported_formats / format_availability) work immediately
-# after `import archivey`, without first calling open_archive().
+# Eager backend registration so list_supported_formats / format_availability work
+# immediately after `import archivey` (open_archive also imports as a safety net).
 import archivey.internal.backends  # noqa: E402,F401
 
-# Keep the importlib.metadata helpers out of the public `archivey` namespace
-# (so `__all__` stays the single, hand-curated description of the public API).
+# Keep importlib.metadata helpers out of the public namespace (__all__ is authoritative).
 del PackageNotFoundError, version

--- a/src/archivey/config.py
+++ b/src/archivey/config.py
@@ -120,10 +120,10 @@ ListingLimits.UNLIMITED = ListingLimits(
 
 @dataclass(frozen=True)
 class ArchiveyConfig:
-    """Library tuning knobs passed explicitly as ``config=`` to :func:`open_archive` / :func:`extract`.
+    """Library tuning knobs passed as ``config=`` to :func:`open_archive` / :func:`extract`.
 
     Per-call operationals (``format``, ``streaming``, ``password``, extraction's
-    ``members``/``filter``/``policy``/…) stay keyword arguments — not part of this object.
+    ``members``/``filter``/``policy``/…) stay keyword arguments — not fields here.
     """
 
     # Tri-state for the [seekable] rapidgzip accelerator (gzip / zlib / raw deflate).
@@ -132,6 +132,8 @@ class ArchiveyConfig:
     use_rapidgzip: AcceleratorMode = AcceleratorMode.AUTO
     # Tri-state for rapidgzip's bundled bzip2 random-access backend.
     use_indexed_bzip2: AcceleratorMode = AcceleratorMode.AUTO
+    # When True, a missing TAR (etc.) end-of-archive marker becomes TruncatedError
+    # instead of ARCHIVE_EOF_MARKER_MISSING (see gotchas / strict_archive_eof).
     strict_archive_eof: bool = False
     # Legacy encoding for a ZIP member name stored without the UTF-8 flag whose bytes are
     # also not valid UTF-8 (the sniff prefers UTF-8 first). Default cp437 per APPNOTE; set a
@@ -163,3 +165,4 @@ PasswordProvider = Callable[[PasswordRequest], str | bytes | None]
 """Callable consulted when static password candidates fail for an encrypted unit."""
 
 PasswordInput = str | bytes | Sequence[str | bytes] | PasswordProvider | None
+"""Accepted ``password=`` shapes: one value, an ordered candidate list, a provider, or None."""

--- a/src/archivey/core.py
+++ b/src/archivey/core.py
@@ -184,7 +184,8 @@ def open_archive(
     reader_source = resolved.open_source
     archive_name = resolved.archive_name
 
-    # --- Resolve format (caller override → directory shortcut → magic detect) ---
+    # --- Resolve format: directory path forces DIRECTORY (overrides format=);
+    # else caller format, else magic detect. ---
     resolved_format = format
     if isinstance(reader_source, Path) and reader_source.is_dir():
         resolved_format = ArchiveFormat.DIRECTORY

--- a/src/archivey/core.py
+++ b/src/archivey/core.py
@@ -1,4 +1,10 @@
-"""Public entry points: open archives and query format support."""
+"""Public entry points: open archives and query format support.
+
+``open_archive`` pipeline (in order): register backends → validate streaming/
+concurrency → resolve source → detect or accept format → multi-volume checks →
+backend capability gates (password / seekability) → normalize stream origin →
+``backend.open_read(...)``.
+"""
 
 from __future__ import annotations
 
@@ -153,7 +159,8 @@ def open_archive(
     passwords *and* a colliding wrong candidate *and* a STORED member) but can matter
     for very large stored members.
     """
-    # Import backends to ensure they are registered
+    # Safety net for `from archivey.core import open_archive` (package __init__ also
+    # imports backends so list_supported_formats works on a bare `import archivey`).
     import archivey.internal.backends  # noqa: F401
 
     open_site = capture_open_site()
@@ -168,98 +175,94 @@ def open_archive(
     passwords = _PasswordCandidates.from_input(password)
 
     effective_config = config if config is not None else DEFAULT_ARCHIVEY_CONFIG
-    # The reader's diagnostic collector is created here, before detection, so automatic
-    # detection and the reader share one budget/occurrence order (see diagnostics design)
-    # and ``reader.diagnostics`` covers the whole open — which is what one-shot extract()
-    # reads back, no cross-call collector plumbing needed.
+    # Collector is created before detection so open + detect share one budget /
+    # occurrence order; one-shot extract() then reads reader.diagnostics for the
+    # whole call without cross-call plumbing.
     collector = collector_from_config(effective_config)
     resolved = resolve_source(source)
-    open_source = resolved.open_source
+    # Mutated below (peekable wrap, RAR volume reopen, mid-stream origin fix).
+    reader_source = resolved.open_source
     archive_name = resolved.archive_name
 
-    # A path source: a directory short-circuits detection.
-    if isinstance(open_source, Path) and open_source.is_dir():
-        format = ArchiveFormat.DIRECTORY
+    # --- Resolve format (caller override → directory shortcut → magic detect) ---
+    resolved_format = format
+    if isinstance(reader_source, Path) and reader_source.is_dir():
+        resolved_format = ArchiveFormat.DIRECTORY
 
     detected: FormatInfo | None = None
-    if format is None:
-        # Non-seekable streams must be wrapped before detection so the peeked prefix is
-        # replayed to the backend; the same wrapper is then handed over.
-        if is_stream(open_source) and not is_seekable(open_source):
-            open_source = PeekableStream(open_source)
-        detected = detect_format(open_source, collector=collector)
-        format = detected.format
+    if resolved_format is None:
+        # Non-seekable streams: wrap before detection so the peeked prefix is
+        # replayed to the backend; the same wrapper is handed over.
+        if is_stream(reader_source) and not is_seekable(reader_source):
+            reader_source = PeekableStream(reader_source)
+        detected = detect_format(reader_source, collector=collector)
+        resolved_format = detected.format
 
-    if resolved.volume_count > 1 and format.container not in (
+    if resolved.volume_count > 1 and resolved_format.container not in (
         ContainerFormat.SEVEN_Z,
         ContainerFormat.RAR,
     ):
-        _raise_multi_volume_not_supported(format, archive_name)
+        _raise_multi_volume_not_supported(resolved_format, archive_name)
 
-    # RAR multi-volume: unrar needs real sibling volume files on disk. When
-    # resolve_source concatenated an explicit path sequence, reopen volume 1 only.
-    if format.container == ContainerFormat.RAR and isinstance(
-        open_source, ConcatenatedFile
+    # RAR multi-volume: unrar needs real sibling files on disk. When resolve_source
+    # concatenated an explicit path sequence, reopen volume 1 only.
+    if resolved_format.container == ContainerFormat.RAR and isinstance(
+        reader_source, ConcatenatedFile
     ):
-        volume_paths = open_source.volume_paths
+        volume_paths = reader_source.volume_paths
         if volume_paths:
-            open_source.close()
-            open_source = volume_paths[0]
+            reader_source.close()
+            reader_source = volume_paths[0]
 
     registry = get_registry()
-    backend_cls = registry.reader_for_format(format)
+    backend_cls = registry.reader_for_format(resolved_format)
 
-    # A concrete password for a format that has no encryption is API misuse, rejected
-    # centrally (backends declare SUPPORTS_PASSWORD as data and never see the argument
-    # otherwise). A PasswordProvider alone is fine — backends that never need a password
-    # never call it (CLI registers a TTY getpass provider by default).
+    # Concrete passwords for formats with no encryption are API misuse (rejected
+    # here). A PasswordProvider alone is fine — unused backends never call it.
     if passwords.has_static_candidates() and not backend_cls.SUPPORTS_PASSWORD:
         raise UnsupportedOperationError(
-            f"Format {format!r} does not support passwords (it carries no encryption).",
-            source_format=format,
+            f"Format {resolved_format!r} does not support passwords "
+            f"(it carries no encryption).",
+            source_format=resolved_format,
             archive_name=archive_name,
         )
 
-    # Fail fast on a non-seekable source (the access-mode contract: streaming=False
-    # promises repeatable random access, which a single forward pass cannot honor, and
-    # the library never implicitly buffers). Under streaming=True the source is usable
-    # only when the backend can walk its format front-to-back (TAR, single-file codecs);
-    # a trailing-index format (ZIP central directory, ISO descriptors) cannot.
-    if is_stream(open_source) and not is_seekable(open_source):
+    # Access-mode contract: streaming=False never implicitly buffers a pipe.
+    # streaming=True still needs a front-to-back format (TAR, raw codecs); trailing
+    # indexes (ZIP CD, ISO) cannot.
+    if is_stream(reader_source) and not is_seekable(reader_source):
         if not streaming:
             raise StreamNotSeekableError(
                 f"Random access (streaming=False) requires a seekable source. Open with "
-                f"streaming=True for a single forward pass over this {format!r} stream, "
+                f"streaming=True for a single forward pass over this "
+                f"{resolved_format!r} stream, "
                 f"or buffer it to disk or a BytesIO and reopen.",
-                source_format=format,
+                source_format=resolved_format,
                 archive_name=archive_name,
             )
         if not backend_cls.SUPPORTS_STREAMING_NON_SEEKABLE:
             raise StreamNotSeekableError(
-                f"Format {format!r} cannot be read from a non-seekable source even in "
-                f"streaming mode (its index/metadata is not at the front of the stream). "
-                f"Buffer it to disk or a BytesIO and reopen.",
-                source_format=format,
+                f"Format {resolved_format!r} cannot be read from a non-seekable source "
+                f"even in streaming mode (its index/metadata is not at the front of "
+                f"the stream). Buffer it to disk or a BytesIO and reopen.",
+                source_format=resolved_format,
                 archive_name=archive_name,
             )
 
-    # Normalize the stream origin once for every backend: a seekable stream positioned
-    # mid-file is wrapped so the backend sees tell() == 0 at the archive's first byte
-    # (the stream-position contract in format-detection). Done after detection, which
-    # peeks from and restores the same origin.
-    if is_stream(open_source) and is_seekable(open_source):
-        open_source = fix_stream_start_position(open_source)
+    # Mid-file seekable streams: wrap so every backend sees tell()==0 at the first
+    # archive byte (done after detection, which peeked from the same origin).
+    if is_stream(reader_source) and is_seekable(reader_source):
+        reader_source = fix_stream_start_position(reader_source)
 
-    # Thread the encoding: an explicit caller encoding wins, else the detector's hint, else
-    # None (the backend auto-detects).
+    # Explicit encoding wins; else detector hint; else backend auto-detect.
     effective_encoding = encoding
     if effective_encoding is None and detected is not None:
         effective_encoding = detected.encoding_hint
 
     backend = backend_cls()
     return backend.open_read(
-        open_source,
-        format=format,
+        reader_source,
+        format=resolved_format,
         streaming=streaming,
         passwords=passwords,
         encoding=effective_encoding,
@@ -305,7 +308,7 @@ def open_stream(
         path = Path(source)
         if not path.is_file():
             raise FileNotFoundError(f"Compressed stream not found: {path}")
-        open_source: Path | BinaryIO = path
+        codec_input: Path | BinaryIO = path
         source_is_seekable = True
     else:
         if not is_stream(source):
@@ -314,9 +317,10 @@ def open_stream(
             )
         source_is_seekable = is_seekable(source)
         if not source_is_seekable:
-            open_source = PeekableStream(source)
+            codec_input = PeekableStream(source)
         else:
-            open_source = fix_stream_start_position(source)
+            # Same mid-stream origin contract as open_archive.
+            codec_input = fix_stream_start_position(source)
 
     if seekable and not source_is_seekable:
         raise StreamNotSeekableError(
@@ -325,7 +329,7 @@ def open_stream(
             "forward-only pass."
         )
 
-    stream_format = _resolve_stream_format(format, open_source, collector)
+    stream_format = _resolve_stream_format(format, codec_input, collector)
     if stream_format is StreamFormat.UNCOMPRESSED:
         raise UnsupportedFormatError(
             "open_stream requires a compressed stream format "
@@ -339,7 +343,7 @@ def open_stream(
         seekable=seekable and source_is_seekable,
     )
     codec_source: str | BinaryIO = (
-        str(open_source) if isinstance(open_source, Path) else open_source
+        str(codec_input) if isinstance(codec_input, Path) else codec_input
     )
     return open_codec_stream(
         codec,
@@ -355,6 +359,7 @@ def _resolve_stream_format(
     open_source: Path | BinaryIO,
     collector: DiagnosticCollector,
 ) -> StreamFormat:
+    """Map open_stream's ``format=`` argument (or auto-detect) to a StreamFormat."""
     if isinstance(format, StreamFormat):
         return format
     if isinstance(format, ArchiveFormat):
@@ -406,10 +411,9 @@ def extract(
     Returns an :class:`~archivey.ExtractionReport` whose diagnostic summary spans
     detection, open, and extraction for this call.
     """
-    # Peek at the resolved open target only to pick the access mode; open_archive
-    # re-resolves the original source itself (resolution is cheap and idempotent).
-    resolved_target = resolve_source(source).open_source
-    streaming = is_stream(resolved_target) and not is_seekable(resolved_target)
+    # Peek only to choose access mode; open_archive re-resolves ``source`` (cheap).
+    peek_target = resolve_source(source).open_source
+    streaming = is_stream(peek_target) and not is_seekable(peek_target)
 
     with open_archive(
         source,
@@ -419,8 +423,7 @@ def extract(
         encoding=encoding,
         config=config,
     ) as reader:
-        # The reader already carries `config` (passed to open_archive above), so
-        # extract_all falls back to it — no need to forward `config` a second time.
+        # Reader already carries ``config`` from open_archive — do not forward again.
         report = reader.extract_all(
             dest,
             policy=policy,
@@ -429,10 +432,8 @@ def extract(
             on_progress=on_progress,
             limits=limits,
         )
-        # `reader.diagnostics` is the reader's cumulative snapshot. Because this reader was
-        # opened fresh for this one-shot call, that already spans detection, open, and
-        # extraction exactly once — a superset of extract_all's extraction-only delta — so
-        # the one-shot report is assembled entirely from the public surface.
+        # extract_all's report.diagnostics is extraction-only. This reader was opened
+        # fresh for this call, so reader.diagnostics already spans detect+open+extract.
         return ExtractionReport(
             results=report.results,
             diagnostics=reader.diagnostics,

--- a/src/archivey/cost.py
+++ b/src/archivey/cost.py
@@ -16,13 +16,13 @@ class ListingCost(Enum):
     """How expensive it is to *enumerate* all members (list names + metadata)."""
 
     INDEXED = "indexed"
-    """An index / central directory is present (ZIP central directory, 7z header, ISO
-    directory tree parsed at open); members can be enumerated without scanning header-to-header
-    or decompressing payload. A filesystem directory is NOT indexed — its walk is a scan
-    (`REQUIRES_SCANNING`). RAR is ``INDEXED``: the reader walks all file headers at open
-    time to build the member table (the optional Quick Open record is parsed but not
-    relied on as the sole source), so by the time ``members()`` is called the list is
-    already in memory at O(1) cost."""
+    """Members can be listed without scanning header-to-header or decompressing payload.
+
+    Examples: ZIP central directory, 7z header, ISO directory tree at open. A
+    filesystem directory is **not** indexed (its walk is ``REQUIRES_SCANNING``).
+    RAR is ``INDEXED`` because the reader walks all file headers at open and caches
+    the table — by ``members()`` time the list is already in memory.
+    """
 
     REQUIRES_SCANNING = "requires_scanning"
     """No index, but members can be enumerated by seeking/scanning header-to-header

--- a/src/archivey/diagnostics.py
+++ b/src/archivey/diagnostics.py
@@ -2,6 +2,15 @@
 
 See ``openspec/specs/diagnostics`` (and the ``diagnostics-warnings-as-data`` change)
 for the lifecycle, retention, and policy contracts.
+
+Layout of this module:
+
+1. **Codes / severity / disposition** — stable enums callers match on.
+2. **Context payloads** — one frozen dataclass per ``kind``; fields are JSON-safe
+   scalars so :meth:`Diagnostic.to_dict` needs no per-class serializers.
+3. **Records** — :class:`Diagnostic`, :class:`DiagnosticSummary`, policy, reports.
+4. **Helpers** — ``validate_code_context``, ``raw_name_to_base64``, ``format_path_name``
+   (used when *emitting* diagnostics; end users mostly read the records).
 """
 
 from __future__ import annotations
@@ -34,12 +43,11 @@ def _freeze_mapping(mapping: Mapping[_K, _V] | None) -> Mapping[_K, _V]:
 
 @dataclass(frozen=True)
 class _JsonSafeContext:
-    """Base for the flat, frozen context dataclasses below: a single JSON-safe ``to_dict``.
+    """Shared ``to_dict`` for the flat context dataclasses below.
 
-    It carries no fields itself (so subclasses keep their own field lists) but is a
-    dataclass, which lets ``dataclasses.asdict`` accept ``self``. Every context field is a
-    ``str`` / ``int`` / ``None`` (or a ``Literal`` thereof), so ``asdict`` yields a
-    JSON-serializable mapping in field order — no per-class boilerplate needed.
+    Subclasses declare their own fields (this base adds none). Every field is a
+    JSON-safe scalar (``str`` / ``int`` / ``None`` / ``Literal``), so
+    ``dataclasses.asdict`` is enough — no per-class boilerplate.
     """
 
     def to_dict(self) -> dict[str, object]:
@@ -86,6 +94,8 @@ class DiagnosticDisposition(str, Enum):
 
 @dataclass(frozen=True)
 class NameNormalizationContext(_JsonSafeContext):
+    """Member path rewritten for display/lookup (separators, ``.``/``..``, etc.)."""
+
     kind: Literal["name_normalization"] = "name_normalization"
     archive_name: str | None = None
     member_name: str = ""
@@ -97,6 +107,8 @@ class NameNormalizationContext(_JsonSafeContext):
 
 @dataclass(frozen=True)
 class NameEncodingContext(_JsonSafeContext):
+    """Member name bytes decoded with an inferred (not declared) encoding."""
+
     kind: Literal["name_encoding"] = "name_encoding"
     archive_name: str | None = None
     member_name: str = ""
@@ -108,6 +120,8 @@ class NameEncodingContext(_JsonSafeContext):
 
 @dataclass(frozen=True)
 class FormatConflictContext(_JsonSafeContext):
+    """Extension suggested one format; content detection chose another."""
+
     kind: Literal["format_conflict"] = "format_conflict"
     source_name: str | None = None
     extension: str | None = None
@@ -117,6 +131,8 @@ class FormatConflictContext(_JsonSafeContext):
 
 @dataclass(frozen=True)
 class ScanRaceContext(_JsonSafeContext):
+    """Directory-archive entry vanished between listing and open (TOCTOU)."""
+
     kind: Literal["scan_race"] = "scan_race"
     archive_name: str | None = None
     relative_path: str = ""
@@ -125,6 +141,8 @@ class ScanRaceContext(_JsonSafeContext):
 
 @dataclass(frozen=True)
 class ArchiveEofContext(_JsonSafeContext):
+    """Expected end-of-archive marker missing, short, or non-null (e.g. TAR trailer)."""
+
     kind: Literal["archive_eof"] = "archive_eof"
     archive_name: str | None = None
     format: str = ""
@@ -136,6 +154,8 @@ class ArchiveEofContext(_JsonSafeContext):
 
 @dataclass(frozen=True)
 class MemberTimestampContext(_JsonSafeContext):
+    """A stored timestamp field was present but unusable / out of range."""
+
     kind: Literal["member_timestamp"] = "member_timestamp"
     archive_name: str | None = None
     member_name: str = ""
@@ -147,6 +167,8 @@ class MemberTimestampContext(_JsonSafeContext):
 
 @dataclass(frozen=True)
 class SymlinkTargetContext(_JsonSafeContext):
+    """Symlink/hardlink target could not be resolved inside the archive."""
+
     kind: Literal["symlink_target"] = "symlink_target"
     archive_name: str | None = None
     member_name: str = ""
@@ -156,6 +178,8 @@ class SymlinkTargetContext(_JsonSafeContext):
 
 @dataclass(frozen=True)
 class DigestContext(_JsonSafeContext):
+    """Stored digest present but not verifiable with the available data."""
+
     kind: Literal["digest"] = "digest"
     archive_name: str | None = None
     member_name: str = ""
@@ -166,6 +190,8 @@ class DigestContext(_JsonSafeContext):
 
 @dataclass(frozen=True)
 class SeekIndexContext(_JsonSafeContext):
+    """Seek index build failed or was skipped; stream may redecompress on rewind."""
+
     kind: Literal["seek_index"] = "seek_index"
     archive_name: str | None = None
     member_name: str | None = None
@@ -177,6 +203,8 @@ class SeekIndexContext(_JsonSafeContext):
 
 @dataclass(frozen=True)
 class StreamRewindContext(_JsonSafeContext):
+    """A backward seek re-decompressed from an earlier offset (no accelerator)."""
+
     kind: Literal["stream_rewind"] = "stream_rewind"
     archive_name: str | None = None
     member_name: str | None = None
@@ -189,6 +217,8 @@ class StreamRewindContext(_JsonSafeContext):
 
 @dataclass(frozen=True)
 class ExtractionOutcomeContext(_JsonSafeContext):
+    """Per-member extraction blocked by policy or failed with an error."""
+
     kind: Literal["extraction_outcome"] = "extraction_outcome"
     archive_name: str | None = None
     member_name: str = ""
@@ -265,7 +295,12 @@ _CODE_CONTEXT_KINDS: Mapping[DiagnosticCode, str] = MappingProxyType(
 
 
 def validate_code_context(code: DiagnosticCode, context: DiagnosticContext) -> None:
-    """Reject unregistered or mismatched code→context pairings."""
+    """Reject unregistered or mismatched code→context pairings.
+
+    Most codes map 1:1 onto a context ``kind`` via ``_CODE_CONTEXT_KINDS``. A few
+    codes share a kind and need an extra field check so blocked≠failed, directory
+    vanish≠entry vanish, etc. — those guards live below the kind match.
+    """
     expected = _CODE_CONTEXT_KINDS.get(code)
     if expected is None:
         raise ValueError(f"Unknown diagnostic code: {code!r}")
@@ -274,6 +309,7 @@ def validate_code_context(code: DiagnosticCode, context: DiagnosticContext) -> N
             f"Diagnostic code {code.value!r} requires context kind {expected!r}, "
             f"got {context.kind!r}"
         )
+    # Shared-kind codes: kind alone is not enough.
     if code is DiagnosticCode.SCAN_DIRECTORY_VANISHED and (
         not isinstance(context, ScanRaceContext) or context.entry_kind != "directory"
     ):
@@ -291,6 +327,7 @@ def validate_code_context(code: DiagnosticCode, context: DiagnosticContext) -> N
     ):
         raise ValueError("EXTRACTION_MEMBER_FAILED requires status='failed'")
     if isinstance(context, ExtractionOutcomeContext):
+        # Group metadata is all-or-nothing so partial fills cannot look like a group.
         group_id, group_size = context.failure_group_id, context.failure_group_size
         if (group_id is None) ^ (group_size is None):
             raise ValueError(

--- a/src/archivey/exceptions.py
+++ b/src/archivey/exceptions.py
@@ -1,4 +1,16 @@
-"""Archivey exception hierarchy."""
+"""Archivey exception hierarchy.
+
+Two roots (intentional):
+
+- :class:`ArchiveyError` — archive / environment / format problems. Safe to catch
+  broadly when wrapping untrusted input.
+- :class:`ArchiveyUsageError` — caller API misuse. Deliberately **outside** the
+  ``ArchiveyError`` tree so ``except ArchiveyError`` does not hide bugs in calling
+  code.
+
+Under ``ArchiveyError``, names track the failing phase: open → read → extract,
+plus feature/package/resource limits.
+"""
 
 from __future__ import annotations
 

--- a/src/archivey/measurement.py
+++ b/src/archivey/measurement.py
@@ -16,6 +16,10 @@ Enable performance counters by wrapping ``open_archive()`` in
 Counters stay at zero (and :meth:`~archivey.ArchiveReader.io_stats` returns
 ``None``) unless the reader was opened inside an :func:`enable_measurement`
 context — zero overhead on the hot path when measurement is off.
+
+``IoStats`` is defined here (public value type). ``enable_measurement`` is
+implemented under ``archivey.internal.measurement`` and re-exported so callers
+have a single public import path.
 """
 
 from __future__ import annotations

--- a/src/archivey/reader.py
+++ b/src/archivey/reader.py
@@ -32,11 +32,18 @@ MemberSelector = (
 class ArchiveReader(ABC):
     """The public, read-only interface to an open archive.
 
-    This is the type returned by :func:`archivey.open_archive` and the one programs
-    should annotate against. It declares **only** the public contract; the concrete
-    machinery (and the internal hooks format backends implement) lives in the
-    ``BaseArchiveReader`` helper, which every real reader extends. Implements the
-    context-manager protocol, so use it in a ``with`` block.
+    Returned by :func:`archivey.open_archive`. Annotate against this type; concrete
+    machinery lives in the internal ``BaseArchiveReader`` helper. Use in a ``with``
+    block.
+
+    **Listing APIs** (easy to mix up):
+
+    - :meth:`members` — complete list or raise; random-access only (fails on streaming).
+    - :meth:`members_report` — always returns a report; check ``error is None`` for
+      completeness (preferred for damaged archives).
+    - :meth:`scan_members` — like ``members``, but also finishes a streaming forward
+      pass so you can obtain a full list after a partial iteration.
+    - :meth:`members_report_if_available` — never scans; ``None`` if not yet cached.
     """
 
     @property

--- a/src/archivey/reader.py
+++ b/src/archivey/reader.py
@@ -41,8 +41,9 @@ class ArchiveReader(ABC):
     - :meth:`members` — complete list or raise; random-access only (fails on streaming).
     - :meth:`members_report` — always returns a report; check ``error is None`` for
       completeness (preferred for damaged archives).
-    - :meth:`scan_members` — like ``members``, but also finishes a streaming forward
-      pass so you can obtain a full list after a partial iteration.
+    - :meth:`scan_members` — random-access: same as ``members``; streaming: start or
+      finish the forward pass and return the resolved list (also OK after a completed
+      pass).
     - :meth:`members_report_if_available` — never scans; ``None`` if not yet cached.
     """
 

--- a/src/archivey/types.py
+++ b/src/archivey/types.py
@@ -13,21 +13,28 @@ if TYPE_CHECKING:
 
 
 class MemberStreams(Flag):
-    """Declared member-stream capabilities for :func:`archivey.open_archive`.
+    """Opt-in member-stream capabilities for :func:`archivey.open_archive`.
 
-    Default (no bits) is forward-only streams with at most one live member stream.
-    Combine with ``|``::
+    Default (no bits set — ``MemberStreams(0)``) is the cheap contract:
+
+    - at most one live member stream at a time
+    - streams are forward-only (``seek()`` raises)
+
+    Combine flags with ``|``::
 
         MemberStreams.CONCURRENT | MemberStreams.SEEKABLE
 
-    ``CONCURRENT`` unlocks a supported worker seam: concurrent first-touch
-    materialization is coordinated (one build, waiters share the published snapshot),
-    then concurrent ``open()`` and independent stream I/O on different members are
-    correct under cooperative use and are exercised on free-threaded CPython by the
-    Linux ``3.13t`` ``free-threaded-concurrency`` CI job. ``close()`` drains in-flight
-    worker calls before closing; escaped streams keep the lifecycle-lease contract.
-    Callers still synchronize their own shared stream objects; distinct reader-wide
-    passes (``__iter__`` / ``stream_members`` / ``extract_all``) remain single-owner.
+    ``CONCURRENT``
+        Multiple overlapping ``open()`` calls are allowed. First-touch member
+        materialization is coordinated (one build; waiters share the snapshot);
+        ``close()`` drains in-flight worker calls. Callers still synchronize any
+        *shared* stream objects they hand around. Reader-wide passes
+        (``__iter__`` / ``stream_members`` / ``extract_all``) remain single-owner.
+        Does **not** remove solid open-order cost — see :class:`~archivey.AccessCost`.
+
+    ``SEEKABLE``
+        Member streams support ``seek()`` where the backend can position
+        (often via an index or accelerator). Without this flag, seek raises.
     """
 
     CONCURRENT = auto()
@@ -61,11 +68,18 @@ class StreamFormat(str, Enum):
 
 @dataclass(frozen=True)
 class ArchiveFormat:
+    """A ``(container, stream)`` pair identifying how an archive is packaged.
+
+    Prefer the named class attributes (``ArchiveFormat.ZIP``, ``ArchiveFormat.TAR_GZ``,
+    …) over constructing pairs by hand. Those names are assigned immediately below
+    the class body; the ``ClassVar`` declarations exist so type checkers see them
+    without per-use suppressions. ``_FORMAT_NAMES`` is built from the same
+    assignments so ``repr`` / ``display_name`` stay in sync automatically.
+    """
+
     container: ContainerFormat
     stream: StreamFormat
 
-    # Named instances, populated just after the class definition. Declared here as
-    # ClassVars so both type checkers know they exist (no per-use `type: ignore`).
     ZIP: ClassVar[ArchiveFormat]
     TAR: ClassVar[ArchiveFormat]
     TAR_GZ: ClassVar[ArchiveFormat]
@@ -170,11 +184,12 @@ _FORMAT_NAMES: dict[ArchiveFormat, str] = {
 
 @dataclass(frozen=True)
 class MissingComponent:
-    """A package / extra / external tool a format is missing, and what it unlocks.
+    """A package, extra, or external tool required for a format (or a codec inside it).
 
-    Lives here (a leaf module) rather than in the registry so the codec descriptors that
-    declare a codec's ``requirement`` can reference it without a registry↔codecs import
-    cycle. Re-exported from ``internal.registry`` for the public API.
+    Appears on :class:`~archivey.FormatAvailability` when something is absent, and as
+    the ``requirement`` on internal codec/backend descriptors. Defined in this leaf
+    module (not the registry) so codec descriptors can reference it without a
+    registry ↔ codecs import cycle.
     """
 
     name: str  # e.g. "pycdlib", "[7z]", "unrar"
@@ -185,12 +200,11 @@ class MissingComponent:
 
 
 class MagicSignature(NamedTuple):
-    """One exact magic-byte signal a backend declares as data, with the format it implies.
+    """Exact magic-byte match declared by a backend/codec descriptor (not end-user API).
 
-    A match is accepted on the byte comparison alone. Formats too unspecific for an exact
-    magic (zlib's 2-byte CMF/FLG header) or with no signature at all (Brotli) are recognized
-    by a content probe instead — see the codec descriptor's ``content_probe`` and
-    ``format-detection``.
+    Detection accepts a match on the byte comparison alone. Formats too unspecific
+    for an exact magic (zlib's 2-byte CMF/FLG header) or with no signature (Brotli)
+    use a content probe instead — see codec ``content_probe`` and ``format-detection``.
     """
 
     offset: int
@@ -199,6 +213,13 @@ class MagicSignature(NamedTuple):
 
 
 class MemberType(Enum):
+    """Kind of archive entry.
+
+    ``ANTI`` is a deletion/tombstone (solid 7z incremental updates), not a payload
+    file — ``is_file`` is false and extraction skips it. ``OTHER`` covers device
+    nodes, FIFOs, sockets, etc., and is always rejected by safe extraction.
+    """
+
     FILE = "file"
     DIRECTORY = "directory"
     SYMLINK = "symlink"
@@ -243,9 +264,12 @@ class CompressionAlgorithm(Enum):
 
 @dataclass(frozen=True)
 class CompressionMethod:
-    """A single codec in a member's compression chain. Members store a
-    ``tuple[CompressionMethod, ...]`` to model multi-codec filter chains (e.g. a 7z
-    ``(BCJ2, LZMA2)`` chain)."""
+    """One codec in a member's filter chain.
+
+    Members store ``tuple[CompressionMethod, ...]``. Order matches the compress /
+    pack direction: pre-filters first, packing codec last (closest to the stored
+    bytes). Example: 7z ``(BCJ2, LZMA2)`` — decompress by applying LZMA2, then BCJ2.
+    """
 
     algo: CompressionAlgorithm
     level: int | None = None  # compression level, if the format records it
@@ -286,7 +310,12 @@ EXTRA_IS_JUNCTION = "is_junction"
 
 @dataclass(slots=True)
 class ArchiveMember:
-    """Represents a single archive entry. Mutable; callers must treat as read-only."""
+    """One archive entry.
+
+    Mutable on purpose: backends fill late-bound fields in place after the member
+    is first constructed (``link_target_member``, digests, attached diagnostics).
+    Callers must treat instances as read-only — use :meth:`replace` for edits.
+    """
 
     type: MemberType
     """What kind of entry this is (file, directory, symlink, …)."""
@@ -330,17 +359,23 @@ class ArchiveMember:
     link_target: str | None = None
     """For a symlink/hardlink, the raw target path string as stored."""
 
+    # compare=False: identity is path/type/metadata, not the resolved peer object
+    # (resolution is late-bound and would make equality order-dependent).
     link_target_member: "ArchiveMember | None" = field(default=None, compare=False)
     """For a link, the resolved target member within this archive, if found."""
 
     compression: tuple[CompressionMethod, ...] = field(default_factory=tuple)
-    """The codec chain applied to this member (outermost last)."""
+    """Codec chain in compress order — pre-filters first, packing codec last."""
 
     is_encrypted: bool = False
     """Whether this member's data is encrypted."""
 
     is_current: bool = True
-    """Whether this member is the live final state of its path (last-entry-wins)."""
+    """Last-entry-wins: ``True`` for the live final state of this path.
+
+    Duplicate names keep earlier rows with ``is_current=False`` (history /
+    superseded). :meth:`~archivey.ArchiveReader.get` returns the current one.
+    """
 
     is_sparse: bool = False
     """Whether this member is stored as a sparse file."""
@@ -354,12 +389,15 @@ class ArchiveMember:
     windows_attrs: int | None = None
     """Raw Windows file-attribute bitmask, if recorded."""
 
+    # compare=False: digests may be filled after first construction; equality is
+    # about the entry identity, not verification state (see archive-data-model).
     hashes: Mapping[HashAlgorithm, bytes] = field(default_factory=dict, compare=False)
     """Stored content digests keyed by :class:`HashAlgorithm` (values always ``bytes``).
 
     CRC-32 is four big-endian bytes (:func:`crc32_digest`). Excluded from equality.
     """
 
+    # compare=False: format-specific bags must not affect logical identity.
     extra: dict[str, Any] = field(default_factory=dict, compare=False)
     """Format-specific extra fields (e.g. ``extra["is_junction"]``). Excluded from equality."""
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Readability pass on the top-level `src/archivey` modules (`__init__`, `core`, `types`, `reader`, `config`, `cost`, `diagnostics`, `exceptions`, `measurement` — not `internal/` or `cli/`). **No intentional behavior or performance changes.**

### Confusing spots found (then addressed)

| Area | Why it was hard to follow | Change |
| --- | --- | --- |
| `MemberStreams` docstring | Dense concurrency/CI lease language for a Flag enum | Rewrote as clear default + flag bullets |
| `open_archive` | Shadowed `format` / mutated `open_source` | Locals `resolved_format` / `reader_source` + pipeline section comments |
| Listing APIs on `ArchiveReader` | `members` / `members_report` / `scan_members` easy to mix up | Class docstring comparison table |
| `ArchiveMember` mutability + `compare=False` | Non-obvious why fields are mutable / excluded from equality | Comments explaining late-bound fills and identity |
| Compression chain order | “outermost last” ambiguous | Compress-order wording + decompress-in-reverse example |
| `MagicSignature` / `MissingComponent` | Looked like end-user API / wrong re-export story | Clarified backend vs public roles |
| `__init__` F401 imports | Unclear why many types are imported but not in `__all__` | Package map + “advanced but importable” policy |
| Diagnostics contexts | Near-identical dataclasses with no one-liners | Module layout + per-context purpose docs |
| Exception roots | Easy to miss `ArchiveyUsageError` is outside the tree | Hierarchy overview at module top |

### Review follow-up

- `scan_members` class blurb now matches the method contract (random-access ≡ `members`; streaming starts or finishes the forward pass).
- Format-resolve comment clarifies that a directory path forces `DIRECTORY` even when `format=` is set.

### Verification

- **Tests (before & after):** `1839 passed, 87 skipped, 3 deselected`
- **Structural benchmarks:** `bytes_decompressed` and `source_seek_count` identical on all 14 cases; wall-time ratios ≈0.85–1.02× (noise only)
- **Lint/types:** `ruff` / `pyrefly` / `ty` clean on touched modules

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ca74c320-330b-4222-81f2-88d24a80845e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ca74c320-330b-4222-81f2-88d24a80845e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

