### PR TITLE
Clarify format backends with layout notes and module maps

### DIFF
--- a/src/archivey/internal/backends/__init__.py
+++ b/src/archivey/internal/backends/__init__.py
@@ -1,8 +1,24 @@
-# Importing each backend module is REQUIRED, not incidental: every backend
-# self-registers with the BackendRegistry as an import-time side effect (each module
-# ends with `register_reader(...)`). Importing this package therefore makes the
-# bundled backends available for selection. Do not remove these imports — without
-# them the registry would be empty and `open_archive()` would find no backend.
+"""Format backends — one self-registering reader module per archive format.
+
+Importing this package is required: each submodule ends with ``register_reader(...)``,
+so a bare ``import archivey.internal.backends`` fills the registry. Do not remove the
+side-effect imports below.
+
+Module map:
+
+- :mod:`.zip_reader` — ZIP (stdlib central directory; codecs/crypto for member data)
+- :mod:`.tar_reader` — TAR / compressed TAR (stdlib ``tarfile``)
+- :mod:`.iso_reader` — ISO 9660 (``pycdlib``, ``[iso]``)
+- :mod:`.directory_reader` — filesystem directory as a pseudo-archive
+- :mod:`.single_file_reader` — bare ``.gz`` / ``.xz`` / … as a one-member archive
+- :mod:`.sevenzip_methods` / ``sevenzip_parser`` / ``sevenzip_pipeline`` /
+  ``sevenzip_reader`` — native 7z (method registry → header parse → folder decode → ABC)
+- :mod:`.rar_parser` / ``rar_unrar`` / ``rar_reader`` — native RAR metadata + ``unrar`` data
+
+Typical split inside a format: ``*ReadBackend`` (registry / ``open_read``) +
+``*Reader`` (``BaseArchiveReader``). Native 7z/RAR also split parse vs decode.
+"""
+
 from archivey.internal.backends import (
     directory_reader as _directory_reader,  # noqa: F401
 )

--- a/src/archivey/internal/backends/directory_reader.py
+++ b/src/archivey/internal/backends/directory_reader.py
@@ -69,10 +69,10 @@ class DirectoryReader(BaseArchiveReader):
 
     _SUPPORTS_RANDOM_ACCESS = True
     # A filesystem directory has no O(1) upfront index: enumerating members is a recursive
-    # os.scandir walk, i.e. a scan. So this is False (like plain TAR) — members_report_if_available()
+    # os.scandir walk (a scan). So this is False (like plain TAR) — members_report_if_available()
     # returns None rather than triggering an uncached walk on every call, and the walk only runs
     # once under the materialization election (which also removes the free-threaded cache race on
-    # _uname_cache/_gname_cache). See review C2/C3 and format-directory spec.
+    # _uname_cache/_gname_cache). See format-directory.
     _MEMBER_LIST_UPFRONT = False
 
     def __init__(

--- a/src/archivey/internal/backends/iso_reader.py
+++ b/src/archivey/internal/backends/iso_reader.py
@@ -14,9 +14,10 @@ the choice in ``ArchiveInfo.extra["iso.namespace"]``:
 
 The directory tree lives in the header region → ``INDEXED`` listing and ``DIRECT``
 random access. A non-seekable source is rejected (trailing metadata; no streaming).
-``pycdlib`` uses absolute offsets, so the image must start at ``tell() == 0`` —
-``open_archive`` wraps mid-positioned streams (stream-position contract). A compressed
-``.iso.xz`` is a single-file compressor wrapping the image, not mounted here.
+Write is out of scope (``UnsupportedOperationError``). ``pycdlib`` uses absolute
+offsets, so the image must start at ``tell() == 0`` — ``open_archive`` wraps
+mid-positioned streams (stream-position contract). A compressed ``.iso.xz`` is a
+single-file compressor wrapping the image, not mounted here.
 
 **Process-global side effect.** Importing this module (which ``import archivey`` does
 eagerly, to register backends) installs a directory-cycle guard *into pycdlib's own

--- a/src/archivey/internal/backends/iso_reader.py
+++ b/src/archivey/internal/backends/iso_reader.py
@@ -1,23 +1,22 @@
 """ISO 9660 backend on the v2 ABC, backed by the optional ``pycdlib`` library (``[iso]``).
 
-ISO 9660 images carry up to three parallel filesystem namespaces — plain ISO 9660, Joliet,
-and Rock Ridge — with different filename and metadata fidelity. The backend auto-selects the
-**richest** available (Rock Ridge > Joliet > plain) and records the choice in
-``ArchiveInfo.extra["iso.namespace"]`` so callers can reason about what metadata to expect:
-Rock Ridge carries POSIX mode/uid/gid and symlinks; Joliet and plain carry none of those
-(those fields are ``None``), and plain names are upper-case 8.3 with a ``;version`` suffix.
+Image layout (what ``pycdlib`` addresses)::
 
-The directory tree lives in the header region, giving O(1) (``INDEXED``) listing and
-``DIRECT`` random access. A non-seekable source is rejected (random access needs seek,
-and the trailing metadata rules out non-seekable streaming too) and write is
-out of scope (``UnsupportedOperationError``). The image is read uncompressed in place — a
-compressed ``.iso.xz`` is a single-file compressor wrapping the image, not mounted here
-(see the seek-heavy-container note in the proposal).
+    Sector 16+ : volume descriptors (PVD at 16 * 2048 = 32768 bytes)
+    Directory records form the tree; file data at extent * block_size
 
-``pycdlib`` addresses the image with absolute offsets (the PVD at 32 KiB etc.), so it
-needs the archive to start at ``tell() == 0`` — which ``open_archive`` guarantees by
-wrapping any mid-positioned seekable stream in a zero-origin view before handing it to
-a backend (the stream-position contract in ``format-detection``).
+Namespaces — auto-select richest available (Rock Ridge > Joliet > plain) and record
+the choice in ``ArchiveInfo.extra["iso.namespace"]``:
+
+- Rock Ridge — POSIX mode/uid/gid and symlinks
+- Joliet / plain — those fields are ``None``; plain names are upper-case 8.3 with a
+  ``;version`` suffix
+
+The directory tree lives in the header region → ``INDEXED`` listing and ``DIRECT``
+random access. A non-seekable source is rejected (trailing metadata; no streaming).
+``pycdlib`` uses absolute offsets, so the image must start at ``tell() == 0`` —
+``open_archive`` wraps mid-positioned streams (stream-position contract). A compressed
+``.iso.xz`` is a single-file compressor wrapping the image, not mounted here.
 
 **Process-global side effect.** Importing this module (which ``import archivey`` does
 eagerly, to register backends) installs a directory-cycle guard *into pycdlib's own

--- a/src/archivey/internal/backends/rar_parser.py
+++ b/src/archivey/internal/backends/rar_parser.py
@@ -1,8 +1,26 @@
-"""Native RAR metadata parser (RAR 1.5 / 2.x through RAR5).
+"""Native RAR metadata parser (RAR 1.5 / 2.x / 3.x through RAR5).
 
 Parses archive headers into :class:`RarArchive` / :class:`RarMemberInfo` without
 decompressing member data and without importing ``rarfile``. Header encryption uses
 :mod:`archivey.internal.streams.crypto` (never ``cryptography`` directly).
+
+On-disk layout this module walks::
+
+    [ optional SFX stub ][ magic ]
+        RAR 1.5–3.x:  b"Rar!\\x1a\\x07\\x00"      → RarArchive.version == 4
+        RAR5:         b"Rar!\\x1a\\x07\\x01\\x00"  → RarArchive.version == 5
+    [ block sequence … until ENDARC ]
+        RAR3 family: MARK / MAIN / FILE / … / ENDARC
+          each: CRC16 | type | flags | header_size | [body] | [packed add_size]
+        RAR5: vint-framed MAIN / FILE / SERVICE / ENCRYPTION / ENDARC
+          optional encryption block before encrypted headers
+    FILE rows point at packed bytes after the header (``data_offset``).
+
+``RarArchive.version`` uses **4 for the whole RAR3-on-disk family** (1.5/2.x/3.x) and
+**5 for RAR5** — not "RAR 4.x product version". Multi-volume sets are merged by
+:func:`parse_rar_volumes` (split sizes/CRC; offsets rebased for
+:class:`~archivey.internal.volumes.ConcatenatedFile`). Member **payload** decode is
+``unrar`` via :mod:`.rar_unrar` / :mod:`.rar_reader`.
 
 RAR3 SHA-1 / string-to-key and Unicode filename decompression are adapted from
 ``rarfile`` 4.3 (https://github.com/markokr/rarfile), Copyright (c) 2005-2024
@@ -212,7 +230,7 @@ class RarMemberInfo:
 
 @dataclass
 class RarArchive:
-    version: int  # 4 or 5 (use 4 for RAR3 on-disk format)
+    version: int  # 4 = RAR3-on-disk family (1.5/2/3); 5 = RAR5 (not "RAR 4.x")
     is_solid: bool
     has_header_encryption: bool
     comment: str | None

--- a/src/archivey/internal/backends/rar_reader.py
+++ b/src/archivey/internal/backends/rar_reader.py
@@ -1,4 +1,22 @@
-"""Native RAR reader backend (metadata via rar_parser; data via RARLAB unrar)."""
+"""Native RAR reader backend.
+
+Module split:
+
+- :mod:`.rar_parser` — metadata, offsets, encryption headers, multi-volume merge
+- :mod:`.rar_unrar` — spawn RARLAB ``unrar p`` (password on stdin; ``-n./member``)
+- this module — ``BaseArchiveReader``: list from the parser; member **data** via unrar
+
+Data-open shapes:
+
+- Solid archive → one ``unrar p`` ALL-pipe + :class:`SolidBlockReader` demux
+- Non-solid → per-member named ``unrar p -n./…`` opens
+- Stream / non-path sources may be materialized to a temp ``.rar`` so ``unrar``
+  can open a real path (and resolve sibling volumes)
+
+WinRAR ``-ver`` history members are presented as ``path;n`` (see
+:func:`_presented_filename`). Passwords feed three places: header parse, ``unrar``,
+and RAR5 ConvertHashToMAC when checksums are tweaked.
+"""
 
 from __future__ import annotations
 

--- a/src/archivey/internal/backends/rar_reader.py
+++ b/src/archivey/internal/backends/rar_reader.py
@@ -9,7 +9,8 @@ Module split:
 Data-open shapes:
 
 - Solid archive → one ``unrar p`` ALL-pipe + :class:`SolidBlockReader` demux
-- Non-solid → per-member named ``unrar p -n./…`` opens
+- Non-solid stored (no encrypt / split) → direct sliced view (no ``unrar``)
+- Other non-solid → per-member named ``unrar p -n./…`` opens
 - Stream / non-path sources may be materialized to a temp ``.rar`` so ``unrar``
   can open a real path (and resolve sibling volumes)
 

--- a/src/archivey/internal/backends/rar_unrar.py
+++ b/src/archivey/internal/backends/rar_unrar.py
@@ -1,4 +1,10 @@
-"""Locate RARLAB ``unrar`` and spawn ``unrar p`` for member data."""
+"""CLI wrapper around RARLAB ``unrar`` for member **payload** bytes.
+
+No RAR structure knowledge beyond argv safety — metadata/listing is
+:mod:`.rar_parser`. Locates RARLAB ``unrar`` on ``PATH`` (not ``unrar-free`` /
+``unar`` / ``7z``) and spawns ``unrar p`` with the password on stdin (bare ``-p``,
+secret not in argv) and optional ``-n./member`` include masks.
+"""
 
 from __future__ import annotations
 

--- a/src/archivey/internal/backends/sevenzip_methods.py
+++ b/src/archivey/internal/backends/sevenzip_methods.py
@@ -1,4 +1,14 @@
-"""7z coder method registry — single source for IDs, algorithms, and decode kind."""
+"""7z coder method registry — single source for IDs, algorithms, and decode kind.
+
+:class:`MethodKind` drives :func:`sevenzip_pipeline.plan_folder`:
+
+- ``COPY`` / ``AES`` / ``BCJ2`` / ``SINGLE`` — self-explanatory stages
+- ``LZMA_FAMILY`` — **not** "is LZMA": Delta and BCJ share this kind because they
+  batch into the same liblzma / ``pybcj`` staging run as LZMA1/2
+
+BCJ entries carry both short and long on-disk method ids (``aliases``) — 7-Zip
+has historically written either form.
+"""
 
 from __future__ import annotations
 
@@ -12,6 +22,12 @@ from archivey.types import CompressionAlgorithm
 
 
 class MethodKind(Enum):
+    """How :func:`sevenzip_pipeline.plan_folder` should stage this method.
+
+    ``LZMA_FAMILY`` includes Delta/BCJ as well as LZMA1/2 — they compose into one
+    staging run, not because they are LZMA codecs themselves.
+    """
+
     COPY = auto()
     AES = auto()
     BCJ2 = auto()

--- a/src/archivey/internal/backends/sevenzip_parser.py
+++ b/src/archivey/internal/backends/sevenzip_parser.py
@@ -3,6 +3,30 @@
 Reads the signature/end header and turns header blocks into small data objects.
 Encoded headers are returned as descriptors; the reader/pipeline materializes them.
 
+On-disk layout this parser assumes::
+
+    [ 32-byte signature header ]
+        magic 7z\\xBC\\xAF'\\x1C | ver | start-hdr CRC
+        | nextHeaderOffset | nextHeaderSize | nextHeaderCRC
+    [ packed streams … ]                 # from offset 32 + pack_pos (from header)
+    [ next header at 32 + nextHeaderOffset ]
+        either kHeader (plain property tree)
+        or kEncodedHeader (another packed folder; decode in sevenzip_pipeline)
+
+Plain header (property-tagged nesting)::
+
+    [ArchiveProperties?] [AdditionalStreams?] MainStreamsInfo FilesInfo
+    MainStreamsInfo = PackInfo + UnpackInfo(Folders/Coders) + SubstreamsInfo?
+    FilesInfo = names, empty/anti bits, times, attrs
+    Non-empty files map 1:1 onto folder substreams in order
+    (``_map_files_to_folders``). A *folder* is the solid pack unit (coder chain +
+    packed slice); files are substreams inside it.
+
+Call graph: ``read_signature_and_next_header`` → ``parse_header_block`` → (maybe
+``EncodedHeader``) → ``materialize_archive``. End-to-end open with encoded-header
+decode lives in :func:`sevenzip_pipeline.parse_sevenzip_archive` /
+:class:`SevenZipReader`.
+
 In-memory header walking uses a byte cursor over ``memoryview`` (not ``BytesIO``);
 ``read_signature_and_next_header`` stays on the real file stream.
 """
@@ -103,6 +127,8 @@ class SevenZipFileRecord:
     compressed_size: int | None
     is_encrypted: bool
     is_solid: bool
+    # Filled with raw on-disk method **bytes** here; the reader rebuilds public
+    # ``CompressionMethod`` tuples for ArchiveMember.compression.
     compression_methods: tuple[bytes | CompressionMethod, ...]
 
 
@@ -1098,9 +1124,10 @@ def _read_boolean(cur: _Cursor, count: int, *, check_all: bool = False) -> list[
 
 
 def _read_utf16(cur: _Cursor) -> str:
-    """Read one null-terminated UTF-16LE string (legacy / single-name helper).
+    """Read one null-terminated UTF-16LE string.
 
-    Prefer :func:`_decode_utf16_names` for the ``kName`` property (bulk path).
+    Unused on the current ``kName`` path (prefer :func:`_decode_utf16_names`); kept
+    as a single-name helper for tests / future properties.
     """
     chunks = bytearray()
     for _ in range(_MAX_UTF16_CHARS):

--- a/src/archivey/internal/backends/sevenzip_pipeline.py
+++ b/src/archivey/internal/backends/sevenzip_pipeline.py
@@ -1,4 +1,25 @@
-"""7z folder decode pipeline — registry-driven linear coder chains."""
+"""7z folder decode pipeline — registry-driven linear coder chains.
+
+A *folder* is a coder graph over one packed slice. This module only accepts a
+**linear** 1-in/1-out chain (``bind_pairs == (i+1 → i)``, ``packed_indices == [0]``).
+
+Decode order (packed → unpacked)::
+
+    AES? → (COPY skipped) → SINGLE codecs | LZMA-family run | BCJ2 rejected
+
+``MethodKind.LZMA_FAMILY`` means “participates in a liblzma / BCJ staging run”,
+not “is LZMA”: Delta and BCJ are batched with LZMA1/2 here.
+
+- LZMA2 ± Delta ± BCJ → one stdlib ``lzma`` raw filter chain
+- LZMA1 + BCJ → capped LZMA1 stages + separate ``pybcj`` (BPO-21872 truncation)
+- BCJ alone → ``pybcj`` stages
+- BCJ2 (``0x0303011B``) → ``UnsupportedFeatureError`` (never garbage output)
+
+Two phases: :func:`plan_folder` resolves stages (pure — no I/O); then
+:func:`open_folder_pipeline` / :func:`_execute_stage` fold stages onto the packed
+source. Encoded-header decode and the convenience :func:`parse_sevenzip_archive`
+also live here (parser stays structure-only).
+"""
 
 from __future__ import annotations
 
@@ -55,9 +76,10 @@ _decode_filter_properties: Callable[[int, bytes], dict] = _raw_decode_filter_pro
 
 
 # A folder's coder chain is decoded in two phases: `plan_folder` resolves it into an
-# ordered list of these concrete stages (pure — no streams opened), then `execute`
-# folds each stage onto the packed source. Keeping the branchy LZMA1+BCJ staging in
-# the planner makes the decode flow inspectable and keeps I/O out of the decision.
+# ordered list of these concrete stages (pure — no streams opened), then
+# `_execute_stage` / `open_folder_pipeline` fold each stage onto the packed source.
+# Keeping the branchy LZMA1+BCJ staging in the planner makes the decode flow
+# inspectable and keeps I/O out of the decision.
 
 
 @dataclass
@@ -109,7 +131,7 @@ def plan_folder(folder: SevenZipFolder) -> list[_Stage]:
     """Resolve a folder's coder chain into ordered decode stages, opening no streams.
 
     Runs all wiring validation (1-in/1-out, linear chain, BCJ2 reject) and groups the
-    coders; ``execute`` turns the returned plan into a stream.
+    coders; :func:`open_folder_pipeline` turns the returned plan into a stream.
     """
     if any(
         coder.num_in_streams != 1 or coder.num_out_streams != 1

--- a/src/archivey/internal/backends/sevenzip_reader.py
+++ b/src/archivey/internal/backends/sevenzip_reader.py
@@ -1,4 +1,22 @@
-"""Native 7z reader backend."""
+"""Native 7z reader backend (``BaseArchiveReader`` wiring).
+
+Module split:
+
+- :mod:`.sevenzip_methods` — method-id registry / :class:`MethodKind`
+- :mod:`.sevenzip_parser` — signature + header property tree → :class:`SevenZipArchive`
+- :mod:`.sevenzip_pipeline` — folder coder plan/execute + encoded-header decode
+- this module — passwords, member list, solid-folder demux, CRC/encryption mapping
+
+Open path: signature → ``parse_header_block`` → (decode ``EncodedHeader`` loop) →
+``materialize_archive`` → list members. Member open folds the folder's packed
+slice through :func:`open_folder_pipeline`; solid folders use
+:class:`~archivey.internal.streams.streamtools.solid.SolidBlockReader` so one
+decode serves consecutive files.
+
+Password bytes for the 7z KDF are UTF-16LE (:func:`_password_to_kdf_bytes`). An
+empty header after decrypt is treated as a wrong password (never a silent empty
+listing); see threat-model O8 / ``DIGEST_UNVERIFIABLE`` for store+AES without CRC.
+"""
 
 from __future__ import annotations
 

--- a/src/archivey/internal/backends/sevenzip_reader.py
+++ b/src/archivey/internal/backends/sevenzip_reader.py
@@ -15,7 +15,8 @@ decode serves consecutive files.
 
 Password bytes for the 7z KDF are UTF-16LE (:func:`_password_to_kdf_bytes`). An
 empty header after decrypt is treated as a wrong password (never a silent empty
-listing); see threat-model O8 / ``DIGEST_UNVERIFIABLE`` for store+AES without CRC.
+listing) — threat-model O8. Separately, store/AES members with no folder digest
+and no member CRC emit ``DIGEST_UNVERIFIABLE`` (decryption cannot be authenticated).
 """
 
 from __future__ import annotations

--- a/src/archivey/internal/backends/single_file_reader.py
+++ b/src/archivey/internal/backends/single_file_reader.py
@@ -87,7 +87,7 @@ class SingleFileReader(BaseArchiveReader):
 
     Source shapes at open:
 
-    - Path → reopen per ``open()`` (or seekable shared handle under CONCURRENT)
+    - Path → reopen per ``open()`` (independent FDs; concurrent opens stay isolated)
     - Seekable stream → :class:`SharedSource` views from position 0
     - Non-seekable → one pending stream; first open consumes it
 

--- a/src/archivey/internal/backends/single_file_reader.py
+++ b/src/archivey/internal/backends/single_file_reader.py
@@ -2,16 +2,17 @@
 
 A bare ``.gz`` / ``.bz2`` / ``.xz`` / ``.zst`` / ``.lz4`` / ``.lz`` (lzip) /
 ``.lzma`` (LZMA Alone) / ``.zz`` (zlib) / ``.br`` (brotli) / ``.Z`` (unix-compress)
-stream is presented as a one-member
-pseudo-archive: a single ``FILE`` member whose name is inferred from the source filename,
-decompressed through the ``compressed-streams`` codec layer. The backend is codec-agnostic;
-the only per-format logic lives in small **per-codec metadata hooks** (gzip's stored
-filename/mtime, xz/lzip/lzma-alone decompressed size), so a new standalone codec becomes
-readable by adding the codec + enum + detection entry — no new backend class (see
-``format-single-file-compressors``).
+stream is presented as a **one-member pseudo-archive**: exactly one ``FILE`` member
+whose name is inferred by stripping the codec extension (or ``.uncompressed`` when
+there is no known suffix). There is no member table — size/mtime/crc come from
+per-codec :class:`~archivey.internal.streams.codecs.MetadataContext` hooks when cheap
+(gzip FNAME/mtime, xz/lzip size, …); otherwise they are filled/verified on read via
+the shared codec layer.
 
-ZST and LZ4 are first-class standalone formats here (their codecs already exist from
-Phase 2); only their *seekable-decompressor* refinements remain for Phase 8.
+The backend is codec-agnostic; adding a standalone codec is "add codec + enum +
+detection" — no new backend class (see ``format-single-file-compressors``). Basic
+ZST/LZ4 read is already here; remaining seekable-index / accelerator work for those
+codecs is tracked under Phase 8 in ``PLAN.md``.
 """
 
 from __future__ import annotations
@@ -82,7 +83,17 @@ def _infer_member_name(archive_name: str | None) -> str:
 
 
 class SingleFileReader(BaseArchiveReader):
-    """Presents one standalone compressed stream as a one-member archive."""
+    """Presents one standalone compressed stream as a one-member archive.
+
+    Source shapes at open:
+
+    - Path → reopen per ``open()`` (or seekable shared handle under CONCURRENT)
+    - Seekable stream → :class:`SharedSource` views from position 0
+    - Non-seekable → one pending stream; first open consumes it
+
+    Seekable sources may probe-open at init so format/size errors surface at
+    ``open_archive`` time rather than first ``read``.
+    """
 
     _SUPPORTS_RANDOM_ACCESS = True
     _MEMBER_LIST_UPFRONT = True

--- a/src/archivey/internal/backends/tar_reader.py
+++ b/src/archivey/internal/backends/tar_reader.py
@@ -1,13 +1,27 @@
 """TAR backend on the v2 ABC, backed by the stdlib ``tarfile`` module.
 
-Random-access reading (``streaming=False``) scans 512-byte headers on a seekable source
-(decompressing first for a compressed tar) and opens any member on demand. Forward-only
-reading (``streaming=True``) walks the archive in one progressive pass — including on a
-non-seekable source for plain and compressed tars — via ``_iter_with_data()`` /
-``stream_members()``. After a full scan or streaming pass the end-of-archive is checked
-(``_verify_tar_eof``): a rejected header raises ``CorruptionError`` regardless of config,
-while a missing two-block null trailer warns unless ``config.strict_archive_eof`` escalates
-it to ``TruncatedError``.
+On-disk layout (ustar/pax/gnu as ``tarfile`` sees it)::
+
+    [ 512-byte header ][ file data, padded to 512 ]*
+    [ 512 zero bytes ][ 512 zero bytes ]   # two null end-of-archive trailers
+
+There is no central directory: listing is a header scan (``REQUIRES_SCANNING``) or a
+progressive forward pass. Compressed forms (``.tar.gz`` / …) wrap the same layout in
+a stream codec and behave as **solid** for random member opens.
+
+Random-access reading (``streaming=False``) needs a seekable source (decompressing
+first for a compressed tar) and opens any member on demand. Forward-only
+(``streaming=True``) walks one progressive pass — including on a non-seekable source —
+via ``_iter_with_data()`` / ``stream_members()``.
+
+After a full scan or streaming pass, :meth:`_verify_tar_eof` checks the end:
+
+- A rejected (non-null) header where ``tarfile`` stopped → ``CorruptionError``.
+- A missing two-block null trailer → ``ARCHIVE_EOF_MARKER_MISSING`` unless
+  ``config.strict_archive_eof`` escalates to ``TruncatedError``.
+
+Note: after ``getmembers()`` / a walk, ``tarfile`` has typically already consumed the
+*first* trailer zero-block; the EOF probe therefore inspects the *next* 512 bytes.
 """
 
 from __future__ import annotations
@@ -188,7 +202,12 @@ class _EofProbeStream:
 
 
 class TarReader(BaseArchiveReader):
-    """Reads a TAR archive (plain or compressed) via stdlib ``tarfile``."""
+    """Reads a TAR archive (plain or compressed) via stdlib ``tarfile``.
+
+    ``_SUPPORTS_RANDOM_ACCESS`` is True (seekable uncompressed / decompressed sources
+    can open any member), but ``_MEMBER_LIST_UPFRONT`` is False — there is no central
+    directory, so a complete list always requires a scan (or a finished stream pass).
+    """
 
     _SUPPORTS_RANDOM_ACCESS = True
     # TAR has no central directory: the member list only exists after a scan, so it is not

--- a/src/archivey/internal/backends/zip_reader.py
+++ b/src/archivey/internal/backends/zip_reader.py
@@ -1,9 +1,22 @@
-"""ZIP backend on the v2 ABC, backed by the stdlib ``zipfile`` module.
+"""ZIP backend on the v2 ABC.
 
-The central directory is read on open, giving O(1) member listing (``INDEXED``) and
-direct random access (``DIRECT``) to any member. A non-seekable source fails fast (the
-central directory lives at EOF), and split/spanned multi-volume sets are rejected with a
-clear "rejoin first" error (see ``format-zip``).
+Layout this code assumes::
+
+    [ local file header + payload ]*   # PK\\x03\\x04 … name | extra | [data]
+    [ central directory ]              # ZipFile reads this at open (INDEXED listing)
+    [ EOCD (+ optional ZIP64) ]        # at EOF → seekable source required
+
+Who does what:
+
+- ``zipfile.ZipFile`` / ``ZipInfo`` — central-directory parse, listing, shared ``fp`` lock.
+- Unencrypted member **data** — slice the local payload and decode via the shared
+  codec layer (not ``ZipExtFile``), so accelerators / rewind warnings stay uniform.
+- ZipCrypto — encryption header + weak 1-byte check (+ CRC confirm when ambiguous).
+- WinZip AES (method 99) — ``internal.zip_aes``, then the codec for the real method
+  from extra field ``0x9901``.
+
+Split/spanned multi-volume sets (``.z01``…``.zip``) are rejected — rejoin first
+(see ``format-zip``).
 """
 
 from __future__ import annotations
@@ -216,8 +229,8 @@ def _is_candidate_integrity_failure(exc: Exception) -> bool:
 
 
 # NTFS FILETIME conversion + the shared TimestampIssue type live in internal.timestamps
-# (also used by the native 7z reader, and RAR later). Local aliases keep this module's
-# call sites — including the DOS date_time issue below — unchanged.
+# (also used by the native 7z reader). Local aliases keep this module's call sites —
+# including the DOS date_time issue below — and test imports of the underscored names.
 _TimestampIssue = TimestampIssue
 _filetime_to_datetime = filetime_to_datetime
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Readability pass on `src/archivey/internal/backends/` (the format backends — there is no separate `formats/` package). **No intentional behavior or performance changes.**

Where format structure notes help most, module tops now sketch the on-disk layout the code actually assumes (ZIP EOCD/CD/local, TAR 512-byte blocks + dual null trailer, RAR3/RAR5 block loops, 7z signature + property tree + folders, ISO PVD/namespaces).

### Confusing spots → fixes

| Area | Why hard | Change |
| --- | --- | --- |
| Package `__init__` | Side-effect imports only | Module map (which file owns which format / split) |
| `zip_reader` | “backed by zipfile” understates codecs/AES | Layout + who does CD vs data vs crypto |
| `tar_reader` | EOF probe / trailer easy to miss | Layout + first-trailer-already-consumed note |
| `rar_parser` | `version==4` means RAR3 family | Layout + version naming clarification |
| `rar_reader` / `rar_unrar` | Three modules, unclear roles | Responsibility split + CLI-wrapper note |
| `sevenzip_*` | Parser vs pipeline vs reader; `LZMA_FAMILY` includes BCJ | Layout, module split, MethodKind docs, fix stale `execute` wording |
| `iso_reader` | Dangling “proposal” pointer | Sector/namespace layout; write out of scope restored |
| `single_file_reader` | Phase 8 wording sounded unfinished | Pseudo-archive contract + clarified Phase 8 |
| Stale “RAR later” in zip timestamps | RAR already exists | Updated comment |

### Review follow-up

- `SingleFileReader`: Path opens use independent FDs (not `SharedSource` under `CONCURRENT`)
- `rar_reader`: document STORED direct-slice fast path alongside solid / `unrar` shapes
- `sevenzip_reader`: split threat-model O8 (empty header) from `DIGEST_UNVERIFIABLE` (store/AES without CRC)
- `iso_reader`: restore write-out-of-scope note (no invented `known-issues` cross-ref for `.iso.xz`)

### Verification

- **Tests (before & after):** `1839 passed, 87 skipped, 3 deselected`
- **Structural benchmarks:** `bytes_decompressed` and `source_seek_count` identical on all 14 cases; wall-time ratios ≈0.75–1.12× (CI-scale noise)
- **Lint/types:** `ruff` / `pyrefly` / `ty` clean on touched modules

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ca74c320-330b-4222-81f2-88d24a80845e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ca74c320-330b-4222-81f2-88d24a80845e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

