### PR TITLE
Propose verification-integrity-mode (STREAMING default + STRICT opt-in)

### DIFF
--- a/openspec/changes/verification-integrity-mode/.openspec.yaml
+++ b/openspec/changes/verification-integrity-mode/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: library
+created: 2026-07-21

--- a/openspec/changes/verification-integrity-mode/brief.md
+++ b/openspec/changes/verification-integrity-mode/brief.md
@@ -1,0 +1,18 @@
+<!--
+The "coffee brief": a spoken-word-friendly summary of this change, readable (or
+read aloud) in under a minute. Prose only — NO tables, NO code blocks, minimal
+symbols — so text-to-speech reads cleanly. Aim for ~200–280 words. Derive it from
+proposal.md / design.md / tasks.md; do not introduce new decisions here.
+-->
+
+# verification-integrity-mode — A streaming default and a strict opt-in for content verification
+
+**Status:** Design proposal, open questions on naming and where the small first half lands. Depends on the gzip truncation change. Effort: the default-consistency half is small; the strict mode is larger.
+
+**Why it matters:** Content verification today is verify-as-you-go. If you read a member fully, you get a verdict; if you read part of it, or seek, or read then close, verification is quietly abandoned. That is a deliberate streaming choice, but it means integrity is not guaranteed for every access pattern. Two things are inconsistent. Encrypted members break the rule the strict way: WinZip AES drains and checks its authentication tag on close, raising a corruption error from close, verifying a partial read that a checksummed member would not. Checksummed members break it the lax way: there is no way to demand full verification, which is exactly what extracting an untrusted archive wants.
+
+**What it does:** It makes verification a mode. The default, streaming, is uniform: a verdict only from the read that finishes the stream; partial reads, seeks, and close are quiet, and close never surfaces a first content fault, for checksums and encrypted members alike. The encrypted close-drain goes away, though a full read still authenticates. A new opt-in strict mode guarantees a verdict no matter how you read: it verifies the whole member before handing out untrusted bytes, forces a full pass around a seek, and completes verification on close, the same way for checksums and authentication tags. Strict can force a full decompress or decrypt in advance, so it knowingly breaks the performance budget, and that cost is documented.
+
+**Assessment:** Not overkill. It fits the safe-by-default and honest-cost goals, and it turns the encrypted always-authenticate behavior into one uniform mode instead of a per-format surprise.
+
+**Your call:** Names for the mode, whether the small default-consistency fix rides with the gzip change, and whether a strict seek verifies ahead or simply fails.

--- a/openspec/changes/verification-integrity-mode/design.md
+++ b/openspec/changes/verification-integrity-mode/design.md
@@ -1,0 +1,148 @@
+## Context
+
+Provenance: review of PR #183 (`gzip-zlib-truncation-recovery`). That change made
+"content faults surface from read, never from `close`" the contract for decode +
+verify streams, and made `MemberVerifier.finish_on_close` teardown-only. Two
+things fall out of that and motivate this change.
+
+### The default verification contract today
+
+`compressed-streams` ("Decompressed output digests are verified at clean EOF"):
+digests are computed incrementally and the verdict fires from the read that
+completes the stream (terminal empty `read`, or `read(-1)`). **Abandon = no
+verdict**: a partial read, a seek off the sequential frontier
+(`note_seek` disables verification), or a read-then-close that never hits the
+completing read consumes bytes without a verdict. This is a deliberate streaming /
+≤1.3× perf choice — you only pay to verify what you fully read.
+
+### The two asymmetries
+
+| Path | Today | Problem |
+| --- | --- | --- |
+| CRC/digest member, partial/seek/close | No verdict (quiet) | Correct for streaming, but no way to *demand* verification |
+| WinZip AES member, partial read then close | `close()` drains ciphertext + verifies HMAC, **raises `CorruptionError`** | Content fault from `close`; verifies an abandon a CRC member would not; per-format surprise |
+
+`WinZipAesDecryptStream.close` (`zip_aes.py`) intentionally drains "so a short-read
+caller still gets HMAC checked." That is a security instinct (don't hand out
+unauthenticated AE-2 plaintext) implemented as a per-format `close` side effect —
+exactly the inconsistency the mode below resolves.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+1. One **uniform** streaming default: verdict only from the completing read;
+   partial/seek/close abandon with no verdict; `close()` never a first content
+   fault — for digest **and** encrypted members alike.
+2. An opt-in **`STRICT`** mode that guarantees a verdict regardless of access
+   pattern (partial read, seek, close), uniformly for CRC/digest and auth tags.
+3. Honest cost: STRICT may decode/decrypt-ahead and breaks the ≤1.3× budget by
+   design; documented, never default.
+4. Encrypted "always authenticate" expressed as a **mode**, not a backend-specific
+   `close` behavior.
+
+**Non-Goals:**
+
+- Changing which algorithms are computable, or the `DIGEST_UNVERIFIABLE`
+  diagnostic model.
+- A per-member override in v1 (mode is archive-level `config`); revisit if needed.
+- Verified random-access indexes — STRICT on a seekable member may simply force a
+  full verifying pass rather than building a per-block MAC index.
+
+## Assessment — is a mode overkill? (the maintainer's question)
+
+**No — it is on-mission and it removes a special case rather than adding one.**
+
+- **VISION fit.** "Safe by default," "damaged/hostile input is first-class," and
+  "honest cost signals" all point at *offering guaranteed verification with a
+  truthful price*, not at forcing it on every read (which would blow the perf
+  budget) nor at hiding it per-format.
+- **It resolves the AES inconsistency instead of entrenching it.** "Always
+  authenticate encrypted content" becomes `STRICT`, applied uniformly to every
+  integrity check, so the default stops being "CRC lax, AES strict-on-close."
+- **The default stays cheap.** Streaming verification (verify what you fully read)
+  keeps the ≤1.3× budget; STRICT is the opt-in for untrusted-archive extraction.
+
+**Where the cost is real** (so it is *not* free, and should be its own change, not
+folded into the gzip PR):
+
+- STRICT on a **seekable** member must either verify-ahead (buffer / re-decode the
+  whole member) or fail the seek — there is no cheap "verify a random-access read."
+- STRICT must intercept the seek-disables-verification path and the partial-read
+  path, which is real machinery in `MemberVerifier` / the fused `ArchiveStream`.
+- Interaction with `extraction_limits` (a STRICT verify-ahead must still honor
+  output caps / bomb bounds).
+
+**Verdict:** worth doing, as a **separate** change. The *default-consistency* half
+(remove the AES close-drain; `close` never a content fault, uniformly) is small
+and unblocks the gzip PR's contract; the `STRICT` half is the larger, opt-in piece.
+
+## Decisions
+
+1. **`VerificationMode` on `ArchiveyConfig`.** `STREAMING` (default) and `STRICT`.
+   Archive-level for v1 (mirrors `strict_archive_eof`, `extraction_limits`). Naming
+   open (see Q1). **Rejected:** a bare `verify_strict: bool` — an enum leaves room
+   for a future `OFF` (skip verification) or `EAGER` variant without a breaking flag.
+
+2. **Default `STREAMING` is uniform across digest and auth tags.** Verdict only
+   from the completing read; partial/seek/close abandon; `close()` never surfaces a
+   first content `TruncatedError` / `CorruptionError`. **Encrypted members follow
+   this too:** the WinZip AES HMAC still fires on a full read (the authenticating
+   bytes are consumed), but the `close`-time drain is removed from the default
+   path. **Rejected:** keep AES authenticating on close in the default — it is the
+   inconsistency this change exists to remove.
+
+3. **`STRICT` guarantees a verdict regardless of access pattern**, uniformly:
+   - Partial read of a member whose integrity cannot yet be confirmed: STRICT does
+     not silently hand out un-verifiable bytes — it forces a full verifying pass
+     and raises on a corrupt/tampered member (subject to bomb/output caps).
+   - A seek that would disable frontier verification: STRICT forces a full verifying
+     pass first, or fails the seek with a typed error — never silently drops the
+     check.
+   - `close()` after a partial read: STRICT completes verification (drain + verdict)
+     — this is the *mode's* behavior, applied to every integrity check, replacing
+     the per-format AES close-drain.
+   **Rejected:** STRICT that only tightens `close` (still lets a mid-stream seek
+   skip verification) — that would leave a silent hole.
+
+4. **Honest cost.** STRICT is documented as breaking the ≤1.3× budget (it may fully
+   decode/decrypt ahead of use). The cost model / `costs` doc states it; STRICT is
+   never selected implicitly.
+
+5. **Sequencing.** Land Decision 2 (default-consistency: remove the AES close-drain;
+   uniform quiet close) first — it is small and completes the gzip PR's contract.
+   Decision 3 (`STRICT`) follows as the larger opt-in piece. Both can ship in this
+   change or Decision 2 can be pulled into the gzip PR; see Q2.
+
+## Open Questions
+
+1. **Names.** `VerificationMode.{STREAMING, STRICT}` vs. `{LAZY, EAGER}` vs.
+   `{AS_YOU_GO, FULL}`; field name `verification_mode`. Also: do we want a third
+   `OFF` (skip verification entirely) now or later?
+
+2. **Where does the default-consistency fix land?** In this change, or pulled into
+   `gzip-zlib-truncation-recovery` (since it completes that change's
+   "close never raises a content fault" claim for encrypted members too)? The
+   `gzip` change's spec already says "close never a first content fault"; the AES
+   close-drain is currently a live exception to it.
+
+3. **STRICT on seekable members: verify-ahead vs. fail-the-seek.** Buffer/re-decode
+   the whole member to verify (costly, but random access keeps working) or refuse a
+   seek in STRICT with a typed error (cheap, but less capable)? Recommendation:
+   verify-ahead when the source is seekable and within `extraction_limits`, else a
+   typed error.
+
+4. **Security nuance for encrypted members in STREAMING.** Removing the AES
+   close-drain means a partial read of an encrypted member returns *unauthenticated*
+   AE-2 plaintext with no error (same posture as unverified CRC). Confirm this is
+   acceptable as the default (a partial read *cannot* authenticate anyway — the MAC
+   is at the end), with STRICT as the answer for callers who must authenticate.
+
+## Risks / Trade-offs
+
+| Risk | Mitigation |
+| --- | --- |
+| STRICT silently blows the perf budget | Documented cost; never default; honest `costs` entry |
+| Removing AES close-drain weakens default integrity | STREAMING default matches CRC posture; STRICT restores guaranteed auth uniformly; full reads still authenticate |
+| STRICT verify-ahead as a new bomb surface | Reuse `extraction_limits` / output caps in the verify-ahead pass |
+| Mode proliferation / config surface growth | Enum with a small, documented set; archive-level only in v1 |

--- a/openspec/changes/verification-integrity-mode/proposal.md
+++ b/openspec/changes/verification-integrity-mode/proposal.md
@@ -1,0 +1,86 @@
+## Why
+
+Decompressed-content verification (CRC/digest, declared length, and encrypted
+members' authentication tags) is **verify-as-you-go**: the verdict fires from the
+read that completes the stream, and a partial read, a seek off the sequential
+frontier, or a read-then-close **abandons** verification with no verdict. That is
+a deliberate streaming / perf-budget choice, but it means integrity is **not
+guaranteed for every access pattern** — a caller can consume unverified (and for
+encrypted members, unauthenticated) bytes and get no error.
+
+Two inconsistencies make this sharp:
+
+- **Encrypted members break the rule in the *strict* direction.** WinZip AES
+  (`WinZipAesDecryptStream.close`) drains the remaining ciphertext and verifies
+  the trailing HMAC **on `close()`**, raising `CorruptionError` from close even
+  for a partial-read caller. That surfaces a content fault from close (the very
+  thing `compressed-streams` now forbids), verifies partial-read abandons that a
+  CRC member would not, and makes the same access pattern behave differently by
+  format — a "no surprises" violation.
+- **Digest/CRC members break it in the *lax* direction.** A caller that reads a
+  fixed prefix, or seeks, then closes gets no verdict — acceptable for streaming,
+  but there is no opt-in for "verify everything regardless of how I read it,"
+  which is exactly what extracting untrusted archives wants.
+
+The uniform, honest fix is a **verification mode**: a consistent streaming
+default (no content fault ever from `close`, for CRC *and* AES alike) plus an
+opt-in strict mode that guarantees verification independent of access pattern.
+
+Depends on `gzip-zlib-truncation-recovery` (the "content faults raise from read,
+never from close" requirement and the `finish_on_close` teardown-only close).
+
+## What Changes
+
+- **Default (`STREAMING`) made uniform.** Content verdicts (digest, length,
+  auth-tag) fire only from the completing read; partial read / seek-off-frontier /
+  read-then-close abandon with no verdict; `close()` never surfaces a first
+  content fault — **including encrypted members**. The WinZip AES close-drain is
+  removed from the default path (the HMAC still fires on a full read, when the
+  authenticating bytes are consumed).
+- **New opt-in `VerificationMode.STRICT`** on `ArchiveyConfig`. STRICT guarantees
+  a verdict regardless of access pattern, uniformly for CRC/digest *and* encrypted
+  auth tags:
+  - a member whose integrity cannot be confirmed never returns bytes that are
+    silently trusted — STRICT verifies the whole member (decompress/decrypt-ahead)
+    and raises before/at the point the unverifiable bytes would be handed out;
+  - a seek that would disable frontier verification first forces a full verifying
+    pass (or fails the seek) rather than silently dropping the check;
+  - `close()` after a partial read completes verification (drain + verdict).
+- **Honest cost signal.** STRICT can force a full decompress/decrypt ahead of use
+  and therefore **breaks the ≤~1.3× budget by design**; the cost model / docs say
+  so, and the mode is never the default.
+- **Encrypted-member policy is a mode, not a per-format special case.** "Always
+  authenticate" becomes STRICT behavior applied uniformly, not a gzip-vs-AES
+  surprise baked into one backend's `close`.
+
+## Capabilities
+
+### New Capabilities
+
+<!-- none -->
+
+### Modified Capabilities
+
+- `compressed-streams` — verification timing becomes a documented **mode**:
+  a uniform streaming default (no content fault from `close` for digest *and*
+  auth-tag members; abandon = no verdict) and an opt-in `STRICT` mode guaranteeing
+  a verdict across partial reads, seeks, and close, with an honest cost signal.
+
+## Impact
+
+- Modules: `config.py` (`VerificationMode` enum + `ArchiveyConfig` field);
+  `internal/streams/verify.py` (`MemberVerifier` mode plumbing);
+  `internal/zip_aes.py` (`WinZipAesDecryptStream.close` no longer drains/authenticates
+  in the default mode); the fused `ArchiveStream` path; possibly the seek path that
+  disables verification.
+- Public API: new `VerificationMode` + `ArchiveyConfig.verification_mode`
+  (default `STREAMING`); no change to the streaming default's observable behavior
+  except that encrypted members no longer raise a content fault from `close` in
+  the default mode.
+- Deps/extras: none.
+- Tests: default — AES partial-read-then-close is quiet, full read still
+  authenticates; STRICT — partial read of a corrupt/tampered member raises,
+  seek-then-read still verifies (or the seek fails), close completes verification;
+  parity across CRC and AES.
+- Docs: `costs` (STRICT breaks the budget), `safe-extraction` (when to use STRICT),
+  `usage` (the config knob), a decision note.

--- a/openspec/changes/verification-integrity-mode/specs/compressed-streams/spec.md
+++ b/openspec/changes/verification-integrity-mode/specs/compressed-streams/spec.md
@@ -1,0 +1,94 @@
+## ADDED Requirements
+
+### Requirement: Content verification runs in a selectable mode
+
+`ArchiveyConfig` SHALL expose a `verification_mode` (`VerificationMode`) with at
+least `STREAMING` (default) and `STRICT`. The mode governs decompressed-content
+verification — digest/CRC, declared length, and encrypted-member authentication
+tags — **uniformly across formats** (a digest member and an encrypted member
+behave the same for a given mode).
+
+**`STREAMING` (default).** Verification is sequential and lazy: a content verdict
+(`CorruptionError` for a digest/auth mismatch, `TruncatedError` for a hash-less
+short) SHALL surface only from the read that completes the stream (the terminal
+empty `read`, or `read(-1)` / `readall`). A partial read, a seek off the
+sequential frontier, or a read-then-close that never reaches the completing read
+SHALL **abandon** verification with no verdict. `close()` SHALL NOT surface a
+first content fault — **including encrypted members**. An encrypted member's
+authentication tag SHALL still be verified when a full read consumes the
+authenticating bytes, but SHALL NOT be force-drained and verified from `close()`.
+
+**`STRICT`.** Verification SHALL be guaranteed regardless of access pattern,
+uniformly for digest and auth-tag members:
+
+- A member whose integrity cannot be confirmed SHALL NOT silently yield bytes that
+  are then trusted: on a partial read STRICT SHALL force a full verifying pass and
+  raise on a corrupt/tampered/short member, subject to `extraction_limits` /
+  output caps (a bounded verify-ahead, never an unbounded slurp).
+- A seek that would disable frontier verification SHALL first force a full
+  verifying pass, or SHALL fail the seek with a typed error — never silently drop
+  the check.
+- `close()` after a partial read SHALL complete verification (drain to EOF and run
+  the verdict) — this is the mode's behavior applied to every integrity check,
+  replacing any per-format close-time authentication.
+
+STRICT MAY require a full decompress/decrypt ahead of use and therefore MAY exceed
+the ≤~1.3× stdlib budget; this cost SHALL be documented and STRICT SHALL never be
+selected implicitly.
+
+#### Scenario: verification mode matrix
+
+| Case | STREAMING (default) | STRICT |
+| --- | --- | --- |
+| Full read of a good member | Verdict on completing read; passes | Passes |
+| Full read of a corrupt member | `CorruptionError` on completing read | `CorruptionError` |
+| Partial read then close, corrupt member | No verdict (quiet) | Full verifying pass; raises `CorruptionError` |
+| Seek off frontier then read, corrupt member | No verdict (verification disabled) | Full verifying pass first, or seek fails with a typed error |
+| Encrypted member, full read, bad HMAC | `CorruptionError` on completing read | `CorruptionError` |
+| Encrypted member, partial read then close, bad HMAC | No verdict (quiet); `close()` does not drain/authenticate | Full verifying pass; raises `CorruptionError` |
+| STRICT verify-ahead vs. a decompression bomb | n/a | Bounded by `extraction_limits`; over-cap raises, never unbounded slurp |
+
+## MODIFIED Requirements
+
+### Requirement: Decompressed output digests are verified at clean EOF
+
+The verification stage SHALL compute available expected digest algorithms
+incrementally over decompressed bytes and raise `CorruptionError` for a
+computable mismatch at clean EOF. In the default `STREAMING` mode a mismatch SHALL
+surface from the read that completes the stream (the terminal empty `read`, or a
+bytes-returning full `read(-1)` / `readall`, which raises and returns no bytes);
+partial/random-access reads SHALL NOT produce a digest verdict, and `close()`
+SHALL NOT be the sole surface for a digest or short-length verdict. This
+lazy-abandon behavior is the `STREAMING` contract; `STRICT` guarantees a verdict
+regardless of access pattern (see "Content verification runs in a selectable
+mode"). The timing and close rules apply **uniformly to encrypted-member
+authentication tags**: an auth-tag mismatch is a content fault subject to the same
+mode contract, and MUST NOT be surfaced as a first content fault from `close()` in
+`STREAMING`.
+
+Supported computable algorithms SHALL include `crc32` (via `zlib.crc32`),
+`adler32` (via `zlib.adler32`), the `hashlib.algorithms_available` set, and
+`blake2sp` (the 8-way parallel BLAKE2s tree hash used by RAR5), computed via an
+internal zero-dependency hasher. A well-formed member carrying only a `blake2sp`
+digest SHALL therefore be verified, not skipped. When an expected `adler32` is
+installed on a verifying stream, it SHALL likewise be computed and checked (not
+skipped as unknown).
+
+When an expected digest cannot be computed because the algorithm is genuinely unknown
+or a backend is missing, the system SHALL emit `DIGEST_UNVERIFIABLE` with algorithm,
+non-secret reason, and member identity when available. Diagnostic policy controls
+collection, logging/callback delivery, member attachment, and escalation.
+
+#### Scenario: digest matrix
+
+| Case | Expected |
+| --- | --- |
+| Expected `blake2sp` on a well-formed RAR5 member | Computed and verified; mismatch raises `CorruptionError` |
+| Expected `adler32` on a verifying stream | Computed and verified; mismatch raises `CorruptionError` |
+| Expected digest under a genuinely-unknown algorithm name | `DIGEST_UNVERIFIABLE` counted/retained/logged; bytes still returned without that check |
+| Full member read reaches EOF with computable digest mismatch | `CorruptionError` naming the algorithm |
+| Chunked read reaches EOF with mismatch | All valid chunks delivered; following terminal read raises |
+| Caller abandons stream before clean EOF (`STREAMING`) | No digest verdict or mismatch exception |
+| Caller abandons stream before clean EOF (`STRICT`) | Full verifying pass forced; mismatch raises |
+| Encrypted-member auth-tag mismatch, partial read then close (`STREAMING`) | No verdict; `close()` does not authenticate |
+| Unverifiable digest resolves to `RAISE` | `DiagnosticRaisedError` halts open/read |

--- a/openspec/changes/verification-integrity-mode/tasks.md
+++ b/openspec/changes/verification-integrity-mode/tasks.md
@@ -1,0 +1,67 @@
+# Tasks — verification integrity mode (STREAMING default + STRICT opt-in)
+
+> Depends on `gzip-zlib-truncation-recovery` (read-path verdicts;
+> `finish_on_close` teardown-only). Decisions/naming still open — see
+> `design.md` Open Questions (confirm Q1 names and Q2 landing spot before coding).
+
+## 1. Default-consistency (small; completes the never-raise-on-close contract)
+
+- [ ] 1.1 Remove the authenticate-on-`close` drain from
+      `WinZipAesDecryptStream.close` (`zip_aes.py`): `close` closes the source and
+      wrapper, never drains ciphertext / verifies the HMAC. The HMAC still fires on
+      a full read (when `_pull` consumes the MAC). Result: default (`STREAMING`)
+      encrypted members never surface a content fault from `close`.
+- [ ] 1.2 Confirm the fused `ArchiveStream` + `MemberVerifier` path and the plain
+      decode path close a partially-read encrypted member quietly, matching CRC
+      members (parity with the `gzip-zlib-truncation-recovery` close contract).
+- [ ] 1.3 Tests: encrypted member — full read with a bad HMAC raises
+      `CorruptionError` on the completing read; partial read then `close` is quiet;
+      a wrong-password fast-fail (pre-stream) still raises at open, unchanged.
+
+## 2. `VerificationMode` config surface
+
+- [ ] 2.1 Add `VerificationMode` (`STREAMING` default, `STRICT`) and
+      `ArchiveyConfig.verification_mode` (per Q1 naming). Thread it to
+      `MemberVerifier` / the fused stream construction.
+- [ ] 2.2 `STREAMING` keeps today's behavior (verify-as-you-go; abandon = no
+      verdict; close never a first content fault) — assert no observable change
+      except 1.x.
+
+## 3. `STRICT` mode
+
+- [ ] 3.1 Partial read in STRICT: force a bounded full verifying pass (honoring
+      `extraction_limits` / output caps) before the stream is considered done;
+      raise `CorruptionError` / `TruncatedError` on a corrupt/tampered/short member.
+- [ ] 3.2 Seek in STRICT that would disable frontier verification: force a full
+      verifying pass first, or fail the seek with a typed error (Q3 — pick per
+      seekable source + limits). Never silently drop the check.
+- [ ] 3.3 `close()` in STRICT after a partial read: complete verification
+      (drain + verdict), uniformly for digest and auth-tag members.
+- [ ] 3.4 STRICT verify-ahead must not become a bomb: cap by `extraction_limits`;
+      over-cap raises rather than slurping unbounded.
+
+## 4. Tests
+
+- [ ] 4.1 Mode matrix (spec): STREAMING vs STRICT × {full read, partial+close,
+      seek+read} × {good, corrupt, short} × {CRC/digest, encrypted}.
+- [ ] 4.2 Parity: a digest member and an encrypted member behave identically for a
+      given mode.
+- [ ] 4.3 STRICT bomb bound: a highly compressible corrupt member verify-ahead
+      stops at the cap.
+- [ ] 4.4 Three dependency configs where crypto/extras affect the path
+      (`[all]`, `[all-lowest]`, `[core-only]`).
+
+## 5. Docs
+
+- [ ] 5.1 `costs`: STRICT breaks the ≤~1.3× budget (full decode/decrypt ahead of
+      use); STREAMING is the budgeted default.
+- [ ] 5.2 `safe-extraction`: when to choose STRICT (untrusted archives / mandatory
+      authentication); note STREAMING returns unauthenticated bytes on a partial
+      read of an encrypted member.
+- [ ] 5.3 `usage`: the `verification_mode` knob; decision note recording the AES
+      close-drain removal and the mode rationale.
+
+## 6. Verify
+
+- [ ] 6.1 Targeted pytest for §§1–4; `pyrefly check` + `ty check`; `ruff`.
+- [ ] 6.2 `openspec validate --strict verification-integrity-mode`.


### PR DESCRIPTION
## Summary

OpenSpec change proposal (docs only) — a follow-up from the PR #183 review. No code. `openspec validate --strict verification-integrity-mode` passes.

Content verification is **verify-as-you-go**: a full read yields a verdict, but a partial read / seek / read-then-close abandons verification silently. Two inconsistencies:
- **Encrypted members** break it the *strict* way — `WinZipAesDecryptStream.close` drains and verifies the HMAC on `close()`, raising a content fault from close and verifying an abandon a CRC member wouldn't (a per-format surprise, and a close-time content fault the `compressed-streams` contract forbids).
- **Digest/CRC members** break it the *lax* way — no opt-in for "verify everything regardless of how I read," which untrusted-archive extraction wants.

## Proposal

- **`STREAMING` (default), made uniform** — verdict only from the completing read; partial/seek/close abandon with no verdict; `close()` never a first content fault, **including encrypted members** (the AES close-drain is removed; a full read still authenticates).
- **`VerificationMode.STRICT` (opt-in)** — guarantees a verdict regardless of access pattern (bounded verify-ahead on partial reads, force-or-fail around seeks, complete on close), uniformly for digest and auth tags, with an **honest cost signal** (STRICT can break the ≤~1.3× budget by design).
- Turns encrypted "always authenticate" into a **mode**, not a backend-specific `close` side effect.

## Assessment (the "is a config overkill?" question)

Not overkill — it's on-mission (VISION safe-by-default + honest cost) and it *removes* the AES special case rather than adding one. The default-consistency half is small and completes PR #183's "close never a content fault" claim; the STRICT half is the larger opt-in piece. Details and the cost caveats are in `design.md`.

## Open questions (in `design.md`)

1. Mode/field names (`STREAMING`/`STRICT` vs `LAZY`/`EAGER`…; a future `OFF`?).
2. Whether the small default-consistency fix rides with `gzip-zlib-truncation-recovery` instead.
3. STRICT on seekable members: verify-ahead vs. fail-the-seek.
4. Confirm STREAMING returning unauthenticated bytes on a partial read of an encrypted member is the accepted default.

## Testing

- `openspec validate --strict verification-integrity-mode` → valid. No source/test changes (proposal-stage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01B95mCP2hhHZp199PAuK6Q4)_