### PR TITLE
Propose unify-pass-driver (S2+S3 pay-now; Q3=b)

### DIFF
--- a/openspec/changes/unify-pass-driver/.openspec.yaml
+++ b/openspec/changes/unify-pass-driver/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: library
+created: 2026-07-20

--- a/openspec/changes/unify-pass-driver/brief.md
+++ b/openspec/changes/unify-pass-driver/brief.md
@@ -1,0 +1,13 @@
+# unify-pass-driver — one pass driver and one member-list finalize path
+
+**Status:** Ready to implement after proposal review. Depends on nothing. Blocks nothing. Not breaking if the suite stays green. Effort: medium to large.
+
+**Why it matters:** Native RAR added a fourth copy of the stream-members close-previous loop, exactly as the old simplification review predicted. The member-list pipeline still has two drive loops and two mirrored double-fault guards. Shipping 0.2.0 with that debt fights the zero-debt goal; the maintainer chose to pay it now rather than gate the next backend.
+
+**What it does:** First widen mutation fuzz over static solid RAR fixtures. Then collapse link finalization into one helper, and replace the four hand-rolled pass-stream loops with one shared driver that backends customize via hooks.
+
+**Decided:** Pay before 0.2.0, not an entry gate. TAR keeps no previous-close as an explicit flag. Seven-zip and solid RAR close the last stream in the driver finally. No public API or OpenSpec requirement deltas if behavior is preserved. Do not teach the declarative RAR corpus builder solid mode in this change.
+
+**Your call later:** Helper naming is implementer choice. Whether wave-one mutation also includes symlink or file-version solid fixtures, or only the two basic solid archives.
+
+**Bottom line:** Internal cleanup with a solid-RAR mutation safety net first; review proposal and design, then implement.

--- a/openspec/changes/unify-pass-driver/brief.md
+++ b/openspec/changes/unify-pass-driver/brief.md
@@ -6,7 +6,7 @@
 
 **What it does:** First widen mutation fuzz over static solid RAR fixtures. Then collapse link finalization into one helper, and replace the four hand-rolled pass-stream loops with one shared driver that backends customize via hooks.
 
-**Decided:** Pay before 0.2.0, not an entry gate. TAR keeps no previous-close as an explicit flag. Seven-zip and solid RAR close the last stream in the driver finally. No public API or OpenSpec requirement deltas if behavior is preserved. Do not teach the declarative RAR corpus builder solid mode in this change.
+**Decided:** Pay before 0.2.0, not an entry gate. TAR keeps no previous-close as an explicit flag. The shared driver always closes the last stream in its `finally` (all backends — no `leave_last_open`); resource cleanup runs after that close. No public API or OpenSpec requirement deltas if behavior is preserved. Do not teach the declarative RAR corpus builder solid mode in this change.
 
 **Your call later:** Helper naming is implementer choice. Whether wave-one mutation also includes symlink or file-version solid fixtures, or only the two basic solid archives.
 

--- a/openspec/changes/unify-pass-driver/design.md
+++ b/openspec/changes/unify-pass-driver/design.md
@@ -11,7 +11,10 @@ Today’s S3 copies (`_iter_with_data`):
 | 7z | yes | close in `finally` | `SolidBlockReader` / folder swap |
 | RAR solid | yes | close in `finally` | `unrar p` pipe + `SolidBlockReader` + `pipe_offset` |
 
-Outer `stream_members` always owns pass acquire/release and closes the *current* handle in its `finally` — so 7z/RAR may double-close the last stream (must stay idempotent).
+Outer `stream_members` always owns pass acquire/release and closes the *current* handle in its `finally` — so 7z/RAR may double-close the last stream (must stay idempotent). The
+unified driver leans into that: it closes the last stream in **its own** `finally` for
+every backend, and `stream_members`'s `finally` becomes an idempotent backstop (Decision 3
+drops the base-only leave-open special case).
 
 S2 today: `_materialize_members` vs `_ProgressivePassIterator` + `_finalize_materialized_links` vs `_finalize_pass_links`, with near-identical double-fault comments. Shared already: `_register_member`, `_stamp_progressive_member` → register, `_publish_materialized`, `_index_member_name`.
 
@@ -20,7 +23,9 @@ S2 today: `_materialize_members` vs `_ProgressivePassIterator` + `_finalize_mate
 **Goals:**
 
 - Delete the *category* of hand-rolled close-previous loops and mirrored finalize guards.
-- Encode ownership (close_previous / leave_last_open / pass resources) in one place.
+- Encode ownership (close_previous / last-stream close / pass resources) in one place —
+  the driver always closes the last stream in its `finally`, so there is no per-backend
+  leave-last-open flag (see Decision 3).
 - Land T1 solid-RAR mutation **before** touching demux loops.
 - Preserve all must-not-break behaviors listed in the exploration map (solid RAR/7z, progressive TAR, double-fault, stream_members close/ownership).
 
@@ -65,19 +70,46 @@ Introduce a single helper on `BaseArchiveReader` (name TBD in implement, e.g. `_
 - Iterate members.
 - Optionally close previous on advance (`close_previous`).
 - Call a per-member open hook → `ArchiveStream | None`.
-- On exit: optional resource cleanup hook; optionally close last stream (`leave_last_open`).
+- In its own `finally`: run an optional resource-cleanup hook, then **always close the
+  last still-open stream**.
 
 Backend `_iter_with_data` becomes: obtain member source + resource state, then `yield from` the driver with a closure/hook for open (7z folder swap and RAR `pipe_offset` live in the hook).
+
+**Drop `leave_last_open` — the driver always closes the last stream.** Base today
+uniquely *leaves the last stream open* and lets `stream_members`'s `finally` close it
+(`base_reader.py:493-495`); 7z/RAR close it in their own `finally`. That asymmetry is the
+only thing a `leave_last_open` flag would encode, and it is not a contract: the
+`archive-reading` spec (`spec.md:459-483`) requires only close-previous-on-advance and
+close-current-on-abandon; it never asks for a last stream that outlives iteration. The
+shared driver already needs a `finally` for the resource hook, so closing the last stream
+there is free for every backend — removing the flag, and removing a latent trap (any
+*direct* `_iter_with_data` consumer that is not `stream_members` — e.g. a future native
+streaming-ZIP backend — silently leaks base's last stream today). Double-close (driver
+`finally` + `stream_members` `finally`) is fine: `ArchiveStream.close` is idempotent, which
+7z/RAR already rely on.
+
+> **Provenance of `leave_last_open` (why it exists at all).** It is not a designed
+> feature. Initial scaffold (#5) closed *nothing* on the selected path. #59
+> ("declared member-stream capabilities") added close-previous to **both**
+> `_iter_with_data` *and* `stream_members` at once, and — having no `finally` of its own in
+> the inner method — deferred the last close to `stream_members` with a bare `pass` +
+> terse note. #73 (a comment-only "docstring fix") then rewrote that note into the
+> confident "intentionally left open … closing it here would invalidate a handle the
+> caller may still read." That justification is inaccurate: a loop-level `try/finally`
+> closes the last stream at *teardown*, after the caller's final loop body — exactly what
+> v1/`archivey-dev` base did (`base_reader.py:637-641`). So the current behavior is an
+> incidental #59 division-of-labor choice later rationalized as intentional, not a
+> requirement to preserve.
 
 | Hook / flag | Base | TAR stream | 7z | RAR solid |
 | --- | --- | --- | --- | --- |
 | member source | progressive or materialized | progressive | `_members` | `_members` |
 | open hook | `_lazy_member_stream` | `extractfile` wrap | folder swap + lazy solid | `pipe_offset` + lazy solid |
 | `close_previous` | True | False | True | True |
-| `leave_last_open` | True | True | False | False |
 | resource `finally` | none | none | close solid | close solid + clear `_live_unrar` |
+| last stream | closed by driver `finally` (all backends) | | | |
 
-**Rejected:** force TAR onto close-previous tracking. **Rejected:** five abstract classes / strategy objects — keep one helper + closures.
+**Rejected:** force TAR onto close-previous tracking. **Rejected:** five abstract classes / strategy objects — keep one helper + closures. **Rejected:** keep `leave_last_open` as a per-backend flag — it only re-encodes base's incidental leave-open (see provenance above); the driver `finally` closes the last stream uniformly.
 
 ### 4. Shared link finalize (S2)
 

--- a/openspec/changes/unify-pass-driver/design.md
+++ b/openspec/changes/unify-pass-driver/design.md
@@ -24,8 +24,8 @@ S2 today: `_materialize_members` vs `_ProgressivePassIterator` + `_finalize_mate
 
 - Delete the *category* of hand-rolled close-previous loops and mirrored finalize guards.
 - Encode ownership (close_previous / last-stream close / pass resources) in one place —
-  the driver always closes the last stream in its `finally`, so there is no per-backend
-  leave-last-open flag (see Decision 3).
+  the driver always closes the last stream in its `finally` (before any resource hook),
+  so there is no per-backend leave-last-open flag (see Decision 3).
 - Land T1 solid-RAR mutation **before** touching demux loops.
 - Preserve all must-not-break behaviors listed in the exploration map (solid RAR/7z, progressive TAR, double-fault, stream_members close/ownership).
 
@@ -70,8 +70,10 @@ Introduce a single helper on `BaseArchiveReader` (name TBD in implement, e.g. `_
 - Iterate members.
 - Optionally close previous on advance (`close_previous`).
 - Call a per-member open hook → `ArchiveStream | None`.
-- In its own `finally`: run an optional resource-cleanup hook, then **always close the
-  last still-open stream**.
+- In its own `finally`: **close the last still-open stream first**, then run an
+  optional resource-cleanup hook (solid block / `unrar` pipe). Order matches
+  today’s 7z/RAR (`previous.close()` before `solid.close()`): do not tear down
+  the block/pipe under a live member wrapper.
 
 Backend `_iter_with_data` becomes: obtain member source + resource state, then `yield from` the driver with a closure/hook for open (7z folder swap and RAR `pipe_offset` live in the hook).
 
@@ -134,7 +136,8 @@ Q3=(b) supersedes any draft that added S2+S3 as a native-ZIP entry gate (`PLAN.m
 | Risk | Mitigation |
 | --- | --- |
 | Silent solid demux / pipe_offset skew | T1 mutation first; solid RAR/7z + measurement decode-once tests |
-| Double-close / leave-last-open mismatch | Explicit flags; cooperative close tests; idempotent `ArchiveStream.close` |
+| Double-close (driver `finally` + `stream_members` `finally`) | Idempotent `ArchiveStream.close`; cooperative close/abandon tests |
+| Resource `finally` before last-stream close | Forbidden — close last stream, then solid/`_live_unrar` (match 7z/RAR today) |
 | Progressive vs eager finalize order drift | Port existing call sites carefully; double-fault contract tests |
 | TAR streaming regresses without previous-close | `close_previous=False`; TAR materialize-from-pass tests |
 | Scope creep into L5 / corpus `-s` | Non-goals; keep PR focused |

--- a/openspec/changes/unify-pass-driver/design.md
+++ b/openspec/changes/unify-pass-driver/design.md
@@ -1,0 +1,113 @@
+## Context
+
+Provenance: `review/debt-ledger/structural.md` (S2/S3), `review/archive/2026-07-12-codebase-deep-review/deep-simplification.md` (original S2/S3), debt-ledger **Q3** maintainer decision **(b) pay pre-release** (2026-07-20). Fuzzing-before-Phase-6 is the analogous entry-gate precedent; here the gate is inverted — pay *now*, before any fifth backend is contemplated.
+
+Today’s S3 copies (`_iter_with_data`):
+
+| Backend | Close previous? | Last stream on exhaust | Extra resources |
+| --- | --- | --- | --- |
+| Base (ZIP/dir/ISO/nonsolid RAR) | yes | leave open (`stream_members` finally) | none |
+| TAR streaming | **no** (tarfile invalidates) | n/a | none |
+| 7z | yes | close in `finally` | `SolidBlockReader` / folder swap |
+| RAR solid | yes | close in `finally` | `unrar p` pipe + `SolidBlockReader` + `pipe_offset` |
+
+Outer `stream_members` always owns pass acquire/release and closes the *current* handle in its `finally` — so 7z/RAR may double-close the last stream (must stay idempotent).
+
+S2 today: `_materialize_members` vs `_ProgressivePassIterator` + `_finalize_materialized_links` vs `_finalize_pass_links`, with near-identical double-fault comments. Shared already: `_register_member`, `_stamp_progressive_member` → register, `_publish_materialized`, `_index_member_name`.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Delete the *category* of hand-rolled close-previous loops and mirrored finalize guards.
+- Encode ownership (close_previous / leave_last_open / pass resources) in one place.
+- Land T1 solid-RAR mutation **before** touching demux loops.
+- Preserve all must-not-break behaviors listed in the exploration map (solid RAR/7z, progressive TAR, double-fault, stream_members close/ownership).
+
+**Non-Goals:**
+
+- Lazy `ArchiveMember` derivation (L5) — separate, deferred.
+- Changing public `stream_members` / `members()` / `scan_members()` contracts.
+- Teaching the declarative RAR corpus builder `-s` (optional later; T1 uses static fixtures).
+- Unifying `_get_members_index_only` away (genuinely different; keep).
+- Making TAR start tracking `previous` (rejected — tarfile owns that).
+
+## Investigations
+
+Four-copy map and S2 overlap confirmed against `main` @ post-#171 tree (see agent exploration 2026-07-20). Materialization is **not** always a drained data pass:
+
+1. RA indexed: materialize metadata first, then lazy opens.
+2. Streaming TAR: progressive pass *is* the forward pass; data co-travels.
+3. Solid 7z/RAR: index upfront; demux loop is separate from listing.
+
+So “one drive loop” means one *stamp/finalize/publish* path and one *stream-pair* driver with hooks — not forcing every backend’s data demux to be the listing mechanism.
+
+T1 gap: `test_mutation_fuzz.py` `_PARAMS` iterates declarative `CORPUS` only; `_rar_build` has no `-s`. Static `tests/fixtures/rar/basic_solid__.rar` (+ rar4) already exist for example tests.
+
+## Decisions
+
+### 1. Pay S2+S3 before 0.2.0 (Q3 = b)
+
+Not an entry gate for native ZIP. Clean structure preferred; suite is the regression net.
+
+**Rejected:** (a) entry gate until next backend — would leave four copies shipping.
+
+### 2. T1 before structural edit
+
+Add mutation params over static solid RAR4/RAR5 fixtures (reuse `_exercise` / kinds / timeout). Skip when `unrar` absent via existing runnable/skip patterns.
+
+**Rejected:** only rely on existing example tests; **Rejected:** flip all CORPUS RAR to `-s` in this change (blast radius on oracles/sizes).
+
+### 3. Shared stream driver API (S3)
+
+Introduce a single helper on `BaseArchiveReader` (name TBD in implement, e.g. `_drive_pass_streams`) roughly:
+
+- Iterate members.
+- Optionally close previous on advance (`close_previous`).
+- Call a per-member open hook → `ArchiveStream | None`.
+- On exit: optional resource cleanup hook; optionally close last stream (`leave_last_open`).
+
+Backend `_iter_with_data` becomes: obtain member source + resource state, then `yield from` the driver with a closure/hook for open (7z folder swap and RAR `pipe_offset` live in the hook).
+
+| Hook / flag | Base | TAR stream | 7z | RAR solid |
+| --- | --- | --- | --- | --- |
+| member source | progressive or materialized | progressive | `_members` | `_members` |
+| open hook | `_lazy_member_stream` | `extractfile` wrap | folder swap + lazy solid | `pipe_offset` + lazy solid |
+| `close_previous` | True | False | True | True |
+| `leave_last_open` | True | True | False | False |
+| resource `finally` | none | none | close solid | close solid + clear `_live_unrar` |
+
+**Rejected:** force TAR onto close-previous tracking. **Rejected:** five abstract classes / strategy objects — keep one helper + closures.
+
+### 4. Shared link finalize (S2)
+
+One `_finalize_links(members, by_name_lists, *, error, child_scope, enforce_limits)` (exact shape at implement time) used by both eager and progressive paths. Double-fault policy: swallow secondary `CorruptionError`/`TruncatedError` when `error is not None`; re-raise when finalizing a clean EOF (`error is None`) — matching today’s progressive semantics; eager incomplete path always has `error` set.
+
+Eager success path: finalize with `error=None` and no swallow. Progressive clean EOF: same. Progressive/eager incomplete: swallow secondary damage.
+
+**Rejected:** keep two finalizers with “see other comment” prose. **Rejected:** changing when `is_current` is applied relative to link resolve without a failing test forcing it — preserve order per path as today unless tests allow convergence.
+
+### 5. No public spec delta in this change
+
+Behavior-preserving internal refactor + test widening. If a public contract accidentally changes, that is a bug, not a spec edit.
+
+**Rejected:** writing speculative `archive-reading` deltas “to document the driver” before behavior is proven identical.
+
+### 6. Do not record PLAN entry-gate language
+
+Q3=(b) supersedes any draft that added S2+S3 as a native-ZIP entry gate (`PLAN.md` / `IDEAS.md`). Those edits must not land (PR #173 closed).
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+| --- | --- |
+| Silent solid demux / pipe_offset skew | T1 mutation first; solid RAR/7z + measurement decode-once tests |
+| Double-close / leave-last-open mismatch | Explicit flags; cooperative close tests; idempotent `ArchiveStream.close` |
+| Progressive vs eager finalize order drift | Port existing call sites carefully; double-fault contract tests |
+| TAR streaming regresses without previous-close | `close_previous=False`; TAR materialize-from-pass tests |
+| Scope creep into L5 / corpus `-s` | Non-goals; keep PR focused |
+
+## Open Questions
+
+1. Exact helper name / whether it is a nested function vs method — implementer’s call; no API surface.
+2. Whether to add a third static fixture (`symlinks_solid__.rar` / `file_version_solid__.rar`) in T1 wave-1 or wave-2 — default wave-1 = two basic solid files only.

--- a/openspec/changes/unify-pass-driver/proposal.md
+++ b/openspec/changes/unify-pass-driver/proposal.md
@@ -1,0 +1,47 @@
+## Why
+
+The 2026-07-12 deep-simplification review predicted that native RAR would add a
+fourth divergent copy of the `stream_members` close-previous / open-current /
+yield / cleanup skeleton. It did (`review/debt-ledger/structural.md` S3). The
+member-list pipeline is only half-unified (S2): shared stamper and publication
+landed, but two drive loops and two mirrored double-fault guards remain. Debt-ledger
+**Q3** decided **pay before 0.2.0** (not “entry gate for the next backend”): the
+maintainer prefers clean structure over shipping with known copy-#5 debt, and the
+existing suite should catch regressions. The solid-RAR demux path that carries the
+trickiest invariants is currently example-tested only — mutation fuzz never hits it
+(T1).
+
+## What Changes
+
+- **T1 first:** extend mutation fuzz to curated static solid RAR fixtures
+  (`basic_solid__.rar`, `basic_solid__rar4.rar`) so damaged solid demux is under
+  the generative net before the refactor.
+- **S3:** one shared pass-stream driver on `BaseArchiveReader`; backends supply
+  open/resource hooks instead of re-copying the close-previous loop. TAR keeps
+  “no previous-close” (tarfile owns invalidation) as an explicit hook flag, not an
+  undocumented omission.
+- **S2:** one link-finalizer + one double-fault policy used by both eager
+  materialization and progressive pass finalize; eliminate mirrored guard prose.
+- No public API renames or behavior changes intended. **Not BREAKING** if the
+  must-not-break suite stays green.
+
+## Capabilities
+
+### New Capabilities
+
+<!-- none -->
+
+### Modified Capabilities
+
+- `testing-contract` — mutation harness MUST cover solid RAR demux (T1); S2/S3
+  themselves are internal and do not change public reading requirements.
+
+## Impact
+
+- **Modules:** `internal/base_reader.py` (driver + finalize); thin rewrites of
+  `_iter_with_data` in `tar_reader.py`, `sevenzip_reader.py`, `rar_reader.py`.
+- **Public API:** none intended.
+- **Tests:** T1 mutation params; existing solid RAR/7z, progressive TAR,
+  double-fault, `stream_members` close/ownership suites are the gate.
+- **Docs:** record Q3=(b) in `review/debt-ledger/`; do **not** add an “entry gate”
+  to `PLAN.md` / `IDEAS.md` (that was the rejected (a) framing).

--- a/openspec/changes/unify-pass-driver/proposal.md
+++ b/openspec/changes/unify-pass-driver/proposal.md
@@ -19,7 +19,8 @@ trickiest invariants is currently example-tested only — mutation fuzz never hi
 - **S3:** one shared pass-stream driver on `BaseArchiveReader`; backends supply
   open/resource hooks instead of re-copying the close-previous loop. TAR keeps
   “no previous-close” (tarfile owns invalidation) as an explicit hook flag, not an
-  undocumented omission.
+  undocumented omission. The driver always closes the last stream in its
+  `finally` (no `leave_last_open`); resource cleanup runs after that close.
 - **S2:** one link-finalizer + one double-fault policy used by both eager
   materialization and progressive pass finalize; eliminate mirrored guard prose.
 - No public API renames or behavior changes intended. **Not BREAKING** if the
@@ -39,7 +40,8 @@ trickiest invariants is currently example-tested only — mutation fuzz never hi
 ## Impact
 
 - **Modules:** `internal/base_reader.py` (driver + finalize); thin rewrites of
-  `_iter_with_data` in `tar_reader.py`, `sevenzip_reader.py`, `rar_reader.py`.
+  `_iter_with_data` in `internal/backends/tar_reader.py`,
+  `internal/backends/sevenzip_reader.py`, `internal/backends/rar_reader.py`.
 - **Public API:** none intended.
 - **Tests:** T1 mutation params; existing solid RAR/7z, progressive TAR,
   double-fault, `stream_members` close/ownership suites are the gate.

--- a/openspec/changes/unify-pass-driver/specs/testing-contract/spec.md
+++ b/openspec/changes/unify-pass-driver/specs/testing-contract/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: Mutation harness covers solid demux paths
+
+The corpus mutation harness SHALL exercise at least one **solid** RAR4 and one
+**solid** RAR5 archive under the same typed-error-or-success invariant as
+declarative-corpus mutations (truncate, bitflip, zero, junk). Static curated
+fixtures MAY supply those archives when the declarative builder does not emit
+solid RAR. When `unrar` is absent, solid-RAR mutation cases SHALL skip cleanly
+rather than fail.
+
+#### Scenario: solid RAR mutation matrix
+
+| Case | Expected |
+| --- | --- |
+| Solid RAR5 fixture × each mutation kind | Success or typed `ArchiveyError`; never raw third-party exception / hang |
+| Solid RAR4 fixture × each mutation kind | Same invariant |
+| `unrar` not on PATH | Solid-RAR mutation cases skipped |
+| Declarative nonsolid CORPUS RAR | Unchanged existing coverage |

--- a/openspec/changes/unify-pass-driver/tasks.md
+++ b/openspec/changes/unify-pass-driver/tasks.md
@@ -20,11 +20,14 @@
 
 ## 3. S3 — one pass-stream driver
 
-- [ ] 3.1 Add shared driver helper on `BaseArchiveReader` (`close_previous` /
-      `leave_last_open` / open hook / resource `finally`).
+- [ ] 3.1 Add shared driver helper on `BaseArchiveReader` (`close_previous` / open hook /
+      resource `finally`). The driver **always closes the last stream in its own `finally`**
+      — no `leave_last_open` flag (design Decision 3): drop base's leave-open special case
+      and its `base_reader.py:493-495` comment.
 - [ ] 3.2 Rewrite base / TAR streaming / 7z / RAR solid `_iter_with_data` to use the
-      driver (TAR: `close_previous=False`; 7z/RAR solid: `leave_last_open=False` +
-      resource cleanup).
+      driver (TAR: `close_previous=False`; 7z/RAR solid: add resource-cleanup hook). Rely on
+      idempotent `ArchiveStream.close` for the driver `finally` + `stream_members` `finally`
+      double-close.
 
 ## 4. Triage docs
 

--- a/openspec/changes/unify-pass-driver/tasks.md
+++ b/openspec/changes/unify-pass-driver/tasks.md
@@ -1,0 +1,37 @@
+## 1. Safety net (T1)
+
+- [ ] 1.1 Extend `tests/test_mutation_fuzz.py` with static solid RAR4/RAR5 fixtures
+      (`basic_solid__.rar`, `basic_solid__rar4.rar`); reuse `_exercise` / mutation kinds;
+      skip cleanly when `unrar` is unavailable.
+- [ ] 1.2 Confirm solid demux path is exercised under at least truncate + bitflip kinds
+      (smoke locally with default `_N`).
+
+## 2. S2 — one finalize path
+
+- [ ] 2.1 Collapse `_finalize_materialized_links` / `_finalize_pass_links` into one
+      helper with explicit double-fault policy (`error is not None` → swallow secondary
+      Corruption/Truncated; clean EOF → re-raise).
+- [ ] 2.2 Point eager materialization and `_ProgressivePassIterator` at the shared
+      finalizer; delete mirrored guard comments.
+
+## 3. S3 — one pass-stream driver
+
+- [ ] 3.1 Add shared driver helper on `BaseArchiveReader` (`close_previous` /
+      `leave_last_open` / open hook / resource `finally`).
+- [ ] 3.2 Rewrite base / TAR streaming / 7z / RAR solid `_iter_with_data` to use the
+      driver (TAR: `close_previous=False`; 7z/RAR solid: `leave_last_open=False` +
+      resource cleanup).
+
+## 4. Triage docs
+
+- [ ] 4.1 Record debt-ledger Q3 = (b) pay-now in `QUESTIONS.md` / `STATUS.md` /
+      `SUMMARY.md`; do not add PLAN/IDEAS entry-gate language.
+
+## 5. Verify
+
+- [ ] 5.1 Targeted: mutation solid-RAR slice; `test_rar_reader` solid; `test_sevenzip_reader` solid;
+      `test_measurement` solid decode-once; TAR progressive/materialize; double-fault
+      (`test_reader_contract`); `stream_members` close/ownership cooperative tests.
+- [ ] 5.2 Full suite in `[all]` (and note `[core-only]` / `[all-lowest]` before merge).
+- [ ] 5.3 `openspec validate --strict unify-pass-driver`
+- [ ] 5.4 `ruff format` / `ruff check` / `pyrefly check` / `ty check` clean on touched paths

--- a/openspec/changes/unify-pass-driver/tasks.md
+++ b/openspec/changes/unify-pass-driver/tasks.md
@@ -10,7 +10,11 @@
 
 - [ ] 2.1 Collapse `_finalize_materialized_links` / `_finalize_pass_links` into one
       helper with explicit double-fault policy (`error is not None` → swallow secondary
-      Corruption/Truncated; clean EOF → re-raise).
+      Corruption/Truncated; clean EOF → re-raise). Scope note: "one helper" unifies the
+      *double-fault policy and guard prose*, not necessarily byte-identical behavior —
+      per design Decision 4, preserve each path's existing `is_current`/link-resolve
+      ordering (a branch inside the shared helper is acceptable) unless a failing test
+      forces convergence. Don't reorder eager vs progressive finalize on faith.
 - [ ] 2.2 Point eager materialization and `_ProgressivePassIterator` at the shared
       finalizer; delete mirrored guard comments.
 

--- a/openspec/changes/unify-pass-driver/tasks.md
+++ b/openspec/changes/unify-pass-driver/tasks.md
@@ -23,11 +23,14 @@
 - [ ] 3.1 Add shared driver helper on `BaseArchiveReader` (`close_previous` / open hook /
       resource `finally`). The driver **always closes the last stream in its own `finally`**
       — no `leave_last_open` flag (design Decision 3): drop base's leave-open special case
-      and its `base_reader.py:493-495` comment.
+      and its `base_reader.py:493-495` comment. **`finally` order:** close last stream,
+      *then* resource cleanup (solid / clear `_live_unrar`) — same as today’s 7z/RAR;
+      never tear down the block/pipe under a live member wrapper.
 - [ ] 3.2 Rewrite base / TAR streaming / 7z / RAR solid `_iter_with_data` to use the
       driver (TAR: `close_previous=False`; 7z/RAR solid: add resource-cleanup hook). Rely on
       idempotent `ArchiveStream.close` for the driver `finally` + `stream_members` `finally`
-      double-close.
+      double-close. Module paths live under `internal/backends/`
+      (`sevenzip_reader.py`, `rar_reader.py`).
 
 ## 4. Triage docs
 

--- a/review/STATUS.md
+++ b/review/STATUS.md
@@ -48,13 +48,8 @@ OpenSpec archived: `archive/2026-07-20-stop-on-failure-not-policy/`.
 |---|---------|--------|
 | **Q1** | Perf wall-budget enforcement (perf Q2) | **decided** — nightly drift vs previous JSON (a); absolute bands informational |
 | **Q2** | ZIP listing above band: L5 pre-release vs publish honest number | lean: publish honest number; L5 follow-up |
-<<<<<<< HEAD
-| **Q3** | S2+S3: entry gate for next backend vs pay pre-release | lean: entry gate |
-| **Q4** | rapidgzip-truncation rides past 0.2.0? | **decided** — PAY before 0.2.0; implement later |
-=======
 | **Q3** | S2+S3: entry gate vs pay pre-release | **decided** — (b) pay now; OpenSpec `unify-pass-driver` |
-| **Q4** | rapidgzip-truncation rides past 0.2.0? | lean: KEEP change open |
->>>>>>> 87fb147 (Triage: mark debt-ledger Q3 decided in STATUS glance)
+| **Q4** | rapidgzip-truncation rides past 0.2.0? | **decided** — PAY before 0.2.0; implement later |
 | **Q5** | CHANGELOG form | lean: committed `CHANGELOG.md` |
 
 ### `performance/QUESTIONS.md`

--- a/review/STATUS.md
+++ b/review/STATUS.md
@@ -7,7 +7,7 @@ Triage after archiving `cli-product/` and OpenSpec `stop-on-failure-not-policy`
 
 | Review | Findings delivered? | Code/docs follow-ups | Ready to archive? |
 |--------|---------------------|----------------------|-------------------|
-| `debt-ledger/` | yes (2026-07-20) | pay-list D1/D2/D3/T1/T2/T3/D4/T7 + **DD4/rapidgzip-truncation** open; **D5/D6 done**; **Q1/Q4 decided**; Q2/Q3/Q5 open | no |
+| `debt-ledger/` | yes (2026-07-20) | pay-list D1/D2/D3/T1/T2/T3/D4/T7 + **DD4/rapidgzip-truncation** open; **D5/D6 done**; **Q1/Q3/Q4 decided**; Q2/Q5 open | no |
 | `performance/` | yes (#134 + follow-ups) | P3–P5 done; listing L0–L3 + peers (#143/#146/#148); residual band miss; **Q2 decided** (drift gate); **Q4 open** | no |
 
 Archived this pass: `archive/2026-07-19-api-coherence/`,
@@ -48,8 +48,13 @@ OpenSpec archived: `archive/2026-07-20-stop-on-failure-not-policy/`.
 |---|---------|--------|
 | **Q1** | Perf wall-budget enforcement (perf Q2) | **decided** — nightly drift vs previous JSON (a); absolute bands informational |
 | **Q2** | ZIP listing above band: L5 pre-release vs publish honest number | lean: publish honest number; L5 follow-up |
+<<<<<<< HEAD
 | **Q3** | S2+S3: entry gate for next backend vs pay pre-release | lean: entry gate |
 | **Q4** | rapidgzip-truncation rides past 0.2.0? | **decided** — PAY before 0.2.0; implement later |
+=======
+| **Q3** | S2+S3: entry gate vs pay pre-release | **decided** — (b) pay now; OpenSpec `unify-pass-driver` |
+| **Q4** | rapidgzip-truncation rides past 0.2.0? | lean: KEEP change open |
+>>>>>>> 87fb147 (Triage: mark debt-ledger Q3 decided in STATUS glance)
 | **Q5** | CHANGELOG form | lean: committed `CHANGELOG.md` |
 
 ### `performance/QUESTIONS.md`

--- a/review/STATUS.md
+++ b/review/STATUS.md
@@ -29,7 +29,6 @@ OpenSpec archived: `archive/2026-07-20-stop-on-failure-not-policy/`.
 | **T3** | Benchmark-gate RAR / encrypted / accelerator data cases (perf P6 remainder). |
 | **D4 / T7** | `open-issues.md` sweep; corpus-matrix audit. |
 | **DD4** | Finish `rapidgzip-truncation-investigation` (characterize → narrow/extend/remove) before 0.2.0 — later PR; see change `design.md`. |
-| **Q3 record** | S2/S3 entry gate for next backend → `PLAN.md` / `IDEAS.md`. |
 
 ### From `performance/`
 

--- a/review/debt-ledger/QUESTIONS.md
+++ b/review/debt-ledger/QUESTIONS.md
@@ -40,17 +40,17 @@ before release; the honest-number option costs nothing and the claim stays
 falsifiable-but-true. But this is a positioning call — VISION is the
 maintainer's document.
 
-## Q3 — S2+S3 unification: accept "entry gate for the next backend", or pay pre-release?
+## Q3 — S2+S3 unification: accept "entry gate for the next backend", or pay pre-release? — **DECIDED (2026-07-20)**
 
-The ledger's recommended verdict (structural.md) is: carry the four-copy pass
-driver and the split materialization/progressive drive loops **through**
-0.2.0, and make their unification a hard *entry gate* for the next backend
-(native streaming ZIP), recorded in `PLAN.md`. The alternative reading of the
-zero-debt goal is that 0.2.0 itself should ship debt-free and this is the
-best-motivated structural item on the books (S3 predicted the RAR copy; it
-happened). Both are defensible; the difference is release risk vs ledger
-purity. Which does the maintainer want? (If pre-release: do S2+S3 as one
-OpenSpec change, guarded by the T1 mutation-net extension landing *first*.)
+**Decision: (b) pay before 0.2.0.** Unify S2+S3 as one OpenSpec change
+(`unify-pass-driver`) now — clean structure preferred over shipping with four
+divergent pass-driver copies; the suite is the regression net. T1 (solid-RAR
+mutation) lands first as the safety net. **Rejected:** (a) entry gate for the
+next backend (do not add PLAN/IDEAS entry-gate language).
+
+The ledger's recommended verdict (structural.md) had been: carry the four-copy
+pass driver through 0.2.0 and gate the next backend. Maintainer overrode toward
+ledger purity / release-risk tolerance in favor of paying now.
 
 ## Q4 — Is `rapidgzip-truncation-investigation` allowed to ride past 0.2.0? — **DECIDED (2026-07-20)**
 

--- a/review/debt-ledger/SUMMARY.md
+++ b/review/debt-ledger/SUMMARY.md
@@ -19,8 +19,9 @@ missing release artifacts (SECURITY.md, CHANGELOG); (2) the **S2/S3
 structural prediction came true** — the pass-driver skeleton now exists in
 four divergent copies (RAR's is the fourth, exactly as forecast in 2026-07-12)
 and the member-list pipeline still carries mirrored double-fault guards — but
-none of it is public surface, so the recommended verdict is a *hard entry gate
-on the next backend*, not a release blocker; (3) the **generative test nets
+none of it is public surface, so the *original* recommended verdict was a *hard
+entry gate on the next backend*, not a release blocker (**overridden 2026-07-20:
+Q3 = (b) pay before 0.2.0** via `unify-pass-driver`); (3) the **generative test nets
 stop at the declarative corpus** — solid-RAR demux, the code where the RAR
 review found its bugs, is never mutated or swept, and the seek-interleaving
 property test that closed stream-decoder F5 exists only for XZ.
@@ -42,8 +43,8 @@ stable over time.
 | **T1** | Mutation-fuzz + conformance sweep cover only declarative `CORPUS`; **solid-RAR demux** (where RAR-review bugs lived) has no generative net | `tests/test_mutation_fuzz.py:118`; `rar_reader.py:578-649` | **F2** | **PAY** — mutate static fixtures / build solid RAR into corpus |
 | **T3** | Benchmark gate has no RAR/encrypted/accelerator data cases — D1's claim can't be honest for unmeasured paths | `tests/test_benchmark_gate.py` | **F2** | **PAY** (already tracked as perf P6 remainder) |
 | **T2** | Seek-interleaving property test exists only for XZ; lzip/`.Z` share the arithmetic class that hid F1 | `test_seekable_streams.py:507` | **F2** | **PAY** — parametrize existing test |
-| **S3** | Pass driver now **4 divergent copies** (base/TAR/7z/RAR; close-previous enforced 3 ways + not at all in one) — S3's prediction realized; next backend makes 5 | `base_reader.py:450`, `tar_reader.py:439`, `sevenzip_reader.py:303`, `rar_reader.py:578` | **F2** | **KEEP thru 0.2.0, PAY as entry gate for next backend** — Q3 to confirm |
-| **S2** | Member-list pipeline half-unified: shared stamper/publication landed, but dual drive loops + **mirrored double-fault guards** remain | `base_reader.py:782-816` vs `:1021-1048,1640-1690` | **F2** | **KEEP thru 0.2.0, PAY with S3** (one change) |
+| **S3** | Pass driver now **4 divergent copies** (base/TAR/7z/RAR; close-previous enforced 3 ways + not at all in one) — S3's prediction realized; next backend makes 5 | `base_reader.py:450`, `backends/tar_reader.py`, `backends/sevenzip_reader.py:303`, `backends/rar_reader.py:578` | **F2** | **PAY before 0.2.0** (Q3 = b, 2026-07-20) — OpenSpec `unify-pass-driver`; T1 first |
+| **S2** | Member-list pipeline half-unified: shared stamper/publication landed, but dual drive loops + **mirrored double-fault guards** remain | `base_reader.py` finalize helpers | **F2** | **PAY with S3** in `unify-pass-driver` (Q3 = b) |
 | **D4** | `open-issues.md` contradicts its own bucket rules (P1 decided+implemented yet listed as to-fix; dead change-path refs) | `docs/internal/open-issues.md:34-55,185` | **F2** | **PAY** — 15-min sweep |
 | **D5/D6** | Lifecycle housekeeping: `stop-on-failure-not-policy` complete-but-unarchived; `cli-product/` review done-pending-archive | `openspec list`; `review/STATUS.md` | **F2** | **DONE** (2026-07-20) — OpenSpec → `archive/2026-07-20-stop-on-failure-not-policy/`; review → `archive/2026-07-20-cli-product/` |
 | **T7** | Corpus matrix thin spots post-oracle-retirement: ISO only in `basic`; encrypted-header 7z / multi-volume outside the nets | `tests/sample_archives.py:307-345` | **F2** | **PAY** — half-day audit + cheap extensions |
@@ -62,11 +63,12 @@ stable over time.
 3. **D3** — start `CHANGELOG.md`.
 4. **T1 + T2** — widen the generative nets (solid-RAR mutation; lzip/`.Z`
    seek property test). Cheap, reuses machinery, and T1 doubles as the
-   safety net for the eventual S2/S3 change.
+   safety net for `unify-pass-driver` (S2+S3).
 5. **T3** — benchmark-gate RAR/encrypted/accelerator cases (D1 dependency).
 6. **D4 + T7** — the housekeeping sweep (open-issues, corpus-matrix audit).
    (**D5/D6** archived 2026-07-20.)
-7. Record the **S2/S3 entry-gate** decision (Q3) in `PLAN.md`/`IDEAS.md`.
+7. **S2+S3 / `unify-pass-driver`** — pay before 0.2.0 (Q3 = b); proposal in
+   `openspec/changes/unify-pass-driver/` (do **not** add PLAN/IDEAS entry-gate language).
 8. **DD4 / rapidgzip-truncation-investigation** — characterize + narrow/extend/remove
    ISIZE backstop before 0.2.0 (Q4 = PAY; implementation deferred, change enriched).
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

**Proposal-only** OpenSpec change for debt-ledger **Q3 = (b)** (pay S2+S3 before 0.2.0). No implementation in this PR.

Files: `openspec/changes/unify-pass-driver/{proposal,design,brief,tasks}.md` + delta `specs/testing-contract/spec.md`.

Closed the mistaken entry-gate PR (#173).

### Latest design notes (post-review)

- **No `leave_last_open`:** driver always closes the last stream in its `finally` (all backends). Provenance: base leave-open was incidental (#59/#73), not a contract.
- **`finally` order:** close last stream **first**, then resource cleanup (solid / `_live_unrar`) — matches today’s 7z/RAR; do not tear down the block under a live member wrapper.
- **S2:** one finalize helper unifies double-fault *policy*; does not force byte-identical eager/progressive `is_current` order unless a test requires it.
- Triage: Q3 recorded in QUESTIONS / STATUS / SUMMARY (no PLAN/IDEAS entry-gate language).

---

## Brief

**Status:** Ready to implement after proposal review. Not breaking if the suite stays green.

**What it does:** T1 solid-RAR mutation first → S2 one finalize path → S3 shared pass-stream driver (hooks + `close_previous`; always close last stream; resource hook after).

**Decided:** Pay before 0.2.0, not an entry gate. TAR: `close_previous=False`. All backends: last stream closed by driver `finally`.

---

## Driver hook matrix (after Decision 3)

| Hook / flag | Base | TAR stream | 7z | RAR solid |
| --- | --- | --- | --- | --- |
| `close_previous` | True | False | True | True |
| resource `finally` | none | none | close solid | close solid + clear `_live_unrar` |
| last stream | closed by driver `finally` (all backends), **before** resource hook | | | |

---

## Tasks (after approval)

1. **T1** — solid RAR mutation safety net  
2. **S2** — one finalize path + double-fault policy  
3. **S3** — shared driver; backends under `internal/backends/`  
4. Triage docs (partially done in this PR)  
5. Verify — targeted suites + `[all]` / openspec / ruff / types  

Full text on the branch; implementation waits on OK.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7685c81a-bce7-4a44-847d-b5d07eb87a87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7685c81a-bce7-4a44-847d-b5d07eb87a87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

