### PR TITLE
Nightly wall-ratio drift gate (perf Q2 / debt-ledger Q1)

### DIFF
--- a/.github/workflows/benchmark-wall.yml
+++ b/.github/workflows/benchmark-wall.yml
@@ -2,12 +2,13 @@ name: Benchmark wall-time
 
 # Wall-time drift tracker for the VISION perf budget. Off the PR path (shared-runner
 # absolute ratios are too noisy to block merges) and NOT run per-PR. Instead: a daily
-# schedule with a change guard — the expensive run fires only when the default branch
-# actually moved since the previous nightly, so bursts of activity get next-morning
-# signal while long dormant stretches cost only the ~15s guard step.
-# `workflow_dispatch` forces a run on demand (optional skip-drift to re-seed).
+# schedule with a change guard — the expensive run fires when the default branch moved
+# recently, or when the last *measurement* is older than ~30 days (runner / toolchain
+# drift). On quiet days the job re-publishes the previous JSON (with measured_at kept,
+# republished_at stamped) so dormant successes still carry an artifact for the next
+# drift compare. `workflow_dispatch` forces a run (optional skip-drift to re-seed).
 #
-# Hard fails (when the run fires):
+# Hard fails (when the expensive run fires):
 #   1. ~10× wall-ratio sanity ceiling
 #   2. wall-ratio *drift* vs the previous successful run's JSON artifact
 #      (debt-ledger Q1 / perf Q2 option (a) — relative regression, not absolute ≤1.3×)
@@ -40,29 +41,87 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
-      - name: Decide whether to run (skip unchanged nightly)
+
+      - name: Fetch previous wall JSON
+        id: prev
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          echo "found=false" >> "$GITHUB_OUTPUT"
+          echo "baseline=" >> "$GITHUB_OUTPUT"
+          mkdir -p previous-wall
+          # Prefer a successful prior run on the default branch that uploaded our
+          # artifact. Skip re-publishes keep an artifact on every success, so a
+          # modest limit stays enough after that lands; paginate a bit for the
+          # transition from pre-republish history.
+          mapfile -t runs < <(
+            gh run list \
+              --workflow benchmark-wall.yml \
+              --branch "$DEFAULT_BRANCH" \
+              --status success \
+              --limit 100 \
+              --json databaseId \
+              --jq '.[].databaseId'
+          )
+          for id in "${runs[@]}"; do
+            rm -rf previous-wall
+            mkdir -p previous-wall
+            if gh run download "$id" -n benchmark-wall-realistic -D previous-wall 2>/dev/null; then
+              if [ -f previous-wall/benchmark-wall-realistic.json ]; then
+                echo "Found wall artifact from run $id"
+                echo "found=true" >> "$GITHUB_OUTPUT"
+                echo "baseline=previous-wall/benchmark-wall-realistic.json" >> "$GITHUB_OUTPUT"
+                echo "source_run_id=$id" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+            fi
+          done
+          echo "No previous wall artifact found."
+
+      - name: Decide whether to run
         id: guard
         env:
           EVENT: ${{ github.event_name }}
+          PREV_FOUND: ${{ steps.prev.outputs.found }}
+          BASELINE: ${{ steps.prev.outputs.baseline }}
         run: |
           if [ "$EVENT" = "workflow_dispatch" ]; then
-            echo "Manual dispatch — running."
+            echo "Manual dispatch — full run."
             echo "run=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          # Scheduled: run only if the default-branch HEAD was committed since roughly
-          # the previous nightly. Cron is daily; 25h gives a 1h margin so a commit made
-          # just before yesterday's run isn't missed. During dormant stretches HEAD is
-          # older than the window and the expensive job is skipped.
+
+          # Force a full measurement when provenance is missing or older than
+          # ~30 days (keyed off measured_at inside the JSON — not artifact
+          # upload time, which re-publish refreshes daily).
+          if [ "$PREV_FOUND" = "true" ] && [ -n "$BASELINE" ]; then
+            age_s=$(python3 benchmarks/wall_baseline.py age-seconds "$BASELINE")
+            max_s=$((30 * 86400))
+            if [ "$age_s" -gt "$max_s" ]; then
+              echo "measured_at age ${age_s}s > ${max_s}s (~30d) — full run."
+              echo "run=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            echo "measured_at age ${age_s}s within ${max_s}s."
+          else
+            echo "No previous measurement — full run (seed)."
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Otherwise: run only if default-branch HEAD moved since roughly the
+          # previous nightly. Cron is daily; 25h gives a 1h margin.
           last=$(git log -1 --format=%ct)
           age=$(( $(date +%s) - last ))
           if [ "$age" -lt 90000 ]; then
-            echo "HEAD committed ${age}s ago (< 25h) — changes since last run; running."
+            echo "HEAD committed ${age}s ago (< 25h) — full run."
             echo "run=true" >> "$GITHUB_OUTPUT"
           else
-            echo "HEAD committed ${age}s ago (>= 25h) — no changes since last run; skipping."
+            echo "HEAD committed ${age}s ago (>= 25h) and measurement fresh — re-publish skip."
             echo "run=false" >> "$GITHUB_OUTPUT"
           fi
+
       - name: Install uv
         if: steps.guard.outputs.run == 'true'
         uses: astral-sh/setup-uv@v5
@@ -75,58 +134,41 @@ jobs:
       - name: Sync (dev + all extras)
         if: steps.guard.outputs.run == 'true'
         run: uv sync --group dev --extra all
-      - name: Fetch previous wall JSON (drift baseline)
-        id: prev
-        if: steps.guard.outputs.run == 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
-          # Boolean workflow_dispatch input; false on schedule.
-          SKIP_DRIFT: ${{ github.event_name == 'workflow_dispatch' && inputs.skip_drift || false }}
-        run: |
-          echo "baseline=" >> "$GITHUB_OUTPUT"
-          if [ "$SKIP_DRIFT" = "true" ]; then
-            echo "skip_drift input set — not loading a previous baseline (re-seed)."
-            exit 0
-          fi
-          mkdir -p previous-wall
-          # Prefer a successful prior run on the default branch that uploaded our
-          # artifact. Skip if this is the first run after enabling drift (seed).
-          mapfile -t runs < <(
-            gh run list \
-              --workflow benchmark-wall.yml \
-              --branch "$DEFAULT_BRANCH" \
-              --status success \
-              --limit 30 \
-              --json databaseId \
-              --jq '.[].databaseId'
-          )
-          for id in "${runs[@]}"; do
-            rm -rf previous-wall
-            mkdir -p previous-wall
-            if gh run download "$id" -n benchmark-wall-realistic -D previous-wall 2>/dev/null; then
-              if [ -f previous-wall/benchmark-wall-realistic.json ]; then
-                echo "Using drift baseline from run $id"
-                echo "baseline=previous-wall/benchmark-wall-realistic.json" >> "$GITHUB_OUTPUT"
-                exit 0
-              fi
-            fi
-          done
-          echo "No previous wall artifact found — seed run (drift check skipped)."
+
       - name: Full realistic wall-time run
         if: steps.guard.outputs.run == 'true'
         env:
           BASELINE: ${{ steps.prev.outputs.baseline }}
+          # Boolean workflow_dispatch input; false on schedule.
+          SKIP_DRIFT: ${{ github.event_name == 'workflow_dispatch' && inputs.skip_drift || false }}
         run: |
           extra=()
-          if [ -n "$BASELINE" ]; then
+          if [ "$SKIP_DRIFT" = "true" ]; then
+            echo "skip_drift input set — not passing a drift baseline (re-seed)."
+          elif [ -n "$BASELINE" ]; then
             extra+=(--wall-drift-baseline "$BASELINE")
+          else
+            echo "No previous baseline — seed run (drift check omitted)."
           fi
           uv run --no-sync python -m benchmarks.harness \
             --mode full --scale realistic \
             --json-out benchmark-wall-realistic.json \
             --text-out benchmark-wall-realistic.md \
             "${extra[@]}"
+
+      - name: Re-publish previous baseline (skip path)
+        if: steps.guard.outputs.run == 'false' && steps.prev.outputs.found == 'true'
+        env:
+          BASELINE: ${{ steps.prev.outputs.baseline }}
+        run: |
+          python3 benchmarks/wall_baseline.py republish \
+            "$BASELINE" \
+            .
+          echo "Re-published previous wall baseline (measured_at preserved)." >> "$GITHUB_STEP_SUMMARY"
+          if [ -f benchmark-wall-realistic.md ]; then
+            cat benchmark-wall-realistic.md >> "$GITHUB_STEP_SUMMARY"
+          fi
+
       - name: Publish report to job summary
         if: always() && steps.guard.outputs.run == 'true'
         run: |
@@ -135,11 +177,13 @@ jobs:
           else
             echo "No benchmark report produced (harness did not write text output)." >> "$GITHUB_STEP_SUMMARY"
           fi
+
       - name: Upload wall-time results
-        if: always() && steps.guard.outputs.run == 'true'
+        if: always() && (steps.guard.outputs.run == 'true' || (steps.guard.outputs.run == 'false' && steps.prev.outputs.found == 'true'))
         uses: actions/upload-artifact@v4
         with:
           name: benchmark-wall-realistic
           path: |
             benchmark-wall-realistic.md
             benchmark-wall-realistic.json
+          if-no-files-found: error

--- a/.github/workflows/benchmark-wall.yml
+++ b/.github/workflows/benchmark-wall.yml
@@ -1,11 +1,17 @@
 name: Benchmark wall-time
 
 # Wall-time drift tracker for the VISION perf budget. Off the PR path (shared-runner
-# ratios are too noisy to block merges) and NOT run per-PR (that taxed every PR with a
-# multi-minute realistic run). Instead: a daily schedule with a change guard — the
-# expensive run fires only when the default branch actually moved since the previous
-# nightly, so bursts of activity get next-morning signal while long dormant stretches
-# cost only the ~15s guard step. `workflow_dispatch` forces a run on demand.
+# absolute ratios are too noisy to block merges) and NOT run per-PR. Instead: a daily
+# schedule with a change guard — the expensive run fires only when the default branch
+# actually moved since the previous nightly, so bursts of activity get next-morning
+# signal while long dormant stretches cost only the ~15s guard step.
+# `workflow_dispatch` forces a run on demand (optional skip-drift to re-seed).
+#
+# Hard fails (when the run fires):
+#   1. ~10× wall-ratio sanity ceiling
+#   2. wall-ratio *drift* vs the previous successful run's JSON artifact
+#      (debt-ledger Q1 / perf Q2 option (a) — relative regression, not absolute ≤1.3×)
+# Absolute VISION / Q1 listing bands remain informational prints.
 #
 # The PR-blocking structural gate (seek baselines + solid decode-once) lives in
 # `ci.yml` (`benchmark` job) and runs on every PR.
@@ -13,10 +19,19 @@ on:
   schedule:
     - cron: "17 6 * * *"
   workflow_dispatch:
+    inputs:
+      skip_drift:
+        description: "Skip wall-ratio drift check (accept current ratios as new baseline)"
+        type: boolean
+        default: false
 
 concurrency:
   group: benchmark-wall
   cancel-in-progress: true
+
+permissions:
+  contents: read
+  actions: read
 
 jobs:
   benchmark-wall:
@@ -60,16 +75,58 @@ jobs:
       - name: Sync (dev + all extras)
         if: steps.guard.outputs.run == 'true'
         run: uv sync --group dev --extra all
-      # Not continue-on-error: off the PR path, so a red run is a useful notification.
-      # `--mode full` only hard-fails on a real structural regression or the ~10× wall
-      # sanity ceiling; VISION-band jitter is printed, not failed — so noise won't flake.
+      - name: Fetch previous wall JSON (drift baseline)
+        id: prev
+        if: steps.guard.outputs.run == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          # Boolean workflow_dispatch input; false on schedule.
+          SKIP_DRIFT: ${{ github.event_name == 'workflow_dispatch' && inputs.skip_drift || false }}
+        run: |
+          echo "baseline=" >> "$GITHUB_OUTPUT"
+          if [ "$SKIP_DRIFT" = "true" ]; then
+            echo "skip_drift input set — not loading a previous baseline (re-seed)."
+            exit 0
+          fi
+          mkdir -p previous-wall
+          # Prefer a successful prior run on the default branch that uploaded our
+          # artifact. Skip if this is the first run after enabling drift (seed).
+          mapfile -t runs < <(
+            gh run list \
+              --workflow benchmark-wall.yml \
+              --branch "$DEFAULT_BRANCH" \
+              --status success \
+              --limit 30 \
+              --json databaseId \
+              --jq '.[].databaseId'
+          )
+          for id in "${runs[@]}"; do
+            rm -rf previous-wall
+            mkdir -p previous-wall
+            if gh run download "$id" -n benchmark-wall-realistic -D previous-wall 2>/dev/null; then
+              if [ -f previous-wall/benchmark-wall-realistic.json ]; then
+                echo "Using drift baseline from run $id"
+                echo "baseline=previous-wall/benchmark-wall-realistic.json" >> "$GITHUB_OUTPUT"
+                exit 0
+              fi
+            fi
+          done
+          echo "No previous wall artifact found — seed run (drift check skipped)."
       - name: Full realistic wall-time run
         if: steps.guard.outputs.run == 'true'
-        run: >
-          uv run --no-sync python -m benchmarks.harness
-          --mode full --scale realistic
-          --json-out benchmark-wall-realistic.json
-          --text-out benchmark-wall-realistic.md
+        env:
+          BASELINE: ${{ steps.prev.outputs.baseline }}
+        run: |
+          extra=()
+          if [ -n "$BASELINE" ]; then
+            extra+=(--wall-drift-baseline "$BASELINE")
+          fi
+          uv run --no-sync python -m benchmarks.harness \
+            --mode full --scale realistic \
+            --json-out benchmark-wall-realistic.json \
+            --text-out benchmark-wall-realistic.md \
+            "${extra[@]}"
       - name: Publish report to job summary
         if: always() && steps.guard.outputs.run == 'true'
         run: |

--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -4,9 +4,16 @@
 decode-once). Wall-time / VISION ≤1.3× runs off the PR path as a **change-guarded
 nightly** (`benchmark-wall.yml`): a daily schedule whose expensive realistic run is
 skipped unless the default branch changed since the previous run (this project is
-bursty/dormant, and per-PR taxed every PR). It records drift (JSON + markdown report
-artifacts, job summary table, and informational VISION print) and goes red only on a gross
-regression.
+bursty/dormant, and per-PR taxed every PR). When it runs it:
+
+- records drift (JSON + markdown report artifacts, job summary table);
+- hard-fails on the ~10× sanity ceiling **or** on **wall-ratio drift** vs the
+  previous successful nightly's JSON (relative regression gate — debt-ledger Q1 /
+  perf Q2 option (a));
+- prints absolute VISION / Q1 listing bands as informational only.
+
+`workflow_dispatch` can pass `skip_drift=true` to accept the current ratios as a
+new baseline after an intentional slowdown.
 
 Re-run with:
 
@@ -122,5 +129,6 @@ lock baseline lives in `benchmarks/tar_iso_lock_baseline.py`).
   written to the Actions job summary so it is readable without downloading) — a daily
   schedule that skips its expensive run unless the default branch changed since the previous
   run (bursty/dormant project; per-PR was rejected for taxing every PR). `workflow_dispatch`
-  forces a run.
-- Wall timing: unmeasured archivey vs stdlib; VISION band informational.
+  forces a run (`skip_drift` re-seeds after intentional regressions).
+- Wall timing: unmeasured archivey vs stdlib; absolute VISION bands informational;
+  nightly hard-fails on wall-ratio *drift* vs the previous successful artifact.

--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -2,11 +2,15 @@
 
 **Blocking PR gate = structural invariants only** (seek-count baselines + solid
 decode-once). Wall-time / VISION ≤1.3× runs off the PR path as a **change-guarded
-nightly** (`benchmark-wall.yml`): a daily schedule whose expensive realistic run is
-skipped unless the default branch changed since the previous run (this project is
-bursty/dormant, and per-PR taxed every PR). When it runs it:
+nightly** (`benchmark-wall.yml`): a daily schedule whose expensive realistic run
+fires when the default branch changed recently **or** the last measurement is
+older than ~30 days (runner / toolchain drift). Quiet days **re-publish** the
+previous JSON (preserving `measured_at`, stamping `republished_at`) so dormant
+successes still carry an artifact for the next drift compare. When the expensive
+run fires it:
 
-- records drift (JSON + markdown report artifacts, job summary table);
+- records results (JSON + markdown report artifacts, job summary table) with
+  `measured_at` / source provenance;
 - hard-fails on the ~10× sanity ceiling **or** on **wall-ratio drift** vs the
   previous successful nightly's JSON (relative regression gate — debt-ledger Q1 /
   perf Q2 option (a));
@@ -127,8 +131,8 @@ lock baseline lives in `benchmarks/tar_iso_lock_baseline.py`).
 - **Change-guarded nightly (off the PR path, `benchmark-wall.yml`):** `--mode full
   --scale realistic` with JSON + markdown report artifact upload (the markdown is also
   written to the Actions job summary so it is readable without downloading) — a daily
-  schedule that skips its expensive run unless the default branch changed since the previous
-  run (bursty/dormant project; per-PR was rejected for taxing every PR). `workflow_dispatch`
-  forces a run (`skip_drift` re-seeds after intentional regressions).
+  schedule that skips its expensive run unless the default branch changed recently or
+  `measured_at` is older than ~30 days; skips re-publish the previous artifact.
+  `workflow_dispatch` forces a run (`skip_drift` re-seeds after intentional regressions).
 - Wall timing: unmeasured archivey vs stdlib; absolute VISION bands informational;
   nightly hard-fails on wall-ratio *drift* vs the previous successful artifact.

--- a/benchmarks/harness.py
+++ b/benchmarks/harness.py
@@ -17,8 +17,9 @@ Modes:
   on shared runners, so full mode is **not** a PR gate. The change-guarded nightly
   (``benchmark-wall.yml``) hard-fails on (1) the ~10× sanity ceiling and (2)
   **wall-ratio drift** vs the previous successful nightly's JSON artifact
-  (perf-review Q2 / debt-ledger Q1 option (a)). VISION absolute bands stay
-  informational prints.
+  (perf-review Q2 / debt-ledger Q1 option (a)). Quiet days re-publish that
+  artifact (preserving ``measured_at``); a full re-measure is forced at least
+  every ~30 days. VISION absolute bands stay informational prints.
 
 Formats covered here: ZIP, TAR, gzip, tar.gz/tar.bz2 (+ accelerators), solid 7z
 (and solid RAR when the ``rar`` writer is available to build fixtures). Listing
@@ -46,6 +47,11 @@ from archivey.config import AcceleratorMode, ArchiveyConfig
 from archivey.internal.base_reader import BaseArchiveReader
 from archivey.internal.measurement import enable_measurement
 from benchmarks.fixtures import FixtureSet, materialize_fixtures
+from benchmarks.wall_baseline import (
+    measurement_provenance,
+    overlapping_wall_ratio_count,
+    wall_ratio_map,
+)
 
 ROOT = Path(__file__).resolve().parents[1]
 BASELINES_DIR = Path(__file__).resolve().parent / "baselines"
@@ -888,15 +894,7 @@ def _wall_checks(
 
 def _previous_wall_ratios(previous: dict[str, Any]) -> dict[str, float]:
     """Map case name → wall_ratio from a prior harness JSON payload."""
-    out: dict[str, float] = {}
-    for row in previous.get("results", []):
-        if not isinstance(row, dict):
-            continue
-        name = row.get("case")
-        ratio = row.get("wall_ratio")
-        if isinstance(name, str) and isinstance(ratio, (int, float)):
-            out[name] = float(ratio)
-    return out
+    return wall_ratio_map(previous)
 
 
 def _wall_drift_checks(
@@ -911,6 +909,9 @@ def _wall_drift_checks(
     Compares peer ratios only (cases with ``wall_ratio`` on both sides). Absolute
     wall seconds are not gated — machine skew dominates; the ratio cancels most of
     it. Missing previous / new cases / dropped cases are skipped (seed or rename).
+    Callers that *require* a baseline should fail closed when
+    ``overlapping_wall_ratio_count`` is 0 — this helper alone treats empty prior
+    as no failures (true seed).
     """
     if previous is None:
         return []
@@ -1010,6 +1011,18 @@ def format_text_report(payload: dict[str, Any]) -> str:
         f"- **scale:** `{scale}`",
         f"- **warmup:** `{payload.get('warmup', False)}`",
     ]
+    measured = payload.get("measured_at")
+    if isinstance(measured, str) and measured:
+        lines.append(f"- **measured_at:** `{measured}`")
+        source_run = payload.get("source_run_id")
+        if source_run:
+            lines.append(f"- **source_run_id:** `{source_run}`")
+        source_sha = payload.get("source_sha")
+        if isinstance(source_sha, str) and source_sha:
+            lines.append(f"- **source_sha:** `{source_sha[:12]}`")
+    republished = payload.get("republished_at")
+    if isinstance(republished, str) and republished:
+        lines.append(f"- **republished_at:** `{republished}` (ratios unchanged)")
     if detail:
         lines.extend(
             [
@@ -1086,6 +1099,8 @@ def format_text_report(payload: dict[str, Any]) -> str:
             f"- Nightly also fails on wall-ratio *drift* vs the previous successful "
             f"run's JSON (>{WALL_RATIO_DRIFT_FACTOR:.2f}× and "
             f"+{WALL_RATIO_DRIFT_MIN_ABS:.2f} abs) — not on absolute VISION bands.",
+            "- Quiet nights re-publish the previous artifact (preserving "
+            "`measured_at`); a full re-measure is forced at least every ~30 days.",
             "- Structural seek/bytes gates live on the PR path (`ci.yml`), not here.",
             "",
         ]
@@ -1135,7 +1150,8 @@ def main(argv: list[str] | None = None) -> int:
         default=None,
         help=(
             "Previous harness JSON (nightly artifact). When set, fail if any "
-            "case's wall_ratio regresses beyond --wall-drift-factor"
+            "case's wall_ratio regresses beyond --wall-drift-factor and "
+            "--wall-drift-min-abs (missing file / no overlapping ratios fail closed)"
         ),
     )
     parser.add_argument(
@@ -1145,6 +1161,15 @@ def main(argv: list[str] | None = None) -> int:
         help=(
             "Max allowed relative wall_ratio increase vs --wall-drift-baseline "
             f"(default {WALL_RATIO_DRIFT_FACTOR})"
+        ),
+    )
+    parser.add_argument(
+        "--wall-drift-min-abs",
+        type=float,
+        default=WALL_RATIO_DRIFT_MIN_ABS,
+        help=(
+            "Min absolute wall_ratio increase required together with "
+            f"--wall-drift-factor (default {WALL_RATIO_DRIFT_MIN_ABS})"
         ),
     )
     parser.add_argument(
@@ -1187,6 +1212,9 @@ def main(argv: list[str] | None = None) -> int:
         "warmup": warmup,
         "results": [asdict(r) for r in results],
     }
+    # Stamp when ratios were actually timed (nightly skip re-publish preserves this).
+    if args.mode == "full":
+        payload.update(measurement_provenance())
     report = format_text_report(payload)
     if args.json_out is not None:
         args.json_out.parent.mkdir(parents=True, exist_ok=True)
@@ -1223,21 +1251,29 @@ def main(argv: list[str] | None = None) -> int:
             prev = load_json(args.wall_drift_baseline)
             if prev is None:
                 print(
-                    f"wall-drift baseline missing: {args.wall_drift_baseline} "
-                    "(skipping drift check — seed run)",
+                    f"wall-drift baseline missing: {args.wall_drift_baseline}",
                     file=sys.stderr,
+                )
+                return 2
+            comparable = overlapping_wall_ratio_count(results, prev)
+            if comparable == 0:
+                failures.append(
+                    f"wall-drift baseline {args.wall_drift_baseline} has no "
+                    "overlapping wall_ratio cases to compare"
                 )
             else:
                 drift = _wall_drift_checks(
                     results,
                     prev,
                     factor=args.wall_drift_factor,
+                    min_abs=args.wall_drift_min_abs,
                 )
                 failures.extend(drift)
                 if not drift:
                     print(
                         f"Wall-ratio drift OK vs {args.wall_drift_baseline} "
-                        f"(factor={args.wall_drift_factor})",
+                        f"({comparable} cases; factor={args.wall_drift_factor}, "
+                        f"min_abs={args.wall_drift_min_abs})",
                         file=sys.stderr,
                     )
 

--- a/benchmarks/harness.py
+++ b/benchmarks/harness.py
@@ -13,9 +13,12 @@ Modes:
   solid decode-once bounds, and a non-solid over-decode bound on ``read_all``.
   Under-decode remains an integrity check; over-decode catches silent re-open churn
   that the old seek slack (baseline×2+8) used to absorb.
-- ``full``: also report wall-time ratios vs stdlib peers. Ratios are noisy on
-  shared runners, so full mode is a **manual / nightly drift tool**, not the PR
-  gate. Sanity ceiling only (no committed wall-time baseline).
+- ``full``: also report wall-time ratios vs stdlib peers. Absolute ratios are noisy
+  on shared runners, so full mode is **not** a PR gate. The change-guarded nightly
+  (``benchmark-wall.yml``) hard-fails on (1) the ~10× sanity ceiling and (2)
+  **wall-ratio drift** vs the previous successful nightly's JSON artifact
+  (perf-review Q2 / debt-ledger Q1 option (a)). VISION absolute bands stay
+  informational prints.
 
 Formats covered here: ZIP, TAR, gzip, tar.gz/tar.bz2 (+ accelerators), solid 7z
 (and solid RAR when the ``rar`` writer is available to build fixtures). Listing
@@ -64,13 +67,17 @@ SOLID_RANDOM_BYTES_FACTOR = 1.5
 # absorbed a full ZIP decode-twice seek doubling (28→52). Fixtures are
 # deterministic; baseline+8 still covers observed host jitter (e.g. gzip 1→3).
 SEEK_BASELINE_SLACK = 8
-# Wall-time sanity ceiling for --mode full. No committed wall_time.json: cold-pass
-# ci ratios were misleading, and shared-runner noise makes ratio regression gates
-# flake. VISION ≤1.3× / ~2× is informational on realistic full runs / nightly.
+# Wall-time sanity ceiling for --mode full. Absolute VISION ≤1.3× / ~2× bands stay
+# informational (shared-runner noise); nightly enforces *drift* vs the previous
+# successful run's JSON instead (debt-ledger Q1 / perf Q2 option (a)).
 WALL_RATIO_BUDGET = 10.0
 WALL_RATIO_VISION = 1.3
 WALL_RATIO_VISION_SAFETY = 2.0
-# Q1 listing bands (informational in full-mode reports; not PR-gated — see Q2):
+# Relative wall_ratio regression vs previous nightly. Dual gate: new > old×factor
+# AND new − old ≥ min abs delta (avoids failing 1.02→1.08 noise on near-parity paths).
+WALL_RATIO_DRIFT_FACTOR = 1.25
+WALL_RATIO_DRIFT_MIN_ABS = 0.15
+# Q1 listing bands (informational in full-mode reports; not PR-gated):
 # ZIP/TAR wrap stdlib → 2–3×/member; native 7z/RAR → ≈parity with py7zr/rarfile.
 LISTING_RATIO_ZIP_TAR = 3.0
 LISTING_RATIO_NATIVE = 1.25
@@ -849,7 +856,7 @@ def _wall_checks(
     *,
     enforce_vision: bool = False,
 ) -> list[str]:
-    """Sanity / informational wall checks — no committed wall-time baseline."""
+    """Sanity ceiling (+ optional informational VISION-band messages as failures)."""
     failures: list[str] = []
     for r in results:
         if r.wall_ratio is None:
@@ -875,6 +882,53 @@ def _wall_checks(
             failures.append(
                 f"{r.case}: wall_ratio={r.wall_ratio:.2f} > VISION safety "
                 f"{WALL_RATIO_VISION_SAFETY}× (target {WALL_RATIO_VISION}×)"
+            )
+    return failures
+
+
+def _previous_wall_ratios(previous: dict[str, Any]) -> dict[str, float]:
+    """Map case name → wall_ratio from a prior harness JSON payload."""
+    out: dict[str, float] = {}
+    for row in previous.get("results", []):
+        if not isinstance(row, dict):
+            continue
+        name = row.get("case")
+        ratio = row.get("wall_ratio")
+        if isinstance(name, str) and isinstance(ratio, (int, float)):
+            out[name] = float(ratio)
+    return out
+
+
+def _wall_drift_checks(
+    results: list[CaseResult],
+    previous: dict[str, Any] | None,
+    *,
+    factor: float = WALL_RATIO_DRIFT_FACTOR,
+    min_abs: float = WALL_RATIO_DRIFT_MIN_ABS,
+) -> list[str]:
+    """Fail when wall_ratio regresses vs a previous nightly JSON.
+
+    Compares peer ratios only (cases with ``wall_ratio`` on both sides). Absolute
+    wall seconds are not gated — machine skew dominates; the ratio cancels most of
+    it. Missing previous / new cases / dropped cases are skipped (seed or rename).
+    """
+    if previous is None:
+        return []
+    prior = _previous_wall_ratios(previous)
+    if not prior:
+        return []
+    failures: list[str] = []
+    for r in results:
+        if r.wall_ratio is None:
+            continue
+        old = prior.get(r.case)
+        if old is None or old <= 0:
+            continue
+        new = r.wall_ratio
+        if new > old * factor and (new - old) >= min_abs:
+            failures.append(
+                f"{r.case}: wall_ratio={new:.2f} drifted from previous {old:.2f} "
+                f"(>{factor:.2f}× and +{min_abs:.2f} abs; nightly drift gate)"
             )
     return failures
 
@@ -1028,8 +1082,10 @@ def format_text_report(payload: dict[str, Any]) -> str:
             "",
             f"- VISION target ≤{WALL_RATIO_VISION}× stdlib on common paths "
             f"(~{WALL_RATIO_VISION_SAFETY}× safety band is informational on nightly).",
-            f"- Sanity ceiling {WALL_RATIO_BUDGET:.0f}× fails the job; VISION band "
-            "jitter is printed, not failed.",
+            f"- Sanity ceiling {WALL_RATIO_BUDGET:.0f}× fails the job.",
+            f"- Nightly also fails on wall-ratio *drift* vs the previous successful "
+            f"run's JSON (>{WALL_RATIO_DRIFT_FACTOR:.2f}× and "
+            f"+{WALL_RATIO_DRIFT_MIN_ABS:.2f} abs) — not on absolute VISION bands.",
             "- Structural seek/bytes gates live on the PR path (`ci.yml`), not here.",
             "",
         ]
@@ -1072,6 +1128,24 @@ def main(argv: list[str] | None = None) -> int:
         type=Path,
         default=None,
         help="Write a human-friendly markdown report to this path",
+    )
+    parser.add_argument(
+        "--wall-drift-baseline",
+        type=Path,
+        default=None,
+        help=(
+            "Previous harness JSON (nightly artifact). When set, fail if any "
+            "case's wall_ratio regresses beyond --wall-drift-factor"
+        ),
+    )
+    parser.add_argument(
+        "--wall-drift-factor",
+        type=float,
+        default=WALL_RATIO_DRIFT_FACTOR,
+        help=(
+            "Max allowed relative wall_ratio increase vs --wall-drift-baseline "
+            f"(default {WALL_RATIO_DRIFT_FACTOR})"
+        ),
     )
     parser.add_argument(
         "--fixture-dir",
@@ -1137,14 +1211,35 @@ def main(argv: list[str] | None = None) -> int:
         check_seek_baselines=(args.scale == "ci"),
     )
     if args.mode == "full":
-        # Sanity ceiling only — no committed wall_time.json (shared-runner noise).
-        # VISION ≤1.3× / ~2× on realistic corpora is informational drift signal.
+        # Sanity ceiling always; absolute VISION bands stay informational prints.
+        # Nightly drift vs previous JSON is the hard wall-ratio gate (Q2 option a).
         for f in _wall_checks(results, enforce_vision=False):
             failures.append(f)
         if args.scale == "realistic":
             for f in _wall_checks(results, enforce_vision=True):
-                if "VISION safety" in f:
+                if "VISION safety" in f or "Q1 listing" in f or "Q1 native" in f:
                     print(f"VISION BUDGET (informational): {f}", file=sys.stderr)
+        if args.wall_drift_baseline is not None:
+            prev = load_json(args.wall_drift_baseline)
+            if prev is None:
+                print(
+                    f"wall-drift baseline missing: {args.wall_drift_baseline} "
+                    "(skipping drift check — seed run)",
+                    file=sys.stderr,
+                )
+            else:
+                drift = _wall_drift_checks(
+                    results,
+                    prev,
+                    factor=args.wall_drift_factor,
+                )
+                failures.extend(drift)
+                if not drift:
+                    print(
+                        f"Wall-ratio drift OK vs {args.wall_drift_baseline} "
+                        f"(factor={args.wall_drift_factor})",
+                        file=sys.stderr,
+                    )
 
     if failures:
         print("BENCHMARK GATE FAILURES:", file=sys.stderr)

--- a/benchmarks/wall_baseline.py
+++ b/benchmarks/wall_baseline.py
@@ -1,0 +1,224 @@
+"""Wall-artifact provenance helpers (stdlib only).
+
+Used by ``benchmarks/harness.py`` and by ``benchmark-wall.yml`` on skip
+re-publish paths (no ``uv sync`` / archivey import required).
+
+Provenance fields on harness JSON:
+
+- ``measured_at`` — UTC ISO-8601 when ratios were actually timed (Z suffix)
+- ``source_run_id`` / ``source_sha`` — Actions identity of that measurement
+- ``republished_at`` / ``republish_run_id`` — set when a skip re-uploads the
+  same ratios so dormant nightly successes keep an artifact in the recent
+  window without pretending a new measurement happened
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+# Force a full realistic run at least this often even when HEAD is unchanged
+# (runner image / CPython patch drift). Keyed off ``measured_at``, never
+# artifact upload time — re-publish refreshes upload time daily.
+MEASURE_MAX_AGE_DAYS = 30
+MEASURE_MAX_AGE_SECONDS = MEASURE_MAX_AGE_DAYS * 86400
+
+ARTIFACT_JSON_NAME = "benchmark-wall-realistic.json"
+ARTIFACT_MD_NAME = "benchmark-wall-realistic.md"
+
+
+def utc_now_iso() -> str:
+    """UTC timestamp with ``Z`` suffix, second precision."""
+    return (
+        datetime.now(timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def parse_utc_iso(value: str) -> datetime | None:
+    """Parse harness ``measured_at`` / ``republished_at`` strings."""
+    text = value.strip()
+    if not text:
+        return None
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        dt = datetime.fromisoformat(text)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def measured_at_age_seconds(
+    payload: dict[str, Any], *, now: datetime | None = None
+) -> float | None:
+    """Seconds since ``measured_at``, or ``None`` if missing/unparseable."""
+    raw = payload.get("measured_at")
+    if not isinstance(raw, str):
+        return None
+    measured = parse_utc_iso(raw)
+    if measured is None:
+        return None
+    current = now or datetime.now(timezone.utc)
+    return max(0.0, (current - measured).total_seconds())
+
+
+def measurement_provenance(
+    *,
+    run_id: str | None = None,
+    sha: str | None = None,
+) -> dict[str, str]:
+    """Fresh measurement stamps for a full harness run."""
+    out: dict[str, str] = {"measured_at": utc_now_iso()}
+    rid = run_id if run_id is not None else os.environ.get("GITHUB_RUN_ID")
+    commit = sha if sha is not None else os.environ.get("GITHUB_SHA")
+    if rid:
+        out["source_run_id"] = rid
+    if commit:
+        out["source_sha"] = commit
+    return out
+
+
+def stamp_republish(
+    payload: dict[str, Any],
+    *,
+    run_id: str | None = None,
+) -> dict[str, Any]:
+    """Copy payload and mark a skip re-publish; keep original ``measured_at``."""
+    out = dict(payload)
+    out["republished_at"] = utc_now_iso()
+    rid = run_id if run_id is not None else os.environ.get("GITHUB_RUN_ID")
+    if rid:
+        out["republish_run_id"] = rid
+    return out
+
+
+def wall_ratio_map(payload: dict[str, Any]) -> dict[str, float]:
+    """Case name → wall_ratio from a harness JSON payload."""
+    out: dict[str, float] = {}
+    for row in payload.get("results", []):
+        if not isinstance(row, dict):
+            continue
+        name = row.get("case")
+        ratio = row.get("wall_ratio")
+        # bool is a subclass of int — reject it explicitly.
+        if (
+            isinstance(name, str)
+            and isinstance(ratio, (int, float))
+            and not isinstance(ratio, bool)
+        ):
+            out[name] = float(ratio)
+    return out
+
+
+def overlapping_wall_ratio_count(
+    results: list[Any],
+    previous: dict[str, Any],
+) -> int:
+    """How many current cases have a positive prior ``wall_ratio`` to compare."""
+    prior = wall_ratio_map(previous)
+    count = 0
+    for r in results:
+        ratio = getattr(r, "wall_ratio", None)
+        if ratio is None:
+            continue
+        name = getattr(r, "case", None)
+        if not isinstance(name, str):
+            continue
+        old = prior.get(name)
+        if old is not None and old > 0:
+            count += 1
+    return count
+
+
+def republish_files(
+    src_json: Path,
+    dest_dir: Path,
+    *,
+    run_id: str | None = None,
+    src_md: Path | None = None,
+) -> dict[str, Any]:
+    """Stamp re-publish provenance and write JSON (+ optional markdown) into dest."""
+    payload = json.loads(src_json.read_text())
+    if not isinstance(payload, dict):
+        raise SystemExit(f"wall baseline root must be an object: {src_json}")
+    stamped = stamp_republish(payload, run_id=run_id)
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    dest_json = dest_dir / ARTIFACT_JSON_NAME
+    dest_json.write_text(json.dumps(stamped, indent=2) + "\n")
+
+    md_src = src_md if src_md is not None else src_json.with_name(ARTIFACT_MD_NAME)
+    dest_md = dest_dir / ARTIFACT_MD_NAME
+    measured = stamped.get("measured_at", "?")
+    republished = stamped.get("republished_at", "?")
+    header = (
+        f"_Re-published without re-measurement "
+        f"(measured_at={measured}, republished_at={republished})._\n\n"
+    )
+    if md_src.is_file():
+        body = md_src.read_text()
+        if body.startswith("_Re-published without re-measurement"):
+            # Drop a previous re-publish banner if present.
+            parts = body.split("\n\n", 1)
+            body = parts[1] if len(parts) == 2 else body
+        dest_md.write_text(header + body)
+    else:
+        dest_md.write_text(
+            header
+            + "# Benchmark report\n\n"
+            + "(Original markdown missing; JSON baseline re-published.)\n"
+        )
+    return stamped
+
+
+def _cli(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    age = sub.add_parser("age-seconds", help="Print measured_at age in seconds")
+    age.add_argument("json_path", type=Path)
+
+    rep = sub.add_parser(
+        "republish", help="Stamp and write re-published artifact files"
+    )
+    rep.add_argument("src_json", type=Path)
+    rep.add_argument("dest_dir", type=Path)
+    rep.add_argument(
+        "--run-id",
+        default=None,
+        help="Override GITHUB_RUN_ID for republish_run_id",
+    )
+
+    args = parser.parse_args(argv)
+    if args.cmd == "age-seconds":
+        payload = json.loads(args.json_path.read_text())
+        seconds = measured_at_age_seconds(payload)
+        if seconds is None:
+            # Missing provenance → treat as infinitely stale so the workflow
+            # forces a full run to stamp measured_at.
+            print(MEASURE_MAX_AGE_SECONDS + 1)
+        else:
+            print(int(seconds))
+        return 0
+    if args.cmd == "republish":
+        stamped = republish_files(args.src_json, args.dest_dir, run_id=args.run_id)
+        print(
+            f"Re-published baseline measured_at={stamped.get('measured_at')} "
+            f"republished_at={stamped.get('republished_at')}",
+            file=sys.stderr,
+        )
+        return 0
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(_cli())

--- a/review/STATUS.md
+++ b/review/STATUS.md
@@ -36,7 +36,7 @@ OpenSpec archived: `archive/2026-07-20-stop-on-failure-not-policy/`.
 |----|--------|
 | **P7 residual** | ZIP many-small ~3.7× (above 2–3×); 7z ~2.0–2.2× (above 1.25×). Next: **L3** large RAR listing fixture; **L5** lazy derivation (needs OpenSpec) — or publish honest numbers (debt-ledger Q2). |
 | **P6 remainder** | RAR / encrypted / accelerator *data* harness cases still missing (= debt-ledger T3). |
-| **VISION/docs** | Re-word ≤1.3× claim to match Q1 once **Q2** is chosen (= debt-ledger D1). |
+| **VISION/docs** | Re-word ≤1.3× claim to match Q1 now that **Q2** is (a) (= debt-ledger D1). |
 
 ---
 

--- a/review/STATUS.md
+++ b/review/STATUS.md
@@ -7,8 +7,8 @@ Triage after archiving `cli-product/` and OpenSpec `stop-on-failure-not-policy`
 
 | Review | Findings delivered? | Code/docs follow-ups | Ready to archive? |
 |--------|---------------------|----------------------|-------------------|
-| `debt-ledger/` | yes (2026-07-20) | pay-list D1/D2/D3/T1/T2/T3/D4/T7 open; **D5/D6 done**; **QUESTIONS Q1–Q5** open | no |
-| `performance/` | yes (#134 + follow-ups) | P3–P5 done; listing L0–L3 + peers (#143/#146/#148); residual band miss; **Q2/Q4 open** | no |
+| `debt-ledger/` | yes (2026-07-20) | pay-list D1/D2/D3/T1/T2/T3/D4/T7 open; **D5/D6 done**; **Q1 decided**; Q2–Q5 open | no |
+| `performance/` | yes (#134 + follow-ups) | P3–P5 done; listing L0–L3 + peers (#143/#146/#148); residual band miss; **Q2 decided** (drift gate); **Q4 open** | no |
 
 Archived this pass: `archive/2026-07-19-api-coherence/`,
 `archive/2026-07-19-stream-layering/`, `archive/2026-07-20-cli-product/`.
@@ -44,20 +44,20 @@ OpenSpec archived: `archive/2026-07-20-stop-on-failure-not-policy/`.
 
 ### `debt-ledger/QUESTIONS.md`
 
-| Q | Finding | Lean |
-|---|---------|------|
-| **Q1** | Perf wall-budget enforcement (perf Q2) | nightly drift-vs-previous JSON |
-| **Q2** | ZIP listing above band: L5 pre-release vs publish honest number | publish honest number; L5 follow-up |
-| **Q3** | S2+S3: entry gate for next backend vs pay pre-release | entry gate |
-| **Q4** | rapidgzip-truncation rides past 0.2.0? | KEEP change open |
-| **Q5** | CHANGELOG form | committed `CHANGELOG.md` |
+| Q | Finding | Status |
+|---|---------|--------|
+| **Q1** | Perf wall-budget enforcement (perf Q2) | **decided** — nightly drift vs previous JSON (a); absolute bands informational |
+| **Q2** | ZIP listing above band: L5 pre-release vs publish honest number | lean: publish honest number; L5 follow-up |
+| **Q3** | S2+S3: entry gate for next backend vs pay pre-release | lean: entry gate |
+| **Q4** | rapidgzip-truncation rides past 0.2.0? | lean: KEEP change open |
+| **Q5** | CHANGELOG form | lean: committed `CHANGELOG.md` |
 
 ### `performance/QUESTIONS.md`
 
-| Q | Finding |
-|---|---------|
-| **Q2** | **P1** wall-budget enforcement (= debt-ledger Q1) |
-| **Q4** | Verify-skip knob (lean leave-as-is; close when archiving) |
+| Q | Finding | Status |
+|---|---------|--------|
+| **Q2** | **P1** wall-budget enforcement | **decided** (= debt-ledger Q1 (a)) |
+| **Q4** | Verify-skip knob (lean leave-as-is; close when archiving) | open |
 
 ---
 

--- a/review/debt-ledger/QUESTIONS.md
+++ b/review/debt-ledger/QUESTIONS.md
@@ -4,7 +4,13 @@ Decisions this ledger cannot make unilaterally (pause-and-ask rule). Everything
 else in the ledger carries a recommended verdict the maintainer can simply
 accept or flip.
 
-## Q1 — Performance Q2 (wall-budget enforcement) is now blocking the release's honesty, not just the harness
+## Q1 — Performance Q2 (wall-budget enforcement) is now blocking the release's honesty, not just the harness — **DECIDED (2026-07-20)**
+
+**Decision: (a).** Nightly wall-ratio drift vs the previous successful
+`benchmark-wall` JSON artifact (`benchmark-wall.yml` +
+`--wall-drift-baseline`); absolute VISION bands remain informational; peers
+`(c)` already in harness. Unblocks D1 wording: CI enforces structural axes on
+every PR and wall-ratio *drift* on nightly — not absolute ≤1.3×.
 
 `review/performance/QUESTIONS.md` Q2 has been open since 2026-07-18. The
 ledger's D1 (re-word the ≤1.3× claim) can land its *band* changes without Q2,

--- a/review/debt-ledger/QUESTIONS.md
+++ b/review/debt-ledger/QUESTIONS.md
@@ -8,9 +8,11 @@ accept or flip.
 
 **Decision: (a).** Nightly wall-ratio drift vs the previous successful
 `benchmark-wall` JSON artifact (`benchmark-wall.yml` +
-`--wall-drift-baseline`); absolute VISION bands remain informational; peers
-`(c)` already in harness. Unblocks D1 wording: CI enforces structural axes on
-every PR and wall-ratio *drift* on nightly — not absolute ≤1.3×.
+`--wall-drift-baseline`); quiet days re-publish that artifact (preserving
+`measured_at`); full re-measure at least every ~30 days. Absolute VISION bands
+remain informational; peers `(c)` already in harness. Unblocks D1 wording: CI
+enforces structural axes on every PR and wall-ratio *drift* on nightly — not
+absolute ≤1.3×.
 
 `review/performance/QUESTIONS.md` Q2 has been open since 2026-07-18. The
 ledger's D1 (re-word the ≤1.3× claim) can land its *band* changes without Q2,

--- a/review/debt-ledger/drift-and-decisions.md
+++ b/review/debt-ledger/drift-and-decisions.md
@@ -103,7 +103,7 @@ Archived to `review/archive/2026-07-20-cli-product/`. Parked leftovers:
 
 | ID | Decision | Where it lives | Verdict |
 |---|---|---|---|
-| **DD1** | Performance **Q2** — where the wall budget is enforced (nightly-vs-previous JSON, 2× band on read_all, or informational) | `review/performance/QUESTIONS.md` Q2 | **DECIDED (2026-07-20)** — (a) nightly wall-ratio drift vs previous successful JSON; absolute bands informational. |
+| **DD1** | Performance **Q2** — where the wall budget is enforced (nightly-vs-previous JSON, 2× band on read_all, or informational) | `review/performance/QUESTIONS.md` Q2 | **DECIDED (2026-07-20)** — (a) nightly wall-ratio drift vs previous successful JSON; skip re-publish + ≥30d forced re-measure; absolute bands informational. |
 | DD2 | Performance **Q4** — verify-skip knob | same, Q4 | **KEEP** (lean leave-as-is already recorded; perf case ~nil post-#137). Record as closed-no-knob. |
 | DD3 | ZIP listing above its own band — land **L5** or publish the honest number | STATUS "residual band miss" | **DECIDE pre-0.2.0** (part of D1; `QUESTIONS.md` Q2). |
 | DD4 | `rapidgzip-truncation-investigation` (1/11) — the shipped ISIZE backstop is a heuristic built on admittedly incomplete knowledge (`proposal.md`) | in-flight change | **KEEP for 0.2.0 with justification**: accelerators are opt-in, AUTO additionally gated on verifiable decompressed size, threat model already scopes accelerators out of the defended surface; refining the backstop post-release is non-breaking. Keep the change open; don't let 0.2.0 *close* it silently. |

--- a/review/debt-ledger/drift-and-decisions.md
+++ b/review/debt-ledger/drift-and-decisions.md
@@ -103,7 +103,7 @@ Archived to `review/archive/2026-07-20-cli-product/`. Parked leftovers:
 
 | ID | Decision | Where it lives | Verdict |
 |---|---|---|---|
-| DD1 | Performance **Q2** — where the wall budget is enforced (nightly-vs-previous JSON, 2× band on read_all, or informational) | `review/performance/QUESTIONS.md` Q2 | **DECIDE pre-0.2.0** — it fixes D1's wording ("gated" vs "measured"). See `QUESTIONS.md` Q1. |
+| **DD1** | Performance **Q2** — where the wall budget is enforced (nightly-vs-previous JSON, 2× band on read_all, or informational) | `review/performance/QUESTIONS.md` Q2 | **DECIDED (2026-07-20)** — (a) nightly wall-ratio drift vs previous successful JSON; absolute bands informational. |
 | DD2 | Performance **Q4** — verify-skip knob | same, Q4 | **KEEP** (lean leave-as-is already recorded; perf case ~nil post-#137). Record as closed-no-knob. |
 | DD3 | ZIP listing above its own band — land **L5** or publish the honest number | STATUS "residual band miss" | **DECIDE pre-0.2.0** (part of D1; `QUESTIONS.md` Q2). |
 | DD4 | `rapidgzip-truncation-investigation` (1/11) — the shipped ISIZE backstop is a heuristic built on admittedly incomplete knowledge (`proposal.md`) | in-flight change | **KEEP for 0.2.0 with justification**: accelerators are opt-in, AUTO additionally gated on verifiable decompressed size, threat model already scopes accelerators out of the defended surface; refining the backstop post-release is non-breaking. Keep the change open; don't let 0.2.0 *close* it silently. |

--- a/review/performance/QUESTIONS.md
+++ b/review/performance/QUESTIONS.md
@@ -54,10 +54,12 @@ Consequences to implement:
 
 **Decision: (a) (+ (c) already paid).** Nightly compares wall ratios against the
 *previous successful nightly's* JSON artifact and fails on relative drift
-(`WALL_RATIO_DRIFT_FACTOR` / `WALL_RATIO_DRIFT_MIN_ABS` in `harness.py`). Absolute
-VISION ≤1.3× / ~2× bands stay informational prints; PR path stays structural-only.
-`(c)` peers for open/list/extract landed in #139/#143. `(b)` absolute 2× band on
-`read_all` deferred until ZIP is stably inside the band. `workflow_dispatch`
+(`WALL_RATIO_DRIFT_FACTOR` / `WALL_RATIO_DRIFT_MIN_ABS` in `harness.py`). Quiet
+days re-publish that artifact (preserving `measured_at`); a full re-measure is
+forced at least every ~30 days. Absolute VISION ≤1.3× / ~2× bands stay
+informational prints; PR path stays structural-only. `(c)` peers for
+open/list/extract landed in #139/#143. `(b)` absolute 2× band on `read_all`
+deferred until ZIP is stably inside the band. `workflow_dispatch`
 `skip_drift=true` re-seeds after intentional slowdowns.
 
 Today: nowhere (`gate-efficacy.md` G1) — deliberate, because shared-runner ratios

--- a/review/performance/QUESTIONS.md
+++ b/review/performance/QUESTIONS.md
@@ -2,11 +2,12 @@
 
 Decisions this review cannot make unilaterally (per the pause-and-ask rule).
 
-> **Status (2026-07-18):** Q3, Q5, Q6 **resolved** (#136 / #139). Q1 has a
-> **maintainer direction** (#140) — listing peers (#143) + L1/L2/L3 listing
-> fixes (#146) landed; ZIP open+list still above the 2–3× band. **Still need a
-> decision:** Q2 (wall enforcement), Q4 (verify-skip knob; perf case ~nil
-> post-#137). See `../STATUS.md`.
+> **Status (2026-07-20):** Q2 **decided** — nightly wall-ratio drift vs previous
+> successful JSON (option (a)); absolute VISION bands stay informational.
+> Q3, Q5, Q6 **resolved** (#136 / #139). Q1 has a **maintainer direction** (#140)
+> — listing peers (#143) + L1/L2/L3 listing fixes (#146) landed; ZIP open+list
+> still above the 2–3× band. **Still need a decision:** Q4 (verify-skip knob;
+> perf case ~nil post-#137). See `../STATUS.md`.
 
 ## Q1 — What does "≤1.3× on common paths" cover, exactly? — DIRECTION RECORDED
 
@@ -49,7 +50,15 @@ Consequences to implement:
    band (met at realistic scale), many-small read_all follows the listing
    story (its cost *is* per-member machinery).
 
-## Q2 — Where should the wall budget be *enforced*? — OPEN
+## Q2 — Where should the wall budget be *enforced*? — **DECIDED (2026-07-20)**
+
+**Decision: (a) (+ (c) already paid).** Nightly compares wall ratios against the
+*previous successful nightly's* JSON artifact and fails on relative drift
+(`WALL_RATIO_DRIFT_FACTOR` / `WALL_RATIO_DRIFT_MIN_ABS` in `harness.py`). Absolute
+VISION ≤1.3× / ~2× bands stay informational prints; PR path stays structural-only.
+`(c)` peers for open/list/extract landed in #139/#143. `(b)` absolute 2× band on
+`read_all` deferred until ZIP is stably inside the band. `workflow_dispatch`
+`skip_drift=true` re-seeds after intentional slowdowns.
 
 Today: nowhere (`gate-efficacy.md` G1) — deliberate, because shared-runner ratios
 flake. Options, not mutually exclusive:

--- a/review/performance/SUMMARY.md
+++ b/review/performance/SUMMARY.md
@@ -42,7 +42,7 @@ bounded.
 
 | # | Severity | Finding | Where | Status |
 |---|----------|---------|-------|--------|
-| P1 | **blocker** | ≤1.3× wall budget enforced nowhere; nightly hard-fails only at 10×, VISION band informational | `benchmarks/harness.py:55,826-834`, `benchmark-wall.yml` | **open** — decision needed (Q2) |
+| P1 | **blocker** | ≤1.3× wall budget enforced nowhere; nightly hard-fails only at 10×, VISION band informational | `benchmarks/harness.py:55,826-834`, `benchmark-wall.yml` | **done** — nightly drift gate (Q2 (a), 2026-07-20); absolute bands still informational |
 | P2 | **blocker** | Budget not met: ZIP read-all 2.2–2.3×, extract-all 2.4–3.7×, open+list 5–8×; TAR read 1.8× | `budget-table.md` | **partial** — #136/#137/#139: large-member ZIP read ≤1.25×, realistic extract ~1.9×; open+list / many-small remain under Q1 |
 | P3 | **blocker** | Selective solid-7z extraction decodes ~whole folder for one early member (31× needed bytes); CLI `extract archive.7z <name>` hits it | `sevenzip_reader.py:283-323`, `extraction.py:340` | **fixed by #136** — verified 31.0× → 1.00× |
 | P4 | high | Non-solid re-decompression is invisible to the gate: decode-twice-deliver-once ZIP regression passes (byte axis counts delivered output; seek slack ×2+8 absorbs churn; wall ungated) | `gate-efficacy.md` G4, `repro.py` probe 3 | **fixed by #139** — over-decode ×1.1 bound + seek slack baseline+8; probe CAUGHT |

--- a/review/performance/SUMMARY.md
+++ b/review/performance/SUMMARY.md
@@ -42,7 +42,7 @@ bounded.
 
 | # | Severity | Finding | Where | Status |
 |---|----------|---------|-------|--------|
-| P1 | **blocker** | ≤1.3× wall budget enforced nowhere; nightly hard-fails only at 10×, VISION band informational | `benchmarks/harness.py:55,826-834`, `benchmark-wall.yml` | **done** — nightly drift gate (Q2 (a), 2026-07-20); absolute bands still informational |
+| P1 | **blocker** | ≤1.3× wall budget enforced nowhere; nightly hard-fails only at 10×, VISION band informational | `benchmarks/harness.py:55,826-834`, `benchmark-wall.yml` | **done** — nightly drift gate (Q2 (a), 2026-07-20) + skip re-publish / ≥30d re-measure; absolute bands still informational |
 | P2 | **blocker** | Budget not met: ZIP read-all 2.2–2.3×, extract-all 2.4–3.7×, open+list 5–8×; TAR read 1.8× | `budget-table.md` | **partial** — #136/#137/#139: large-member ZIP read ≤1.25×, realistic extract ~1.9×; open+list / many-small remain under Q1 |
 | P3 | **blocker** | Selective solid-7z extraction decodes ~whole folder for one early member (31× needed bytes); CLI `extract archive.7z <name>` hits it | `sevenzip_reader.py:283-323`, `extraction.py:340` | **fixed by #136** — verified 31.0× → 1.00× |
 | P4 | high | Non-solid re-decompression is invisible to the gate: decode-twice-deliver-once ZIP regression passes (byte axis counts delivered output; seek slack ×2+8 absorbs churn; wall ungated) | `gate-efficacy.md` G4, `repro.py` probe 3 | **fixed by #139** — over-decode ×1.1 bound + seek slack baseline+8; probe CAUGHT |

--- a/review/performance/gate-efficacy.md
+++ b/review/performance/gate-efficacy.md
@@ -4,38 +4,45 @@ VISION defines the budget on three axes: wall time (≤1.3×/~2×), bytes decomp
 and seek patterns, with the solid re-read as the named failure. The machinery is
 `benchmarks/harness.py` (+ `baselines/structural.json`), the `benchmark` job in
 `ci.yml` (PR-blocking, `--mode structural --scale ci`), and the change-guarded
-nightly `benchmark-wall.yml` (`--mode full --scale realistic`, non-blocking wall).
+nightly `benchmark-wall.yml` (`--mode full --scale realistic`, relative wall-ratio
+drift gate; absolute VISION bands informational).
 
-Verdict up front: **the gate reliably catches exactly one regression family — the
-sequential solid path collapsing to per-member re-decode. Everything else VISION
-names is either unasserted (wall ratios), structurally invisible (non-solid
-re-decompression), or inside the slack (a clean 2× solid re-decode).**
+Verdict up front: **the structural gate reliably catches the sequential solid
+path collapsing to per-member re-decode (and related byte/seek regressions).
+Wall ratios are enforced on nightly as *drift vs the previous measurement*, not
+as absolute ≤1.3×.** Absolute VISION / Q1 listing bands remain informational
+prints (shared-runner noise).
 
-> **Status update (#139 merged, verified):** G3, G4, and G5 are closed —
-> `SOLID_DECODE_FACTOR` 2.0 → 1.25, a non-solid over-decode bound (×1.1) on
-> `read_all`, seek slack `baseline×2+8` → `baseline+8`, and
+> **Status update (#139 merged, verified; wall drift 2026-07-20):** G3, G4, and
+> G5 are closed — `SOLID_DECODE_FACTOR` 2.0 → 1.25, a non-solid over-decode bound
+> (×1.1) on `read_all`, seek slack `baseline×2+8` → `baseline+8`, and
 > `sevenzip_solid_random` bounded vs its committed baseline ×1.5 (ci scale).
-> All three `repro.py` probes now report CAUGHT. G1 (wall enforcement) remains
-> the open blocker; G6/G7 are partial — #139 added ZIP `open_list`/`extract`
-> stdlib peers, and the Q1 direction (2026-07-18) adds listing-ratio peers
-> (`zipfile`/`tarfile` bands, `py7zr`/`rarfile` parity) to the missing list.
+> All three `repro.py` probes now report CAUGHT. **G1 is closed as Q2 option (a)**
+> — nightly wall-ratio drift vs previous JSON (`--wall-drift-baseline`), with
+> skip re-publish + ≥30d forced re-measure. Absolute ≤1.3× stays informational.
+> G6/G7 are partial — #139 added ZIP `open_list`/`extract` stdlib peers, and the
+> Q1 direction (2026-07-18) adds listing-ratio peers (`zipfile`/`tarfile` bands,
+> `py7zr`/`rarfile` parity) to the missing list.
 
-## G1 — The wall budget is enforced nowhere (blocker)
+## G1 — Wall budget: nightly relative drift (done — Q2 (a))
 
 - PR gate: `--mode structural` computes wall ratios but never checks them
-  (`_wall_checks` is only called for `--mode full`, `harness.py:826-834`).
-- Nightly: `--mode full` hard-fails only above `WALL_RATIO_BUDGET = 10.0`
-  (`harness.py:55`). The VISION check runs with `enforce_vision=True` only to
-  *print* `VISION BUDGET (informational)` lines (`harness.py:831-834`); they can
-  never fail the job.
-- There is no committed wall baseline, no trend comparison between nightly runs,
-  and no alerting; the job summary table is the only artifact. A steady 2–3×
-  regression on ZIP (which is the *current measured state*, see `budget-table.md`)
-  produces a permanently green nightly.
+  (`_wall_checks` is only called for `--mode full`). Absolute ≤1.3× stays off
+  the PR path by design (shared-runner noise).
+- Nightly expensive run (`benchmark-wall.yml`): hard-fails on
+  `WALL_RATIO_BUDGET = 10.0` **or** on wall-ratio *drift* vs the previous
+  successful artifact (`WALL_RATIO_DRIFT_FACTOR` / `WALL_RATIO_DRIFT_MIN_ABS`).
+  Absolute VISION / Q1 listing lines remain `VISION BUDGET (informational)`
+  prints only.
+- Quiet days **re-publish** the previous JSON (preserving `measured_at`,
+  stamping `republished_at`) so dormant cron successes still carry an artifact
+  for the next compare. A full re-measure is forced when `measured_at` is older
+  than ~30 days (runner / toolchain drift), independent of HEAD age.
+- `workflow_dispatch` + `skip_drift=true` re-seeds after an intentional
+  slowdown. An explicit `--wall-drift-baseline` path fails closed if the file
+  is missing or has no overlapping `wall_ratio` cases.
 
-The "shared runners are noisy" rationale (`harness.py:52-54`, RESULTS.md) is real,
-but the chosen answer — informational print — means the budget is a documentation
-claim, not an enforced property. Options in `QUESTIONS.md` Q2.
+See `QUESTIONS.md` Q2 (decided 2026-07-20) and debt-ledger Q1.
 
 ## G2 — The canonical O(n²) collapse IS caught (fine)
 

--- a/tests/test_benchmark_gate.py
+++ b/tests/test_benchmark_gate.py
@@ -101,6 +101,7 @@ def test_format_text_report_table() -> None:
 def test_wall_drift_checks_regressions_and_noise() -> None:
     """Nightly drift gate: relative+abs dual threshold; seed/missing skipped."""
     from benchmarks.harness import CaseResult, _wall_drift_checks
+    from benchmarks.wall_baseline import overlapping_wall_ratio_count
 
     def _case(name: str, ratio: float | None) -> CaseResult:
         return CaseResult(
@@ -135,13 +136,86 @@ def test_wall_drift_checks_regressions_and_noise() -> None:
     )
     assert ok == []
 
+    # Relative yes, abs no (old small): 0.4 → 0.51 (>1.25× but +0.11 < 0.15).
+    assert (
+        _wall_drift_checks(
+            [_case("zip_read_all", 0.51)],
+            {"results": [{"case": "zip_read_all", "wall_ratio": 0.4}]},
+        )
+        == []
+    )
+
+    # Abs yes, relative no: 2.0 → 2.40 (+0.40 but only 1.20× < 1.25×).
+    assert (
+        _wall_drift_checks(
+            [_case("zip_read_all", 2.40)],
+            {"results": [{"case": "zip_read_all", "wall_ratio": 2.0}]},
+        )
+        == []
+    )
+
     # Improvement — OK.
     better = _wall_drift_checks([_case("zip_read_all", 1.00)], previous)
     assert better == []
 
-    # No previous / empty — seed.
+    # No previous / empty — seed helper returns no failures (callers fail closed).
     assert _wall_drift_checks([_case("zip_read_all", 9.0)], None) == []
     assert _wall_drift_checks([_case("zip_read_all", 9.0)], {"results": []}) == []
+    assert (
+        overlapping_wall_ratio_count([_case("zip_read_all", 9.0)], {"results": []}) == 0
+    )
 
     # New case not in previous — skip.
     assert _wall_drift_checks([_case("brand_new_case", 5.0)], previous) == []
+
+
+def test_wall_baseline_provenance_and_republish(tmp_path: Path) -> None:
+    """measured_at age drives the 30d force-run; re-publish preserves it."""
+    from datetime import datetime, timedelta, timezone
+
+    from benchmarks.wall_baseline import (
+        MEASURE_MAX_AGE_SECONDS,
+        measured_at_age_seconds,
+        measurement_provenance,
+        republish_files,
+        stamp_republish,
+        wall_ratio_map,
+    )
+
+    measured = datetime(2026, 6, 1, 6, 17, tzinfo=timezone.utc)
+    payload = {
+        "measured_at": measured.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "source_run_id": "111",
+        "source_sha": "abc123",
+        "results": [{"case": "zip_read_all", "wall_ratio": 1.2}],
+    }
+    now = measured + timedelta(days=31)
+    age = measured_at_age_seconds(payload, now=now)
+    assert age is not None
+    assert age > MEASURE_MAX_AGE_SECONDS
+
+    stamped = stamp_republish(payload, run_id="222")
+    assert stamped["measured_at"] == payload["measured_at"]
+    assert stamped["source_run_id"] == "111"
+    assert stamped["republish_run_id"] == "222"
+    assert "republished_at" in stamped
+
+    src = tmp_path / "benchmark-wall-realistic.json"
+    src.write_text(json.dumps(payload) + "\n")
+    (tmp_path / "benchmark-wall-realistic.md").write_text("# Benchmark report\n\nok\n")
+    out = tmp_path / "out"
+    republish_files(src, out, run_id="333")
+    written = json.loads((out / "benchmark-wall-realistic.json").read_text())
+    assert written["measured_at"] == payload["measured_at"]
+    assert written["republish_run_id"] == "333"
+    md = (out / "benchmark-wall-realistic.md").read_text()
+    assert "Re-published without re-measurement" in md
+    assert "ok" in md
+
+    fresh = measurement_provenance(run_id="444", sha="deadbeef")
+    assert fresh["source_run_id"] == "444"
+    assert fresh["source_sha"] == "deadbeef"
+    assert fresh["measured_at"].endswith("Z")
+
+    assert wall_ratio_map({"results": [{"case": "a", "wall_ratio": True}]}) == {}
+    assert measured_at_age_seconds({"results": []}) is None

--- a/tests/test_benchmark_gate.py
+++ b/tests/test_benchmark_gate.py
@@ -95,3 +95,53 @@ def test_format_text_report_table() -> None:
     assert "within ≤1.3×" in report
     assert "solid invariant" in report
     assert "64 × 256.0 KiB" in report or "64 × 256 KiB" in report
+    assert "wall-ratio *drift*" in report
+
+
+def test_wall_drift_checks_regressions_and_noise() -> None:
+    """Nightly drift gate: relative+abs dual threshold; seed/missing skipped."""
+    from benchmarks.harness import CaseResult, _wall_drift_checks
+
+    def _case(name: str, ratio: float | None) -> CaseResult:
+        return CaseResult(
+            case=name,
+            format="zip",
+            operation="read_all",
+            wall_s=0.02,
+            bytes_decompressed=100,
+            source_seek_count=1,
+            wall_ratio=ratio,
+        )
+
+    previous = {
+        "results": [
+            {"case": "zip_read_all", "wall_ratio": 1.20},
+            {"case": "gzip_read_all", "wall_ratio": 1.05},
+            {"case": "no_peer", "wall_ratio": None},
+        ]
+    }
+    # Clear regression: 1.20 → 1.80 (>1.25× and +0.15 abs).
+    bad = _wall_drift_checks(
+        [_case("zip_read_all", 1.80), _case("gzip_read_all", 1.06)],
+        previous,
+    )
+    assert len(bad) == 1
+    assert "zip_read_all" in bad[0]
+
+    # Small bump under both thresholds — OK (noise).
+    ok = _wall_drift_checks(
+        [_case("zip_read_all", 1.30), _case("gzip_read_all", 1.10)],
+        previous,
+    )
+    assert ok == []
+
+    # Improvement — OK.
+    better = _wall_drift_checks([_case("zip_read_all", 1.00)], previous)
+    assert better == []
+
+    # No previous / empty — seed.
+    assert _wall_drift_checks([_case("zip_read_all", 9.0)], None) == []
+    assert _wall_drift_checks([_case("zip_read_all", 9.0)], {"results": []}) == []
+
+    # New case not in previous — skip.
+    assert _wall_drift_checks([_case("brand_new_case", 5.0)], previous) == []


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements debt-ledger **Q1** / performance **Q2** decision **(a)**: nightly wall-ratio *drift* vs the previous successful `benchmark-wall` JSON artifact — plus review follow-ups for dormancy and fail-closed behavior.

## Behavior

- Keeps the existing **25h change-guard** (skip expensive run when default-branch HEAD is unchanged).
- **Quiet days re-publish** the previous artifact: `measured_at` / source provenance preserved, `republished_at` stamped — so dormant cron successes still carry a baseline in the recent-artifact window.
- **Force a full re-measure** when `measured_at` is missing or older than **~30 days** (runner / toolchain drift), independent of HEAD age.
- When the expensive run fires:
  - Passes `--wall-drift-baseline` into the harness
  - Fails if any overlapping case’s `wall_ratio` regresses by **>1.25× and +0.15 abs**
  - Still hard-fails the ~10× sanity ceiling
  - Absolute VISION / Q1 listing bands stay **informational** prints
  - Explicit baseline path **fails closed** if missing or has no overlapping ratios
- `workflow_dispatch` input `skip_drift=true` re-seeds after an intentional slowdown
- First run with no prior artifact seeds without failing

## Also

- `benchmarks/wall_baseline.py` (stdlib-only) for provenance / re-publish / age helpers
- Unit tests for dual-threshold edges + re-publish provenance
- `gate-efficacy.md` G1 updated; decision notes in QUESTIONS / STATUS / RESULTS


<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7685c81a-bce7-4a44-847d-b5d07eb87a87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7685c81a-bce7-4a44-847d-b5d07eb87a87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

