### PR TITLE
Clarify internal streams layer for ease of understanding

### DIFF
--- a/src/archivey/internal/streams/__init__.py
+++ b/src/archivey/internal/streams/__init__.py
@@ -1,7 +1,25 @@
-"""The compressed + seekable stream layer.
+"""Compressed + seekable stream layer used by format backends.
 
-Format backends never call codec libraries directly; they compose the backends in
-this package (see the ``compressed-streams`` and ``seekable-decompressor-streams``
-capabilities). The detection peek/rewind primitive (``PeekableStream``) is *not* here
-— it lands with format detection in Phase 3.
+Backends never import codec libraries directly; they compose the pieces below
+(see ``compressed-streams`` / ``seekable-decompressor-streams``).
+
+Package map:
+
+- :mod:`.streamtools` — codec-/format-agnostic ``BinaryIO`` plumbing (slice, lock,
+  shared views, solid demux). Must not import the rest of archivey.
+- :mod:`.codecs` — ``Codec`` / ``StreamCodec`` / ``open_codec_stream`` (the uniform
+  pull-based codec table + detection signals).
+- :mod:`.decompressor_stream` — seekable decode *engine* (``DecompressorStream`` +
+  ``Decoder`` protocol).
+- :mod:`.decompress` — thin ``BaseDecoder`` adapters (zlib, Brotli, PPMd, BCJ,
+  Deflate64) that plug into that engine.
+- :mod:`.xz` / :mod:`.lzip` / :mod:`.unix_compress` — larger codec-specific decoders
+  (index scan / LZW) that also plug into ``DecompressorStream``.
+- :mod:`.archive_stream` — public member/codec handle: exception translate+stamp,
+  lazy open, nested collapse, fused digest verify, lease/finalizer.
+- :mod:`.verify` — ``MemberVerifier`` (+ standalone ``VerifyingStream`` for codec
+  length backstops).
+- :mod:`.crypto` — AES decrypt stage (``[crypto]``) + 7z-local KDF helpers.
+- :mod:`.counting` — measurement wrappers (bytes / seeks).
+- :mod:`.peekable` — non-seekable detection peek/replay (used by ``open_archive``).
 """

--- a/src/archivey/internal/streams/archive_stream.py
+++ b/src/archivey/internal/streams/archive_stream.py
@@ -69,11 +69,24 @@ def _noop_stamp(_exc: ArchiveyError) -> None:
 
 
 class ArchiveStream(ReadOnlyIOStream):
-    """Translate exceptions from an underlying binary stream into ``ArchiveyError``s.
+    """Public member/codec stream handle (exception translation + optional verify).
 
-    The wrapped stream may be opened lazily (on first use) so callers can hand out a
-    handle cheaply; ``seekable()`` answers from the ``seekable`` hint until the stream is
-    actually opened.
+    Responsibilities (one class, several optional knobs):
+
+    1. **Translate + stamp** — raw codec/OS errors → ``ArchiveyError`` with archive
+       context (``translate`` / ``stamp``).
+    2. **Lazy open** — ``open_fn`` may run on first read; ``seekable`` is answered from
+       the hint until then.
+    3. **Collapse nested ``ArchiveStream``s** — ``stream_members`` / codec opens often
+       return another ``ArchiveStream``; ``_collapse_nested`` flattens to one wrapper
+       while composing translators and adopting fused verification.
+    4. **Fused verify** — optional ``MemberVerifier`` (digests / ``expected_size``) runs
+       in ``read`` / ``close``. Distinct from bare ``size=`` (fsspec attribute only —
+       does **not** enable length checks).
+    5. **Lease / finalizer** — ``on_close`` releases reader live-stream state; a
+       weakref finalizer is a safety net if the caller never ``close()``s.
+
+    Prefer constructing via backends / ``open_codec_stream`` rather than by hand.
     """
 
     def __init__(

--- a/src/archivey/internal/streams/codecs.py
+++ b/src/archivey/internal/streams/codecs.py
@@ -1,17 +1,23 @@
 """The uniform, pull-based codec layer.
 
-This is the single place codecs are implemented; format backends compose these stream
-backends instead of importing codec libraries (the ``compressed-streams`` contract). Each
-codec is one :class:`StreamCodec` subclass that bundles everything the rest of the library
-needs to know about it — its open method, exception translator, detection signals (magic /
-content probe / extensions), single-file metadata extraction, and optional-dependency
-requirement — so adding a standalone codec is "add one subclass", not "edit the detector,
-the single-file reader, and the registry separately". The codec objects are collected in
-:data:`STREAM_CODECS`, the single source of truth those consumers iterate directly.
+Format backends compose these stream backends instead of importing codec libraries
+(the ``compressed-streams`` contract). Adding a standalone codec is "add one
+:class:`StreamCodec` subclass" — not "edit the detector, single-file reader, and
+registry separately". Instances live in :data:`STREAM_CODECS`.
 
-Scope here is the spec's codec table. The AES decrypt **stage** lives in ``crypto.py`` and
-the decompressed-digest verification stage in ``verify.py`` — both compose with these
-codec streams in a pipeline.
+Three names that are easy to mix up:
+
+- :class:`Codec` — enum id (``Codec.GZIP``, ``Codec.DEFLATE``, …). What callers pass
+  to :func:`open_codec_stream` / :func:`resolve_codec`.
+- :class:`StreamCodec` — descriptor class per codec: ``open`` / ``translate`` /
+  magic / content probe / optional ``requirement``. Looked up via ``STREAM_CODECS``.
+- :class:`CodecBackend` — *resolved* open+translator for a given ``StreamConfig``
+  (accelerator choice may change the translator). Returned by :func:`resolve_codec`.
+
+AES decrypt lives in ``crypto.py``; digest/length verify in ``verify.py``. Both
+compose *around* these codec streams in a pipeline. Seekable decode engines for
+raw deflate/Brotli/… live in ``decompressor_stream`` + ``decompress``; XZ/lzip/
+``.Z`` have their own modules and are opened from the matching ``StreamCodec``.
 """
 
 from __future__ import annotations
@@ -1327,8 +1333,10 @@ class Deflate64Codec(StreamCodec):
 
 # --- the codec registry ----------------------------------------------------------------
 
-# The single source of truth: one instance per codec. Detection, the single-file reader, and
-# the backend registry iterate these objects and read their fields directly.
+# Single source of truth for *openable* codecs. Detection, the single-file reader, and
+# the backend registry iterate these. Filter-only ``Codec`` enum members (DELTA / BCJ_*)
+# are intentionally absent — they compose into raw LZMA via ``LZMA_FILTER_IDS``, not
+# standalone ``StreamCodec.open``.
 STREAM_CODECS: tuple[StreamCodec, ...] = (
     StoredCodec(),
     GzipCodec(),

--- a/src/archivey/internal/streams/crypto.py
+++ b/src/archivey/internal/streams/crypto.py
@@ -1,15 +1,19 @@
-"""The single, wrapped crypto backend (AES decrypt stage).
+"""AES decrypt stage via the ``[crypto]`` extra (``cryptography`` package).
 
-Per the ``compressed-streams`` spec, Archivey standardises on the ``cryptography``
-package (the ``[crypto]`` extra) as its one crypto backend, reached **only** through this
-internal abstraction so format parsers never import ``cryptography`` directly and the
-backend stays swappable. AES decryption is modelled as a *stage* that composes ahead of a
-decompressor in a pipeline (e.g. AES → LZMA2 for an encrypted 7z folder).
+Format parsers must not import ``cryptography`` directly — only this module does
+(the backend stays swappable). AES is a *pipeline stage* ahead of a decompressor
+(e.g. AES → LZMA2 for an encrypted 7z folder).
 
-The format-agnostic AES-CBC decrypt stage lives here. The 7z SHA-256 KDF is 7z-specific
-(RAR and WinZip-AES derive keys differently), so it lives as a local helper beside this
-module rather than on the generic ``CryptoBackend`` surface — see
-:func:`derive_sevenzip_aes_key` and :class:`SevenZipKeyCache`.
+Layers here:
+
+- :class:`DecryptStage` / :func:`open_aes_decrypt_stage` — feed ciphertext chunks,
+  get plaintext (used when composing inside a larger open).
+- :class:`AesDecryptStream` / :func:`open_aes_decrypt_stream` — pull ``BinaryIO``
+  wrapper over a ciphertext source.
+- :func:`derive_sevenzip_aes_key` / :func:`parse_sevenzip_aes_properties` —
+  **7z-local** KDF helpers. RAR and WinZip-AES derive keys differently, so these
+  are not on the generic :class:`CryptoBackend` surface; they live beside it for
+  the 7z reader only.
 """
 
 from __future__ import annotations

--- a/src/archivey/internal/streams/decompress.py
+++ b/src/archivey/internal/streams/decompress.py
@@ -1,8 +1,10 @@
-"""Forward-only codec decoders: zlib/deflate, Brotli, PPMd, BCJ, Deflate64.
+"""Thin ``BaseDecoder`` adapters: zlib/deflate, Brotli, PPMd, BCJ, Deflate64.
 
-Each is a thin :class:`BaseDecoder` adapter. Construction helpers return a concrete
-:class:`~archivey.internal.streams.decompressor_stream.DecompressorStream` wrapping
-the decoder — there are no per-codec stream subclasses.
+Not the seekable engine — that is :mod:`.decompressor_stream`. Each class here
+implements :class:`~archivey.internal.streams.decompressor_stream.Decoder`; helpers
+return a ``DecompressorStream`` wrapping the adapter (no per-codec stream
+subclasses). XZ / lzip / unix-compress decoders live in their own modules for the
+same reason (larger index/LZW logic).
 """
 
 from __future__ import annotations

--- a/src/archivey/internal/streams/decompressor_stream.py
+++ b/src/archivey/internal/streams/decompressor_stream.py
@@ -1,8 +1,18 @@
-"""Seekable decompressor stream parameterized by a ``Decoder`` strategy.
+"""Seekable decompress *engine*: one stream class, many codec strategies.
 
-One concrete :class:`DecompressorStream` owns the buffer, position, seek-point table,
-and seek algorithm. Codecs plug in through the :class:`Decoder` protocol (feed / flush /
+:class:`DecompressorStream` owns the buffer, position, seek-point table, and seek
+algorithm. Codecs plug in through the :class:`Decoder` protocol (feed / flush /
 recreate / index discovery) — not by subclassing the stream.
+
+Where the decoders live (easy to mix with this file's name):
+
+- :mod:`archivey.internal.streams.decompress` — zlib/deflate, Brotli, PPMd, BCJ,
+  Deflate64 adapters
+- :mod:`archivey.internal.streams.xz` / ``lzip`` / ``unix_compress`` — larger
+  format-specific decoders (index scan / LZW)
+
+``codecs.StreamCodec.open`` wires those into an ``ArchiveStream``; this module is
+only the shared engine underneath.
 """
 
 from __future__ import annotations
@@ -201,10 +211,14 @@ def build_index_backwards(
 
 
 class DecompressorStream(ReadOnlyIOStream):
-    """Seekable decompressor stream driven by a :class:`Decoder` strategy.
+    """Seekable ``BinaryIO`` over compressed bytes, driven by a :class:`Decoder`.
 
-    ``readable``/``writable``/``write``/``readinto`` come from :class:`ReadOnlyIOStream`
-    (``readinto`` is built on this class's ``read``).
+    Owns: output buffer, logical position, seek-point table, and the seek algorithm
+    (bisect to a point → recreate decoder → skip forward). Does **not** know codec
+    formats — ``make_decoder`` supplies that.
+
+    ``seekable=False`` skips index/seek-point work (forward-only cheap path).
+    ``readable``/``writable``/``write``/``readinto`` come from :class:`ReadOnlyIOStream`.
     """
 
     def __init__(

--- a/src/archivey/internal/streams/lzip.py
+++ b/src/archivey/internal/streams/lzip.py
@@ -1,5 +1,7 @@
-"""
-Pure-stdlib seekable lzip decompression over Python's ``lzma`` module.
+"""Seekable lzip decoder for :class:`~.decompressor_stream.DecompressorStream`.
+
+Opened via :class:`~.codecs.LzipCodec` / ``open_codec_stream(Codec.LZIP, …)``.
+Pure-stdlib over Python's ``lzma`` module.
 
 lzip format (per the lzip manual): a file is a sequence of one or more *members* that may
 be concatenated freely. Each member carries its own sizes in a 20-byte trailer (the

--- a/src/archivey/internal/streams/peekable.py
+++ b/src/archivey/internal/streams/peekable.py
@@ -2,14 +2,14 @@
 consumes it.
 
 Format detection needs to inspect the leading bytes of a source, but a non-seekable
-stream (a socket or pipe) cannot be rewound after that inspection. The opener wraps
-such a source in a :class:`PeekableStream` **once**, runs detection through
-:meth:`PeekableStream.peek`, and hands the *same* wrapper to the backend; reads then
-replay the buffered prefix before falling through to the underlying stream, so no bytes
-are dropped (see the ``format-detection`` capability).
+stream (a socket or pipe) cannot be rewound after that inspection. ``open_archive`` /
+``open_stream`` wrap such a source in a :class:`PeekableStream` **once**, run
+detection through :meth:`PeekableStream.peek`, and hand the *same* wrapper to the
+backend; reads then replay the buffered prefix before falling through to the
+underlying stream (see ``format-detection``).
 
-This is the fresh v2 replacement for DEV's ``RecordableStream`` /
-``RewindableStreamWrapper``.
+Lives in this package (not under detection) because it is a stream adapter; the
+opener owns the "when to wrap" policy.
 """
 
 from __future__ import annotations

--- a/src/archivey/internal/streams/streamtools/__init__.py
+++ b/src/archivey/internal/streams/streamtools/__init__.py
@@ -5,8 +5,24 @@ nothing about archivey's error hierarchy or any codec, only about stdlib binary 
 That independence is deliberate — it could be lifted out as a standalone library — so
 nothing here may import from the rest of ``archivey``.
 
-The public surface is re-exported below; import from this package root rather than the
-individual modules.
+Module map:
+
+- :mod:`.base` — ``ReadOnlyIOStream`` / ``DelegatingStream`` (wrapper bases)
+- :mod:`.binaryio` — classify/coerce sources (``is_seekable``, ``ensure_binaryio``, …)
+- :mod:`.slice` — ``SlicingStream`` bound view + ``fix_stream_start_position``
+- :mod:`.shared` — ``SharedSource`` (concurrent independent views over one handle)
+- :mod:`.locked` — ``LockedStream`` / ``CloseLockedStream`` (whole-op lock wrappers)
+- :mod:`.solid` — ``SolidBlockReader`` (forward-only solid demux)
+
+When to use which concurrency helper:
+
+- ``LockedStream`` — one shared handle; hold a lock across each seek+read (TAR/ISO).
+- ``SharedSource`` + locked ``SlicingStream`` — each consumer has its own logical
+  position; every read re-seeks under the lock (ZIP-style shared file).
+- ``SolidBlockReader`` — one forward decode; hand out consecutive member slices
+  (7z folder / RAR pipe). Not seekable.
+
+Import from this package root rather than the individual modules.
 """
 
 from __future__ import annotations

--- a/src/archivey/internal/streams/streamtools/locked.py
+++ b/src/archivey/internal/streams/streamtools/locked.py
@@ -88,8 +88,10 @@ class CloseLockedStream(DelegatingStream):
     Contrast :class:`LockedStream` (locks every op). ZIP under
     ``MemberStreams.CONCURRENT``: stdlib ``zipfile`` already serializes shared-fp
     seek/read via ``_SharedFile``, but ``_fileRefCnt`` on open/close races under
-    free-threaded CPython — serializing close is enough; locking reads would
-    needlessly serialize independent decompressors.
+    free-threaded CPython. This wrapper covers close; the ZIP backend also
+    serializes ``ZipFile.open`` under the same lock (``_handle_guard``) — open +
+    close together are enough; locking reads would needlessly serialize
+    independent decompressors.
     """
 
     def __init__(self, inner: BinaryIO, lock: threading.Lock | threading.RLock) -> None:

--- a/src/archivey/internal/streams/streamtools/locked.py
+++ b/src/archivey/internal/streams/streamtools/locked.py
@@ -1,4 +1,18 @@
-"""Lock-wrapping stream for library-owned seek-before-read shared handles."""
+"""Lock-wrapping streams for library-owned shared handles.
+
+Two wrappers (easy to mix up):
+
+- :class:`LockedStream` — hold ``lock`` across **every** read/seek/tell on
+  ``inner`` (TAR/ISO under ``MemberStreams.CONCURRENT``: seek-then-read must be
+  atomic). Archivey buffering/error wrappers sit *outside* this layer.
+- :class:`CloseLockedStream` — only serializes ``close()`` (and optionally
+  ``flush``); reads stay unlocked. Use when concurrent readers share a handle
+  for I/O but close must not race.
+
+For independent logical positions over one file, prefer
+:class:`~archivey.internal.streams.streamtools.shared.SharedSource` instead of
+``LockedStream`` (ZIP-style re-seek-under-lock views).
+"""
 
 from __future__ import annotations
 
@@ -69,12 +83,13 @@ class LockedStream(DelegatingStream):
 
 
 class CloseLockedStream(DelegatingStream):
-    """Hold ``lock`` only across ``close``; leave read/seek to the inner stream.
+    """Serialize only ``close()``; leave read/seek unlocked on ``inner``.
 
-    Used by ZIP under ``MemberStreams.CONCURRENT``: stdlib ``zipfile`` serializes
-    shared-fp seek/read via ``_SharedFile``, but ``_fileRefCnt`` on open/close is
-    unlocked and races under free-threaded CPython. Serializing open + close is enough;
-    holding the lock across reads would needlessly serialize independent decompressors.
+    Contrast :class:`LockedStream` (locks every op). ZIP under
+    ``MemberStreams.CONCURRENT``: stdlib ``zipfile`` already serializes shared-fp
+    seek/read via ``_SharedFile``, but ``_fileRefCnt`` on open/close races under
+    free-threaded CPython — serializing close is enough; locking reads would
+    needlessly serialize independent decompressors.
     """
 
     def __init__(self, inner: BinaryIO, lock: threading.Lock | threading.RLock) -> None:

--- a/src/archivey/internal/streams/streamtools/slice.py
+++ b/src/archivey/internal/streams/streamtools/slice.py
@@ -4,14 +4,14 @@ Used to present a member's byte range inside a container as a standalone stream,
 ``fix_stream_start_position``) to give a mid-positioned stream a clean ``tell() == 0``
 origin for codec libraries that assume it.
 
-With an optional ``lock``, the same class is the concurrent-safe view minted by
-:class:`~archivey.internal.streams.streamtools.shared.SharedSource`: every ``read``
-re-seeks the underlying to the view's own absolute position under the lock, so interleaved
-views never clobber each other. Construction must not call unlocked ``tell``/``seek`` on
-that shared handle when ``start`` is already known — ``BufferedReader.tell`` is not
-thread-safe. Without a lock (the historical default) ``read`` continues from wherever the
-shared handle currently sits — correct for single-consumer use, which is how every
-pre-SharedSource caller uses it.
+Two modes (same class — easy to miss):
+
+1. **Single-consumer (no lock, historical default)** — ``read`` continues from wherever
+   the underlying handle currently sits. Correct when only one view is live.
+2. **SharedSource mode (``lock`` set)** — every ``read`` does
+   ``seek(start + _pos); read(n)`` under the lock so interleaved views never clobber
+   each other. Construction must not call unlocked ``tell``/``seek`` on that shared
+   handle when ``start`` is already known — ``BufferedReader.tell`` is not thread-safe.
 """
 
 from __future__ import annotations

--- a/src/archivey/internal/streams/streamtools/solid.py
+++ b/src/archivey/internal/streams/streamtools/solid.py
@@ -5,6 +5,7 @@ forward-only (often non-seekable) byte stream whose members occupy consecutive,
 known-size ranges. :class:`SolidBlockReader` owns that stream and hands out one member
 sub-stream at a time, skipping forward **lazily**: the gap before a member is consumed
 only when the *next* member is opened, so closing a never-advanced member costs nothing.
+Closing the reader closes the block without draining.
 
 Not the same as :class:`~archivey.internal.streams.streamtools.shared.SharedSource`
 (independent seekable views) or :class:`~archivey.internal.streams.streamtools.locked.LockedStream`

--- a/src/archivey/internal/streams/streamtools/solid.py
+++ b/src/archivey/internal/streams/streamtools/solid.py
@@ -3,20 +3,18 @@
 A *solid block* — a 7z folder, or a RAR ``unrar p`` pipe — decodes to a single
 forward-only (often non-seekable) byte stream whose members occupy consecutive,
 known-size ranges. :class:`SolidBlockReader` owns that stream and hands out one member
-sub-stream at a time, skipping forward **lazily**: the gap before a member (a preceding
-member's unread tail, or an inter-member gap) is consumed only when the *next* member is
-opened, so closing a member the caller never advances past costs nothing. Closing the
-reader closes the block without draining.
+sub-stream at a time, skipping forward **lazily**: the gap before a member is consumed
+only when the *next* member is opened, so closing a never-advanced member costs nothing.
 
-``open_member(..., lazy=True)`` returns the same :class:`_MemberSlice` type but defers
-that open (and its skip-decode) until the first read — so an iterator that yields then
-closes an unselected member pays nothing. This is the sequential/iteration primitive.
-Random access into a solid block is served differently (a seekable slice over a
-seekable decode), so this class is deliberately forward-only and does not seek.
+Not the same as :class:`~archivey.internal.streams.streamtools.shared.SharedSource`
+(independent seekable views) or :class:`~archivey.internal.streams.streamtools.locked.LockedStream`
+(lock around seek+read on one handle). This class is deliberately forward-only.
 
-Like the rest of ``streamtools`` this module knows nothing about archivey's error
-hierarchy: a truncated block surfaces as a plain :class:`EOFError` for the caller to
-translate into a format-specific error.
+``open_member(..., lazy=True)`` defers open/skip until the first read — so an
+iterator that yields then closes an unselected member pays nothing.
+
+Like the rest of ``streamtools``, truncated blocks surface as plain :class:`EOFError`
+for the caller to translate.
 """
 
 from __future__ import annotations

--- a/src/archivey/internal/streams/unix_compress.py
+++ b/src/archivey/internal/streams/unix_compress.py
@@ -1,10 +1,10 @@
-"""Unix-compress (``.Z``) LZW decode via :class:`DecompressorStream`.
+"""Unix-compress (``.Z``) LZW decoder for :class:`~.decompressor_stream.DecompressorStream`.
 
-The LZW kernel is adapted from `uncompresspy` (https://github.com/kYwzor/uncompresspy),
-Copyright (c) 2025 Tiago Gomes, used under the BSD 3-Clause License (see the notice at
-the bottom of this file). Archivey wraps it in an :class:`UnixCompressDecoder` so
-CLEAR boundaries become :class:`~archivey.internal.streams.decompressor_stream.SeekPoint`s
-and forward decode never requires a seekable source.
+Opened via :class:`~.codecs.UnixCompressCodec`. The LZW kernel is adapted from
+`uncompresspy` (https://github.com/kYwzor/uncompresspy), Copyright (c) 2025 Tiago
+Gomes, used under the BSD 3-Clause License (see the notice at the bottom of this
+file). CLEAR boundaries become seek points; forward decode never needs a seekable
+source.
 """
 
 from __future__ import annotations

--- a/src/archivey/internal/streams/verify.py
+++ b/src/archivey/internal/streams/verify.py
@@ -1,12 +1,15 @@
 """Decompressed-output digest (and length) verification.
 
 Container digests (``ArchiveMember.hashes``) and optional declared decompressed
-length are checked on a clean sequential read to EOF. The logic lives in
-:class:`MemberVerifier` so it can run either as a standalone
-:class:`VerifyingStream` wrapper (codec length backstops) or **fused into**
-:class:`~archivey.internal.streams.archive_stream.ArchiveStream` (the member
-hot path — one fewer Python layer, and nested codec ``ArchiveStream``s can
-collapse through).
+length are checked on a clean sequential read to EOF.
+
+Two delivery shapes (same rules, different wrappers):
+
+- :class:`MemberVerifier` — the logic object. **Fused into**
+  :class:`~archivey.internal.streams.archive_stream.ArchiveStream` on the member
+  hot path (one fewer Python layer; nested codec ``ArchiveStream``s can collapse).
+- :class:`VerifyingStream` — standalone ``BinaryIO`` wrapper around an inner +
+  verifier. Kept for codec length backstops and tests; prefer fusion for members.
 
 Per the ``compressed-streams`` spec:
 

--- a/src/archivey/internal/streams/xz.py
+++ b/src/archivey/internal/streams/xz.py
@@ -1,6 +1,7 @@
-"""
-Seekable XZ decompression over stdlib ``lzma``: backward index scan + streaming state
-machine.
+"""Seekable XZ decoder for :class:`~.decompressor_stream.DecompressorStream`.
+
+Opened via :class:`~.codecs.XzCodec` / ``open_codec_stream(Codec.XZ, …)``. Backward
+index scan + streaming state machine over stdlib ``lzma``.
 
 XZ binary format (summary):
   A file is a sequence of one or more XZ streams, optionally separated by 4-byte-aligned


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Readability pass on `src/archivey/internal/streams/` (including `streamtools/`). **No intentional behavior or performance changes** — comments, module maps, and clarifying docstrings only.

### Confusing spots found (then addressed)

| Area | Why it was hard to follow | Change |
| --- | --- | --- |
| `streams/__init__.py` | Stale note that PeekableStream “is not here”; no package map | Full module map + corrected PeekableStream role |
| `Codec` / `StreamCodec` / `CodecBackend` | Three similarly named concepts | Explicit triad in `codecs.py` module doc |
| `decompress.py` vs `decompressor_stream.py` | Near-identical names | Cross-linked roles (adapters vs engine) |
| `xz` / `lzip` / `unix_compress` | Unclear how they relate to codecs | “Opened via XzCodec / …” headers |
| `ArchiveStream` | Dense: collapse, fused verify, lease, `size` vs `expected_size` | Responsibility bullets on the class |
| `MemberVerifier` vs `VerifyingStream` | When to use which | Two-delivery-shapes section in `verify.py` |
| `LockedStream` / `CloseLockedStream` / `SharedSource` / `SolidBlockReader` | Four concurrency shapes | Maps in `streamtools/__init__` + per-module contrasts |
| `SlicingStream` dual mode | Lock vs no-lock easy to miss | Explicit two-mode module doc |
| Filter-only codecs | `Codec.DELTA`/`BCJ_*` absent from `STREAM_CODECS` | Registry comment explaining why |

### Review follow-up

- `CloseLockedStream` ZIP note restored: this wrapper locks close only; the ZIP backend also serializes `ZipFile.open` under the same handle lock.
- `SolidBlockReader` module doc restores that closing the reader closes the block without draining.

### Verification

- **Tests (before & after):** `1839 passed, 87 skipped, 3 deselected`
- **Structural benchmarks:** `bytes_decompressed` and `source_seek_count` identical on all 14 cases; wall-time ratios ≈0.61–1.02× (CI-scale noise only)
- **Lint/types:** `ruff` / `pyrefly` / `ty` clean on touched modules

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ca74c320-330b-4222-81f2-88d24a80845e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ca74c320-330b-4222-81f2-88d24a80845e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

