### PR TITLE
Unify pass-stream driver and link finalize (S2+S3)

### DIFF
--- a/openspec/changes/unify-pass-driver/tasks.md
+++ b/openspec/changes/unify-pass-driver/tasks.md
@@ -1,32 +1,32 @@
 ## 1. Safety net (T1)
 
-- [ ] 1.1 Extend `tests/test_mutation_fuzz.py` with static solid RAR4/RAR5 fixtures
+- [x] 1.1 Extend `tests/test_mutation_fuzz.py` with static solid RAR4/RAR5 fixtures
       (`basic_solid__.rar`, `basic_solid__rar4.rar`); reuse `_exercise` / mutation kinds;
       skip cleanly when `unrar` is unavailable.
-- [ ] 1.2 Confirm solid demux path is exercised under at least truncate + bitflip kinds
+- [x] 1.2 Confirm solid demux path is exercised under at least truncate + bitflip kinds
       (smoke locally with default `_N`).
 
 ## 2. S2 — one finalize path
 
-- [ ] 2.1 Collapse `_finalize_materialized_links` / `_finalize_pass_links` into one
+- [x] 2.1 Collapse `_finalize_materialized_links` / `_finalize_pass_links` into one
       helper with explicit double-fault policy (`error is not None` → swallow secondary
       Corruption/Truncated; clean EOF → re-raise). Scope note: "one helper" unifies the
       *double-fault policy and guard prose*, not necessarily byte-identical behavior —
       per design Decision 4, preserve each path's existing `is_current`/link-resolve
       ordering (a branch inside the shared helper is acceptable) unless a failing test
       forces convergence. Don't reorder eager vs progressive finalize on faith.
-- [ ] 2.2 Point eager materialization and `_ProgressivePassIterator` at the shared
+- [x] 2.2 Point eager materialization and `_ProgressivePassIterator` at the shared
       finalizer; delete mirrored guard comments.
 
 ## 3. S3 — one pass-stream driver
 
-- [ ] 3.1 Add shared driver helper on `BaseArchiveReader` (`close_previous` / open hook /
+- [x] 3.1 Add shared driver helper on `BaseArchiveReader` (`close_previous` / open hook /
       resource `finally`). The driver **always closes the last stream in its own `finally`**
       — no `leave_last_open` flag (design Decision 3): drop base's leave-open special case
       and its `base_reader.py:493-495` comment. **`finally` order:** close last stream,
       *then* resource cleanup (solid / clear `_live_unrar`) — same as today’s 7z/RAR;
       never tear down the block/pipe under a live member wrapper.
-- [ ] 3.2 Rewrite base / TAR streaming / 7z / RAR solid `_iter_with_data` to use the
+- [x] 3.2 Rewrite base / TAR streaming / 7z / RAR solid `_iter_with_data` to use the
       driver (TAR: `close_previous=False`; 7z/RAR solid: add resource-cleanup hook). Rely on
       idempotent `ArchiveStream.close` for the driver `finally` + `stream_members` `finally`
       double-close. Module paths live under `internal/backends/`
@@ -34,7 +34,7 @@
 
 ## 4. Triage docs
 
-- [ ] 4.1 Record debt-ledger Q3 = (b) pay-now in `QUESTIONS.md` / `STATUS.md` /
+- [x] 4.1 Record debt-ledger Q3 = (b) pay-now in `QUESTIONS.md` / `STATUS.md` /
       `SUMMARY.md`; do not add PLAN/IDEAS entry-gate language.
 
 ## 5. Verify

--- a/openspec/changes/unify-pass-driver/tasks.md
+++ b/openspec/changes/unify-pass-driver/tasks.md
@@ -39,9 +39,9 @@
 
 ## 5. Verify
 
-- [ ] 5.1 Targeted: mutation solid-RAR slice; `test_rar_reader` solid; `test_sevenzip_reader` solid;
+- [x] 5.1 Targeted: mutation solid-RAR slice; `test_rar_reader` solid; `test_sevenzip_reader` solid;
       `test_measurement` solid decode-once; TAR progressive/materialize; double-fault
       (`test_reader_contract`); `stream_members` close/ownership cooperative tests.
-- [ ] 5.2 Full suite in `[all]` (and note `[core-only]` / `[all-lowest]` before merge).
-- [ ] 5.3 `openspec validate --strict unify-pass-driver`
-- [ ] 5.4 `ruff format` / `ruff check` / `pyrefly check` / `ty check` clean on touched paths
+- [x] 5.2 Full suite in `[all]` (and note `[core-only]` / `[all-lowest]` before merge).
+- [x] 5.3 `openspec validate --strict unify-pass-driver`
+- [x] 5.4 `ruff format` / `ruff check` / `pyrefly check` / `ty check` clean on touched paths

--- a/review/debt-ledger/structural.md
+++ b/review/debt-ledger/structural.md
@@ -2,7 +2,7 @@
 
 All line references: `main` @ `7bb862b`.
 
-## S3 — the pass driver is now **four** copies, exactly as predicted (PAY — but gate the next backend, not the release)
+## S3 — the pass driver is now **four** copies, exactly as predicted (PAY before 0.2.0)
 
 The 2026-07-12 `deep-simplification.md` S3 predicted the native RAR reader
 would add a fourth copy of the "close previous / open current / yield /
@@ -10,33 +10,23 @@ cleanup tail" loop skeleton. It did. The four copies today:
 
 | Copy | Where | Skeleton specifics |
 |---|---|---|
-| Base default | `base_reader.py:450-495` | tracks `previous`, closes on advance, **leaves the last stream open** with a comment explaining why |
-| TAR streaming override | `tar_reader.py:439-461` | **no `previous` tracking at all** — relies on tarfile invalidating the prior `extractfile` handle on advance |
-| 7z override | `sevenzip_reader.py:303-343` | `previous` close + solid-folder swap (`folder_index` change → close/reopen `SolidBlockReader`) + `finally` tail closing both |
-| RAR solid override | `rar_reader.py:578-649` | `previous` close + running `pipe_offset` cursor + `finally` tail closing stream, `SolidBlockReader`, and clearing `_live_unrar` |
+| Base default | `base_reader.py` `_iter_with_data` | tracks `previous`, closes on advance; last stream closed by shared driver `finally` |
+| TAR streaming override | `tar_reader.py` `_iter_with_data` | **no previous-close** — relies on tarfile invalidating the prior `extractfile` handle on advance (`close_previous=False`) |
+| 7z override | `sevenzip_reader.py` `_iter_with_data` | `previous` close + solid-folder swap (`folder_index` change → close/reopen `SolidBlockReader`) + resource `finally` |
+| RAR solid override | `rar_reader.py` `_iter_with_data` | `previous` close + running `pipe_offset` cursor + resource `finally` (solid + clear `_live_unrar`) |
 
 This is the drift S3 warned about, live: the close-previous invariant is
 enforced three different ways and *not at all* in one copy (TAR's omission is
-defensible — tarfile owns invalidation — but that reasoning exists only in this
-review, not in the code). The `stream_members` ownership contract remains a
-"MUST override correctly" docstring instruction to backend authors
-(`base_reader.py:450-474`) rather than machinery. Every future backend — and a
-**native streaming ZIP reader is the named next backend** (`IDEAS.md`,
-`open-issues.md` P2/P4) — adds a fifth copy carrying the same invariants.
+defensible — tarfile owns invalidation — but that reasoning existed only in
+review prose until the shared driver encoded it as `close_previous=False`).
+Every future backend would otherwise add a fifth copy carrying the same
+invariants.
 
-**Verdict: KEEP through 0.2.0, PAY before the next backend.** The duplication
-is invisible at the public surface — nothing about it freezes at release — and
-a behavior-preserving refactor of exactly the loops that carry the library's
-trickiest invariants (RAR pipe-offset demux, 7z solid swap) is the wrong thing
-to rush against a release date. The explicit justification for carrying it
-past 0.2.0: (a) zero public-surface exposure; (b) all four copies are
-currently guarded by the strongest suite the project has had (three dependency
-configs, corpus sweep, solid-RAR fixture tests). The debt becomes intolerable
-the moment a fifth copy is written, so the pay-trigger is hard: **the S3
-unification is an entry gate for the native-ZIP (or any new) backend**, the
-same way fuzzing was an entry gate for Phase 6. Recommend recording that gate
-in `PLAN.md`/`IDEAS.md` now so it cannot be forgotten. (Maintainer may
-override and pay pre-release — see `QUESTIONS.md` Q3.)
+**Verdict: PAY before 0.2.0 (Q3 = b, 2026-07-20).** Maintainer overrode the
+earlier "KEEP through 0.2.0 / entry gate for the next backend" lean: clean
+structure preferred; the suite (incl. T1 solid-RAR mutation) is the regression
+net. OpenSpec change: `unify-pass-driver`. Do **not** record PLAN/IDEAS
+entry-gate language.
 
 ## S2 — member-list pipeline: **half paid**; the remaining half is the risky half (PAY together with S3)
 
@@ -69,11 +59,10 @@ reproduced the "invariant enforced twice, in parallel prose" pattern:
   laziness is genuinely different; it would survive unification as a pure
   enumeration).
 
-**Verdict: same as S3 — KEEP through 0.2.0 with the justification above, PAY
-as one OpenSpec change with S3** ("materialization is a drained forward
-pass" + a narrow per-backend open hook). Doing S2 and S3 together is cheaper
-than either alone because the unified pass driver *is* the single drive loop
-S2 wants.
+**Verdict: PAY with S3 before 0.2.0 (Q3 = b)** as one OpenSpec change
+(`unify-pass-driver`) — "one finalize path" + shared pass-stream driver.
+Doing S2 and S3 together is cheaper than either alone because the unified
+pass driver *is* the single drive loop S2 wants.
 
 ## S1 — one error boundary: **paid, and it held** (fine; one small residue)
 

--- a/src/archivey/internal/backends/rar_reader.py
+++ b/src/archivey/internal/backends/rar_reader.py
@@ -604,49 +604,47 @@ class RarReader(BaseArchiveReader):
             _UnrarOwnedStream(stdout, proc, has_verifiable_hash=True)
         )
         solid = SolidBlockReader(owned)
-        previous: ArchiveStream | None = None
         pipe_offset = 0
-        try:
-            for member in self._members:
-                if previous is not None:
-                    previous.close()
-                    previous = None
-                raw = member._raw
-                assert isinstance(raw, RarMemberInfo)
-                if not raw.is_payload_file() or not member.is_file:
-                    yield member, None
-                    continue
-                size = _member_stream_size(member)
-                # Capture the pipe offset for this member, then advance the running
-                # cursor. ``lazy=True`` defers skip-decode until first read; verify
-                # is fused into the outer ArchiveStream so a never-opened handle
-                # skips verify on close (no solid positioning for unread members).
-                member_offset = pipe_offset
-                pipe_offset += size
-                lazy_solid = solid.open_member(member_offset, size, lazy=True)
 
-                hashes, vsize, transforms, verify_member = self._payload_verify_args(
-                    member
-                )
-                stream = self._wrap_member_stream(
-                    None,
-                    member.name,
-                    open_fn=lambda inner=lazy_solid: inner,
-                    size=member.size,
-                    track_output=False,
-                    seekable=False,
-                    expected_hashes=hashes,
-                    expected_size=vsize,
-                    digest_transforms=transforms,
-                    verify_member=verify_member,
-                )
-                previous = stream
-                yield member, stream
-        finally:
-            if previous is not None:
-                previous.close()
+        def _open(member: ArchiveMember) -> ArchiveStream | None:
+            nonlocal pipe_offset
+            raw = member._raw
+            assert isinstance(raw, RarMemberInfo)
+            if not raw.is_payload_file() or not member.is_file:
+                return None
+            size = _member_stream_size(member)
+            # Capture the pipe offset for this member, then advance the running
+            # cursor. ``lazy=True`` defers skip-decode until first read; verify
+            # is fused into the outer ArchiveStream so a never-opened handle
+            # skips verify on close (no solid positioning for unread members).
+            member_offset = pipe_offset
+            pipe_offset += size
+            lazy_solid = solid.open_member(member_offset, size, lazy=True)
+
+            hashes, vsize, transforms, verify_member = self._payload_verify_args(member)
+            return self._wrap_member_stream(
+                None,
+                member.name,
+                open_fn=lambda inner=lazy_solid: inner,
+                size=member.size,
+                track_output=False,
+                seekable=False,
+                expected_hashes=hashes,
+                expected_size=vsize,
+                digest_transforms=transforms,
+                verify_member=verify_member,
+            )
+
+        def _cleanup() -> None:
             solid.close()
             self._live_unrar = None
+
+        yield from self._drive_pass_streams(
+            iter(self._members),
+            open_member=_open,
+            close_previous=True,
+            cleanup=_cleanup,
+        )
 
     def _translate_exception(self, exc: Exception) -> ArchiveyError | None:
         if isinstance(exc, EOFError):

--- a/src/archivey/internal/backends/sevenzip_reader.py
+++ b/src/archivey/internal/backends/sevenzip_reader.py
@@ -303,44 +303,41 @@ class SevenZipReader(BaseArchiveReader):
     def _iter_with_data(self) -> Iterator[tuple[ArchiveMember, ArchiveStream | None]]:
         current_folder: int | None = None
         solid: SolidBlockReader | None = None
-        previous: ArchiveStream | None = None
-        try:
-            for member in self._members:
-                if previous is not None:
-                    previous.close()
-                    previous = None
-                if not member.is_file:
-                    yield member, None
-                    continue
-                raw = member._raw
-                assert isinstance(raw, _MemberRaw)
-                if raw.folder_index is None:
-                    stream = self._wrap_member_stream(
-                        io.BytesIO(b""), member.name, size=member.size
+
+        def _open(member: ArchiveMember) -> ArchiveStream | None:
+            nonlocal current_folder, solid
+            if not member.is_file:
+                return None
+            raw = member._raw
+            assert isinstance(raw, _MemberRaw)
+            if raw.folder_index is None:
+                return self._wrap_member_stream(
+                    io.BytesIO(b""), member.name, size=member.size
+                )
+            if raw.folder_index != current_folder:
+                if solid is not None:
+                    solid.close()
+                current_folder = raw.folder_index
+                # Count at the folder decode layer (solid invariant); member wraps
+                # pass track_output=False so sequential reads are not double-counted.
+                solid = SolidBlockReader(
+                    self._track_decompressed(
+                        self._open_folder_stream(raw.folder_index, member)
                     )
-                    previous = stream
-                    yield member, stream
-                    continue
-                if raw.folder_index != current_folder:
-                    if solid is not None:
-                        solid.close()
-                    current_folder = raw.folder_index
-                    # Count at the folder decode layer (solid invariant); member wraps
-                    # pass track_output=False so sequential reads are not double-counted.
-                    solid = SolidBlockReader(
-                        self._track_decompressed(
-                            self._open_folder_stream(raw.folder_index, member)
-                        )
-                    )
-                assert solid is not None
-                member_stream = self._member_stream_from_solid(solid, member)
-                previous = member_stream
-                yield member, member_stream
-        finally:
-            if previous is not None:
-                previous.close()
+                )
+            assert solid is not None
+            return self._member_stream_from_solid(solid, member)
+
+        def _cleanup() -> None:
             if solid is not None:
                 solid.close()
+
+        yield from self._drive_pass_streams(
+            iter(self._members),
+            open_member=_open,
+            close_previous=True,
+            cleanup=_cleanup,
+        )
 
     def _to_member(self, record: SevenZipFileRecord) -> ArchiveMember:
         member_type = self._member_type(record)

--- a/src/archivey/internal/backends/tar_reader.py
+++ b/src/archivey/internal/backends/tar_reader.py
@@ -444,6 +444,10 @@ class TarReader(BaseArchiveReader):
         # stream_members, and scan_members share one cursor and finalization.
         # close_previous=False: tarfile invalidates the prior extractfile handle on
         # advance; tracking previous would be incorrect.
+        # The driver's finally closes the last stream inside this translation context
+        # (pre-unify, only stream_members's finally closed it, outside translation).
+        # Close-time faults on the final member now surface typed; the outer
+        # stream_members finally still idempotently closes afterward.
         with self._translated_errors():
 
             def _open(member: ArchiveMember) -> ArchiveStream | None:

--- a/src/archivey/internal/backends/tar_reader.py
+++ b/src/archivey/internal/backends/tar_reader.py
@@ -442,23 +442,28 @@ class TarReader(BaseArchiveReader):
             return
         # Pull from the shared instance-held progressive pass so __iter__,
         # stream_members, and scan_members share one cursor and finalization.
+        # close_previous=False: tarfile invalidates the prior extractfile handle on
+        # advance; tracking previous would be incorrect.
         with self._translated_errors():
-            for member in self._begin_forward_pass():
-                if member.is_file:
-                    info = cast("tarfile.TarInfo", member._raw)
-                    with self._handle_guard():
-                        raw = self._tar.extractfile(info)
-                    if raw is None:
-                        raw = BytesIO(b"")
-                    stream: BinaryIO = ensure_binaryio(raw)
-                    if self._handle_lock is not None:
-                        stream = LockedStream(stream, self._handle_lock)
-                    yield (
-                        member,
-                        self._wrap_member_stream(stream, member.name, size=member.size),
-                    )
-                else:
-                    yield member, None
+
+            def _open(member: ArchiveMember) -> ArchiveStream | None:
+                if not member.is_file:
+                    return None
+                info = cast("tarfile.TarInfo", member._raw)
+                with self._handle_guard():
+                    raw = self._tar.extractfile(info)
+                if raw is None:
+                    raw = BytesIO(b"")
+                stream: BinaryIO = ensure_binaryio(raw)
+                if self._handle_lock is not None:
+                    stream = LockedStream(stream, self._handle_lock)
+                return self._wrap_member_stream(stream, member.name, size=member.size)
+
+            yield from self._drive_pass_streams(
+                self._begin_forward_pass(),
+                open_member=_open,
+                close_previous=False,
+            )
 
     def _capture_eof_probe(self, members: list[tarfile.TarInfo]) -> None:
         """Snapshot whether tarfile stopped the header scan on a *rejected* (non-null)

--- a/src/archivey/internal/base_reader.py
+++ b/src/archivey/internal/base_reader.py
@@ -807,6 +807,8 @@ class BaseArchiveReader(ArchiveReader):
 
         try:
             if child_scope:
+                # Also wraps ``_internal_member_opens()`` (live-stream gate exemption) —
+                # the two always travel together for eager link-data reads.
                 # Link-data reads are a private child scope under an active root when one
                 # exists; otherwise they only need the live-stream gate exemption.
                 root = self._state.current_root()

--- a/src/archivey/internal/base_reader.py
+++ b/src/archivey/internal/base_reader.py
@@ -447,6 +447,45 @@ class BaseArchiveReader(ArchiveReader):
         """
         ...
 
+    def _drive_pass_streams(
+        self,
+        members: Iterator[ArchiveMember],
+        *,
+        open_member: Callable[[ArchiveMember], ArchiveStream | None],
+        close_previous: bool = True,
+        cleanup: Callable[[], None] | None = None,
+        after_members: Callable[[], None] | None = None,
+    ) -> Iterator[tuple[ArchiveMember, ArchiveStream | None]]:
+        """Shared close-previous / open / yield / finally driver for ``_iter_with_data``.
+
+        Backends supply an ``open_member`` hook (return ``None`` for non-file members)
+        and an optional ``cleanup`` for pass-scoped resources (solid block, ``unrar``
+        pipe). ``close_previous=False`` is for TAR streaming, where tarfile invalidates
+        the prior ``extractfile`` handle on advance.
+
+        The driver **always** closes the last still-open stream in its ``finally``
+        before running ``cleanup`` — never tear down a solid block / pipe under a live
+        member wrapper. Double-close with ``stream_members``'s ``finally`` is fine:
+        ``ArchiveStream.close`` is idempotent.
+        """
+        previous: ArchiveStream | None = None
+        try:
+            for member in members:
+                if close_previous and previous is not None:
+                    previous.close()
+                    previous = None
+                stream = open_member(member)
+                if stream is not None:
+                    previous = stream
+                yield member, stream
+            if after_members is not None:
+                after_members()
+        finally:
+            if previous is not None:
+                previous.close()
+            if cleanup is not None:
+                cleanup()
+
     def _iter_with_data(self) -> Iterator[tuple[ArchiveMember, ArchiveStream | None]]:
         """Yield (member, stream) pairs in archive order; backs ``stream_members``.
 
@@ -477,22 +516,22 @@ class BaseArchiveReader(ArchiveReader):
         if members is None:
             report = self._materialize_members(enforce_listing_limits=False).report
             members = iter(report.members)
-        previous: ArchiveStream | None = None
-        for member in members:
-            if previous is not None:
-                previous.close()
-                previous = None
+
+        def _open(member: ArchiveMember) -> ArchiveStream | None:
             if member.is_file:
-                stream = self._lazy_member_stream(member)
-                previous = stream
-                yield member, stream
-            else:
-                yield member, None
-        if report is not None and report.error is not None:
-            raise report.error
-        # The last yielded stream (``previous``) is intentionally left open: the caller
-        # still holds it until they advance/close the generator (stream_members closes it
-        # in its finally). Closing it here would invalidate a handle the caller may still read.
+                return self._lazy_member_stream(member)
+            return None
+
+        def _raise_report_error() -> None:
+            if report is not None and report.error is not None:
+                raise report.error
+
+        yield from self._drive_pass_streams(
+            members,
+            open_member=_open,
+            close_previous=True,
+            after_members=_raise_report_error,
+        )
 
     def _lazy_member_stream(self, member: ArchiveMember) -> ArchiveStream:
         """A stream over ``member``'s data that defers ``_open_member`` to the first read.
@@ -732,31 +771,64 @@ class BaseArchiveReader(ArchiveReader):
         self._materialized = holder
         return holder
 
-    def _finalize_materialized_links(
+    def _finalize_links(
         self,
         members: list[ArchiveMember],
         by_name_lists: dict[str, list[ArchiveMember]],
+        *,
+        error: ArchiveyError | None = None,
+        child_scope: bool = False,
+        is_current_first: bool = False,
     ) -> None:
-        _apply_last_entry_wins_is_current(members)
-        if not any(member.is_link for member in members):
-            return
-        # Link-data reads are a private child scope under an active root when one
-        # exists; otherwise they only need the live-stream gate exemption.
-        root = self._state.current_root()
-        child = (
-            self._state.enter_child(root, "link_reads") if root is not None else None
-        )
+        """Resolve hardlink/symlink targets with one double-fault policy.
+
+        When ``error is not None`` (incomplete listing / terminal pass damage), a
+        secondary ``CorruptionError`` / ``TruncatedError`` during link-target reads is
+        swallowed so the recovered prefix stays publishable. When ``error is None``
+        (clean EOF / complete listing), secondary faults propagate.
+
+        Eager materialization stamps ``is_current`` *before* link resolve and uses a
+        child scope + internal-open exemption for link-data reads. Progressive finalize
+        stamps ``is_current`` *after* link resolve and does not open a child scope —
+        preserve those orderings unless a failing test forces convergence.
+        """
+        if is_current_first:
+            _apply_last_entry_wins_is_current(members)
+            if not any(member.is_link for member in members):
+                return
+
+        def _resolve() -> None:
+            for member in members:
+                if member.is_link:
+                    self._ensure_link_target(member)
+            for member in members:
+                if member.is_link and member.link_target:
+                    self._resolve_link(member, by_name_lists)
+
         try:
-            with self._internal_member_opens():
-                for member in members:
-                    if member.is_link:
-                        self._ensure_link_target(member)
-                for member in members:
-                    if member.is_link and member.link_target:
-                        self._resolve_link(member, by_name_lists)
-        finally:
-            if child is not None:
-                self._state.release_child(child)
+            if child_scope:
+                # Link-data reads are a private child scope under an active root when one
+                # exists; otherwise they only need the live-stream gate exemption.
+                root = self._state.current_root()
+                child = (
+                    self._state.enter_child(root, "link_reads")
+                    if root is not None
+                    else None
+                )
+                try:
+                    with self._internal_member_opens():
+                        _resolve()
+                finally:
+                    if child is not None:
+                        self._state.release_child(child)
+            else:
+                _resolve()
+        except (CorruptionError, TruncatedError):
+            if error is None:
+                raise
+
+        if not is_current_first:
+            _apply_last_entry_wins_is_current(members)
 
     def _materialize_members(
         self, *, enforce_listing_limits: bool = True
@@ -792,16 +864,15 @@ class BaseArchiveReader(ArchiveReader):
                     self._index_member_name(by_name_lists, member)
                     members.append(member)
             except (CorruptionError, TruncatedError) as exc:
-                # Keep the recovered prefix even if link finalization hits a second
-                # archive-damage fault (e.g. ZIP/7z/RAR symlink target bytes in the
-                # prefix are also truncated). Prefer the original listing error on the
-                # report; leave unresolved links as-is. Without this guard the secondary
-                # fault escapes to the outer BaseException handler and members_report()
-                # loses the prefix (members() raises either way).
-                try:
-                    self._finalize_materialized_links(members, by_name_lists)
-                except (CorruptionError, TruncatedError):
-                    pass
+                # Prefer the original listing error on the report; leave unresolved
+                # links as-is when a secondary link-target fault is swallowed.
+                self._finalize_links(
+                    members,
+                    by_name_lists,
+                    error=exc,
+                    child_scope=True,
+                    is_current_first=True,
+                )
                 holder = self._publish_materialized(
                     members,
                     by_name_lists,
@@ -810,7 +881,13 @@ class BaseArchiveReader(ArchiveReader):
                 self._state.complete_materialization()
                 return holder
 
-            self._finalize_materialized_links(members, by_name_lists)
+            self._finalize_links(
+                members,
+                by_name_lists,
+                error=None,
+                child_scope=True,
+                is_current_first=True,
+            )
             holder = self._publish_materialized(members, by_name_lists, error=None)
             self._state.complete_materialization()
             return holder
@@ -1025,22 +1102,13 @@ class BaseArchiveReader(ArchiveReader):
         # scan_members drains with enforcement: refuse to publish an over-limit report.
         if self._progressive_enforce_listing_limits:
             self._listing_tracker.assert_within_limits()
-        try:
-            for member in self._pass_scanned:
-                if member.is_link:
-                    self._ensure_link_target(member)
-            for member in self._pass_scanned:
-                if member.is_link and member.link_target:
-                    self._resolve_link(member, self._pass_by_name_lists)
-        except (CorruptionError, TruncatedError):
-            # Same double-fault guard as the RA incomplete path: when finalizing after
-            # terminal listing damage, a secondary link-target fault must not wipe the
-            # recovered prefix. On a clean EOF finalize (error is None) the secondary
-            # fault still propagates — caller poisons the pass instead of publishing
-            # a false-complete report.
-            if error is None:
-                raise
-        _apply_last_entry_wins_is_current(self._pass_scanned)
+        self._finalize_links(
+            self._pass_scanned,
+            self._pass_by_name_lists,
+            error=error,
+            child_scope=False,
+            is_current_first=False,
+        )
         self._publish_materialized(
             self._pass_scanned,
             self._pass_by_name_lists,
@@ -1663,9 +1731,9 @@ class _ProgressivePassIterator(Iterator[ArchiveMember]):
                 self._reader._finalize_pass_links(error=exc)
             except BaseException as finalize_exc:
                 # Non-archive-damage finalize failures (e.g. listing-limit refusal) must
-                # not leave a half-published cache. CorruptionError/TruncatedError during
+                # not leave a half-published cache. Secondary Corruption/Truncated during
                 # link finalization after terminal listing damage is swallowed inside
-                # _finalize_pass_links so the recovered prefix stays published.
+                # _finalize_links so the recovered prefix stays published.
                 self._error = finalize_exc
                 raise
             raise

--- a/tests/test_mutation_fuzz.py
+++ b/tests/test_mutation_fuzz.py
@@ -55,6 +55,7 @@ from __future__ import annotations
 
 import io
 import os
+import shutil
 import tempfile
 from collections.abc import Iterator
 from dataclasses import dataclass
@@ -65,12 +66,15 @@ import pytest
 
 from archivey import (
     AcceleratorMode,
+    ArchiveFormat,
     ArchiveyConfig,
     ArchiveyError,
     ExtractionLimits,
+    FormatSupport,
     OnError,
     OverwritePolicy,
     detect_format,
+    format_availability,
     open_archive,
 )
 from tests.sample_archives import (
@@ -80,6 +84,8 @@ from tests.sample_archives import (
     corpus_archive_path,
 )
 from tests.test_corpus_sweep import _skip_unless_runnable
+
+_RAR_FIXTURES = Path(__file__).resolve().parent / "fixtures" / "rar"
 
 # Bump to change every derived mutation (a fresh sweep of the mutation space).
 HARNESS_VERSION = 1
@@ -121,6 +127,37 @@ _PARAMS = [
     for kind in MUTATION_KINDS
     if _FUZZ_KIND is None or _FUZZ_KIND in kind
 ]
+
+# Static solid RAR fixtures (declarative CORPUS builders do not emit ``-s``).
+# Wave-1: the two basic solid archives; symlink/file-version solids are optional later.
+_SOLID_RAR_SOURCES: tuple[tuple[CorpusEntry, Path], ...] = (
+    (
+        CorpusEntry("basic-solid-rar5", (), ("rar",), requires_binaries=("unrar",)),
+        _RAR_FIXTURES / "basic_solid__.rar",
+    ),
+    (
+        CorpusEntry("basic-solid-rar4", (), ("rar",), requires_binaries=("unrar",)),
+        _RAR_FIXTURES / "basic_solid__rar4.rar",
+    ),
+)
+
+_SOLID_RAR_PARAMS = [
+    pytest.param(entry, path, kind, id=f"{entry.id}-rar-{kind}")
+    for entry, path in _SOLID_RAR_SOURCES
+    for kind in MUTATION_KINDS
+    if _FUZZ_KIND is None or _FUZZ_KIND in kind
+]
+
+
+def _skip_unless_solid_rar_runnable() -> None:
+    """Skip solid-RAR mutation when the reader or ``unrar`` decompressor is absent."""
+    availability = format_availability(ArchiveFormat.RAR)
+    if availability.support is FormatSupport.NONE:
+        pytest.skip(
+            f"format 'rar' not readable here: {availability.missing or 'no backend'}"
+        )
+    if shutil.which("unrar") is None:
+        pytest.skip("unrar unavailable")
 
 
 @dataclass(frozen=True)
@@ -417,8 +454,16 @@ def _exercise(
                     continue
                 try:
                     with ar.open(member) as f:
-                        while f.read(1 << 16):
-                            if f.tell() > _READ_CAP:
+                        # Track bytes locally: solid / forward-only streams are not
+                        # seekable, so ``f.tell()`` would raise a raw OSError and
+                        # break the typed-error invariant.
+                        got = 0
+                        while True:
+                            chunk = f.read(1 << 16)
+                            if not chunk:
+                                break
+                            got += len(chunk)
+                            if got > _READ_CAP:
                                 break
                 except ArchiveyError:
                     pass  # per-member decode failure: exactly the contract
@@ -464,6 +509,36 @@ def test_mutations_fail_typed_or_succeed(
 
             # Detection must uphold the same invariant on arbitrary bytes (it may return
             # any format, or raise FormatDetectionError — never a raw codec exception).
+            try:
+                detect_format(io.BytesIO(mutated))
+            except ArchiveyError:
+                pass
+            except Exception as exc:  # noqa: BLE001 - invariant check
+                pytest.fail(
+                    f"{_failure_context(entry, key, kind, seed, desc)} "
+                    f"detect_format raw {type(exc).__name__}: {exc!r}"
+                )
+
+    _clear_active_mutation()
+
+
+@pytest.mark.timeout(_FUZZ_TIMEOUT)
+@pytest.mark.parametrize(("entry", "path", "kind"), _SOLID_RAR_PARAMS)
+def test_solid_rar_mutations_fail_typed_or_succeed(
+    entry: CorpusEntry, path: Path, kind: str, tmp_path: Path
+) -> None:
+    """Solid RAR4/RAR5 demux under the same mutation invariant as declarative CORPUS."""
+    _skip_unless_solid_rar_runnable()
+    data = path.read_bytes()
+    key = "rar"
+    seed = mutation_seed(entry, key)
+
+    for desc, mutated in _mutations_for_test(data, seed, kind):
+        _set_active_mutation(entry, key, kind, seed, desc)
+        with tempfile.TemporaryDirectory(prefix="out-", dir=tmp_path) as out_raw:
+            out_dir = Path(out_raw)
+            _exercise(mutated, entry, key, out_dir, kind, seed, desc)
+
             try:
                 detect_format(io.BytesIO(mutated))
             except ArchiveyError:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements OpenSpec change `unify-pass-driver` (debt-ledger Q3 = pay before 0.2.0).

## What

- **T1:** Mutation fuzz now covers static solid RAR4/RAR5 fixtures (`basic_solid__.rar`, `basic_solid__rar4.rar`); skips cleanly without `unrar`. Harness read-cap no longer uses `tell()` (solid streams are non-seekable).
- **S2:** One `_finalize_links` helper with explicit double-fault policy; eager and progressive paths keep their existing `is_current` / child-scope ordering.
- **S3:** Shared `_drive_pass_streams` on `BaseArchiveReader`; base / TAR / 7z / RAR solid `_iter_with_data` rewritten to use it. Driver always closes the last stream in `finally` (then resource cleanup). TAR keeps `close_previous=False`.
- **Docs:** `review/debt-ledger/structural.md` updated to Q3=(b); QUESTIONS/STATUS/SUMMARY already recorded the decision.

## Review follow-up

- Inline note that `child_scope` also wraps `_internal_member_opens` (no rename).
- Comment on TAR path: last-stream close now runs inside `_translated_errors` (intentional; typed close faults).

## Verify

- Targeted solid RAR/7z, measurement, TAR streaming, double-fault, cooperative `stream_members` — green
- Full suite `[all]`: **1878 passed**, 58 skipped
- `openspec validate --strict unify-pass-driver` — valid
- `ruff` / `pyrefly` / `ty` — clean

Before merge: also run `[core-only]` and `[all-lowest]` per CONTRIBUTING.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dd611701-95a6-49cc-8323-ca9d7a311c3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dd611701-95a6-49cc-8323-ca9d7a311c3a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

