### PR TITLE
Review order: code first, then OpenSpec/context

### DIFF
--- a/.claude/skills/code-review-skill/SKILL.md
+++ b/.claude/skills/code-review-skill/SKILL.md
@@ -112,6 +112,11 @@ Transform code reviews from gatekeeping to knowledge sharing through constructiv
 
 ### Phase 1: Context Gathering (2-3 minutes)
 
+> **Archivey override:** For PRs in this repo, follow the addendum’s **§8 (code first,
+> then context)** instead of absorbing OpenSpec / design / long PR rationale here.
+> Keep only logistics (diff scope, size, CI, linked artifact *names*) before the cold
+> code pass; full narrative context is pass 2.
+
 Before diving into code, understand:
 1. Read PR description and linked issue / OpenSpec change / `review/` finding ID
 2. Skim the **[Archivey Review Addendum](reference/archivey-review-addendum.md)** for

--- a/.claude/skills/code-review-skill/SKILL.md
+++ b/.claude/skills/code-review-skill/SKILL.md
@@ -112,18 +112,25 @@ Transform code reviews from gatekeeping to knowledge sharing through constructiv
 
 ### Phase 1: Context Gathering (2-3 minutes)
 
-> **Archivey override:** For PRs in this repo, follow the addendum’s **§8 (code first,
-> then context)** instead of absorbing OpenSpec / design / long PR rationale here.
-> Keep only logistics (diff scope, size, CI, linked artifact *names*) before the cold
-> code pass; full narrative context is pass 2.
+> **Archivey override:** For PRs in this repo, **do not** use the generic “read the
+> design narrative before the diff” Phase 1. Follow the addendum’s **§8 (code first,
+> then context)** instead. Keep only logistics before the cold code pass; full
+> narrative context is pass 2 (required — do not skip).
 
-Before diving into code, understand:
-1. Read PR description and linked issue / OpenSpec change / `review/` finding ID
-2. Skim the **[Archivey Review Addendum](reference/archivey-review-addendum.md)** for
-   applicable VISION / contract / domain checklist rows
-3. Check PR size (>400 lines? Ask to split)
-4. Review CI/CD status (tests / ruff / type-check)
-5. Note any relevant architectural decisions or open `QUESTIONS.md` items
+**Logistics only** (≤1 minute — no OpenSpec / design / long PR rationale yet):
+
+1. Scope: `git diff main...HEAD` (or the paths / PR the author named); note size
+   (>400 lines? Ask to split)
+2. CI / local gates (`ruff`, pyrefly/ty, pytest) — enough to know whether failures
+   are in-scope
+3. Linked artifact **names** only (issue #, `openspec/changes/<name>/`, `review/`
+   finding ID) so you know what to open in pass 2 — not the prose yet
+4. Skim **[Archivey Review Addendum](reference/archivey-review-addendum.md) §8**
+   for the two-pass process (§1–§5 as a mental checklist only — do not load linked
+   designs yet)
+
+Then run Phases 2–3 as **pass 1 (code alone)**. Open the PR narrative, OpenSpec
+change, and contracts as **pass 2** per addendum §8 before writing the verdict.
 
 > For large diffs, pipe the diff through [`scripts/pr-analyzer.py`](scripts/pr-analyzer.py) (`git diff main...HEAD | python scripts/pr-analyzer.py`) to triage complexity and get a suggested review approach before reading.
 

--- a/.claude/skills/code-review-skill/assets/review-checklist.md
+++ b/.claude/skills/code-review-skill/assets/review-checklist.md
@@ -2,14 +2,22 @@
 
 Quick reference for reviewing changes in this Python archive library.
 
-## Pre-Review (2 min)
+Archivey order: **code first, then context** (addendum §8). Do not absorb OpenSpec /
+design / long PR rationale before the cold code pass.
 
-- [ ] Read PR description and linked issue / OpenSpec change
-- [ ] Check PR size (<400 lines ideal)
-- [ ] Verify CI status (tests / ruff / type-check)
-- [ ] Understand the behavior under change (format? safety? API?)
+## Logistics (≤1 min) — before either pass
 
-## Architecture & Design (5 min)
+- [ ] Scope: diff vs `main` (or named paths); size (<400 lines ideal, else ask to split)
+- [ ] CI / local gates (`ruff`, pyrefly/ty, pytest)
+- [ ] Linked artifact **names** only (issue #, `openspec/changes/<name>/`, `review/` ID)
+  — not the prose yet
+
+## Pass 1 — code alone
+
+Read the changed code (+ nearby context) cold. Self-explanatory resulting tree;
+local *why* for non-obvious choices; bugs / safety / tests.
+
+### Architecture & Design (5 min)
 
 - [ ] Solution fits the problem
 - [ ] Consistent with existing backends / patterns
@@ -17,7 +25,7 @@ Quick reference for reviewing changes in this Python archive library.
 - [ ] Public API impact is intentional and documented
 - [ ] Changes land in the right module layer
 
-## Logic & Correctness (10 min)
+### Logic & Correctness (10 min)
 
 - [ ] Edge cases / truncated / hostile input handled
 - [ ] `None` / optional metadata handled
@@ -25,7 +33,7 @@ Quick reference for reviewing changes in this Python archive library.
 - [ ] Error handling uses the library exception contract
 - [ ] Format parity preserved (or differences are explicit data)
 
-## Security (5 min)
+### Security (5 min)
 
 - [ ] No hardcoded secrets
 - [ ] Path traversal / symlink escape considered on extract paths
@@ -33,21 +41,21 @@ Quick reference for reviewing changes in this Python archive library.
 - [ ] Subprocess args are lists (no `shell=True` footguns)
 - [ ] Passwords / key material not logged
 
-## Performance (3 min)
+### Performance (3 min)
 
 - [ ] No silent re-decompression / O(n²) member loops
 - [ ] Streaming preferred over full buffering where appropriate
 - [ ] Handles closed; no unbounded buffers
 - [ ] Hot-path copies justified
 
-## Testing (5 min)
+### Testing (5 min)
 
 - [ ] Tests exist for new behavior
 - [ ] Edge / error / hostile cases covered
 - [ ] Tests are readable and deterministic
 - [ ] Fixtures reused when possible
 
-## Code Quality (3 min)
+### Code Quality (3 min)
 
 - [ ] Clear names
 - [ ] No unnecessary duplication
@@ -55,11 +63,20 @@ Quick reference for reviewing changes in this Python archive library.
 - [ ] Complex parser logic explained where needed
 - [ ] No magic numbers (use named constants)
 
-## Documentation (2 min)
+### Documentation (2 min)
 
 - [ ] Public APIs documented
 - [ ] Specs / ADRs updated if behavior contracts change
 - [ ] Breaking changes called out
+- [ ] Resulting code is self-explanatory; non-obvious *why* is near the code (not only
+  in OpenSpec / PR prose)
+
+## Pass 2 — context (required)
+
+- [ ] PR description + linked issue / full OpenSpec change / `review/` finding
+- [ ] Contract fit: OpenSpec / VISION / threat model / addendum (§1, §3, §5)
+- [ ] Spec ↔ code ↔ docs: match, intentional revision, or pause-and-ask
+- [ ] Concerns that only dissolve after external prose → usually 🟡 doc debt in the code
 
 ---
 

--- a/.claude/skills/code-review-skill/reference/archivey-review-addendum.md
+++ b/.claude/skills/code-review-skill/reference/archivey-review-addendum.md
@@ -140,6 +140,10 @@ when reality or a better design wins.
 ### Comments
 
 - [ ] Explain *why* (format quirks, hostile-input edges), not narrate *what*
+- [ ] Diff stands alone for a cold read (`CONTRIBUTING.md`); OpenSpec / PR prose is not
+  the only explanation
+- [ ] Links to specs / decisions / explorations / OpenSpec changes are fine for complex
+  decisions — but an inline summary should usually carry the *why*
 - [ ] Match surrounding comment density
 
 ---

--- a/.claude/skills/code-review-skill/reference/archivey-review-addendum.md
+++ b/.claude/skills/code-review-skill/reference/archivey-review-addendum.md
@@ -4,6 +4,9 @@
 > Use the skill’s process, severity labels, and Python/quality guides as the base;
 > use **this file** for what archivey uniquely cares about.
 >
+> **Review order:** archivey PRs use **code first, then context** (§8). That overrides
+> the skill’s Phase 1 “read the design narrative before the diff.”
+>
 > Do not merge these rules into the upstream-derived guides — keep the delta visible.
 
 **Authoritative sources (read these when a finding touches them):**
@@ -239,7 +242,7 @@ In-flight themes to know (see `STATUS.md` for live items):
 | Label | Archivey examples |
 |-------|-------------------|
 | 🔴 `[blocking]` | Path escape on default extract; catch-all exception translation; core grows a hard dep; unjustified type suppressions; silent solid O(n²) on a common API; deliberate new debt with no recorded decision; public contract change left undocumented *and* undiscussed |
-| 🟡 `[important]` | Dishonest cost signal; format parity hole without docs; missing red-green test for a bugfix; threat-model gap touched but unaddressed; CLI forced to import `internal/`; code contorted to match a questionable spec without raising a revision |
+| 🟡 `[important]` | Dishonest cost signal; format parity hole without docs; missing red-green test for a bugfix; threat-model gap touched but unaddressed; CLI forced to import `internal/`; code contorted to match a questionable spec without raising a revision; non-obvious logic that only makes sense after reading OpenSpec/`design.md`/long PR prose (pass-1 doc debt, §8) |
 | 🟢 `[nit]` | Naming, comment polish, non-user-facing refactor suggestions |
 | 💡 / 📚 / 🎉 | Alternatives, teaching notes, praise — non-blocking |
 
@@ -248,16 +251,70 @@ error/safety contract?** If yes → 🔴.
 
 ---
 
-## 8. Suggested review order (PR)
+## 8. Suggested review order (PR) — code first, then context
 
-1. Read PR description + linked issue / OpenSpec change / `review/` finding ID.
-2. Skim this addendum’s domain checklist (§5) for applicable rows.
-3. Run the skill’s four-phase process; pull generic Python/quality/security guides
-   only as needed.
-4. Verify gates relevant to the change (`ruff`, pyrefly/ty, targeted pytest; three
-   configs before push when behavior depends on extras/versions).
+This **overrides** the skill’s Phase 1 “absorb the design narrative before the
+diff.” For archivey PRs, use two passes with different jobs. Context is still
+**required** — it comes second, not never.
+
+### Before either pass (logistics only — ≤1 minute)
+
+Do **not** read the OpenSpec change, design notes, or long PR rationale yet.
+
+- [ ] Scope: `git diff main...HEAD` (or the paths / PR the author named); note size
+  (>400 lines? ask to split)
+- [ ] CI / local gates red or green (`ruff`, pyrefly/ty, pytest) — enough to know
+  whether failures are in-scope
+- [ ] Linked artifact **names** only (issue #, `openspec/changes/<name>/`,
+  `review/` finding ID) so you know what to open in pass 2 — not the prose yet
+
+### Pass 1 — code alone
+
+Read the diff (and nearby touched code) **cold**. Ask:
+
+- [ ] Does the change make sense **self-contained** — logic, edge cases, API shape,
+  safety/streaming/cost without needing external docs?
+- [ ] Are **non-obvious** choices explained **in the code** (or an adjacent module
+  docstring / comment) — format quirks, hostile-input edges, why this branch /
+  sentinel / exception path exists?
+- [ ] Would a future reader who only has the tree (not the OpenSpec change) understand
+  *why*, not just *what*?
+- [ ] Tests: behavior coverage, red–green for fixes (§4); domain checklist rows that
+  are visible from the diff (§5)
+
+Use the skill’s high-level + line-by-line techniques here
+(correctness / security / performance / maintainability / reuse). Skim this
+addendum’s §1–§5 only as a **mental checklist**, not by loading linked designs.
+
+**Documentation debt rule:** if a pass-1 concern only dissolves after reading
+external prose (OpenSpec `design.md`, long PR body, `docs/decisions/`, …), that is
+usually **🟡 `[important]` documentation debt in the code** — not proof you should
+have absorbed the design first. Specs and design notes explain *why we chose this
+approach*; they are a poor substitute for *why this local path exists*.
+
+### Pass 2 — whole context (do not skip)
+
+Now open the narrative and contracts:
+
+1. PR description + linked issue / full OpenSpec change (proposal, delta specs,
+   `design.md`) / `review/` brief or finding.
+2. Applicable rows in this addendum (§1 VISION ranking, §3 contracts, §5 domain)
+   and authoritative sources at the top of this file when a finding touches them.
+3. Spec ↔ code ↔ docs: match, intentional revision, or **pause-and-ask** (§3) —
+   including “self-contained and clear, but disagrees with the capability scenario
+   / invents undecided behavior / breaks format parity.”
+4. Gates relevant to the change (targeted pytest; three configs before push when
+   behavior depends on extras/versions).
 5. Write feedback with skill severity labels; put maintainer decisions in questions,
    not silent resolutions.
+
+| Pass | Job | Pass if… |
+|------|-----|----------|
+| **1. Code alone** | Correctness, clarity, local docs for non-obvious choices | Diff stands alone; surprises are explained near the code |
+| **2. Context** | Fit to OpenSpec / VISION / threat model / this addendum | Behavior matches (or intentionally revises) contracts; no silent discrepancies |
+
+**Do not treat a solid pass 1 as license to skip pass 2.** A locally clear change can
+still undercut a VISION claim, disagree with a scenario, or land unjustified debt.
 
 ---
 

--- a/.claude/skills/code-review-skill/reference/archivey-review-addendum.md
+++ b/.claude/skills/code-review-skill/reference/archivey-review-addendum.md
@@ -140,8 +140,8 @@ when reality or a better design wins.
 ### Comments
 
 - [ ] Explain *why* (format quirks, hostile-input edges), not narrate *what*
-- [ ] Diff stands alone for a cold read (`CONTRIBUTING.md`); OpenSpec / PR prose is not
-  the only explanation
+- [ ] Resulting code is self-explanatory (`CONTRIBUTING.md`); OpenSpec / PR prose is not
+  the only explanation — future editors see the tree, not the diff
 - [ ] Links to specs / decisions / explorations / OpenSpec changes are fine for complex
   decisions — but an inline summary should usually carry the *why*
 - [ ] Match surrounding comment density
@@ -274,17 +274,17 @@ Do **not** read the OpenSpec change, design notes, or long PR rationale yet.
 
 ### Pass 1 — code alone
 
-Read the diff (and nearby touched code) **cold**. Ask:
+Read the changed code (diff + nearby context) **cold**. Ask:
 
-- [ ] Does the change make sense **self-contained** — logic, edge cases, API shape,
-  safety/streaming/cost without needing external docs?
+- [ ] Does the **resulting** code make sense **self-contained** — logic, edge cases,
+  API shape, safety/streaming/cost without needing external docs?
 - [ ] Are **non-obvious** choices explained **in the code** (or an adjacent module
   docstring / comment) — format quirks, hostile-input edges, why this branch /
   sentinel / exception path exists?
-- [ ] Would a future reader who only has the tree (not the OpenSpec change) understand
-  *why*, not just *what*?
+- [ ] Would a future editor who only has the tree (not the PR or OpenSpec change)
+  understand *why*, not just *what*?
 - [ ] Tests: behavior coverage, red–green for fixes (§4); domain checklist rows that
-  are visible from the diff (§5)
+  are visible from the change (§5)
 
 Use the skill’s high-level + line-by-line techniques here
 (correctness / security / performance / maintainability / reuse). Skim this
@@ -293,7 +293,9 @@ addendum’s §1–§5 only as a **mental checklist**, not by loading linked des
 **Documentation debt rule:** if a pass-1 concern only dissolves after reading
 external prose (OpenSpec `design.md`, long PR body, `docs/decisions/`, …), that is
 usually **🟡 `[important]` documentation debt in the code** — not proof you should
-have absorbed the design first. Specs and design notes explain *why we chose this
+have absorbed the design first. A comment that **summarizes *why* inline** and
+optionally points at a spec / decision / exploration is fine; a bare “see design.md”
+with no local reason is not. Specs and design notes explain *why we chose this
 approach*; they are a poor substitute for *why this local path exists*.
 
 ### Pass 2 — whole context (do not skip)
@@ -314,7 +316,7 @@ Now open the narrative and contracts:
 
 | Pass | Job | Pass if… |
 |------|-----|----------|
-| **1. Code alone** | Correctness, clarity, local docs for non-obvious choices | Diff stands alone; surprises are explained near the code |
+| **1. Code alone** | Correctness, clarity, local docs for non-obvious choices | Resulting code is self-explanatory; surprises are explained near the code |
 | **2. Context** | Fit to OpenSpec / VISION / threat model / this addendum | Behavior matches (or intentionally revises) contracts; no silent discrepancies |
 
 **Do not treat a solid pass 1 as license to skip pass 2.** A locally clear change can

--- a/.cursor/commands/code-review.md
+++ b/.cursor/commands/code-review.md
@@ -19,12 +19,18 @@ changes unless the user explicitly asks for them.
 This repo vendors a fuller review skill under `.claude/skills/code-review-skill/`.
 Combine the priorities above with that skill’s process:
 
-1. **Read first:** `.claude/skills/code-review-skill/reference/archivey-review-addendum.md`
-   (VISION ranking, zero tech debt, specs-as-guidelines, domain checklist)
-2. **Then follow:** `.claude/skills/code-review-skill/SKILL.md`
-   (four-phase review, severity labels, constructive feedback norms)
-3. Open deeper guides under `.claude/skills/code-review-skill/reference/` only as needed
-   (security, performance, Python, error handling, architecture, quality)
+1. **Read process rules:** `.claude/skills/code-review-skill/reference/archivey-review-addendum.md`
+   — especially **§8 (code first, then context)**, plus VISION ranking, contracts,
+   and the domain checklist. Do **not** absorb OpenSpec / design / long PR rationale
+   before the cold code pass.
+2. **Pass 1 — code alone:** diff + nearby code for self-contained sense, local docs
+   for non-obvious choices, bugs/safety/tests. Use
+   `.claude/skills/code-review-skill/SKILL.md` techniques and severity labels;
+   open deeper guides under `reference/` only as needed.
+3. **Pass 2 — context (required):** PR narrative, OpenSpec change, VISION / threat
+   model / addendum rows that apply — check contract fit; pause-and-ask on
+   discrepancies. Findings that only dissolve after external prose are usually
+   documentation debt in the code (addendum §8).
 
 ## Scope
 

--- a/.cursor/commands/code-review.md
+++ b/.cursor/commands/code-review.md
@@ -23,9 +23,9 @@ Combine the priorities above with that skill’s process:
    — especially **§8 (code first, then context)**, plus VISION ranking, contracts,
    and the domain checklist. Do **not** absorb OpenSpec / design / long PR rationale
    before the cold code pass.
-2. **Pass 1 — code alone:** diff + nearby code for self-contained sense, local docs
-   for non-obvious choices, bugs/safety/tests. Use
-   `.claude/skills/code-review-skill/SKILL.md` techniques and severity labels;
+2. **Pass 1 — code alone:** changed code (+ nearby context) for self-explanatory
+   sense in the resulting tree, local docs for non-obvious choices, bugs/safety/tests.
+   Use `.claude/skills/code-review-skill/SKILL.md` techniques and severity labels;
    open deeper guides under `reference/` only as needed.
 3. **Pass 2 — context (required):** PR narrative, OpenSpec change, VISION / threat
    model / addendum rows that apply — check contract fit; pause-and-ask on

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,7 @@ See `openspec/specs/format-7z/spec.md`, `format-rar/spec.md`,
   versions (`[all]`), minimum versions (`[all-lowest]`), and the zero-dep core
   (`[core-only]`) — since optional libraries change behaviour by both presence and version.
   The exact commands are in `CONTRIBUTING.md` ("Before pushing…").
-- See `CONTRIBUTING.md` for coding/testing standards (incl. behaviour-focused tests and
-  the rule to **pause and ask the maintainer on spec/design discrepancies** rather than
-  silently resolving them).
+- See `CONTRIBUTING.md` for coding/testing standards (incl. behaviour-focused tests,
+  **write for a cold read** / self-explanatory diffs with inline *why*, and the rule to
+  **pause and ask the maintainer on spec/design discrepancies** rather than silently
+  resolving them).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,6 @@ See `openspec/specs/format-7z/spec.md`, `format-rar/spec.md`,
   (`[core-only]`) — since optional libraries change behaviour by both presence and version.
   The exact commands are in `CONTRIBUTING.md` ("Before pushing…").
 - See `CONTRIBUTING.md` for coding/testing standards (incl. behaviour-focused tests,
-  **write for a cold read** / self-explanatory diffs with inline *why*, and the rule to
+  **leave the code self-explanatory** with inline *why*, and the rule to
   **pause and ask the maintainer on spec/design discrepancies** rather than silently
   resolving them).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,11 +103,12 @@ workflow must pass `--python <matrix>` (and `UV_PYTHON`) on every `uv sync` /
   `openspec/specs/` that describe it in the same change. The one exception is the
   pause-and-ask rule below: when a cleanup would resolve a genuine design discrepancy,
   surface it instead of silently picking a direction.
-- **Write for a cold read.** Prefer diffs that a reviewer (or future you) can understand
-  from the code alone — names, structure, and nearby comments — without needing the
-  OpenSpec change, `design.md`, or a long PR body first. Those docs are for approach and
-  contract; they are not a substitute for local clarity. Reviews in this repo cold-read
-  the diff before loading design narrative (see the archivey review addendum §8).
+- **Leave the code self-explanatory.** Prefer that the *resulting* tree — names,
+  structure, and nearby comments — makes sense to a future editor who never saw the
+  PR. They will read the current code, not the diff or the OpenSpec change /
+  `design.md` / PR body that motivated it. Those docs are for approach and contract;
+  they are not a substitute for local clarity. Reviews in this repo cold-read the
+  changed code before loading design narrative (see the archivey review addendum §8).
 - **Comments explain *why*, not *what*.** Match the comment density and style of the
   surrounding code. Don't narrate what the code obviously does; do explain non-obvious
   decisions, format quirks, and edge cases (these archives are full of them). For a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,9 +103,17 @@ workflow must pass `--python <matrix>` (and `UV_PYTHON`) on every `uv sync` /
   `openspec/specs/` that describe it in the same change. The one exception is the
   pause-and-ask rule below: when a cleanup would resolve a genuine design discrepancy,
   surface it instead of silently picking a direction.
+- **Write for a cold read.** Prefer diffs that a reviewer (or future you) can understand
+  from the code alone — names, structure, and nearby comments — without needing the
+  OpenSpec change, `design.md`, or a long PR body first. Those docs are for approach and
+  contract; they are not a substitute for local clarity. Reviews in this repo cold-read
+  the diff before loading design narrative (see the archivey review addendum §8).
 - **Comments explain *why*, not *what*.** Match the comment density and style of the
   surrounding code. Don't narrate what the code obviously does; do explain non-obvious
-  decisions, format quirks, and edge cases (these archives are full of them).
+  decisions, format quirks, and edge cases (these archives are full of them). For a
+  complex decision, a comment **may point** at a spec, `docs/decisions/`, architecture
+  note, exploration, or OpenSpec change — but **summarize the reason inline whenever
+  possible** so the pointer is optional depth, not the only explanation.
 - **Match the surrounding code.** Naming, structure, and idiom should read like the file
   you're editing.
 - **Type-checker suppressions must be justified, and are a last resort.** A bare

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,12 +103,13 @@ workflow must pass `--python <matrix>` (and `UV_PYTHON`) on every `uv sync` /
   `openspec/specs/` that describe it in the same change. The one exception is the
   pause-and-ask rule below: when a cleanup would resolve a genuine design discrepancy,
   surface it instead of silently picking a direction.
-- **Leave the code self-explanatory.** Prefer that the *resulting* tree — names,
-  structure, and nearby comments — makes sense to a future editor who never saw the
-  PR. They will read the current code, not the diff or the OpenSpec change /
-  `design.md` / PR body that motivated it. Those docs are for approach and contract;
-  they are not a substitute for local clarity. Reviews in this repo cold-read the
-  changed code before loading design narrative (see the archivey review addendum §8).
+- **Leave the code self-explanatory.** The *resulting* tree — names, structure, and
+  nearby comments — must make sense to a future editor who never saw the PR. They will
+  read the current code, not the diff or the OpenSpec change / `design.md` / PR body
+  that motivated it. Those docs are for approach and contract; they are not a
+  substitute for local clarity. Reviews in this repo cold-read the changed code before
+  loading design narrative and treat non-obvious logic that only makes sense after
+  external prose as important documentation debt (see the archivey review addendum §8).
 - **Comments explain *why*, not *what*.** Match the comment density and style of the
   surrounding code. Don't narrate what the code obviously does; do explain non-obvious
   decisions, format quirks, and edge cases (these archives are full of them). For a


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Archivey PR reviews cold-read changed code before loading design narrative, and authors leave the **resulting code** self-explanatory.

**Reviewer side**
- Addendum §8: **code alone**, then **required context** (OpenSpec / VISION / contracts).
- Pass-1 criterion: the *resulting* tree makes sense without external prose (future editors see the code, not the diff).
- Concerns that only clear up after OpenSpec/PR prose → usually 🟡 in-code documentation debt (unless the comment already summarizes *why* and optionally points out).
- `/code-review` + skill Phase 1 note the archivey override; Phase 1’s checklist is logistics-only (no leftover “read PR/OpenSpec first” steps).
- Quick checklist (`assets/review-checklist.md`) mirrors logistics → pass 1 → pass 2.

**Author side**
- `CONTRIBUTING.md`: the resulting tree **must** be self-explanatory; comments explain *why*; for complex decisions they may point at specs / decisions / explorations / OpenSpec changes, but should summarize the reason inline whenever possible. Reviews treat missing local *why* as important documentation debt.
- `CLAUDE.md`: points agents at that rule.
- Addendum comment checklist aligned with the same bar.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eafcd7f1-46e3-408b-9652-60aa78d74fe9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eafcd7f1-46e3-408b-9652-60aa78d74fe9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

