### PR TITLE
ADR 0014: integrity verdicts surface from reads, never close()

### DIFF
--- a/docs/decisions/0014-integrity-verdicts-from-reads-not-close.md
+++ b/docs/decisions/0014-integrity-verdicts-from-reads-not-close.md
@@ -1,6 +1,6 @@
 # 0014 — Integrity verdicts surface from reads, never from `close()`
 
-- **Status:** proposed
+- **Status:** accepted
 - **Date:** 2026-07 (review of `gzip-zlib-truncation-recovery`, PR #183)
 - **Provenance:** OpenSpec `compressed-streams` (digest verification, read-vs-close
   fault split); `VISION.md` (no silent success; damaged input is first-class);

--- a/docs/decisions/0014-integrity-verdicts-from-reads-not-close.md
+++ b/docs/decisions/0014-integrity-verdicts-from-reads-not-close.md
@@ -45,7 +45,8 @@ contract guarantees.**
 
 - **A — raise on the read that reaches the end.** The read that completes the member
   and finds damage raises (returning no bytes for that call); `close()` never raises.
-  Matches stdlib `zipfile` / `gzip`.
+  Same *failure surface* as stdlib `zipfile` / `gzip` (fault on read, not close) — not
+  byte-identical timing (their large-read / EOF shapes differ).
 - **B — deliver every byte, then raise on the next read; `close()` as a backstop.**
   Uniform for corruption and truncation, but makes a *safety* guarantee depend on
   `close()` actually running — unreliable (GC-driven close is not guaranteed and
@@ -107,9 +108,15 @@ objects to be full-count — the wrapper coalesces.)
 
 Content-integrity verdicts (stored checksum / digest, encrypted-member authentication
 tag, truncation, and declared-size over-run) are delivered from a **`read()` call,
-never from `close()`**. `close()` is teardown-only: it may still propagate a
-resource/teardown error (a subprocess exit code, an inner stream that authenticates in
-its *own* `close()`), but it never introduces a first content fault.
+never from `close()`**. `close()` is teardown-only. It MAY still propagate an
+*unavoidable teardown signal raised by the underlying resource itself* — an `OSError`
+closing a file descriptor, or a subprocess exit code that only arrives when the process
+is reaped (e.g. `unrar` reporting a wrong password on close). It MUST NOT surface the
+**verifier's own** content verdict (checksum / auth / truncation) as a first fault on
+`close()`. One current construct violates this — the WinZip AES stream drains and
+verifies its HMAC in its own `close()` — and is treated as a **known inconsistency to
+remove** (`verification-integrity-mode` Decision 2), **not** a blessed carve-out; until
+it is removed, this guarantee is library-wide *except* for that one path.
 
 A member is verified at the moment a read **reaches its end** — whichever comes first:
 
@@ -126,11 +133,16 @@ At that moment:
 - **Over-run** (decode output exceeds the declared size — a corrupt length field): the
   read that would cross the declared size raises `CorruptionError`, **independent of
   the checksum** (the over-run itself is the corruption, even if the hash-so-far would
-  pass).
+  pass). This is the same stop-at-declared-size → `CorruptionError` bound that
+  `gzip-zlib-truncation-recovery` already specifies as the decompression-bomb cap.
 - **Truncation / short** (decoder end-of-stream before the declared size, or an
   incomplete decode): every recoverable byte was delivered on the preceding full-count
   reads; the read that reaches the short end returns the remaining prefix (a **short
   return**, not an exception), and the *next* read raises `TruncatedError`.
+
+Reaching the declared size is **always** a verifying event — checksum *and* over-run —
+regardless of how the caller got there (`read(n)` with `n == remaining`, or a chunked
+loop). The verdict is a property of *reaching the end*, not of the call shape.
 
 A read that **stops before the end** — at any offset — produces **no verdict**, and
 `close()` stays silent. A seek off the sequential frontier disables the **checksum**
@@ -173,6 +185,23 @@ Corruption is caught whenever such a read reaches the end — independent of whe
 `VerificationMode.STRICT` (`verification-integrity-mode`), which fully verifies a
 member before returning any of it.
 
+### Call × failure matrix (size-declared member)
+
+| Call | Corrupt at full length | Truncated short of declared size |
+| --- | --- | --- |
+| `read(member.size)` | raises `CorruptionError` | returns short (`len < size`), **no exception** |
+| `read(-1)` / `readall` | raises `CorruptionError` | raises `TruncatedError` |
+| chunked until `b""` | raises on the read that reaches the size (withholds that chunk) | delivers the whole prefix (final read returns short); the read *past* the prefix raises `TruncatedError` |
+| partial read, then `close()` | quiet (early stop) | quiet (early stop) |
+
+The load-bearing asymmetry: **`read(member.size)` raises on corruption but returns a
+short buffer on truncation** — because corruption yields wrong bytes (withheld) while
+truncation yields a correct-but-incomplete prefix (delivered). A single-call caller who
+wants to catch both must check `len(data) == member.size` (or use `read(-1)`); **"no
+exception" does not mean "complete."** Size-unknown members have no `member.size` to
+read to, so a bare `read(n)` cannot self-certify at all — use `read(-1)` /
+read-to-`b""`.
+
 ## Open questions
 
 1. **Encrypted members — a defaults question, not just docs.** Treating an
@@ -205,11 +234,32 @@ member before returning any of it.
 
 ## Consequences
 
+- **Resolves the open question that parked `gzip-zlib-truncation-recovery` (#183).**
+  This ADR exists *because* #183's review surfaced the read-vs-close / sized-read hole;
+  the #183 implementation is on hold pending it. #183's earlier Decision 8 — a bounded
+  `read(n)` on a digest mismatch delivers every byte and raises on the terminal empty
+  read ("do not withhold the last data chunk";
+  `test_verify_mismatch_raises_at_eof_without_losing_final_chunk`) — is **revised** by
+  this ADR for the corruption case: the read that reaches the declared size (or decoder
+  EOS) raises and **withholds** that chunk. When #183 resumes, its delta and that test
+  are updated to the withhold-on-reaching-read rule so the two texts agree — not a live
+  conflict, but the settlement that unblocks #183. **Truncation is unchanged** —
+  #183's recoverable-prefix delivery stands.
 - **`read(member.size)` on a corrupt size-declared member raises from that read** and
   returns nothing — closing the silent-acceptance regression, without depending on
-  `close()`. This **reverses "deliver every byte even on a checksum mismatch"**: a
-  corrupt member's final chunk is now withheld. Truncation is unchanged — its
-  recoverable prefix is still delivered.
+  `close()`.
+- **High-level helpers read to the true end.** `extract()` and any whole-member helper
+  MUST consume each member with a *completing* read (`read(-1)`, or a sized read plus a
+  drain to `b""`), so the default extraction path raises `TruncatedError` on a short
+  member rather than silently writing a truncated file. The quiet-truncation short
+  return is a **low-level** `read(member.size)` affordance for callers who opt into it,
+  never the default `extract` behavior.
+- **STRICT is proposed, not shipped (sequencing).** The escape hatch for "never release
+  unverified / unauthenticated bytes" is `VerificationMode.STRICT`
+  (`verification-integrity-mode`, still proposed). This ADR's STREAMING default is
+  accepted now; STRICT is sequenced after. Until it lands, STREAMING —
+  detection-not-prevention — is the only posture, so **encrypted members stream
+  unauthenticated plaintext by default** in the interim.
 - **Full-count `read` is now a contract**, not an accident. The wrapper must coalesce
   short inner reads (bounded reads must loop the inner to `n`-or-terminal, as the
   `read(-1)` drain already does). A short return from a public archivey stream is a

--- a/docs/decisions/0014-integrity-verdicts-from-reads-not-close.md
+++ b/docs/decisions/0014-integrity-verdicts-from-reads-not-close.md
@@ -93,16 +93,27 @@ raises, independent of whether `close()` runs.
 
 ## Decision
 
-### Full-count `read`
+### Full-count `read` — a committed contract, not an accident
 
-archivey's stream `read(n)` (`n ≥ 1`) returns **exactly `n` bytes until a terminal
-boundary** — clean end-of-stream, truncation, or a raised content error. It never
-returns short on healthy, non-terminal data. Consequently a short return **means a
-terminal boundary was reached**, and reading is a reliable way to reach a member's end
-(`read(-1)`, read-until-`b""`, or `read(member.size)` for a size-declared member).
-(`read(0)` is a no-op, never EOF. This full-count guarantee applies to the public
-`ArchiveStream`/codec-stream `read`; it does not require arbitrary *inner* `BinaryIO`
-objects to be full-count — the wrapper coalesces.)
+archivey's public stream `read(n)` (for `n ≥ 1`) is **full-count**: it returns
+**exactly `n` bytes** unless it reaches a terminal boundary — clean end-of-stream,
+truncation, or a raised content error. It does **not** return short on healthy,
+non-terminal data (unlike a raw `io.RawIOBase.read`; like `io.BufferedReader`). Two
+consequences the rest of this ADR depends on:
+
+- a **short return is a terminal signal** — clean EOF, or a truncation prefix; never
+  "healthy data, ask again";
+- **`read(member.size)` reaches the declared size in one call**, which is what makes it
+  a verifying event and closes the motivating regression.
+
+This is a **library-wide contract delta**, not something already true everywhere. Today
+`DecompressorStream.read` coalesces, but `MemberVerifier.read` issues a single
+`inner.read(want)`, and an unverified `ArchiveStream` passes `read(n)` straight to its
+inner (e.g. ZIP's `ZipExtFile`). Adopting this ADR makes full-count part of the
+`compressed-streams` stream contract: **every public `read(n)` path must coalesce to
+`n`-or-terminal** (or document an explicit exception). `read(0)` is a no-op, never EOF.
+The contract binds the public `ArchiveStream` / codec-stream surface; arbitrary *inner*
+`BinaryIO` objects need not be full-count — the wrapper coalesces over them.
 
 ### Where the verdict fires
 
@@ -164,20 +175,25 @@ some wrong bytes." A single-call reader distinguishes the two by length:
 
 ## Guarantee (for users)
 
-> **Read a member to its end and a damaged member raises on a `read()`. Stop before
-> the end and it is not verified. `close()` never raises a content error.**
+> **Read a member to its end: a corrupt member raises `CorruptionError` on a `read()`;
+> a truncated member raises `TruncatedError` or returns short of its declared size; a
+> clean member returns all its bytes, checksum-verified. Stop before the end and it is
+> not verified. `close()` never raises a content error.**
 
 "To its end" means `read(-1)` / `readall`, reading until `read()` returns `b""`, or —
 for a member with a **declared** size — reading that many bytes. For that whole-member
-read:
+read, each outcome tells you exactly what you can trust:
 
-- an **exception** means the member is corrupt (`CorruptionError`) or truncated
-  (`TruncatedError`) — **discard everything read; none of it is trustworthy**;
+- a **`CorruptionError`** means the content is wrong — **discard everything read from
+  this member; none of it is trustworthy** (the raising call returns nothing);
+- a **`TruncatedError`** means the member is incomplete — the bytes **already returned
+  on prior reads are correct** (a salvageable prefix), but the member is not whole; the
+  raising call itself returns nothing;
 - a **full-length** return (`len == member.size`, or a subsequent `b""`) means the
-  content was **checksum-verified**;
+  content was **checksum-verified** — trust it;
 - a **short** return (`len < member.size`, no exception) means **truncation** — the
-  bytes are correct but the member is incomplete; **"no exception" does not mean
-  "complete."** Check the length, or read again to get the `TruncatedError`.
+  bytes returned are correct but the member is incomplete; **"no exception" does not
+  mean "complete."** Check the length, or read again to get the `TruncatedError`.
 
 Corruption is caught whenever such a read reaches the end — independent of whether
 `close()` is ever called. Callers who must verify **regardless** of access pattern
@@ -201,6 +217,63 @@ wants to catch both must check `len(data) == member.size` (or use `read(-1)`); *
 exception" does not mean "complete."** Size-unknown members have no `member.size` to
 read to, so a bare `read(n)` cannot self-certify at all — use `read(-1)` /
 read-to-`b""`.
+
+## Full-count `read`: rationale and trade-offs
+
+Of everything in this ADR, the full-count `read` commitment has the **broadest blast
+radius** — it changes a cross-cutting stream contract, not just the verifier — so it
+gets its own accounting. The two candidate contracts:
+
+- **up-to-`n`** (raw `io.RawIOBase` semantics): `read(n)` may return *any* number of
+  bytes `1..n` on healthy data; only `b""` means end. A stream is free to "decode one
+  compressed block and return whatever it yielded."
+- **full-count** (`io.BufferedReader` / `BytesIO` / on-disk file semantics): `read(n)`
+  returns *exactly* `n` bytes unless it reaches a terminal boundary (EOF, truncation,
+  or a raised content error). We adopt this.
+
+### Why full-count
+
+- **It is what makes the verification story true.** Under up-to-`n`,
+  `data = f.read(member.size)` can return a prefix on healthy data; the single-call
+  caller never reaches the declared size, and corruption is silently accepted — the
+  exact regression this ADR closes. Only full-count guarantees `read(member.size)`
+  reaches the end and therefore verifies.
+- **Simpler contract, simpler docs.** "You get what you asked for; you get less only at
+  the end (EOF or truncation)." That one sentence replaces a page of "a short read
+  might mean anything." A short return regains a single, useful meaning: a terminal
+  boundary (and, with a declared size, a length check distinguishes clean-complete from
+  truncated).
+- **Interchangeable with a buffered file.** Most Python code written against an object
+  from `open(..., 'rb')` (a `BufferedReader`) assumes full-count and breaks subtly
+  against an up-to-`n` object. Full-count makes archivey streams drop-in wherever a
+  buffered binary file is expected, which is the common case.
+- **Reviewers converged on it** as the right load-bearing fix once the sized-read
+  guarantee was on the table.
+
+### What it costs
+
+- **A stream can no longer "read one block, decompress it, return those bytes."** Every
+  public `read(n)` must **coalesce**: loop-decode until it holds `n` output bytes or
+  hits a terminal boundary, and **buffer any overflow** (a block that yields more than
+  `n`) for the next call. `DecompressorStream` already works this way; but
+  `MemberVerifier.read` (a single `inner.read(want)`) and an unverified `ArchiveStream`
+  passthrough (straight to `inner.read(n)`) do **not** — they must be updated. This is a
+  **`compressed-streams` contract delta across backends**, not a local verifier tweak.
+- **More work inside a single call for large `n`.** `read(n)` may decode several blocks
+  before returning. The work is still **bounded by `n`** (the caller's output budget),
+  so the `max_length` output cap and decompression-bomb bounds are unaffected — the same
+  bound `BufferedReader` operates under.
+- **Latency shift on pipe / non-seekable sources.** `read(n)` may wait for enough input
+  to fill `n` rather than returning what is immediately available. Archives are almost
+  always seekable files, so this is minor; a caller wanting incremental low-latency
+  delivery can pass a small `n`.
+- **A small buffer + fill loop in each wrapper.** Already carried by the decompressor
+  engine; the cost is extending it to the verifier and passthrough paths.
+
+**Verdict: worth it.** The cost is concentrated in wrapper plumbing that the
+decompressor path already has, and the payoff is a simpler, `BufferedReader`-compatible
+contract that makes the whole read-to-end verification guarantee — and the honest
+`read(member.size)` idiom — actually true.
 
 ## Open questions
 
@@ -231,6 +304,16 @@ read-to-`b""`.
    We currently disable both under one "seek disables verification" rule for
    simplicity. Keep the simple rule, or preserve the still-sound truncation check across
    seeks? Recommendation: keep it simple, acknowledging we forgo a deliverable verdict.
+4. **A `read_exact(n)` helper for the sized-read truncation footgun?** Full-count makes
+   `read(member.size)` catch corruption, but truncation still comes back as a *silent
+   short buffer* on that single call (the matrix asymmetry) — and typical code passes
+   `data` downstream assuming "no exception" means "complete." A dedicated
+   `read_exact(n)` that raises `TruncatedError` when it cannot deliver `n` would make the
+   whole-member read a single call that catches **both** failures, matching developer
+   intuition. Do we add it (small API surface, kills the footgun for callers who use it),
+   or rely on `read(-1)` / the length check / the `extract()` helper rule? Leaning:
+   add it — it is the natural counterpart to full-count and the cheapest fix for the one
+   footgun both reviews flagged.
 
 ## Consequences
 
@@ -260,10 +343,11 @@ read-to-`b""`.
   accepted now; STRICT is sequenced after. Until it lands, STREAMING —
   detection-not-prevention — is the only posture, so **encrypted members stream
   unauthenticated plaintext by default** in the interim.
-- **Full-count `read` is now a contract**, not an accident. The wrapper must coalesce
-  short inner reads (bounded reads must loop the inner to `n`-or-terminal, as the
-  `read(-1)` drain already does). A short return from a public archivey stream is a
-  documented terminal signal.
+- **Full-count `read` becomes part of the `compressed-streams` contract** — a
+  cross-backend delta, not a local tweak (every public `read(n)` path must coalesce to
+  `n`-or-terminal). See *Full-count `read`: rationale and trade-offs* for the full
+  accounting; the short version is that the decompressor engine already does this and
+  the verifier / passthrough paths must be brought in line.
 - **`close()` never raises a content fault.** Cleanup is safe; a content error can
   neither mask nor be masked by an exception unwinding a `with` body; safety does not
   hinge on `close()` running.

--- a/docs/decisions/0014-integrity-verdicts-from-reads-not-close.md
+++ b/docs/decisions/0014-integrity-verdicts-from-reads-not-close.md
@@ -338,22 +338,27 @@ length signal (plus `read_exact`) to close even that.
    which still honors the top-level guarantee via `read(-1)` / read-to-`b""`?
    Recommendation: **(b)**, documented — the realistic size-unknown reader reads to
    `b""` anyway, and "detection, not prevention" already permits pre-verdict bytes.
-3. **Seek and truncation.** A premature decoder end-of-stream before the declared size
-   is a *structural* fact independent of the incremental hash, so `TruncatedError`
-   could in principle still be raised after a seek even though `CorruptionError` cannot.
-   We currently disable both under one "seek disables verification" rule for
-   simplicity. Keep the simple rule, or preserve the still-sound truncation check across
-   seeks? Recommendation: keep it simple, acknowledging we forgo a deliverable verdict.
-4. **A `read_exact(n)` helper for the sized-read truncation footgun?** Full-count makes
-   `read(member.size)` catch corruption, but truncation still comes back as a *silent
-   short buffer* on that single call (the matrix asymmetry) — and typical code passes
-   `data` downstream assuming "no exception" means "complete." A dedicated
-   `read_exact(n)` that raises `TruncatedError` when it cannot deliver `n` would make the
-   whole-member read a single call that catches **both** failures, matching developer
-   intuition. Do we add it (small API surface, kills the footgun for callers who use it),
-   or rely on `read(-1)` / the length check / the `extract()` helper rule? Leaning:
-   add it — it is the natural counterpart to full-count and the cheapest fix for the one
-   footgun both reviews flagged.
+3. **Seek and structural detection — keep length checks; lose only the checksum**
+   (leaning *narrow*, not "disable everything"). A seek off the sequential frontier
+   breaks *incremental hashing* (non-linear consumption), so the **checksum** verdict is
+   best-effort and forfeited there. But the **length / structural** verdict is
+   position-based, not hash-based: at EOF the stream knows its total decompressed
+   position, so **truncation** (short of the expected size) and **over-run** (past it)
+   stay detectable and SHALL still raise, even after a seek. And a member that is not
+   *truly* seekable — one satisfied by rewinding / re-decoding from the start — preserves
+   linear hashing, so the checksum is not lost there either. Honest scope: **checksum
+   detection is best-effort, forfeited only on a genuine intra-stream seek of a
+   truly-seekable member (itself an opt-in capability); length / truncation detection is
+   always on.**
+4. **`read_exact(n)` — rejected.** A dedicated `read_exact` would kill the sized-read
+   truncation footgun in one call, but it adds a **non-standard method** to the stream
+   surface. A core goal is that code written against archivey streams also works against
+   ordinary file objects (and vice versa), so we do **not** add methods a plain
+   `BinaryIO` lacks. The truncation-short residual is handled with **standard means**
+   instead: the guaranteed whole-member idioms are `read()` / `read(-1)` /
+   iterate-to-`b""` (all standard, all raise on truncation); `read(member.size)` is a
+   *bounded* read whose short return the caller checks by length; and `extract()` /
+   whole-member helpers use a completing read.
 
 ## Consequences
 

--- a/docs/decisions/0014-integrity-verdicts-from-reads-not-close.md
+++ b/docs/decisions/0014-integrity-verdicts-from-reads-not-close.md
@@ -231,23 +231,33 @@ Bytes-read alone cannot separate these after a blind seek: a complete member who
 tail the caller skipped and a genuinely short member both leave the high-water mark
 below the declared size. So a seek that jumps the logical position **to/past the
 declared size without reading the intervening bytes** is concluded by **reading that
-skipped gap** (bounded by the declared size — the checksum is already forfeited, so
-this only advances the length frontier), rather than returning `b""` blind or raising
-from the lagging high-water mark. A genuinely short member then raises
-`TruncatedError` (reporting its true recoverable length); a complete one returns
-`b""`. A member already read to its declared size is length-verified and
+skipped gap and then probing one byte past the declared size** (bounded by the declared
+size — the checksum is already forfeited, so this only advances the length frontier),
+rather than returning `b""` blind or raising from the lagging high-water mark. This
+reproduces the *same* verdict a sequential reaching read runs — length **and**
+over-run:
+
+- a genuinely **short** member raises `TruncatedError` (reporting its true recoverable
+  length);
+- an **over-long** member (one that decodes past its declared size) raises
+  `CorruptionError` — the trailing-byte over-run probe fires whether the size was
+  reached by reading or by a seek-then-gap-fill;
+- a **complete** member returns `b""`.
+
+A member already read to its declared size is length- and over-run-verified and
 short-circuits with **no** extra I/O — the common path pays nothing; only the rare
 seek-past-end-without-a-prior-full-read re-reads. This is what makes the
-`seek(member.size); read(1)` completeness idiom honest in both directions.
+`seek(member.size); read(1)` completeness idiom honest in all three directions.
 
-Over-run still requires having delivered the declared size via reads before probing
-for trailing data. A member that is not *truly* seekable — one satisfied by rewinding
-/ re-decoding from the start — preserves linear hashing, so the checksum is not lost
-there either. Honest scope: **checksum detection is best-effort, forfeited only on a
-genuine intra-stream seek of a truly-seekable member (itself an opt-in capability);
-length / truncation / over-run detection is always on, measured by bytes read —
-reading a seek-skipped gap when needed rather than guessing from the high-water
-mark.**
+Over-run therefore still requires having *delivered* the declared size before probing
+for trailing data — but "delivered" includes the seek-conclusion gap read, not only a
+sequential reaching read. A member that is not *truly* seekable — one satisfied by
+rewinding / re-decoding from the start — preserves linear hashing, so the checksum is
+not lost there either. Honest scope: **checksum detection is best-effort, forfeited
+only on a genuine intra-stream seek of a truly-seekable member (itself an opt-in
+capability); length / truncation / over-run detection is always on, measured by bytes
+read — reading a seek-skipped gap (and probing past the declared size) when needed
+rather than guessing from the high-water mark.**
 
 ### Short returns are never *known*-corrupt bytes
 
@@ -583,10 +593,12 @@ does neither.
   checksum verdict, it stays disabled for that handle. Length / over-run / truncation
   key off the **furthest position an actual read reached** (a read high-water mark),
   not seek-updated `tell` alone. When a seek jumps to/past the declared size without
-  reading the gap, concluding reads that gap (bounded by the declared size) to decide
-  completeness — so past-EOF `seek(declared_size)` neither silences truncation on a
-  short member nor fabricates it on a complete one (`seek(size); read(1)` returns
-  `b""`). A member already read to its declared size short-circuits with no extra I/O.
+  reading the gap, concluding reads that gap (bounded by the declared size) **and
+  probes one byte past the declared size** to decide completeness — so past-EOF
+  `seek(declared_size)` neither silences truncation (short → `TruncatedError`) or
+  over-run (long → `CorruptionError`) nor fabricates either on a complete one
+  (`seek(size); read(1)` returns `b""`). A member already read to its declared size
+  short-circuits with no extra I/O.
 - **Full-count coalescing.** Bounded `read(n)` on the verifier/wrapper uses
   `streamtools.read_full_count` (stop on short) so deferred decompressor truncation
   stays on the next empty `read`. Do not use `read_exact` here. Opaque accelerator

--- a/docs/decisions/0014-integrity-verdicts-from-reads-not-close.md
+++ b/docs/decisions/0014-integrity-verdicts-from-reads-not-close.md
@@ -214,17 +214,40 @@ A seek off the sequential frontier breaks *incremental hashing* (non-linear
 consumption), so the **checksum** verdict is best-effort and forfeited for the rest of
 that handle's life — a seek-forward-then-back-to-end must not re-enable a hash
 comparison over a non-contiguous byte range (false-positive `CorruptionError`). The
-**length / structural** verdict stays on after a seek, but it MUST key off **bytes
-actually read** through the verifier (a read high-water mark), **not** a
-seek-updated logical position alone. Inners like `BytesIO` (and many file objects)
-allow past-EOF seek; `seek(member.size)` on a truncated body must not fabricate a
-clean end and silence `TruncatedError`. Over-run still requires having delivered the
-declared size via reads before probing for trailing data. A member that is not
-*truly* seekable — one satisfied by rewinding / re-decoding from the start —
-preserves linear hashing, so the checksum is not lost there either. Honest scope:
-**checksum detection is best-effort, forfeited only on a genuine intra-stream seek
-of a truly-seekable member (itself an opt-in capability); length / truncation /
-over-run detection is always on, measured by bytes read.**
+**length / structural** verdict stays on after a seek, and it keys off the **furthest
+position an actual read reached** (a read high-water mark), **not** a seek-updated
+logical position alone.
+
+This cuts **both** ways, and the second edge is the one that bites. Inners like
+`BytesIO` (and many file objects) allow past-EOF seek:
+
+- `seek(member.size)` (or past it) on a **truncated** body must not fabricate a clean
+  end and silence `TruncatedError`; but
+- the same seek on a **complete** body must return `b""` — the standard past-EOF read
+  — and must **not** fabricate a `TruncatedError` merely because the high-water mark
+  still lags the declared size (the caller *seeked* there, they did not read short).
+
+Bytes-read alone cannot separate these after a blind seek: a complete member whose
+tail the caller skipped and a genuinely short member both leave the high-water mark
+below the declared size. So a seek that jumps the logical position **to/past the
+declared size without reading the intervening bytes** is concluded by **reading that
+skipped gap** (bounded by the declared size — the checksum is already forfeited, so
+this only advances the length frontier), rather than returning `b""` blind or raising
+from the lagging high-water mark. A genuinely short member then raises
+`TruncatedError` (reporting its true recoverable length); a complete one returns
+`b""`. A member already read to its declared size is length-verified and
+short-circuits with **no** extra I/O — the common path pays nothing; only the rare
+seek-past-end-without-a-prior-full-read re-reads. This is what makes the
+`seek(member.size); read(1)` completeness idiom honest in both directions.
+
+Over-run still requires having delivered the declared size via reads before probing
+for trailing data. A member that is not *truly* seekable — one satisfied by rewinding
+/ re-decoding from the start — preserves linear hashing, so the checksum is not lost
+there either. Honest scope: **checksum detection is best-effort, forfeited only on a
+genuine intra-stream seek of a truly-seekable member (itself an opt-in capability);
+length / truncation / over-run detection is always on, measured by bytes read —
+reading a seek-skipped gap when needed rather than guessing from the high-water
+mark.**
 
 ### Short returns are never *known*-corrupt bytes
 
@@ -558,9 +581,12 @@ does neither.
   hash.
 - **Seek-state tracking.** Once a seek off the sequential frontier disables the
   checksum verdict, it stays disabled for that handle. Length / over-run / truncation
-  key off a **read high-water mark** (bytes actually delivered by `read`), not
-  seek-updated `tell` alone — so past-EOF `seek(declared_size)` cannot silence
-  truncation.
+  key off the **furthest position an actual read reached** (a read high-water mark),
+  not seek-updated `tell` alone. When a seek jumps to/past the declared size without
+  reading the gap, concluding reads that gap (bounded by the declared size) to decide
+  completeness — so past-EOF `seek(declared_size)` neither silences truncation on a
+  short member nor fabricates it on a complete one (`seek(size); read(1)` returns
+  `b""`). A member already read to its declared size short-circuits with no extra I/O.
 - **Full-count coalescing.** Bounded `read(n)` on the verifier/wrapper uses
   `streamtools.read_full_count` (stop on short) so deferred decompressor truncation
   stays on the next empty `read`. Do not use `read_exact` here. Opaque accelerator

--- a/docs/decisions/0014-integrity-verdicts-from-reads-not-close.md
+++ b/docs/decisions/0014-integrity-verdicts-from-reads-not-close.md
@@ -275,16 +275,56 @@ decompressor path already has, and the payoff is a simpler, `BufferedReader`-com
 contract that makes the whole read-to-end verification guarantee — and the honest
 `read(member.size)` idiom — actually true.
 
+### Does full-count *add* a footgun?
+
+A fair worry: because `read(n)` usually returns `n`, callers will make a single call and
+trust it — and on **truncation**, `read(member.size)` returns a short buffer with *no
+exception*, so a caller who neither checks the length nor reads again never sees the
+`TruncatedError`. Two things bound this:
+
+- Full-count **removes the worse footgun and leaves a milder one.** Under up-to-`n`, a
+  single-call `read(member.size)` is unverified for *both* failures — including
+  **corruption**, which hands back *wrong* bytes silently. Full-count converts that into
+  a raised `CorruptionError`. What remains is truncation returning a short buffer of
+  *correct-but-incomplete* bytes — strictly less dangerous than silently trusting wrong
+  bytes, and detectable with a one-line `len == member.size` check that up-to-`n` gives
+  you no honest basis for.
+- The residual is closed by **`read_exact(n)`** (open question 4) for a one-call check,
+  by the length test, and by the `extract()` / whole-member-helper rule that always uses
+  a completing read. Naive single-call `read(n)` is the *low-level* surface; the safe
+  high-level paths never expose the trap.
+
+So full-count does not introduce a new class of danger — it trades a silent
+*wrong-bytes* acceptance for a silent *short-but-correct* one, and hands callers the
+length signal (plus `read_exact`) to close even that.
+
 ## Open questions
 
-1. **Encrypted members — a defaults question, not just docs.** Treating an
-   authentication tag as just-another-checksum in streaming mode means the default
-   *releases unauthenticated plaintext* before the tag is checked — a sharper footgun
-   than emitting bytes with a bad CRC, and arguably in tension with VISION's "no silent
-   success." Should **authenticated** members default to `STRICT` (or refuse to stream
-   unless the caller explicitly opts into detection-not-prevention), rather than
-   inheriting the CRC default? A deliberate defaults decision to make, not inherit; it
-   does not change any mechanism above.
+1. **Encrypted members — default posture, constrained by what STRICT can afford.**
+   Streaming releases unauthenticated plaintext before the tag is checked — sharper than
+   a bad CRC, and in tension with VISION's "no silent success." But "verify before
+   releasing any plaintext" is **not free, and its cost depends on the member**, which
+   is why a blanket `STRICT` default is not simply "buffer everything":
+   - **Compressed + encrypted:** a wrong password almost always yields plaintext the
+     decompressor rejects almost immediately (an early `CorruptionError`), so streaming
+     already fails fast **without buffering**. (Confirm against the existing
+     wrong-password tests.)
+   - **Stored (uncompressed) + encrypted:** wrong-password plaintext is just bytes — no
+     decompressor to reject it — so the authentication tag at the end is the **only**
+     detector. This is the real streaming exposure.
+   - **Very small members:** the stream may end before a decompression error can
+     surface, so the tag is again the only tell.
+
+   So a memory-safe "authenticate before release" cannot buffer arbitrarily. The viable
+   shapes per member are: **buffer in memory only up to a bounded size**; **decrypt
+   twice** (verify pass → rewind → re-decrypt) for a **seekable** stored member (cheap
+   for a local file, costly over a network); and **refuse to stream / require an explicit
+   opt-in** for a **non-seekable** stored member above the buffer bound. Decision: keep
+   STREAMING the default (accepting the stored / tiny residual, which this ADR still
+   surfaces on the completing read / `read(-1)`), or default authenticated members to
+   STRICT with the per-shape strategy above? **Leaning: STREAMING default** — compressed
+   wrong-password fails fast and a blanket STRICT is not implementable memory-safely — but
+   document the stored/tiny exposure sharply and make STRICT the easy opt-in.
 2. **Size-unknown "withhold the corrupt final chunk" requires lookahead.** For a
    size-declared member we know the boundary before releasing the final chunk, so we
    can withhold it. For a size-unknown member (e.g. standalone gzip) the CRC lives in a

--- a/docs/decisions/0014-integrity-verdicts-from-reads-not-close.md
+++ b/docs/decisions/0014-integrity-verdicts-from-reads-not-close.md
@@ -129,6 +129,20 @@ inner (e.g. ZIP's `ZipExtFile`). Adopting this ADR makes full-count part of the
 The contract binds the public `ArchiveStream` / codec-stream surface; arbitrary *inner*
 `BinaryIO` objects need not be full-count — the wrapper coalesces over them.
 
+**Stop-on-short (not RawIO `read_exact`).** The coalesce helper is
+`streamtools.read_full_count`: loop while each piece returns the full ask, and
+**stop on the first short non-empty return** (or empty). That is deliberate —
+`DecompressorStream` deferred truncation returns a short recoverable prefix on the
+completing call and raises on the *next* empty `read`; continuing after a short
+(as `read_exact` does) would pull that deferred `TruncatedError` into the same
+call and collapse the deliver-then-raise shape. Archivey's real inners are
+fill-or-EOF (`DecompressorStream`, typical `ZipExtFile`, `BytesIO`), so
+stop-on-short is full-count for healthy data. It is **not** a promise to keep
+pulling over a RawIO that shorts mid-stream; such an inner needs a buffer in
+front if a caller needs true `BufferedReader` mid-stream coalesce. The public
+contract still holds: a healthy archivey stream does not return short except at
+a terminal boundary.
+
 ### Where the verdict fires
 
 Content-integrity verdicts (stored checksum / digest, encrypted-member authentication
@@ -145,12 +159,14 @@ carve-outs:
 - **WinZip AES** drains and verifies its HMAC in its own `close()` — remove
   (`verification-integrity-mode` Decision 2).
 - **`unrar` / subprocess backends** may only surface wrong-password or CRC exit codes
-  when the process is reaped on close. Work toward parity by **eagerly finalizing** the
-  underlying resource as part of the *completing* read (after the last content byte,
-  reap / close the inner so the fault raises on that `read()`), and on an *early-stop*
-  `close()` **suppress** content-class faults that arrive only from teardown (the
-  caller opted out of a completing read). Until those land, a content error from
-  `close()` on those paths is a known inconsistency, not the contract.
+  when the process is reaped. **Eager-finalize on the completing/empty read** (reap
+  and map the exit there) is the parity path — #183 does this for
+  `_UnrarOwnedStream` so RAR4 encrypted empty exit 2/3 becomes `EncryptionError` on
+  `read()`, not only on `close()`. Early-stop `close()` still maps if no completing
+  read ran; the longer-term follow-up is to **suppress** teardown-only content-class
+  faults on early-stop close (emit the suppressed-fault diagnostic instead). Until
+  that lands, a content error from early-stop `close()` on those paths remains a
+  known inconsistency, not the contract.
 
 `close()` MAY still propagate a true resource teardown signal (`OSError` closing a
 file descriptor, and similar non-content failures).
@@ -198,14 +214,17 @@ A seek off the sequential frontier breaks *incremental hashing* (non-linear
 consumption), so the **checksum** verdict is best-effort and forfeited for the rest of
 that handle's life — a seek-forward-then-back-to-end must not re-enable a hash
 comparison over a non-contiguous byte range (false-positive `CorruptionError`). The
-**length / structural** verdict is position-based, not hash-based: at EOF the stream
-knows its total decompressed position, so **truncation** (short of the expected size)
-and **over-run** (past it) stay detectable and SHALL still raise, even after a seek.
-A member that is not *truly* seekable — one satisfied by rewinding / re-decoding from
-the start — preserves linear hashing, so the checksum is not lost there either.
-Honest scope: **checksum detection is best-effort, forfeited only on a genuine
-intra-stream seek of a truly-seekable member (itself an opt-in capability); length /
-truncation / over-run detection is always on.**
+**length / structural** verdict stays on after a seek, but it MUST key off **bytes
+actually read** through the verifier (a read high-water mark), **not** a
+seek-updated logical position alone. Inners like `BytesIO` (and many file objects)
+allow past-EOF seek; `seek(member.size)` on a truncated body must not fabricate a
+clean end and silence `TruncatedError`. Over-run still requires having delivered the
+declared size via reads before probing for trailing data. A member that is not
+*truly* seekable — one satisfied by rewinding / re-decoding from the start —
+preserves linear hashing, so the checksum is not lost there either. Honest scope:
+**checksum detection is best-effort, forfeited only on a genuine intra-stream seek
+of a truly-seekable member (itself an opt-in capability); length / truncation /
+over-run detection is always on, measured by bytes read.**
 
 ### Short returns are never *known*-corrupt bytes
 
@@ -263,7 +282,7 @@ an integrity verdict to a diagnostic and hope `RAISE` disposition will stand in 
 
 The two new codes are **follow-ups** (emitter + `diagnostics` / OpenSpec delta when the
 seek-forfeit and close-parity paths land) — not blockers for accepting this ADR or for
-resuming #183. Exact code names are TBD at implementation.
+#183's implementation. Exact code names are TBD at implementation.
 
 ## Guarantee (for users)
 
@@ -466,19 +485,16 @@ does neither.
 
 ## Consequences
 
-- **Resolves the open question that parked `gzip-zlib-truncation-recovery` (#183).**
-  This ADR exists *because* #183's review surfaced the read-vs-close / sized-read hole;
-  the #183 implementation is on hold pending it. #183's earlier Decision 8 — a bounded
-  `read(n)` on a digest mismatch delivers every byte and raises on the terminal empty
-  read ("do not withhold the last data chunk";
-  `test_verify_mismatch_raises_at_eof_without_losing_final_chunk`) — is **revised** by
-  this ADR for the corruption case: the read that reaches the declared size (or decoder
-  EOS) raises and **withholds** that chunk for size-declared members. When #183 resumes,
-  its delta and that test are updated to the withhold-on-reaching-read rule so the two
-  texts agree — not a live conflict, but the settlement that unblocks #183.
-  **Truncation-shaped delivery is unchanged** — #183's recoverable-prefix delivery
-  stands (with the best-effort correctness caveat above). Size-unknown timing is
-  decided: verdict on the EOS-observing read, no mandatory lookahead withhold.
+- **Settles the contract that #183 implements.** This ADR exists *because* #183's
+  review surfaced the read-vs-close / sized-read hole. #183's earlier Decision 8 — a
+  bounded `read(n)` on a digest mismatch delivers every byte and raises on the
+  terminal empty read ("do not withhold the last data chunk") — is **revised** here
+  for size-declared corruption: the reaching read raises and **withholds** that
+  chunk. #183 is the implementation vehicle (no longer on hold): its delta, tests,
+  and OpenSpec prose match this ADR. **Truncation-shaped delivery is unchanged** —
+  recoverable-prefix delivery stands (with the best-effort correctness caveat
+  above). Size-unknown timing is decided: verdict on the EOS-observing read, no
+  mandatory lookahead withhold.
 - **`read(member.size)` on a corrupt size-declared member raises from that read** and
   returns nothing — closing the silent-acceptance regression, without depending on
   `close()`.
@@ -495,16 +511,15 @@ does neither.
   detection-not-prevention — is the only posture, so **encrypted members stream
   unauthenticated plaintext by default** in the interim.
 - **Full-count `read` becomes part of the `compressed-streams` contract** — a
-  cross-backend delta, not a local tweak (every public `read(n)` path must coalesce to
-  `n`-or-terminal). See *Full-count `read`: rationale and trade-offs* for the full
-  accounting; the short version is that the decompressor engine already does this and
-  the verifier / passthrough paths must be brought in line.
+  cross-backend delta, not a local tweak. Public paths use stop-on-short coalesce
+  (`read_full_count`) so deferred `DecompressorStream` truncation stays deferred;
+  see *Full-count `read`: rationale and trade-offs* and the stop-on-short note under
+  Decision.
 - **`close()` never raises a content fault — target contract, best-effort today.**
   Cleanup is safe when the target holds; a content error can neither mask nor be masked
   by an exception unwinding a `with` body; safety does not hinge on `close()` running.
-  AES HMAC-on-close and unrar-exit-on-close are documented debt toward that parity
-  (eager finalize on completing read; suppress teardown-only content faults on
-  early-stop close).
+  AES HMAC-on-close remains debt. Unrar eager-finalize on completing/empty read is
+  partially landed in #183; early-stop close suppression is still follow-up.
 - **Detection, not prevention, in streaming mode.** Any bounded read returns some bytes
   before the final verdict; the guarantee is "you are told before you can conclude the
   member is complete-and-intact," not "you are told before you touch any bytes."
@@ -540,17 +555,21 @@ does neither.
   the call returns or raises — the read that reaches the declared size finalizes the
   hash.
 - **Seek-state tracking.** Once a seek off the sequential frontier disables the
-  checksum verdict, it stays disabled for that handle; length / over-run / truncation
-  checks remain active.
-- **Full-count coalescing.** Bounded `read(n)` on the verifier/wrapper must loop the
-  inner stream until it has `n` bytes or a terminal boundary, so the full-count
-  contract holds even over a short-reading inner `BinaryIO`.
+  checksum verdict, it stays disabled for that handle. Length / over-run / truncation
+  key off a **read high-water mark** (bytes actually delivered by `read`), not
+  seek-updated `tell` alone — so past-EOF `seek(declared_size)` cannot silence
+  truncation.
+- **Full-count coalescing.** Bounded `read(n)` on the verifier/wrapper uses
+  `streamtools.read_full_count` (stop on short) so deferred decompressor truncation
+  stays on the next empty `read`. Do not use `read_exact` here. Opaque accelerator
+  EOF on the sized `read(-1)` drain may become `TruncatedError`; `OSError` /
+  `MemoryError` must propagate.
 - **Eager finalize on completing reads (parity path).** Where a backend only reports
   content faults at process/resource teardown (`unrar` exit codes, similar), the
-  completing-read path should reap/finalize immediately after the last content byte so
-  the fault raises on that `read()`; early-stop `close()` should not promote those
-  teardown-only content faults into the caller's close — emit the suppressed-fault
-  diagnostic instead (when that code lands).
+  completing/empty-read path should reap/finalize immediately so the fault raises on
+  that `read()` (#183 for `_UnrarOwnedStream`). Early-stop `close()` should eventually
+  not promote those teardown-only content faults into the caller's close — emit the
+  suppressed-fault diagnostic instead (when that code lands).
 - **Seek-forfeit diagnostic.** When a true intra-stream seek disables the checksum
   verdict for the handle, emit the forfeited-checksum diagnostic once; length /
   over-run / truncation checks remain active without a diagnostic of their own.

--- a/docs/decisions/0014-integrity-verdicts-from-reads-not-close.md
+++ b/docs/decisions/0014-integrity-verdicts-from-reads-not-close.md
@@ -1,0 +1,160 @@
+# 0014 — Integrity verdicts surface from reads, never from `close()`
+
+- **Status:** proposed
+- **Date:** 2026-07 (review of `gzip-zlib-truncation-recovery`, PR #183)
+- **Provenance:** OpenSpec `compressed-streams` (digest verification, read-vs-close
+  fault split); `VISION.md` (no silent success; damaged input is first-class);
+  `verification-integrity-mode` change (STRICT opt-in)
+
+## Context
+
+When a member carries a stored checksum (CRC32 / digest) or, for encrypted members,
+an authentication tag, archivey verifies it **as the member is read** — incrementally,
+in the default (streaming) mode. Two facts make the *timing* of the verdict a real
+design question rather than an implementation detail:
+
+1. **A checksum/auth verdict is only known after the last content byte is consumed.**
+   We hash bytes as they flow; pass/fail is decided at the end.
+2. **A single `read()` call cannot both return bytes and raise.** So if the chunk that
+   completes the member is the one that reveals the checksum is bad, we must choose
+   between returning those bytes and raising.
+
+A subtle third fact governs how callers *reach* the end, and it corrects a tempting
+but wrong heuristic:
+
+3. **A short read is not an end-of-stream signal.** The stream `read(n)` contract
+   (for `n ≥ 1`) guarantees *at least one* byte and permits *fewer than `n`*; only a
+   return of `b""` means EOF. So `read(500)` returning `110` does **not** tell the
+   caller the stream ended — a caller who wants the whole member is expected to keep
+   reading. What actually reveals truncation is: **keep reading toward the size you
+   expect, and you eventually get an error (or `b""`) from a `read()`.**
+
+This came to a head in review. An earlier iteration verified on `close()` when the
+member had been fully consumed. That was then made teardown-only ("`close()` never
+raises a content fault"), which reintroduced a **silent-acceptance regression**: a
+routine full-member read via a sized call —
+
+```python
+with archive.open(member) as f:   # member.size == 500, stored CRC is wrong
+    data = f.read(member.size)     # returns 500 bytes; nothing raises
+process(data)                      # acts on corrupt data
+```
+
+— produced no error at all. A checksum library must never silently hand back content
+it knows (or could know) is corrupt. So we must decide, precisely, **which call
+raises**.
+
+### Options considered
+
+- **A — raise on the read that reaches the end.** The read that completes the member
+  and finds damage raises (returning no bytes for that call); `close()` never raises.
+  Matches stdlib `zipfile` / `gzip`. Downside as first stated: naively applied to
+  *truncation*, it would drop the recoverable prefix (which this whole change exists
+  to deliver).
+- **B — deliver every byte, then raise on the next read; `close()` as a backstop.**
+  Every read returns its bytes; the trailing (empty) read raises, or `close()` does if
+  the caller stops exactly at the end. Uniform for corruption and truncation, but
+  makes a *safety* guarantee depend on `close()` actually running — unreliable
+  (GC-driven close is not guaranteed and swallows exceptions), and a content error
+  from `close()` can mask or be masked by an exception already unwinding a `with`
+  body.
+- **C — verify only when the caller reads to `b""` (or `read(-1)`); silent otherwise.**
+  Simplest `close()` semantics, but silently skips verification on
+  `read(member.size)` — the most natural way to consume a whole member. Silent false
+  confidence is the one outcome a checksum library must not produce.
+
+### The distinction that resolves A-vs-B
+
+Corruption and truncation are not the same failure:
+
+- **Truncation** yields bytes that are *correct but incomplete* — worth delivering
+  (the recoverable-prefix salvage this change is built on). The failing read is the
+  one that reaches the end while still short.
+- **Corruption** yields bytes that are *wrong* — there is no value in handing back the
+  final chunk of a member whose checksum just failed.
+
+So "deliver every byte before failing" is right for truncation and pointless for
+corruption. Option A is correct *for corruption*; truncation naturally serves its
+prefix and fails on the read that reaches the end.
+
+### Why leaving early stops unverified is sound
+
+Given fact (3), a caller who genuinely wants the whole member keeps reading until they
+have the expected size (or `b""`) — and therefore *reaches the end on some read* and
+gets the verdict there. A caller who stops before the end has deliberately opted out.
+There is no principled line between "stopped at byte 50 of 110 available" and "stopped
+at byte 110 of 110 available": both are early stops, and a short read did not tell the
+second caller anything the first didn't know. Verifying one but not the other only
+because it sits on the EOF boundary would be arbitrary. So **all** early stops are
+treated identically: no verdict.
+
+This keeps the safety property — *a member read to its end that is damaged always
+raises* — while making it independent of `close()`.
+
+## Decision
+
+Content-integrity verdicts (stored checksum / digest, encrypted-member authentication
+tag, and short/truncation) are delivered from a **`read()` call, never from
+`close()`**. `close()` is teardown-only; it may still propagate a resource/teardown
+error (a subprocess exit code, an inner stream that authenticates in its *own*
+`close()`), but it never introduces a first content fault.
+
+A member is verified at the moment a read **reaches its end** — whichever comes first:
+
+- the read that consumes the member's **declared** size, or
+- the read that reaches the **decoder's end-of-stream** (its in-band end marker, or the
+  underlying source returning `b""`).
+
+At that moment:
+
+- **Corruption** (checksum / auth mismatch): the reaching read raises `CorruptionError`
+  and returns no bytes. The final chunk of a member known to be corrupt is **withheld**.
+- **Truncation / short** (decoder EOF before the declared size, or an incomplete
+  decode): every recoverable byte was delivered on the preceding bounded reads; the
+  read that reaches the end while still short raises `TruncatedError`.
+
+A read that **stops before the end** — at any offset, including exactly the bytes
+currently available — produces **no verdict**, and `close()` stays silent. A seek off
+the sequential frontier disables verification for the rest of the handle's life
+(incremental hashing assumes linear consumption).
+
+**Guarantee, stated for users:** *Read a member to its end and a damaged member raises
+on a `read()`. Stop before the end and it is not verified. `close()` never raises a
+content error.* "To its end" means `read(-1)` / `readall`, reading until `read()`
+returns `b""`, or reading the declared size. Corruption is caught whenever such a read
+reaches the end — independent of whether `close()` is ever called.
+
+Callers who must verify **regardless** of access pattern — partial reads, seeks, or
+"never release unverified bytes" — use `VerificationMode.STRICT`
+(`verification-integrity-mode`), which fully verifies a member before returning any of
+it. This is the required posture for untrusted input where release of unauthenticated
+plaintext is unacceptable (see Consequences).
+
+## Consequences
+
+- **`read(member.size)` on a corrupt member raises from that read** and returns
+  nothing — closing the silent-acceptance regression, and doing so without depending
+  on `close()`.
+- **This reverses "deliver every byte even on a checksum mismatch."** A corrupt
+  member's final chunk is now withheld (the reaching read raises instead of returning
+  it). Truncation is unchanged — its recoverable prefix is still delivered.
+- **`close()` never raises a content fault.** Cleanup is safe; a content error can
+  neither mask nor be masked by an exception unwinding a `with` body; safety does not
+  hinge on `close()` running.
+- **Detection, not prevention, in streaming mode.** Any bounded read returns some
+  bytes before the final verdict is known; the guarantee is "you are told before you
+  can conclude the member is complete-and-intact," not "you are told before you touch
+  any bytes." Prevention is `VerificationMode.STRICT`.
+- **Encrypted members are a sharper case.** With a single authentication tag over the
+  whole member, streaming *must* release unverified plaintext (the classic
+  release-of-unverified-plaintext problem); the tag is checked only when the member is
+  read to its end. Segment-authenticated formats (per-chunk AEAD) could verify each
+  chunk before release, but archivey's current formats do not. Threat models that
+  cannot tolerate unauthenticated plaintext must use STRICT. The docs state this
+  distinction explicitly even though the API surface treats CRC and auth-tag members
+  the same.
+- **Requires knowing "the end" on the reaching read.** Members with a declared size
+  (most container members, e.g. ZIP) verify on the read that reaches that size.
+  Size-unknown members (e.g. standalone gzip) rely on the decoder's in-band
+  end-of-stream so corruption is still caught on the last data read, matching stdlib
+  `gzip` — not deferred to a trailing empty read.

--- a/docs/decisions/0014-integrity-verdicts-from-reads-not-close.md
+++ b/docs/decisions/0014-integrity-verdicts-from-reads-not-close.md
@@ -19,85 +19,97 @@ design question rather than an implementation detail:
    completes the member is the one that reveals the checksum is bad, we must choose
    between returning those bytes and raising.
 
-A subtle third fact governs how callers *reach* the end, and it corrects a tempting
-but wrong heuristic:
+A third fact governs how callers *reach* the end, and it forced an explicit contract
+choice (see the **full-count `read`** decision below):
 
-3. **A short read is not an end-of-stream signal.** The stream `read(n)` contract
-   (for `n ≥ 1`) guarantees *at least one* byte and permits *fewer than `n`*; only a
-   return of `b""` means EOF. So `read(500)` returning `110` does **not** tell the
-   caller the stream ended — a caller who wants the whole member is expected to keep
-   reading. What actually reveals truncation is: **keep reading toward the size you
-   expect, and you eventually get an error (or `b""`) from a `read()`.**
+3. **In general, `read(n)` may return fewer than `n` bytes on non-terminal data** —
+   the stream contract for `n ≥ 1` guarantees *at least one* byte; only `b""` means
+   EOF. A short return, in the general contract, is *not* an end-of-stream signal.
 
 This came to a head in review. An earlier iteration verified on `close()` when the
-member had been fully consumed. That was then made teardown-only ("`close()` never
-raises a content fault"), which reintroduced a **silent-acceptance regression**: a
-routine full-member read via a sized call —
+member had been fully consumed. Making `close()` teardown-only then reintroduced a
+**silent-acceptance regression** for the most ordinary full-member read:
 
 ```python
 with archive.open(member) as f:   # member.size == 500, stored CRC is wrong
     data = f.read(member.size)     # returns 500 bytes; nothing raises
-process(data)                      # acts on corrupt data
+process(data)                      # acts on corrupt data — no verdict, ever
 ```
 
-— produced no error at all. A checksum library must never silently hand back content
-it knows (or could know) is corrupt. So we must decide, precisely, **which call
-raises**.
+A checksum library must never silently hand back content it knows (or could know) is
+corrupt. So we must decide, precisely, **which call raises** — and, because fact (3)
+means `read(member.size)` might not even reach the end, **what our own `read`
+contract guarantees.**
 
 ### Options considered
 
 - **A — raise on the read that reaches the end.** The read that completes the member
   and finds damage raises (returning no bytes for that call); `close()` never raises.
-  Matches stdlib `zipfile` / `gzip`. Downside as first stated: naively applied to
-  *truncation*, it would drop the recoverable prefix (which this whole change exists
-  to deliver).
+  Matches stdlib `zipfile` / `gzip`.
 - **B — deliver every byte, then raise on the next read; `close()` as a backstop.**
-  Every read returns its bytes; the trailing (empty) read raises, or `close()` does if
-  the caller stops exactly at the end. Uniform for corruption and truncation, but
-  makes a *safety* guarantee depend on `close()` actually running — unreliable
-  (GC-driven close is not guaranteed and swallows exceptions), and a content error
-  from `close()` can mask or be masked by an exception already unwinding a `with`
-  body.
-- **C — verify only when the caller reads to `b""` (or `read(-1)`); silent otherwise.**
+  Uniform for corruption and truncation, but makes a *safety* guarantee depend on
+  `close()` actually running — unreliable (GC-driven close is not guaranteed and
+  swallows exceptions), and a content error from `close()` can mask or be masked by an
+  exception already unwinding a `with` body.
+- **C — verify only when the caller reads to `b""` / `read(-1)`; silent otherwise.**
   Simplest `close()` semantics, but silently skips verification on
-  `read(member.size)` — the most natural way to consume a whole member. Silent false
-  confidence is the one outcome a checksum library must not produce.
+  `read(member.size)` — the most natural whole-member read. Silent false confidence is
+  the one outcome a checksum library must not produce.
 
-### The distinction that resolves A-vs-B
+### Two distinctions that resolve it
 
-Corruption and truncation are not the same failure:
+**Corruption vs. truncation.** These are not the same failure:
 
 - **Truncation** yields bytes that are *correct but incomplete* — worth delivering
-  (the recoverable-prefix salvage this change is built on). The failing read is the
-  one that reaches the end while still short.
-- **Corruption** yields bytes that are *wrong* — there is no value in handing back the
-  final chunk of a member whose checksum just failed.
+  (the recoverable-prefix salvage this change is built on).
+- **Corruption** yields bytes that are *wrong* — no value in returning the final chunk
+  of a member whose checksum just failed.
 
 So "deliver every byte before failing" is right for truncation and pointless for
 corruption. Option A is correct *for corruption*; truncation naturally serves its
-prefix and fails on the read that reaches the end.
+prefix and fails on a later read.
+
+**Full-count vs. up-to-`n` `read`.** The regression example only reaches the end — and
+is therefore verifiable — if our `read(n)` returns the full count. Under an "up-to-`n`"
+`read`, `f.read(500)` could hand back 400 on *healthy* data; a single-call caller stops
+at 400, never reaches the declared size, and gets no verdict — the regression, intact.
+The guarantee "read the declared size → verified" is real only if `read(n)` coalesces
+up to `n` (like `io.BufferedReader`), returning short **only** at a terminal boundary.
+We therefore commit to full-count `read`, which is also what `DecompressorStream`
+already implements.
 
 ### Why leaving early stops unverified is sound
 
-Given fact (3), a caller who genuinely wants the whole member keeps reading until they
-have the expected size (or `b""`) — and therefore *reaches the end on some read* and
-gets the verdict there. A caller who stops before the end has deliberately opted out.
-There is no principled line between "stopped at byte 50 of 110 available" and "stopped
-at byte 110 of 110 available": both are early stops, and a short read did not tell the
-second caller anything the first didn't know. Verifying one but not the other only
-because it sits on the EOF boundary would be arbitrary. So **all** early stops are
-treated identically: no verdict.
-
-This keeps the safety property — *a member read to its end that is damaged always
-raises* — while making it independent of `close()`.
+Under full-count `read`, a caller who wants the whole member reaches its end (they read
+`member.size`, or read until `b""`) and gets the verdict there. A caller who stops
+before the end deliberately opted out. There is no principled line between "stopped at
+byte 50 of a 500-byte member" and "stopped at byte 110 of that same 500-byte member
+when only 110 were decodable": both are early stops of a member whose declared size is
+500. Verifying one but not the other only because it sits on the current EOF boundary
+would be arbitrary. So **all** early stops are treated identically: no verdict, and
+`close()` stays silent — while a member *read to its end* that is damaged always
+raises, independent of whether `close()` runs.
 
 ## Decision
 
+### Full-count `read`
+
+archivey's stream `read(n)` (`n ≥ 1`) returns **exactly `n` bytes until a terminal
+boundary** — clean end-of-stream, truncation, or a raised content error. It never
+returns short on healthy, non-terminal data. Consequently a short return **means a
+terminal boundary was reached**, and reading is a reliable way to reach a member's end
+(`read(-1)`, read-until-`b""`, or `read(member.size)` for a size-declared member).
+(`read(0)` is a no-op, never EOF. This full-count guarantee applies to the public
+`ArchiveStream`/codec-stream `read`; it does not require arbitrary *inner* `BinaryIO`
+objects to be full-count — the wrapper coalesces.)
+
+### Where the verdict fires
+
 Content-integrity verdicts (stored checksum / digest, encrypted-member authentication
-tag, and short/truncation) are delivered from a **`read()` call, never from
-`close()`**. `close()` is teardown-only; it may still propagate a resource/teardown
-error (a subprocess exit code, an inner stream that authenticates in its *own*
-`close()`), but it never introduces a first content fault.
+tag, truncation, and declared-size over-run) are delivered from a **`read()` call,
+never from `close()`**. `close()` is teardown-only: it may still propagate a
+resource/teardown error (a subprocess exit code, an inner stream that authenticates in
+its *own* `close()`), but it never introduces a first content fault.
 
 A member is verified at the moment a read **reaches its end** — whichever comes first:
 
@@ -107,54 +119,133 @@ A member is verified at the moment a read **reaches its end** — whichever come
 
 At that moment:
 
-- **Corruption** (checksum / auth mismatch): the reaching read raises `CorruptionError`
-  and returns no bytes. The final chunk of a member known to be corrupt is **withheld**.
-- **Truncation / short** (decoder EOF before the declared size, or an incomplete
-  decode): every recoverable byte was delivered on the preceding bounded reads; the
-  read that reaches the end while still short raises `TruncatedError`.
+- **Corruption** (checksum / auth mismatch, or a mid-stream structural error): the
+  reaching read raises `CorruptionError` and returns no bytes. The final chunk of a
+  member known to be corrupt is **withheld** (for size-declared members; see the
+  size-unknown consequence and open question below).
+- **Over-run** (decode output exceeds the declared size — a corrupt length field): the
+  read that would cross the declared size raises `CorruptionError`, **independent of
+  the checksum** (the over-run itself is the corruption, even if the hash-so-far would
+  pass).
+- **Truncation / short** (decoder end-of-stream before the declared size, or an
+  incomplete decode): every recoverable byte was delivered on the preceding full-count
+  reads; the read that reaches the short end returns the remaining prefix (a **short
+  return**, not an exception), and the *next* read raises `TruncatedError`.
 
-A read that **stops before the end** — at any offset, including exactly the bytes
-currently available — produces **no verdict**, and `close()` stays silent. A seek off
-the sequential frontier disables verification for the rest of the handle's life
-(incremental hashing assumes linear consumption).
+A read that **stops before the end** — at any offset — produces **no verdict**, and
+`close()` stays silent. A seek off the sequential frontier disables the **checksum**
+verdict for the rest of the handle's life (incremental hashing assumes linear
+consumption); structural truncation past the seek remains detectable in principle, but
+for simplicity we disable both under one rule (see open question 3).
 
-**Guarantee, stated for users:** *Read a member to its end and a damaged member raises
-on a `read()`. Stop before the end and it is not verified. `close()` never raises a
-content error.* "To its end" means `read(-1)` / `readall`, reading until `read()`
-returns `b""`, or reading the declared size. Corruption is caught whenever such a read
-reaches the end — independent of whether `close()` is ever called.
+### Short returns are never corrupt bytes
 
-Callers who must verify **regardless** of access pattern — partial reads, seeks, or
-"never release unverified bytes" — use `VerificationMode.STRICT`
-(`verification-integrity-mode`), which fully verifies a member before returning any of
-it. This is the required posture for untrusted input where release of unauthenticated
-plaintext is unacceptable (see Consequences).
+Because corruption *raises* rather than returning short, a short return from a
+full-count `read` is only ever **clean-but-complete** (you asked for more than the
+member holds) or **truncated** (correct-but-incomplete prefix). It is never "here are
+some wrong bytes." A single-call reader distinguishes the two by length:
+
+- size-declared member: `len(data) == member.size` → complete and verified;
+  `len(data) < member.size` → truncated (the shortfall is the tell), and reading again
+  raises `TruncatedError`;
+- size-unknown member: a bare `read(n)` cannot self-certify — read `-1` or to `b""`.
+
+## Guarantee (for users)
+
+> **Read a member to its end and a damaged member raises on a `read()`. Stop before
+> the end and it is not verified. `close()` never raises a content error.**
+
+"To its end" means `read(-1)` / `readall`, reading until `read()` returns `b""`, or —
+for a member with a **declared** size — reading that many bytes. For that whole-member
+read:
+
+- an **exception** means the member is corrupt (`CorruptionError`) or truncated
+  (`TruncatedError`) — **discard everything read; none of it is trustworthy**;
+- a **full-length** return (`len == member.size`, or a subsequent `b""`) means the
+  content was **checksum-verified**;
+- a **short** return (`len < member.size`, no exception) means **truncation** — the
+  bytes are correct but the member is incomplete; **"no exception" does not mean
+  "complete."** Check the length, or read again to get the `TruncatedError`.
+
+Corruption is caught whenever such a read reaches the end — independent of whether
+`close()` is ever called. Callers who must verify **regardless** of access pattern
+(partial reads, seeks, or "never release unverified bytes") use
+`VerificationMode.STRICT` (`verification-integrity-mode`), which fully verifies a
+member before returning any of it.
+
+## Open questions
+
+1. **Encrypted members — a defaults question, not just docs.** Treating an
+   authentication tag as just-another-checksum in streaming mode means the default
+   *releases unauthenticated plaintext* before the tag is checked — a sharper footgun
+   than emitting bytes with a bad CRC, and arguably in tension with VISION's "no silent
+   success." Should **authenticated** members default to `STRICT` (or refuse to stream
+   unless the caller explicitly opts into detection-not-prevention), rather than
+   inheriting the CRC default? A deliberate defaults decision to make, not inherit; it
+   does not change any mechanism above.
+2. **Size-unknown "withhold the corrupt final chunk" requires lookahead.** For a
+   size-declared member we know the boundary before releasing the final chunk, so we
+   can withhold it. For a size-unknown member (e.g. standalone gzip) the CRC lives in a
+   trailer *after* the last plaintext byte: the decoder emits the final plaintext and
+   only sees end-of-stream on the next pull. Honoring "corruption caught on the last
+   data read / final chunk withheld" for size-unknown members requires a **one-chunk
+   delayed-release buffer** (never hand out chunk *N* until chunk *N+1*-or-EOS has been
+   pulled). Do we (a) require that lookahead for uniform behavior (small constant
+   buffering), or (b) accept that size-unknown members surface the verdict on the read
+   that observes end-of-stream — possibly *after* the final data chunk was released —
+   which still honors the top-level guarantee via `read(-1)` / read-to-`b""`?
+   Recommendation: **(b)**, documented — the realistic size-unknown reader reads to
+   `b""` anyway, and "detection, not prevention" already permits pre-verdict bytes.
+3. **Seek and truncation.** A premature decoder end-of-stream before the declared size
+   is a *structural* fact independent of the incremental hash, so `TruncatedError`
+   could in principle still be raised after a seek even though `CorruptionError` cannot.
+   We currently disable both under one "seek disables verification" rule for
+   simplicity. Keep the simple rule, or preserve the still-sound truncation check across
+   seeks? Recommendation: keep it simple, acknowledging we forgo a deliverable verdict.
 
 ## Consequences
 
-- **`read(member.size)` on a corrupt member raises from that read** and returns
-  nothing — closing the silent-acceptance regression, and doing so without depending
-  on `close()`.
-- **This reverses "deliver every byte even on a checksum mismatch."** A corrupt
-  member's final chunk is now withheld (the reaching read raises instead of returning
-  it). Truncation is unchanged — its recoverable prefix is still delivered.
+- **`read(member.size)` on a corrupt size-declared member raises from that read** and
+  returns nothing — closing the silent-acceptance regression, without depending on
+  `close()`. This **reverses "deliver every byte even on a checksum mismatch"**: a
+  corrupt member's final chunk is now withheld. Truncation is unchanged — its
+  recoverable prefix is still delivered.
+- **Full-count `read` is now a contract**, not an accident. The wrapper must coalesce
+  short inner reads (bounded reads must loop the inner to `n`-or-terminal, as the
+  `read(-1)` drain already does). A short return from a public archivey stream is a
+  documented terminal signal.
 - **`close()` never raises a content fault.** Cleanup is safe; a content error can
   neither mask nor be masked by an exception unwinding a `with` body; safety does not
   hinge on `close()` running.
-- **Detection, not prevention, in streaming mode.** Any bounded read returns some
-  bytes before the final verdict is known; the guarantee is "you are told before you
-  can conclude the member is complete-and-intact," not "you are told before you touch
-  any bytes." Prevention is `VerificationMode.STRICT`.
-- **Encrypted members are a sharper case.** With a single authentication tag over the
-  whole member, streaming *must* release unverified plaintext (the classic
-  release-of-unverified-plaintext problem); the tag is checked only when the member is
-  read to its end. Segment-authenticated formats (per-chunk AEAD) could verify each
-  chunk before release, but archivey's current formats do not. Threat models that
-  cannot tolerate unauthenticated plaintext must use STRICT. The docs state this
-  distinction explicitly even though the API surface treats CRC and auth-tag members
-  the same.
-- **Requires knowing "the end" on the reaching read.** Members with a declared size
-  (most container members, e.g. ZIP) verify on the read that reaches that size.
-  Size-unknown members (e.g. standalone gzip) rely on the decoder's in-band
-  end-of-stream so corruption is still caught on the last data read, matching stdlib
-  `gzip` — not deferred to a trailing empty read.
+- **Detection, not prevention, in streaming mode.** Any bounded read returns some bytes
+  before the final verdict; the guarantee is "you are told before you can conclude the
+  member is complete-and-intact," not "you are told before you touch any bytes."
+  Prevention is `VerificationMode.STRICT`.
+- **Size-declared vs. size-unknown timing differs** (open question 2). Size-declared:
+  verdict on the read that reaches the declared size (the decoder must also consume the
+  trailing CRC/tag to validate before that read returns or raises). Size-unknown:
+  verdict on the read that observes end-of-stream — the last data read only if a
+  lookahead buffer is adopted, otherwise the following read.
+- **Encrypted members are a sharper case** (open question 1). With a single tag over
+  the whole member, streaming *must* release unverified plaintext; segment-authenticated
+  (per-chunk AEAD) formats could verify each chunk before release, but archivey's
+  current formats do not.
+- **Exception type tells you what you can trust.** `CorruptionError` ⇒ the content is
+  wrong; trust **nothing** already read from this member. `TruncatedError` ⇒ the bytes
+  already returned are correct but the member is **incomplete**; a caller may keep a
+  salvaged prefix if incompleteness is acceptable, but must not treat it as the whole
+  member. Documented on the exceptions and in the streaming guide.
+
+## Implementation notes
+
+- **Trailer consumption on exact-size reads.** For a size-declared member,
+  `read(member.size)` must pull the underlying CRC/auth trailer and validate *before*
+  the call returns or raises — the read that reaches the declared size finalizes the
+  hash.
+- **Seek-state tracking.** Once a seek off the sequential frontier disables the
+  checksum verdict, it stays disabled — a seek-forward-then-back-to-end must not
+  re-enable a hash comparison over a non-contiguous byte range (false-positive
+  `CorruptionError`).
+- **Full-count coalescing.** Bounded `read(n)` on the verifier/wrapper must loop the
+  inner stream until it has `n` bytes or a terminal boundary, so the full-count
+  contract holds even over a short-reading inner `BinaryIO`.

--- a/docs/decisions/0014-integrity-verdicts-from-reads-not-close.md
+++ b/docs/decisions/0014-integrity-verdicts-from-reads-not-close.md
@@ -212,11 +212,12 @@ member before returning any of it.
 
 The load-bearing asymmetry: **`read(member.size)` raises on corruption but returns a
 short buffer on truncation** — because corruption yields wrong bytes (withheld) while
-truncation yields a correct-but-incomplete prefix (delivered). A single-call caller who
-wants to catch both must check `len(data) == member.size` (or use `read(-1)`); **"no
-exception" does not mean "complete."** Size-unknown members have no `member.size` to
-read to, so a bare `read(n)` cannot self-certify at all — use `read(-1)` /
-read-to-`b""`.
+truncation yields a correct-but-incomplete prefix (delivered). This is a **deliberate
+idiom** ("salvage the available prefix; raise only on wrong bytes"), not a trap — see
+*`read(member.size)` — read the available prefix without raising* below for why it is
+safe to expose and how a caller checks for truncation (length, or a following `read()`).
+Size-unknown members have no `member.size` to read to, so a bare `read(n)` cannot
+self-certify at all — use `read(-1)` / read-to-`b""`.
 
 ## Full-count `read`: rationale and trade-offs
 
@@ -233,20 +234,30 @@ gets its own accounting. The two candidate contracts:
 
 ### Why full-count
 
-- **It is what makes the verification story true.** Under up-to-`n`,
+- **It matches the file object users actually hold — the strongest reason.** The
+  dominant binary file object in Python is `open(path, 'rb')`, an `io.BufferedReader`,
+  and **`BufferedReader.read(n)` is full-count**: it issues multiple underlying reads to
+  return exactly `n` unless EOF. So `data = f.read(known_size)` is a *correct, everyday*
+  idiom, and an archivey stream is the thing people most often swap in for a file. The
+  real question is therefore not "full-count vs. the stream contract" but **which
+  standard we match** — `BufferedReader` (full-count) or raw `io.RawIOBase` (up-to-`n`).
+  Matching `BufferedReader` makes archivey a **drop-in for file-reading code**; matching
+  `RawIOBase` silently breaks it. Full-count is the *more* compatible choice, not less —
+  and file-reading code is the single most likely thing to be pointed at our streams.
+- **It keeps naive single-call reads safe on healthy data.** Under up-to-`n`, a stream
+  free to "decode one block and return it" can hand back a *partial* buffer on a
+  perfectly good member; a caller who reads once and trusts it **silently loses correct
+  data on an undamaged archive** — the worst outcome, and a frequent one. Full-count
+  eliminates it: a healthy `read(n)` always returns `n`. Its only silent-ish residual is
+  genuine truncation, where the bytes are correct and the shortfall is length-checkable.
+- **It makes the verification story true.** Under up-to-`n`,
   `data = f.read(member.size)` can return a prefix on healthy data; the single-call
   caller never reaches the declared size, and corruption is silently accepted — the
   exact regression this ADR closes. Only full-count guarantees `read(member.size)`
   reaches the end and therefore verifies.
 - **Simpler contract, simpler docs.** "You get what you asked for; you get less only at
-  the end (EOF or truncation)." That one sentence replaces a page of "a short read
-  might mean anything." A short return regains a single, useful meaning: a terminal
-  boundary (and, with a declared size, a length check distinguishes clean-complete from
-  truncated).
-- **Interchangeable with a buffered file.** Most Python code written against an object
-  from `open(..., 'rb')` (a `BufferedReader`) assumes full-count and breaks subtly
-  against an up-to-`n` object. Full-count makes archivey streams drop-in wherever a
-  buffered binary file is expected, which is the common case.
+  the end (EOF or truncation)." One sentence replaces "a short read might mean
+  anything," and a short return regains a single meaning: a terminal boundary.
 - **Reviewers converged on it** as the right load-bearing fix once the sized-read
   guarantee was on the table.
 
@@ -275,28 +286,46 @@ decompressor path already has, and the payoff is a simpler, `BufferedReader`-com
 contract that makes the whole read-to-end verification guarantee — and the honest
 `read(member.size)` idiom — actually true.
 
-### Does full-count *add* a footgun?
+### `read(member.size)` — read the available prefix without raising
 
-A fair worry: because `read(n)` usually returns `n`, callers will make a single call and
-trust it — and on **truncation**, `read(member.size)` returns a short buffer with *no
-exception*, so a caller who neither checks the length nor reads again never sees the
-`TruncatedError`. Two things bound this:
+The worry with full-count is that `read(member.size)` on a **truncated** member returns
+a short buffer with *no exception*, so a caller who neither checks the length nor reads
+again never learns it was short. Rather than treat that as a trap to mitigate, we make
+it a **deliberate, first-class archivey idiom** with a clear meaning:
 
-- Full-count **removes the worse footgun and leaves a milder one.** Under up-to-`n`, a
-  single-call `read(member.size)` is unverified for *both* failures — including
-  **corruption**, which hands back *wrong* bytes silently. Full-count converts that into
-  a raised `CorruptionError`. What remains is truncation returning a short buffer of
-  *correct-but-incomplete* bytes — strictly less dangerous than silently trusting wrong
-  bytes, and detectable with a one-line `len == member.size` check that up-to-`n` gives
-  you no honest basis for.
-- The residual is closed by **`read_exact(n)`** (open question 4) for a one-call check,
-  by the length test, and by the `extract()` / whole-member-helper rule that always uses
-  a completing read. Naive single-call `read(n)` is the *low-level* surface; the safe
-  high-level paths never expose the trap.
+> **`read(member.size)` = "give me the member's content; on a *truncated* member return
+> the correct-but-incomplete prefix instead of raising."**
 
-So full-count does not introduce a new class of danger — it trades a silent
-*wrong-bytes* acceptance for a silent *short-but-correct* one, and hands callers the
-length signal (plus `read_exact`) to close even that.
+It still raises `CorruptionError` on *wrong* bytes (reaching the declared size with a
+bad checksum), so it means **"return what is correct and available,"** never "return
+wrong bytes." It is not a convenience that hides damage: there is **no equivalent
+pattern for a plain file** — a file has no member with a declared size — so
+`read(member.size)` appears only in archivey-aware code, written by someone who already
+knows what a member size *is*, not ported by habit from file-reading code. That is
+exactly why the sized-read asymmetry is safe to expose: the people who write it are the
+people who understand it.
+
+A caller who needs to know whether the member was whole has two standard ways — **no
+extra method required**:
+
+- **Length check** (cheap, weaker): `len(data) == member.size` → complete;
+  `len(data) < member.size` → truncated.
+- **A following `read()`** (authoritative): on a healthy member it returns `b""` (you
+  are at verified EOF — the checksum was already checked when the sized read reached the
+  declared size); on a truncated member it raises `TruncatedError`.
+
+So the whole-member idioms line up by **intent**, all using only standard `BinaryIO`
+methods:
+
+- `read()` / `read(-1)` / iterate-to-`b""` — *read the whole member and verify*; raise
+  on **any** damage (corruption or truncation);
+- `read(member.size)` — *salvage the available prefix*; raise only on corruption, return
+  short on truncation, disambiguated by a length check or a following `read()`.
+
+Either way, **corruption is never silent.** Against up-to-`n` this is a strict
+improvement: up-to-`n` would return a short buffer even on *healthy* data (silently
+losing good bytes) and could accept corruption silently on a single call; full-count
+does neither.
 
 ## Open questions
 
@@ -379,9 +408,9 @@ length signal (plus `read_exact`) to close even that.
 - **High-level helpers read to the true end.** `extract()` and any whole-member helper
   MUST consume each member with a *completing* read (`read(-1)`, or a sized read plus a
   drain to `b""`), so the default extraction path raises `TruncatedError` on a short
-  member rather than silently writing a truncated file. The quiet-truncation short
-  return is a **low-level** `read(member.size)` affordance for callers who opt into it,
-  never the default `extract` behavior.
+  member rather than silently writing a truncated file. The non-raising short return is
+  the deliberate `read(member.size)` **prefix-salvage** idiom for callers who opt into
+  it, never the default `extract` behavior.
 - **STRICT is proposed, not shipped (sequencing).** The escape hatch for "never release
   unverified / unauthenticated bytes" is `VerificationMode.STRICT`
   (`verification-integrity-mode`, still proposed). This ADR's STREAMING default is

--- a/docs/decisions/0014-integrity-verdicts-from-reads-not-close.md
+++ b/docs/decisions/0014-integrity-verdicts-from-reads-not-close.md
@@ -44,9 +44,9 @@ contract guarantees.**
 ### Options considered
 
 - **A — raise on the read that reaches the end.** The read that completes the member
-  and finds damage raises (returning no bytes for that call); `close()` never raises.
-  Same *failure surface* as stdlib `zipfile` / `gzip` (fault on read, not close) — not
-  byte-identical timing (their large-read / EOF shapes differ).
+  and finds damage raises (returning no bytes for that call); `close()` never raises a
+  content fault. Same *failure surface* as stdlib `zipfile` / `gzip` (fault on read,
+  not close) — not byte-identical timing (their large-read / EOF shapes differ).
 - **B — deliver every byte, then raise on the next read; `close()` as a backstop.**
   Uniform for corruption and truncation, but makes a *safety* guarantee depend on
   `close()` actually running — unreliable (GC-driven close is not guaranteed and
@@ -59,16 +59,25 @@ contract guarantees.**
 
 ### Two distinctions that resolve it
 
-**Corruption vs. truncation.** These are not the same failure:
+**Corruption vs. truncation (labels, not proofs).** These are not the same *reported*
+failure, and the labels are often **best-effort guesses** about what went wrong:
 
-- **Truncation** yields bytes that are *correct but incomplete* — worth delivering
-  (the recoverable-prefix salvage this change is built on).
-- **Corruption** yields bytes that are *wrong* — no value in returning the final chunk
-  of a member whose checksum just failed.
+- **`TruncatedError` / a short return** means the stream ended before the declared size
+  (or before a clean decoder end) — the member appears *incomplete*. The bytes already
+  returned are a **salvageable prefix on a best-effort basis**: a corruption that still
+  produces a valid-looking shorter decode is easily mistaken for truncation, so we
+  **cannot guarantee** that prefix is bit-correct relative to the author's intent.
+- **`CorruptionError`** means we observed positive evidence of wrongness — a checksum /
+  auth mismatch, an over-run past the declared size, or a mid-stream structural decode
+  failure. Withholding the final chunk of a member whose checksum just failed is still
+  right: those bytes are known-bad. When only a checksum mismatch is known, prior
+  chunks are also untrustworthy as a whole (the digest covers them).
 
-So "deliver every byte before failing" is right for truncation and pointless for
-corruption. Option A is correct *for corruption*; truncation naturally serves its
-prefix and fails on a later read.
+So "deliver the apparent prefix before failing" is right for the *truncation label* and
+pointless for a known checksum / auth failure. Option A is correct *for corruption*;
+truncation-shaped failures naturally serve their apparent prefix and fail on a later
+read. Callers that need cryptographic certainty use `VerificationMode.STRICT` (and
+still treat exception labels as labels).
 
 **Full-count vs. up-to-`n` `read`.** The regression example only reaches the end — and
 is therefore verifiable — if our `read(n)` returns the full count. Under an "up-to-`n`"
@@ -83,13 +92,18 @@ already implements.
 
 Under full-count `read`, a caller who wants the whole member reaches its end (they read
 `member.size`, or read until `b""`) and gets the verdict there. A caller who stops
-before the end deliberately opted out. There is no principled line between "stopped at
-byte 50 of a 500-byte member" and "stopped at byte 110 of that same 500-byte member
-when only 110 were decodable": both are early stops of a member whose declared size is
-500. Verifying one but not the other only because it sits on the current EOF boundary
-would be arbitrary. So **all** early stops are treated identically: no verdict, and
-`close()` stays silent — while a member *read to its end* that is damaged always
-raises, independent of whether `close()` runs.
+before the end deliberately opted out of checksum / auth verification.
+
+Truncation is observed only when a read **asks for more than the decoder can still
+produce**. If only 110 bytes are available of a `size=500` member, `read(109)` and
+`read(110)` both succeed with a full-count return and no error — the caller never
+tried to go past what exists (a prior pass that discovered the available length and
+then rereads exactly that far is intentional and correct). `read(111)` is the first
+call that crosses the cut: it returns a short 110, and a following read raises
+`TruncatedError`. The same cut relative to the *declared* size is what
+`read(member.size)` reports via `len < size`. Stopping short of both the declared size
+and the available decoder output (e.g. `read(50)` then `close()`) is an early stop: no
+checksum verdict, no truncation verdict, `close()` stays silent on content.
 
 ## Decision
 
@@ -101,8 +115,8 @@ truncation, or a raised content error. It does **not** return short on healthy,
 non-terminal data (unlike a raw `io.RawIOBase.read`; like `io.BufferedReader`). Two
 consequences the rest of this ADR depends on:
 
-- a **short return is a terminal signal** — clean EOF, or a truncation prefix; never
-  "healthy data, ask again";
+- a **short return is a terminal signal** — clean EOF, or a truncation-shaped prefix;
+  never "healthy data, ask again";
 - **`read(member.size)` reaches the declared size in one call**, which is what makes it
   a verifying event and closes the motivating regression.
 
@@ -119,15 +133,27 @@ The contract binds the public `ArchiveStream` / codec-stream surface; arbitrary 
 
 Content-integrity verdicts (stored checksum / digest, encrypted-member authentication
 tag, truncation, and declared-size over-run) are delivered from a **`read()` call,
-never from `close()`**. `close()` is teardown-only. It MAY still propagate an
-*unavoidable teardown signal raised by the underlying resource itself* — an `OSError`
-closing a file descriptor, or a subprocess exit code that only arrives when the process
-is reaped (e.g. `unrar` reporting a wrong password on close). It MUST NOT surface the
-**verifier's own** content verdict (checksum / auth / truncation) as a first fault on
-`close()`. One current construct violates this — the WinZip AES stream drains and
-verifies its HMAC in its own `close()` — and is treated as a **known inconsistency to
-remove** (`verification-integrity-mode` Decision 2), **not** a blessed carve-out; until
-it is removed, this guarantee is library-wide *except* for that one path.
+never from `close()`**. The **target contract** is uniform across formats:
+`close()` is teardown-only and does **not** raise a content fault
+(`CorruptionError` / `TruncatedError` / `EncryptionError` from verification or
+backend finalization).
+
+**Today that target is best-effort; the intention is complete parity.** The verifier
+path already meets it. Two known gaps remain and are **debt to close**, not blessed
+carve-outs:
+
+- **WinZip AES** drains and verifies its HMAC in its own `close()` — remove
+  (`verification-integrity-mode` Decision 2).
+- **`unrar` / subprocess backends** may only surface wrong-password or CRC exit codes
+  when the process is reaped on close. Work toward parity by **eagerly finalizing** the
+  underlying resource as part of the *completing* read (after the last content byte,
+  reap / close the inner so the fault raises on that `read()`), and on an *early-stop*
+  `close()` **suppress** content-class faults that arrive only from teardown (the
+  caller opted out of a completing read). Until those land, a content error from
+  `close()` on those paths is a known inconsistency, not the contract.
+
+`close()` MAY still propagate a true resource teardown signal (`OSError` closing a
+file descriptor, and similar non-content failures).
 
 A member is verified at the moment a read **reaches its end** — whichever comes first:
 
@@ -139,85 +165,131 @@ At that moment:
 
 - **Corruption** (checksum / auth mismatch, or a mid-stream structural error): the
   reaching read raises `CorruptionError` and returns no bytes. The final chunk of a
-  member known to be corrupt is **withheld** (for size-declared members; see the
-  size-unknown consequence and open question below).
+  member known to be corrupt is **withheld** for **size-declared** members. For
+  **size-unknown** members (e.g. standalone gzip, where the CRC lives in a trailer
+  *after* the last plaintext byte), the verdict surfaces on the read that **observes
+  end-of-stream** — possibly after the final data chunk was already released. We do
+  **not** require a one-chunk delayed-release lookahead for uniform withhold timing;
+  `read(-1)` / read-to-`b""` still honors the top-level guarantee, and
+  "detection, not prevention" already permits pre-verdict bytes.
 - **Over-run** (decode output exceeds the declared size — a corrupt length field): the
   read that would cross the declared size raises `CorruptionError`, **independent of
   the checksum** (the over-run itself is the corruption, even if the hash-so-far would
   pass). This is the same stop-at-declared-size → `CorruptionError` bound that
   `gzip-zlib-truncation-recovery` already specifies as the decompression-bomb cap.
 - **Truncation / short** (decoder end-of-stream before the declared size, or an
-  incomplete decode): every recoverable byte was delivered on the preceding full-count
-  reads; the read that reaches the short end returns the remaining prefix (a **short
-  return**, not an exception), and the *next* read raises `TruncatedError`.
+  incomplete decode): every byte the decoder could produce was delivered on the
+  preceding full-count reads; the first read that **asks past** the available output
+  returns the remaining prefix (a **short return**, not an exception), and the *next*
+  read raises `TruncatedError`. A read that requests *exactly* the remaining available
+  bytes succeeds with a full-count return and no error.
 
 Reaching the declared size is **always** a verifying event — checksum *and* over-run —
 regardless of how the caller got there (`read(n)` with `n == remaining`, or a chunked
 loop). The verdict is a property of *reaching the end*, not of the call shape.
 
-A read that **stops before the end** — at any offset — produces **no verdict**, and
-`close()` stays silent. A seek off the sequential frontier disables the **checksum**
-verdict for the rest of the handle's life (incremental hashing assumes linear
-consumption); structural truncation past the seek remains detectable in principle, but
-for simplicity we disable both under one rule (see open question 3).
+A read that **stops before the end** — at any offset short of both the declared size
+and a past-available attempt — produces **no verdict**, and `close()` stays silent on
+content (modulo the best-effort gaps above).
 
-### Short returns are never corrupt bytes
+### Seek: keep length checks; lose only the checksum
 
-Because corruption *raises* rather than returning short, a short return from a
-full-count `read` is only ever **clean-but-complete** (you asked for more than the
-member holds) or **truncated** (correct-but-incomplete prefix). It is never "here are
-some wrong bytes." A single-call reader distinguishes the two by length:
+A seek off the sequential frontier breaks *incremental hashing* (non-linear
+consumption), so the **checksum** verdict is best-effort and forfeited for the rest of
+that handle's life — a seek-forward-then-back-to-end must not re-enable a hash
+comparison over a non-contiguous byte range (false-positive `CorruptionError`). The
+**length / structural** verdict is position-based, not hash-based: at EOF the stream
+knows its total decompressed position, so **truncation** (short of the expected size)
+and **over-run** (past it) stay detectable and SHALL still raise, even after a seek.
+A member that is not *truly* seekable — one satisfied by rewinding / re-decoding from
+the start — preserves linear hashing, so the checksum is not lost there either.
+Honest scope: **checksum detection is best-effort, forfeited only on a genuine
+intra-stream seek of a truly-seekable member (itself an opt-in capability); length /
+truncation / over-run detection is always on.**
 
-- size-declared member: `len(data) == member.size` → complete and verified;
-  `len(data) < member.size` → truncated (the shortfall is the tell), and reading again
-  raises `TruncatedError`;
+### Short returns are never *known*-corrupt bytes
+
+Because a checksum / auth mismatch *raises* rather than returning short, a short
+return from a full-count `read` is only ever **clean-but-complete** (you asked for more
+than the member holds) or **truncation-shaped** (an apparent incomplete prefix). It is
+never "here are bytes we already know fail the digest." A single-call reader
+distinguishes the two by length:
+
+- size-declared member: `len(data) == member.size` → complete and checksum-verified;
+  `len(data) < member.size` → truncation-shaped (the shortfall is the tell), and
+  reading again raises `TruncatedError`;
 - size-unknown member: a bare `read(n)` cannot self-certify — read `-1` or to `b""`.
+
+The truncation-shaped prefix is **best-effort salvage**, not a proof of correctness
+(see Context: corruption can look like truncation).
+
+### `read_exact(n)` — rejected
+
+A dedicated `read_exact` would kill the sized-read truncation footgun in one call, but
+it adds a **non-standard method** to the stream surface. A core goal is that code
+written against archivey streams also works against ordinary file objects (and vice
+versa), so we do **not** add methods a plain `BinaryIO` lacks. The truncation-short
+residual is handled with **standard means** instead: the guaranteed whole-member
+idioms are `read()` / `read(-1)` / iterate-to-`b""` (all standard, all raise on
+truncation-shaped failure); `read(member.size)` is a *bounded* read whose short return
+the caller checks by length; and `extract()` / whole-member helpers use a completing
+read.
 
 ## Guarantee (for users)
 
 > **Read a member to its end: a corrupt member raises `CorruptionError` on a `read()`;
 > a truncated member raises `TruncatedError` or returns short of its declared size; a
 > clean member returns all its bytes, checksum-verified. Stop before the end and it is
-> not verified. `close()` never raises a content error.**
+> not verified. `close()` never raises a content error (target contract; best-effort
+> today on a few backends — see Decision).**
 
 "To its end" means `read(-1)` / `readall`, reading until `read()` returns `b""`, or —
 for a member with a **declared** size — reading that many bytes. For that whole-member
-read, each outcome tells you exactly what you can trust:
+read, each outcome tells you what the library claims — with the honesty caveats below:
 
-- a **`CorruptionError`** means the content is wrong — **discard everything read from
-  this member; none of it is trustworthy** (the raising call returns nothing);
-- a **`TruncatedError`** means the member is incomplete — the bytes **already returned
-  on prior reads are correct** (a salvageable prefix), but the member is not whole; the
-  raising call itself returns nothing;
+- a **`CorruptionError`** means we have positive evidence of wrongness — **discard
+  everything read from this member; none of it is trustworthy** as a complete intact
+  member (the raising call returns nothing). A digest / auth mismatch is the clear
+  case; mid-stream structural failures are likewise treated as untrustworthy;
+- a **`TruncatedError`** means the member appears **incomplete** — the bytes already
+  returned are a **best-effort salvageable prefix**, not a proven-correct prefix
+  (corruption that decodes to a shorter stream is easily labeled truncation). The
+  raising call itself returns nothing; do not treat the prefix as the whole member;
 - a **full-length** return (`len == member.size`, or a subsequent `b""`) means the
-  content was **checksum-verified** — trust it;
-- a **short** return (`len < member.size`, no exception) means **truncation** — the
-  bytes returned are correct but the member is incomplete; **"no exception" does not
-  mean "complete."** Check the length, or read again to get the `TruncatedError`.
+  content was **checksum-verified** — trust it under the digest's strength;
+- a **short** return (`len < member.size`, no exception) means **truncation-shaped** —
+  an apparent incomplete member; **"no exception" does not mean "complete."** Check
+  the length, or read again to get the `TruncatedError`. Prefix correctness remains
+  best-effort.
 
-Corruption is caught whenever such a read reaches the end — independent of whether
-`close()` is ever called. Callers who must verify **regardless** of access pattern
-(partial reads, seeks, or "never release unverified bytes") use
-`VerificationMode.STRICT` (`verification-integrity-mode`), which fully verifies a
-member before returning any of it.
+Corruption that the library can *prove* (digest / auth mismatch, over-run) is caught
+whenever such a read reaches the end — independent of whether `close()` is ever
+called. Callers who must verify **regardless** of access pattern (partial reads,
+seeks, or "never release unverified bytes") use `VerificationMode.STRICT`
+(`verification-integrity-mode`), which fully verifies a member before returning any of
+it.
 
 ### Call × failure matrix (size-declared member)
 
-| Call | Corrupt at full length | Truncated short of declared size |
+Assume a member truncated after 110 decompressed bytes with `member.size == 500`:
+
+| Call | Corrupt at full length | Truncated after 110 of 500 |
 | --- | --- | --- |
+| `read(109)` (from start) | (n/a — not yet at end) | returns 109, **no error** (did not ask past available) |
+| `read(110)` (from start) | (n/a — not yet at end) | returns 110, **no error** (exactly available) |
+| `read(111)` (from start) | (n/a) | returns short 110; following `read()` raises `TruncatedError` |
 | `read(member.size)` | raises `CorruptionError` | returns short (`len < size`), **no exception** |
 | `read(-1)` / `readall` | raises `CorruptionError` | raises `TruncatedError` |
-| chunked until `b""` | raises on the read that reaches the size (withholds that chunk) | delivers the whole prefix (final read returns short); the read *past* the prefix raises `TruncatedError` |
+| chunked until `b""` | raises on the read that reaches the size (withholds that chunk) | delivers the whole prefix; first read *past* available returns short; the next raises `TruncatedError` |
 | partial read, then `close()` | quiet (early stop) | quiet (early stop) |
 
 The load-bearing asymmetry: **`read(member.size)` raises on corruption but returns a
-short buffer on truncation** — because corruption yields wrong bytes (withheld) while
-truncation yields a correct-but-incomplete prefix (delivered). This is a **deliberate
-idiom** ("salvage the available prefix; raise only on wrong bytes"), not a trap — see
-*`read(member.size)` — read the available prefix without raising* below for why it is
-safe to expose and how a caller checks for truncation (length, or a following `read()`).
-Size-unknown members have no `member.size` to read to, so a bare `read(n)` cannot
-self-certify at all — use `read(-1)` / read-to-`b""`.
+short buffer on truncation** — because a known digest failure yields wrong bytes
+(withheld) while a truncation-shaped end yields an apparent incomplete prefix
+(delivered). This is a **deliberate idiom** ("return the available prefix; raise on
+known-wrong bytes"), not a trap — see *`read(member.size)` — read the available prefix
+without raising* below. Size-unknown members have no `member.size` to read to, so a
+bare `read(n)` cannot self-certify at all — use `read(-1)` / read-to-`b""`.
 
 ## Full-count `read`: rationale and trade-offs
 
@@ -249,7 +321,7 @@ gets its own accounting. The two candidate contracts:
   perfectly good member; a caller who reads once and trusts it **silently loses correct
   data on an undamaged archive** — the worst outcome, and a frequent one. Full-count
   eliminates it: a healthy `read(n)` always returns `n`. Its only silent-ish residual is
-  genuine truncation, where the bytes are correct and the shortfall is length-checkable.
+  genuine truncation-shaped ends, where the shortfall is length-checkable.
 - **It makes the verification story true.** Under up-to-`n`,
   `data = f.read(member.size)` can return a prefix on healthy data; the single-call
   caller never reaches the declared size, and corruption is silently accepted — the
@@ -293,36 +365,43 @@ a short buffer with *no exception*, so a caller who neither checks the length no
 again never learns it was short. Rather than treat that as a trap to mitigate, we make
 it a **deliberate, first-class archivey idiom** with a clear meaning:
 
-> **`read(member.size)` = "give me the member's content; on a *truncated* member return
-> the correct-but-incomplete prefix instead of raising."**
+> **`read(member.size)` = "give me the member's content; on a *truncation-shaped*
+> member return the available prefix instead of raising."**
 
-It still raises `CorruptionError` on *wrong* bytes (reaching the declared size with a
-bad checksum), so it means **"return what is correct and available,"** never "return
-wrong bytes." It is not a convenience that hides damage: there is **no equivalent
-pattern for a plain file** — a file has no member with a declared size — so
-`read(member.size)` appears only in archivey-aware code, written by someone who already
-knows what a member size *is*, not ported by habit from file-reading code. That is
-exactly why the sized-read asymmetry is safe to expose: the people who write it are the
-people who understand it.
+It still raises `CorruptionError` on *known-wrong* bytes (reaching the declared size
+with a bad checksum), so it means **"return what is available; raise when we can prove
+wrongness,"** never "return bytes we already know fail the digest." It is not a
+convenience that hides damage: there is **no equivalent pattern for a plain file** — a
+file has no member with a declared size — so `read(member.size)` appears only in
+archivey-aware code, written by someone who already knows what a member size *is*, not
+ported by habit from file-reading code. That is exactly why the sized-read asymmetry is
+safe to expose: the people who write it are the people who understand it.
+
+This is a **narrow first step** toward damaged-input salvage (VISION / `IDEAS.md`), not
+the full salvage mode (e.g. recovering a truncated ZIP that lost its central
+directory). No claims beyond sized-read / streaming prefix delivery for
+truncation-shaped member bodies.
 
 A caller who needs to know whether the member was whole has two standard ways — **no
 extra method required**:
 
 - **Length check** (cheap, weaker): `len(data) == member.size` → complete;
-  `len(data) < member.size` → truncated.
-- **A following `read()`** (authoritative): on a healthy member it returns `b""` (you
-  are at verified EOF — the checksum was already checked when the sized read reached the
-  declared size); on a truncated member it raises `TruncatedError`.
+  `len(data) < member.size` → truncation-shaped.
+- **A following `read()`** (authoritative for the *label*): on a healthy member it
+  returns `b""` (you are at verified EOF — the checksum was already checked when the
+  sized read reached the declared size); on a truncation-shaped member it raises
+  `TruncatedError`.
 
 So the whole-member idioms line up by **intent**, all using only standard `BinaryIO`
 methods:
 
 - `read()` / `read(-1)` / iterate-to-`b""` — *read the whole member and verify*; raise
-  on **any** damage (corruption or truncation);
-- `read(member.size)` — *salvage the available prefix*; raise only on corruption, return
-  short on truncation, disambiguated by a length check or a following `read()`.
+  on **any** damage label (corruption or truncation);
+- `read(member.size)` — *return the available prefix*; raise only on known corruption,
+  return short on truncation-shaped ends, disambiguated by a length check or a
+  following `read()`.
 
-Either way, **corruption is never silent.** Against up-to-`n` this is a strict
+Either way, **known corruption is never silent.** Against up-to-`n` this is a strict
 improvement: up-to-`n` would return a short buffer even on *healthy* data (silently
 losing good bytes) and could accept corruption silently on a single call; full-count
 does neither.
@@ -354,40 +433,6 @@ does neither.
    STRICT with the per-shape strategy above? **Leaning: STREAMING default** — compressed
    wrong-password fails fast and a blanket STRICT is not implementable memory-safely — but
    document the stored/tiny exposure sharply and make STRICT the easy opt-in.
-2. **Size-unknown "withhold the corrupt final chunk" requires lookahead.** For a
-   size-declared member we know the boundary before releasing the final chunk, so we
-   can withhold it. For a size-unknown member (e.g. standalone gzip) the CRC lives in a
-   trailer *after* the last plaintext byte: the decoder emits the final plaintext and
-   only sees end-of-stream on the next pull. Honoring "corruption caught on the last
-   data read / final chunk withheld" for size-unknown members requires a **one-chunk
-   delayed-release buffer** (never hand out chunk *N* until chunk *N+1*-or-EOS has been
-   pulled). Do we (a) require that lookahead for uniform behavior (small constant
-   buffering), or (b) accept that size-unknown members surface the verdict on the read
-   that observes end-of-stream — possibly *after* the final data chunk was released —
-   which still honors the top-level guarantee via `read(-1)` / read-to-`b""`?
-   Recommendation: **(b)**, documented — the realistic size-unknown reader reads to
-   `b""` anyway, and "detection, not prevention" already permits pre-verdict bytes.
-3. **Seek and structural detection — keep length checks; lose only the checksum**
-   (leaning *narrow*, not "disable everything"). A seek off the sequential frontier
-   breaks *incremental hashing* (non-linear consumption), so the **checksum** verdict is
-   best-effort and forfeited there. But the **length / structural** verdict is
-   position-based, not hash-based: at EOF the stream knows its total decompressed
-   position, so **truncation** (short of the expected size) and **over-run** (past it)
-   stay detectable and SHALL still raise, even after a seek. And a member that is not
-   *truly* seekable — one satisfied by rewinding / re-decoding from the start — preserves
-   linear hashing, so the checksum is not lost there either. Honest scope: **checksum
-   detection is best-effort, forfeited only on a genuine intra-stream seek of a
-   truly-seekable member (itself an opt-in capability); length / truncation detection is
-   always on.**
-4. **`read_exact(n)` — rejected.** A dedicated `read_exact` would kill the sized-read
-   truncation footgun in one call, but it adds a **non-standard method** to the stream
-   surface. A core goal is that code written against archivey streams also works against
-   ordinary file objects (and vice versa), so we do **not** add methods a plain
-   `BinaryIO` lacks. The truncation-short residual is handled with **standard means**
-   instead: the guaranteed whole-member idioms are `read()` / `read(-1)` /
-   iterate-to-`b""` (all standard, all raise on truncation); `read(member.size)` is a
-   *bounded* read whose short return the caller checks by length; and `extract()` /
-   whole-member helpers use a completing read.
 
 ## Consequences
 
@@ -398,10 +443,12 @@ does neither.
   read ("do not withhold the last data chunk";
   `test_verify_mismatch_raises_at_eof_without_losing_final_chunk`) — is **revised** by
   this ADR for the corruption case: the read that reaches the declared size (or decoder
-  EOS) raises and **withholds** that chunk. When #183 resumes, its delta and that test
-  are updated to the withhold-on-reaching-read rule so the two texts agree — not a live
-  conflict, but the settlement that unblocks #183. **Truncation is unchanged** —
-  #183's recoverable-prefix delivery stands.
+  EOS) raises and **withholds** that chunk for size-declared members. When #183 resumes,
+  its delta and that test are updated to the withhold-on-reaching-read rule so the two
+  texts agree — not a live conflict, but the settlement that unblocks #183.
+  **Truncation-shaped delivery is unchanged** — #183's recoverable-prefix delivery
+  stands (with the best-effort correctness caveat above). Size-unknown timing is
+  decided: verdict on the EOS-observing read, no mandatory lookahead withhold.
 - **`read(member.size)` on a corrupt size-declared member raises from that read** and
   returns nothing — closing the silent-acceptance regression, without depending on
   `close()`.
@@ -409,8 +456,8 @@ does neither.
   MUST consume each member with a *completing* read (`read(-1)`, or a sized read plus a
   drain to `b""`), so the default extraction path raises `TruncatedError` on a short
   member rather than silently writing a truncated file. The non-raising short return is
-  the deliberate `read(member.size)` **prefix-salvage** idiom for callers who opt into
-  it, never the default `extract` behavior.
+  the deliberate `read(member.size)` **prefix** idiom for callers who opt into it,
+  never the default `extract` behavior.
 - **STRICT is proposed, not shipped (sequencing).** The escape hatch for "never release
   unverified / unauthenticated bytes" is `VerificationMode.STRICT`
   (`verification-integrity-mode`, still proposed). This ADR's STREAMING default is
@@ -422,27 +469,34 @@ does neither.
   `n`-or-terminal). See *Full-count `read`: rationale and trade-offs* for the full
   accounting; the short version is that the decompressor engine already does this and
   the verifier / passthrough paths must be brought in line.
-- **`close()` never raises a content fault.** Cleanup is safe; a content error can
-  neither mask nor be masked by an exception unwinding a `with` body; safety does not
-  hinge on `close()` running.
+- **`close()` never raises a content fault — target contract, best-effort today.**
+  Cleanup is safe when the target holds; a content error can neither mask nor be masked
+  by an exception unwinding a `with` body; safety does not hinge on `close()` running.
+  AES HMAC-on-close and unrar-exit-on-close are documented debt toward that parity
+  (eager finalize on completing read; suppress teardown-only content faults on
+  early-stop close).
 - **Detection, not prevention, in streaming mode.** Any bounded read returns some bytes
   before the final verdict; the guarantee is "you are told before you can conclude the
   member is complete-and-intact," not "you are told before you touch any bytes."
   Prevention is `VerificationMode.STRICT`.
-- **Size-declared vs. size-unknown timing differs** (open question 2). Size-declared:
-  verdict on the read that reaches the declared size (the decoder must also consume the
+- **Size-declared vs. size-unknown timing differs** (decided). Size-declared: verdict
+  on the read that reaches the declared size (the decoder must also consume the
   trailing CRC/tag to validate before that read returns or raises). Size-unknown:
-  verdict on the read that observes end-of-stream — the last data read only if a
-  lookahead buffer is adopted, otherwise the following read.
+  verdict on the read that observes end-of-stream — not a mandatory lookahead withhold
+  of the final data chunk.
 - **Encrypted members are a sharper case** (open question 1). With a single tag over
   the whole member, streaming *must* release unverified plaintext; segment-authenticated
   (per-chunk AEAD) formats could verify each chunk before release, but archivey's
   current formats do not.
-- **Exception type tells you what you can trust.** `CorruptionError` ⇒ the content is
-  wrong; trust **nothing** already read from this member. `TruncatedError` ⇒ the bytes
-  already returned are correct but the member is **incomplete**; a caller may keep a
-  salvaged prefix if incompleteness is acceptable, but must not treat it as the whole
-  member. Documented on the exceptions and in the streaming guide.
+- **Exception labels are best-effort trust signals.** `CorruptionError` ⇒ positive
+  evidence of wrongness; trust **nothing** already read from this member as intact.
+  `TruncatedError` ⇒ the member appears **incomplete**; the bytes already returned are
+  a **best-effort** salvageable prefix (not proven correct — corruption can look like
+  truncation). Documented on the exceptions and in the streaming guide.
+- **Narrow salvage, not full salvage.** Sized-read / streaming prefix delivery for
+  truncation-shaped bodies is a first step toward VISION's damaged-input salvage story;
+  it makes **no** claims about recovering archives that lost structural metadata (e.g.
+  truncated ZIP without a central directory).
 
 ## Implementation notes
 
@@ -451,9 +505,13 @@ does neither.
   the call returns or raises — the read that reaches the declared size finalizes the
   hash.
 - **Seek-state tracking.** Once a seek off the sequential frontier disables the
-  checksum verdict, it stays disabled — a seek-forward-then-back-to-end must not
-  re-enable a hash comparison over a non-contiguous byte range (false-positive
-  `CorruptionError`).
+  checksum verdict, it stays disabled for that handle; length / over-run / truncation
+  checks remain active.
 - **Full-count coalescing.** Bounded `read(n)` on the verifier/wrapper must loop the
   inner stream until it has `n` bytes or a terminal boundary, so the full-count
   contract holds even over a short-reading inner `BinaryIO`.
+- **Eager finalize on completing reads (parity path).** Where a backend only reports
+  content faults at process/resource teardown (`unrar` exit codes, similar), the
+  completing-read path should reap/finalize immediately after the last content byte so
+  the fault raises on that `read()`; early-stop `close()` should not promote those
+  teardown-only content faults into the caller's close.

--- a/docs/decisions/0014-integrity-verdicts-from-reads-not-close.md
+++ b/docs/decisions/0014-integrity-verdicts-from-reads-not-close.md
@@ -385,12 +385,10 @@ gets its own accounting. The two candidate contracts:
 ### What it costs
 
 - **A stream can no longer "read one block, decompress it, return those bytes."** Every
-  public `read(n)` must **coalesce**: loop-decode until it holds `n` output bytes or
-  hits a terminal boundary, and **buffer any overflow** (a block that yields more than
-  `n`) for the next call. `DecompressorStream` already works this way; but
-  `MemberVerifier.read` (a single `inner.read(want)`) and an unverified `ArchiveStream`
-  passthrough (straight to `inner.read(n)`) do **not** — they must be updated. This is a
-  **`compressed-streams` contract delta across backends**, not a local verifier tweak.
+  public `read(n)` must **coalesce** to `n` or a terminal boundary. #183 does this via
+  `read_full_count` (stop on short) on `MemberVerifier` / `ArchiveStream` — see the
+  stop-on-short note under Decision. This is a **`compressed-streams` contract delta
+  across backends**, not a local verifier tweak.
 - **More work inside a single call for large `n`.** `read(n)` may decode several blocks
   before returning. The work is still **bounded by `n`** (the caller's output budget),
   so the `max_length` output cap and decompression-bomb bounds are unaffected — the same
@@ -401,6 +399,10 @@ gets its own accounting. The two candidate contracts:
   delivery can pass a small `n`.
 - **A small buffer + fill loop in each wrapper.** Already carried by the decompressor
   engine; the cost is extending it to the verifier and passthrough paths.
+- **Stop-on-short vs true RawIO coalesce.** Preserving deferred decompressor truncation
+  means the wrapper does not keep pulling after a mid-stream short the way
+  `BufferedReader` would over RawIO. That is acceptable because archivey inners are
+  fill-or-EOF; document it rather than over-claim drop-in RawIO buffering.
 
 **Verdict: worth it.** The cost is concentrated in wrapper plumbing that the
 decompressor path already has, and the payoff is a simpler, `BufferedReader`-compatible

--- a/docs/decisions/0014-integrity-verdicts-from-reads-not-close.md
+++ b/docs/decisions/0014-integrity-verdicts-from-reads-not-close.md
@@ -235,6 +235,36 @@ truncation-shaped failure); `read(member.size)` is a *bounded* read whose short 
 the caller checks by length; and `extract()` / whole-member helpers use a completing
 read.
 
+### Diagnostics — raise vs advisory
+
+This ADR does not invent a new diagnostic taxonomy; it draws the line against the
+existing `diagnostics` model (`DIGEST_UNVERIFIABLE`, rewind / seek-index advisories as
+data; digest mismatch and truncation as hard errors).
+
+**Rule of thumb:** **raise** when the library knows the member is damaged (or
+over-ran). **Diagnose** when the library could not or did not finish a check, or
+*hid* a backend signal — especially when silence would look like success. Never demote
+an integrity verdict to a diagnostic and hope `RAISE` disposition will stand in for
+`CorruptionError` / `TruncatedError`.
+
+| Situation | Raise? | Diagnostic? |
+| --- | --- | --- |
+| Checksum / auth mismatch, over-run, mid-stream decode failure | `CorruptionError` | No |
+| Read past available / completing read short of declared size | `TruncatedError` (or short, then next read) | No |
+| Expected digest present but algorithm / hasher unavailable | No (bytes still flow) | **Yes — already** `DIGEST_UNVERIFIABLE` |
+| Early stop / partial read then `close()` | No (by design) | **No** (default) — deliberate opt-out; diagnosing every peek is noise |
+| Seek forfeits checksum for the handle | No | **Yes — add** (name TBD, e.g. `CHECKSUM_FORFEITED_AFTER_SEEK`): once per handle when a true intra-stream seek drops incremental hashing; same honesty family as `STREAM_REWIND_REDECOMPRESSES` / `SEEK_INDEX_DEGRADED` |
+| Early-stop `close()` suppresses a teardown-only content fault (`unrar` / AES-style parity path) | No (swallowed for close parity) | **Yes — add** (name TBD, e.g. `CONTENT_FAULT_SUPPRESSED_ON_CLOSE`): backend knew something; swallowing without a trace is the surprise |
+| Completing read surfaces that fault via eager finalize | Exception on that `read()` | No extra diagnostic |
+| Streaming released bytes before a later CRC / auth fail | Later `CorruptionError` | No (default) — detection-not-prevention is the mode |
+| `read(member.size)` short; caller ignores length | No | No — idiom + length check; diagnostics are not a `len` substitute |
+| “Could be corruption mislabeled as truncation” | Still `TruncatedError` | No for now — documented caveat; a confidence field waits until something consumes it |
+| Every encrypted member under STREAMING | No | No — accepted default posture; STRICT is the opt-in |
+
+The two new codes are **follow-ups** (emitter + `diagnostics` / OpenSpec delta when the
+seek-forfeit and close-parity paths land) — not blockers for accepting this ADR or for
+resuming #183. Exact code names are TBD at implementation.
+
 ## Guarantee (for users)
 
 > **Read a member to its end: a corrupt member raises `CorruptionError` on a `read()`;
@@ -497,6 +527,11 @@ does neither.
   truncation-shaped bodies is a first step toward VISION's damaged-input salvage story;
   it makes **no** claims about recovering archives that lost structural metadata (e.g.
   truncated ZIP without a central directory).
+- **Diagnostics stay advisory; integrity verdicts stay exceptions.** Early stops and
+  STREAMING pre-verdict byte release are silent by design. Follow-up codes (when those
+  paths land): checksum forfeited after seek, and content fault suppressed on
+  early-stop close — so capability loss and swallowed backend signals stay queryable.
+  `DIGEST_UNVERIFIABLE` is unchanged. See *Diagnostics — raise vs advisory*.
 
 ## Implementation notes
 
@@ -514,4 +549,8 @@ does neither.
   content faults at process/resource teardown (`unrar` exit codes, similar), the
   completing-read path should reap/finalize immediately after the last content byte so
   the fault raises on that `read()`; early-stop `close()` should not promote those
-  teardown-only content faults into the caller's close.
+  teardown-only content faults into the caller's close — emit the suppressed-fault
+  diagnostic instead (when that code lands).
+- **Seek-forfeit diagnostic.** When a true intra-stream seek disables the checksum
+  verdict for the handle, emit the forfeited-checksum diagnostic once; length /
+  over-run / truncation checks remain active without a diagnostic of their own.

--- a/docs/decisions/index.md
+++ b/docs/decisions/index.md
@@ -22,6 +22,7 @@ not fully recovered yet.
 | [0011](0011-zero-dependency-core.md) | Zero third-party deps in core install | recorded |
 | [0012](0012-usage-errors-outside-archiveyerror.md) | `ArchiveyUsageError` ≠ `ArchiveyError` | recorded |
 | [0013](0013-cross-platform-name-safety-policies.md) | Cross-platform extraction name-safety policies | recorded |
+| [0014](0014-integrity-verdicts-from-reads-not-close.md) | Integrity verdicts surface from reads, never `close()` | proposed |
 
 Related long-form material (not ADRs):
 

--- a/docs/decisions/index.md
+++ b/docs/decisions/index.md
@@ -22,7 +22,7 @@ not fully recovered yet.
 | [0011](0011-zero-dependency-core.md) | Zero third-party deps in core install | recorded |
 | [0012](0012-usage-errors-outside-archiveyerror.md) | `ArchiveyUsageError` ≠ `ArchiveyError` | recorded |
 | [0013](0013-cross-platform-name-safety-policies.md) | Cross-platform extraction name-safety policies | recorded |
-| [0014](0014-integrity-verdicts-from-reads-not-close.md) | Integrity verdicts surface from reads, never `close()` | proposed |
+| [0014](0014-integrity-verdicts-from-reads-not-close.md) | Integrity verdicts surface from reads, never `close()` | recorded |
 
 Related long-form material (not ADRs):
 


### PR DESCRIPTION
## Summary

Docs only — a new ADR (`docs/decisions/0014-…`) recording the `read()`/`close()` integrity-verification-timing decision worked out in the `gzip-zlib-truncation-recovery` (PR #183) review, written to circulate for input (`Status: proposed`).

## The decision, in one line

> Read a member to its end and a damaged member raises on a `read()`. Stop before the end and it is not verified. `close()` never raises a content error.

Concretely — a verdict fires on the read that **reaches the member's end** (declared size, or the decoder's end-of-stream):
- **corruption** fails fast on that read and withholds the corrupt final chunk (bytes are wrong — no value in returning them);
- **truncation** delivers its recoverable prefix and raises on the read that reaches the end while still short (bytes are correct-but-incomplete);
- an **early stop at any offset** — including exactly the currently-available bytes — yields **no verdict**; `close()` is teardown-only.

## What the ADR captures

- Why `close()` must not be the surface for a content fault (safety can't depend on `close()` running — GC-close is unreliable and swallows exceptions; a close-time error masks/gets masked in a `with` body).
- The **corruption vs truncation** distinction that resolves the "deliver every byte" vs "fail fast" tension.
- The corrected justification about reads: **a short read is not an EOF signal** (only `b""` is), so the truncation tell is "read toward the expected size and you hit an error on a `read()`" — which is why every early stop is treated identically.
- Consequences: reverses "deliver every byte on a checksum mismatch"; detection-not-prevention in streaming; the encrypted release-of-unverified-plaintext note; and `VerificationMode.STRICT` as the verify-regardless posture.

## Relationship to other PRs

- Motivated by / decides the open item in **#183** (`gzip-zlib-truncation-recovery`).
- References the **verification-integrity-mode** proposal (#185) for STRICT.
- No code; the implementation re-scope (verify-on-terminal-read, `close()` teardown-only, drop the vestigial probe) follows once this is agreed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01B95mCP2hhHZp199PAuK6Q4)_