### PR TITLE
Add rapidgzip and inflate64 native stress harnesses

### DIFF
--- a/.github/workflows/native-codec-stress.yml
+++ b/.github/workflows/native-codec-stress.yml
@@ -1,0 +1,103 @@
+name: Native codec stress
+
+# Per-library investigation vehicles for native codec / accelerator aborts
+# (rapidgzip, inflate64; PPMd keeps its own workflow). See
+# docs/internal/known-issues.md ("Native codec stress inventory").
+#
+# Runs on every PR and on pushes to main so we keep signal, but lives in its *own*
+# workflow on purpose: do **not** add this check as a required status check — a red
+# run here must not block merge. Default pytest excludes ``native_codec_stress``.
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      iterations:
+        description: "Isolated child iterations per scenario"
+        required: false
+        default: "20"
+
+concurrency:
+  group: native-codec-stress-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  native-stress:
+    name: ${{ matrix.os }} / py${{ matrix.python-version }} / ${{ matrix.lib }} stress
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - { os: ubuntu-latest, python-version: "3.11", lib: rapidgzip }
+          - { os: ubuntu-latest, python-version: "3.14", lib: rapidgzip }
+          - { os: windows-latest, python-version: "3.11", lib: rapidgzip }
+          - { os: macos-latest, python-version: "3.11", lib: rapidgzip }
+          - { os: ubuntu-latest, python-version: "3.11", lib: inflate64 }
+          - { os: ubuntu-latest, python-version: "3.14", lib: inflate64 }
+          - { os: windows-latest, python-version: "3.11", lib: inflate64 }
+    env:
+      UV_PYTHON: ${{ matrix.python-version }}
+      ARCHIVEY_RAPIDGZIP_STRESS_ITERS: ${{ github.event.inputs.iterations || '20' }}
+      ARCHIVEY_INFLATE64_STRESS_ITERS: ${{ github.event.inputs.iterations || '20' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        id: setup-uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Python ${{ matrix.python-version }}
+        run: uv python install ${{ matrix.python-version }}
+
+      - name: Sync (dev + all extras)
+        id: sync
+        run: uv sync --python ${{ matrix.python-version }} --group dev --extra all
+
+      - name: Install 7z (inflate64 ZIP fixtures)
+        if: matrix.lib == 'inflate64' && runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y p7zip-full || true
+
+      - name: Install 7z (inflate64 ZIP fixtures, macOS)
+        if: matrix.lib == 'inflate64' && runner.os == 'macOS'
+        run: brew install p7zip || true
+
+      - name: Assert synced venv Python matches matrix
+        run: >
+          uv run --python ${{ matrix.python-version }} --no-sync python -c
+          "import sys; exp=tuple(map(int, '${{ matrix.python-version }}'.split('.')));
+          got=sys.version_info[:2]; assert got==exp, (got, exp); print(sys.version)"
+
+      - name: Stress ${{ matrix.lib }} (script)
+        if: matrix.lib == 'rapidgzip'
+        run: >
+          uv run --python ${{ matrix.python-version }} --no-sync
+          python scripts/rapidgzip_native_stress.py
+          --summary rapidgzip-stress-${{ matrix.os }}-py${{ matrix.python-version }}.md
+
+      - name: Stress ${{ matrix.lib }} (script)
+        if: matrix.lib == 'inflate64'
+        run: >
+          uv run --python ${{ matrix.python-version }} --no-sync
+          python scripts/inflate64_native_stress.py
+          --summary inflate64-stress-${{ matrix.os }}-py${{ matrix.python-version }}.md
+
+      - name: Stress ${{ matrix.lib }} (pytest marker entry points)
+        if: steps.sync.outcome == 'success'
+        run: >
+          uv run --python ${{ matrix.python-version }} --no-sync
+          pytest -m native_codec_stress -k ${{ matrix.lib }} -q --timeout=600 -o addopts=
+
+      - name: Upload stress summary
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.lib }}-stress-${{ matrix.os }}-py${{ matrix.python-version }}
+          path: ${{ matrix.lib }}-stress-${{ matrix.os }}-py${{ matrix.python-version }}.md
+          if-no-files-found: ignore

--- a/docs/internal/known-issues.md
+++ b/docs/internal/known-issues.md
@@ -377,3 +377,40 @@ ARCHIVEY_PPMD_STRESS_ITERS=30 uv run --no-sync python scripts/ppmd_native_stress
 - The earlier open questions (is it archivey's wrapper? the 7z path? warmup-only?) are
   resolved: it is pure `pyppmd` (crash reproduces with no archivey imports), warmup only
   shifts allocator layout, and sized decodes are structurally safe.
+
+## Native codec stress inventory
+
+**Status: living checklist.** Each optional native library that can abort the process
+(or corrupt the heap) gets — or will get — a **dedicated, non-required** stress
+workflow with fresh-process children, matching the PPMd pattern. Do **not** make
+these required status checks: a red stress run is signal, not a merge gate.
+
+| Library | Extra | Stress vehicle | Priority | Why |
+|---------|-------|----------------|----------|-----|
+| `pyppmd` | `[7z]` | `ppmd-native-stress.yml` / `scripts/ppmd_native_stress.py` | **done** | Valid-stream heap corruption (Windows + Linux warmup) |
+| `rapidgzip` | `[seekable]` | `native-codec-stress.yml` / `scripts/rapidgzip_native_stress.py` | **done** | Shutdown abort if not `close()`-d; leading suspect for Linux `[all]` suite heap corruption |
+| `inflate64` | `[7z]` | `native-codec-stress.yml` / `scripts/inflate64_native_stress.py` | **done** | No output-size bound; budgeted-read contract; early-warning soak (no pinned flake yet) |
+| `brotli` | `[7z]` | — | P2 | `output_buffer_limit` / CVE-2025-6176 surface; add when a flake appears or after rapidgzip rate is known |
+| `lz4` | `[lz4]` / `[7z]` | — | P3 | Ordinary C extension; no intermittent abort signal yet |
+| `pybcj` | `[7z]` | — | P3 | Small BCJ filter; low flake evidence |
+| `backports.zstd` | `[zstd]` | — | skip / P3 | Stdlib `compression.zstd` on 3.14+; low priority |
+| `cryptography` / `_cffi_backend` | `[crypto]` | — | skip | Not a codec; different failure mode |
+| `ncompress` | (dev) | — | skip | Test-only LZW *compressor* |
+| `pycdlib` | `[iso]` | — | skip | Pure Python |
+
+Shared helpers live in `scripts/native_stress_common.py`. Pytest entry points use the
+`native_codec_stress` marker (excluded from default `addopts`; selected by the
+workflow with `-o addopts=`).
+
+```bash
+uv sync --group dev --extra all
+uv run --no-sync python scripts/rapidgzip_native_stress.py
+uv run --no-sync python scripts/inflate64_native_stress.py
+# Optional: pytest marker wrappers (also non-default)
+ARCHIVEY_RAPIDGZIP_STRESS_ITERS=10 uv run --no-sync \
+  pytest -m native_codec_stress -k rapidgzip -q --timeout=600 -o addopts=
+```
+
+**Not in scope yet:** a mixed-natives soak that loads rapidgzip + pyppmd + inflate64
+(+ brotli) in one long-lived child — that is the axis the Linux full-suite heap
+corruption likely needs, and should be a follow-up once per-lib rates are known.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -180,10 +180,11 @@ testpaths = ["tests"]
 # the whole job until the CI hard limit. pytest-timeout picks the platform default method
 # (SIGALRM on POSIX — suite continues; a process-killing thread dump on Windows). 60s is far
 # above any real test here (all run in milliseconds), so only a genuine hang trips it.
-addopts = "--cov=archivey --cov-report=term-missing --cov-report=xml --timeout=60 -m 'not ppmd_native_stress'"
+addopts = "--cov=archivey --cov-report=term-missing --cov-report=xml --timeout=60 -m 'not ppmd_native_stress and not native_codec_stress'"
 
 markers = [
     "sample_archives: declarative parametrization over sample archives and config variants",
     "concurrent_reader: post-materialization MemberStreams.CONCURRENT seam (also run under free-threaded CI)",
     "ppmd_native_stress: intermittent pyppmd native-abort stress (non-blocking PPMd native stress workflow only)",
+    "native_codec_stress: non-blocking rapidgzip/inflate64 (etc.) native stress; native-codec-stress workflow only",
 ]

--- a/scripts/inflate64_native_stress.py
+++ b/scripts/inflate64_native_stress.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""Stress-test inflate64 / Deflate64 native decode surfaces.
+
+Background
+----------
+``inflate64`` backs ZIP/7z Deflate64 members. Unlike zlib, it has **no** output-size
+parameter: a small highly-compressible feed can expand hugely in one ``inflate()``.
+archivey bounds peaks via ``Deflate64Decoder``'s budgeted feed under ``max_length``
+(see ``src/archivey/internal/streams/decompress.py``).
+
+No intermittent native-abort flake is pinned to inflate64 yet (unlike pyppmd /
+rapidgzip); this harness is the soak vehicle so we notice if one appears, and so
+the budgeted-read contract stays exercised under process isolation.
+
+Default scenarios::
+
+    uv run --extra all python scripts/inflate64_native_stress.py
+    uv run --extra all python scripts/inflate64_native_stress.py 40 \\
+        --scenarios raw_inflate_roundtrip archivey_bounded_read1
+
+Requires the ``7z`` CLI for ZIP-fixture scenarios (those soft-skip inside the child
+when ``7z`` is absent). Exit code is non-zero if any child crashed or failed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import sys
+import textwrap
+from pathlib import Path
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+from native_stress_common import (  # noqa: E402
+    phase_helpers,
+    run_stress_matrix,
+    safe_print,
+)
+
+_WORK_ENV = "ARCHIVEY_INFLATE64_STRESS_WORK"
+
+_DEFAULT_SCENARIOS: tuple[str, ...] = (
+    "raw_inflate_roundtrip",
+    "raw_inflate_many_cycles",
+    "archivey_bounded_read1",
+    "archivey_readall",
+    "truncated_flush",
+)
+
+_ALL_SCENARIOS: tuple[str, ...] = (
+    *_DEFAULT_SCENARIOS,
+    "zip_deflate64_member",  # needs 7z CLI
+)
+
+_ZIP_MEMBER_HELPER = textwrap.dedent(
+    """\
+    import shutil, struct, subprocess
+
+    def _deflate64_member_bytes(payload: bytes, label: str) -> bytes | None:
+        if shutil.which("7z") is None:
+            _phase("skip-no-7z")
+            return None
+        src = work / f"{label}.txt"
+        src.write_bytes(payload)
+        archive = work / f"{label}.zip"
+        r = subprocess.run(
+            ["7z", "a", "-tzip", "-mm=Deflate64", str(archive), str(src)],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if r.returncode != 0:
+            _phase(f"7z-failed rc={r.returncode}")
+            return None
+        raw = archive.read_bytes()
+        assert raw[:4] == b"PK\\x03\\x04"
+        method = struct.unpack_from("<H", raw, 8)[0]
+        name_len, extra_len = struct.unpack_from("<HH", raw, 26)
+        comp_start = 30 + name_len + extra_len
+        comp_size = struct.unpack_from("<I", raw, 18)[0]
+        if method != 9:
+            _phase(f"skip-not-deflate64 method={method}")
+            return None
+        return raw[comp_start : comp_start + comp_size]
+    """
+)
+
+
+def _write_driver(scenario: str, seed: int) -> str:
+    body = phase_helpers(work_env=_WORK_ENV)
+    if scenario == "raw_inflate_roundtrip":
+        body += textwrap.dedent(
+            """\
+            import inflate64
+            payload = b"inflate64-stress\\n" * 2000
+            if not hasattr(inflate64, "Deflater"):
+                _phase("skip-no-Deflater")
+                raise SystemExit(0)
+            _phase("deflate_via_inflate64.Deflater")
+            d = inflate64.Deflater()
+            packed = d.deflate(payload) + d.flush()
+            _phase(f"inflate packed={len(packed)}")
+            inf = inflate64.Inflater()
+            out = inf.inflate(packed)
+            if not inf.eof:
+                out += inf.inflate(b"")
+            assert out == payload
+            _phase("roundtrip-ok")
+            """
+        )
+    elif scenario == "raw_inflate_many_cycles":
+        body += textwrap.dedent(
+            f"""\
+            import inflate64
+            payload = b"cycle64\\n" * 500
+            if not hasattr(inflate64, "Deflater"):
+                _phase("skip-no-Deflater")
+                raise SystemExit(0)
+            d = inflate64.Deflater()
+            packed = d.deflate(payload) + d.flush()
+            cycles = 25 + ({seed} % 10)
+            _phase(f"cycles={{cycles}}")
+            for i in range(cycles):
+                inf = inflate64.Inflater()
+                out = inf.inflate(packed)
+                if not inf.eof:
+                    out += inf.inflate(b"")
+                assert out == payload
+                if i % 5 == 0:
+                    _phase(f"cycle={{i}}")
+            _phase("cycles-ok")
+            """
+        )
+    elif scenario == "archivey_bounded_read1":
+        body += _ZIP_MEMBER_HELPER
+        body += textwrap.dedent(
+            """\
+            import io
+            from archivey.internal.streams.decompress import Deflate64DecompressorStream
+
+            payload = b"A" * 200_000
+            comp = _deflate64_member_bytes(payload, "bounded")
+            if comp is None:
+                raise SystemExit(0)
+            _phase(f"bounded_read1 compressed={len(comp)}")
+            with Deflate64DecompressorStream(io.BytesIO(comp)) as stream:
+                first = stream.read(1)
+                assert first == b"A"
+                assert len(stream._buffer) < 128_000
+                rest = stream.read()
+            assert first + rest == payload
+            _phase("bounded-ok")
+            """
+        )
+    elif scenario == "archivey_readall":
+        body += _ZIP_MEMBER_HELPER
+        body += textwrap.dedent(
+            """\
+            import io
+            from archivey.internal.streams.decompress import Deflate64DecompressorStream
+
+            payload = b"readall-d64\\n" * 800
+            comp = _deflate64_member_bytes(payload, "readall")
+            if comp is None:
+                raise SystemExit(0)
+            _phase(f"readall compressed={len(comp)}")
+            with Deflate64DecompressorStream(io.BytesIO(comp)) as stream:
+                out = stream.read()
+            assert out == payload
+            _phase("readall-ok")
+            """
+        )
+    elif scenario == "truncated_flush":
+        body += _ZIP_MEMBER_HELPER
+        body += textwrap.dedent(
+            """\
+            import io
+            from archivey.exceptions import TruncatedError
+            from archivey.internal.streams.decompress import Deflate64DecompressorStream
+
+            payload = b"trunc-d64\\n" * 1000
+            comp = _deflate64_member_bytes(payload, "trunc")
+            if comp is None:
+                raise SystemExit(0)
+            truncated = comp[: max(1, len(comp) // 2)]
+            _phase(f"truncated compressed={len(truncated)}/{len(comp)}")
+            with Deflate64DecompressorStream(io.BytesIO(truncated)) as stream:
+                try:
+                    stream.read()
+                    _phase("unexpected-success")
+                    raise SystemExit(1)
+                except TruncatedError:
+                    _phase("truncated-ok")
+            """
+        )
+    elif scenario == "zip_deflate64_member":
+        body += textwrap.dedent(
+            """\
+            import shutil, subprocess
+            from archivey import open_archive
+
+            if shutil.which("7z") is None:
+                _phase("skip-no-7z")
+                raise SystemExit(0)
+            payload = b"zip-member-d64\\n" * 600
+            src = work / "member.txt"
+            src.write_bytes(payload)
+            archive = work / "member.zip"
+            r = subprocess.run(
+                ["7z", "a", "-tzip", "-mm=Deflate64", str(archive), str(src)],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            if r.returncode != 0:
+                _phase(f"7z-failed rc={r.returncode}")
+                raise SystemExit(0)
+            _phase("open_archive")
+            with open_archive(archive) as ar:
+                members = [m for m in ar.members() if m.is_file]
+                assert members
+                data = ar.read(members[0])
+            assert data == payload
+            _phase("zip-member-ok")
+            """
+        )
+    else:
+        raise ValueError(f"unknown scenario: {scenario}")
+    return body
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "iterations",
+        nargs="?",
+        type=int,
+        default=int(os.environ.get("ARCHIVEY_INFLATE64_STRESS_ITERS", "20")),
+        help="Child iterations per scenario (default: env or 20)",
+    )
+    parser.add_argument(
+        "--scenarios",
+        nargs="+",
+        default=list(_DEFAULT_SCENARIOS),
+        choices=list(_ALL_SCENARIOS),
+    )
+    parser.add_argument("--timeout", type=float, default=180.0)
+    parser.add_argument("--summary", type=Path, default=None)
+    args = parser.parse_args(argv)
+
+    try:
+        import inflate64  # noqa: F401
+    except ImportError:
+        safe_print(
+            "inflate64 not installed; cannot stress. Install archivey[7z].",
+            file=sys.stderr,
+        )
+        return 2
+
+    scenarios = list(dict.fromkeys(args.scenarios))
+    needs_7z = any(
+        s
+        in {
+            "archivey_bounded_read1",
+            "archivey_readall",
+            "truncated_flush",
+            "zip_deflate64_member",
+        }
+        for s in scenarios
+    )
+    if needs_7z and shutil.which("7z") is None:
+        safe_print(
+            "warning: 7z CLI not on PATH; 7z-backed scenarios will soft-skip "
+            "inside each child.",
+            file=sys.stderr,
+        )
+
+    return run_stress_matrix(
+        title="inflate64 native stress",
+        scenarios=scenarios,
+        iterations=args.iterations,
+        timeout=args.timeout,
+        work_env=_WORK_ENV,
+        write_driver=_write_driver,
+        summary_path=args.summary,
+        footer=(
+            "inflate64 has no output-size parameter; archivey bounds via budgeted "
+            "feeds under max_length. No pinned intermittent abort yet — this soak "
+            "is the early-warning vehicle. See `docs/internal/known-issues.md`."
+        ),
+        tmp_prefix="archivey-inflate64-stress-",
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/native_stress_common.py
+++ b/scripts/native_stress_common.py
@@ -1,0 +1,231 @@
+"""Shared helpers for per-native-library stress scripts (PPMd / rapidgzip / inflate64 / …).
+
+Each library keeps its own ``scripts/<lib>_native_stress.py`` driver so scenarios stay
+focused; this module owns the subprocess loop, Windows NTSTATUS formatting, phase
+file plumbing, and Markdown summary writing. See ``docs/internal/known-issues.md``.
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+import subprocess
+import sys
+import tempfile
+import textwrap
+from collections.abc import Callable, Sequence
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+WINDOWS_NTSTATUS: dict[int, str] = {
+    0xC0000005: "STATUS_ACCESS_VIOLATION",
+    0xC0000374: "STATUS_HEAP_CORRUPTION",
+    0xC0000409: "STATUS_STACK_BUFFER_OVERRUN",
+    0xC00000FD: "STATUS_STACK_OVERFLOW",
+    0xC0000094: "STATUS_INTEGER_DIVIDE_BY_ZERO",
+    0x80000003: "STATUS_BREAKPOINT",
+}
+
+
+def safe_print(msg: str, *, file=None) -> None:
+    stream = file or sys.stdout
+    encoding = getattr(stream, "encoding", None) or "utf-8"
+    try:
+        stream.write(msg + "\n")
+    except UnicodeEncodeError:
+        stream.write(msg.encode(encoding, errors="replace").decode(encoding) + "\n")
+    stream.flush()
+
+
+def format_rc(returncode: int) -> str:
+    unsigned = returncode & 0xFFFFFFFF
+    if returncode < 0 or returncode > 255:
+        name = WINDOWS_NTSTATUS.get(unsigned)
+        if name is not None:
+            return f"0x{unsigned:08X} ({name}); signed={returncode}"
+        if -64 < returncode < 0:
+            return f"{returncode} (likely signal {-returncode})"
+        return f"0x{unsigned:08X} (unknown); signed={returncode}"
+    return str(returncode)
+
+
+def phase_helpers(*, work_env: str) -> str:
+    """Child-driver preamble: faulthandler + append-only phase log under ``work_env``."""
+    return textwrap.dedent(
+        f"""\
+        from __future__ import annotations
+        import faulthandler
+        import os
+        import sys
+        from pathlib import Path
+
+        faulthandler.enable(all_threads=True, file=sys.stderr)
+        work = Path(os.environ[{work_env!r}])
+        phase_path = work / "phase.txt"
+
+        def _phase(msg: str) -> None:
+            line = msg + "\\n"
+            with phase_path.open("a", encoding="utf-8") as fh:
+                fh.write(line)
+                fh.flush()
+                os.fsync(fh.fileno())
+            print(f"[phase] {{msg}}", flush=True)
+
+        _phase("start")
+        """
+    )
+
+
+def run_child(
+    *,
+    iter_dir: Path,
+    driver_source: str,
+    work_env: str,
+    timeout: float,
+) -> tuple[int, str, str, str]:
+    """Write ``_driver.py``, run it, return ``(rc, phase_text, stdout, stderr)``."""
+    iter_dir.mkdir(parents=True, exist_ok=True)
+    phase_path = iter_dir / "phase.txt"
+    driver = iter_dir / "_driver.py"
+    driver.write_text(driver_source, encoding="utf-8")
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.pathsep.join(
+        [
+            str(REPO_ROOT / "src"),
+            str(REPO_ROOT / "tests"),
+            str(REPO_ROOT),
+            env.get("PYTHONPATH", ""),
+        ]
+    )
+    env[work_env] = str(iter_dir)
+    env.setdefault("PYTHONFAULTHANDLER", "1")
+    env.setdefault("PYTHONIOENCODING", "utf-8")
+    proc = subprocess.run(
+        [sys.executable, "-u", str(driver)],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        env=env,
+        timeout=timeout,
+        check=False,
+        cwd=str(REPO_ROOT),
+    )
+    phase = (
+        phase_path.read_text(encoding="utf-8") if phase_path.exists() else "<missing>"
+    )
+    return proc.returncode, phase, proc.stdout, proc.stderr
+
+
+def run_stress_matrix(
+    *,
+    title: str,
+    scenarios: Sequence[str],
+    iterations: int,
+    timeout: float,
+    work_env: str,
+    write_driver: Callable[[str, int], str],
+    summary_path: Path | None,
+    footer: str,
+    tmp_prefix: str,
+) -> int:
+    """Run ``iterations`` fresh children per scenario; return 0 on all-ok, else 1."""
+    safe_print(
+        f"{title}: scenarios={list(scenarios)!r} "
+        f"iters_per_scenario={iterations} "
+        f"platform={platform.platform()!r} python={sys.version.split()[0]} "
+        f"executable={sys.executable!r}"
+    )
+
+    crashes: list[tuple[str, int, int, str]] = []
+    failures: list[tuple[str, int, int, str]] = []
+    passes_by_scenario: dict[str, int] = dict.fromkeys(scenarios, 0)
+    total_runs = 0
+
+    with tempfile.TemporaryDirectory(prefix=tmp_prefix) as tmp:
+        root = Path(tmp)
+        for scenario in scenarios:
+            safe_print(f"== scenario {scenario} ==")
+            for i in range(1, iterations + 1):
+                total_runs += 1
+                iter_dir = root / scenario / f"iter-{i:04d}"
+                try:
+                    rc, phase, _stdout, stderr = run_child(
+                        iter_dir=iter_dir,
+                        driver_source=write_driver(scenario, i - 1),
+                        work_env=work_env,
+                        timeout=timeout,
+                    )
+                except subprocess.TimeoutExpired:
+                    failures.append((scenario, i, -1, "timeout"))
+                    safe_print(f"  [{scenario} {i}/{iterations}] TIMEOUT")
+                    continue
+                last_phase = (
+                    phase.strip().splitlines()[-1] if phase.strip() else "<empty>"
+                )
+                if rc == 0:
+                    passes_by_scenario[scenario] += 1
+                    safe_print(f"  [{scenario} {i}/{iterations}] ok")
+                    continue
+                unsigned = rc & 0xFFFFFFFF
+                is_crash = unsigned in WINDOWS_NTSTATUS or rc < 0 or rc > 255
+                bucket = crashes if is_crash else failures
+                bucket.append((scenario, i, rc, last_phase))
+                kind = "CRASH" if is_crash else "FAIL"
+                safe_print(
+                    f"  [{scenario} {i}/{iterations}] {kind} "
+                    f"rc={format_rc(rc)} last_phase={last_phase!r}"
+                )
+                if stderr.strip():
+                    tail = "\n".join(stderr.strip().splitlines()[-8:])
+                    safe_print(f"    stderr tail:\n{textwrap.indent(tail, '    ')}")
+
+    lines = [
+        f"# {title} results",
+        "",
+        f"- platform: `{platform.platform()}`",
+        f"- python: `{sys.version.split()[0]}`",
+        f"- scenarios: `{', '.join(scenarios)}`",
+        f"- total child runs: **{total_runs}**",
+        f"- native crashes: **{len(crashes)}**",
+        f"- other failures: **{len(failures)}**",
+        "",
+        "## Passes by scenario",
+        "",
+    ]
+    for scenario in scenarios:
+        lines.append(
+            f"- `{scenario}`: **{passes_by_scenario[scenario]}** / {iterations}"
+        )
+    lines.append("")
+    if crashes:
+        lines.append("## Crashes")
+        lines.append("")
+        for scenario, i, rc, last_phase in crashes:
+            lines.append(
+                f"- `{scenario}` iter {i}: `{format_rc(rc)}` at phase `{last_phase}`"
+            )
+        lines.append("")
+    if failures:
+        lines.append("## Other failures")
+        lines.append("")
+        for scenario, i, rc, last_phase in failures:
+            lines.append(
+                f"- `{scenario}` iter {i}: `{format_rc(rc)}` at phase `{last_phase}`"
+            )
+        lines.append("")
+    lines.append(footer)
+    summary = "\n".join(lines) + "\n"
+
+    if summary_path is not None:
+        summary_path.write_text(summary, encoding="utf-8")
+    gh_summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if gh_summary:
+        with open(gh_summary, "a", encoding="utf-8") as fh:
+            fh.write(summary)
+    safe_print(summary)
+
+    if crashes or failures:
+        return 1
+    return 0

--- a/scripts/rapidgzip_native_stress.py
+++ b/scripts/rapidgzip_native_stress.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""Stress-test rapidgzip native surfaces (gzip + bundled IndexedBzip2File).
+
+Background
+----------
+``rapidgzip`` is archivey's sole random-access accelerator for gzip *and* bzip2
+(bundled ``IndexedBzip2File`` — the standalone ``indexed_bzip2`` package is never
+imported). Known issues (see ``docs/internal/known-issues.md``):
+
+- Worker threads abort the process if not ``close()``-d before finalization
+  (SIGABRT; covered by ``tests/test_accelerator_shutdown.py``).
+- Leading suspect for intermittent Linux full-suite heap corruption under ``[all]``.
+
+This script is the dedicated investigation vehicle, mirroring
+``scripts/ppmd_native_stress.py``: each iteration is a **fresh child process**.
+
+Default scenarios::
+
+    uv run --extra all python scripts/rapidgzip_native_stress.py
+    uv run --extra all python scripts/rapidgzip_native_stress.py 40
+    uv run --extra all python scripts/rapidgzip_native_stress.py --scenarios \
+        archivey_gzip_bytesio many_cycles_path
+
+Exit code is non-zero if any child crashed or failed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import textwrap
+from pathlib import Path
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+from native_stress_common import (  # noqa: E402
+    phase_helpers,
+    run_stress_matrix,
+    safe_print,
+)
+
+_WORK_ENV = "ARCHIVEY_RAPIDGZIP_STRESS_WORK"
+
+_DEFAULT_SCENARIOS: tuple[str, ...] = (
+    "raw_gzip_path_close",
+    "raw_gzip_bytesio_close",
+    "raw_bzip2_bytesio_close",
+    "archivey_gzip_bytesio",
+    "archivey_bzip2_bytesio",
+    "many_cycles_path",
+    "truncated_gzip_close",
+)
+
+_ALL_SCENARIOS: tuple[str, ...] = (
+    *_DEFAULT_SCENARIOS,
+    "guard_cycle_gc",  # expects clean exit (archivey finalize guard)
+)
+
+
+def _write_driver(scenario: str, seed: int) -> str:
+    body = phase_helpers(work_env=_WORK_ENV)
+    if scenario == "raw_gzip_path_close":
+        body += textwrap.dedent(
+            """\
+            import gzip
+            from pathlib import Path
+            import rapidgzip
+            payload = b"rapidgzip-stress-line\\n" * 2000
+            path = work / "payload.gz"
+            path.write_bytes(gzip.compress(payload))
+            _phase(f"open_path size={path.stat().st_size}")
+            with rapidgzip.RapidgzipFile(path, parallelization=0) as f:
+                out = f.read()
+            assert out == payload
+            _phase("roundtrip-ok")
+            """
+        )
+    elif scenario == "raw_gzip_bytesio_close":
+        body += textwrap.dedent(
+            """\
+            import gzip, io
+            import rapidgzip
+            payload = b"rapidgzip-bytesio\\n" * 1500
+            data = gzip.compress(payload)
+            _phase(f"open_bytesio compressed={len(data)}")
+            with rapidgzip.RapidgzipFile(io.BytesIO(data), parallelization=0) as f:
+                out = f.read()
+            assert out == payload
+            _phase("roundtrip-ok")
+            """
+        )
+    elif scenario == "raw_bzip2_bytesio_close":
+        body += textwrap.dedent(
+            """\
+            import bz2, io
+            import rapidgzip
+            payload = b"indexed-bzip2-stress\\n" * 1500
+            data = bz2.compress(payload)
+            _phase(f"open_indexed_bzip2 compressed={len(data)}")
+            with rapidgzip.IndexedBzip2File(io.BytesIO(data), parallelization=0) as f:
+                out = f.read()
+            assert out == payload
+            _phase("roundtrip-ok")
+            """
+        )
+    elif scenario == "archivey_gzip_bytesio":
+        body += textwrap.dedent(
+            """\
+            import gzip, io
+            from archivey.config import AcceleratorMode
+            from archivey.internal.config import StreamConfig
+            from archivey.internal.streams.codecs import Codec, open_codec_stream
+            payload = b"archivey-gzip-accel\\n" * 1200
+            data = gzip.compress(payload)
+            cfg = StreamConfig(use_rapidgzip=AcceleratorMode.ON, seekable=True)
+            _phase("open_codec_stream gzip ON")
+            with open_codec_stream(Codec.GZIP, io.BytesIO(data), config=cfg) as stream:
+                out = stream.read()
+            assert out == payload
+            _phase("roundtrip-ok")
+            """
+        )
+    elif scenario == "archivey_bzip2_bytesio":
+        body += textwrap.dedent(
+            """\
+            import bz2, io
+            from archivey.config import AcceleratorMode
+            from archivey.internal.config import StreamConfig
+            from archivey.internal.streams.codecs import Codec, open_codec_stream
+            payload = b"archivey-bzip2-accel\\n" * 1200
+            data = bz2.compress(payload)
+            cfg = StreamConfig(use_indexed_bzip2=AcceleratorMode.ON, seekable=True)
+            _phase("open_codec_stream bzip2 ON")
+            with open_codec_stream(Codec.BZIP2, io.BytesIO(data), config=cfg) as stream:
+                out = stream.read()
+            assert out == payload
+            _phase("roundtrip-ok")
+            """
+        )
+    elif scenario == "many_cycles_path":
+        body += textwrap.dedent(
+            f"""\
+            import gzip
+            import rapidgzip
+            payload = b"cycle\\n" * 800
+            path = work / "cycle.gz"
+            path.write_bytes(gzip.compress(payload))
+            cycles = 20 + ({seed} % 10)
+            _phase(f"many_cycles={{cycles}}")
+            for i in range(cycles):
+                with rapidgzip.RapidgzipFile(path, parallelization=0) as f:
+                    assert f.read() == payload
+                if i % 5 == 0:
+                    _phase(f"cycle={{i}}")
+            _phase("cycles-ok")
+            """
+        )
+    elif scenario == "truncated_gzip_close":
+        body += textwrap.dedent(
+            """\
+            import gzip, io
+            import rapidgzip
+            payload = b"trunc-me\\n" * 2000
+            data = gzip.compress(payload)[: len(gzip.compress(payload)) // 2]
+            _phase(f"truncated_open compressed={len(data)}")
+            f = rapidgzip.RapidgzipFile(io.BytesIO(data), parallelization=0)
+            try:
+                f.read()
+            except Exception as exc:
+                _phase(f"read_raised {type(exc).__name__}")
+            finally:
+                f.close()
+            _phase("closed-after-truncation")
+            """
+        )
+    elif scenario == "guard_cycle_gc":
+        # Faithful copy of archivey's finalize-close guard; must exit cleanly.
+        body += textwrap.dedent(
+            """\
+            import gc, gzip, io, weakref
+            import rapidgzip
+
+            payload = b"guard\\n" * 1000
+            data = gzip.compress(payload)
+
+            def _close(inner):
+                try:
+                    inner.close()
+                except Exception:
+                    pass
+
+            class Guard:
+                def __init__(self, inner):
+                    self._inner = inner
+                    self._fin = weakref.finalize(self, _close, inner)
+
+            raw = rapidgzip.RapidgzipFile(io.BytesIO(data), parallelization=0)
+            obj = Guard(raw)
+            del raw
+            try:
+                obj._inner.read()
+            except Exception:
+                pass
+            del obj
+            gc.collect()
+            _phase("guard-gc-ok")
+            """
+        )
+    else:
+        raise ValueError(f"unknown scenario: {scenario}")
+    return body
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "iterations",
+        nargs="?",
+        type=int,
+        default=int(os.environ.get("ARCHIVEY_RAPIDGZIP_STRESS_ITERS", "20")),
+        help="Child iterations per scenario (default: env or 20)",
+    )
+    parser.add_argument(
+        "--scenarios",
+        nargs="+",
+        default=list(_DEFAULT_SCENARIOS),
+        choices=list(_ALL_SCENARIOS),
+    )
+    parser.add_argument("--timeout", type=float, default=180.0)
+    parser.add_argument("--summary", type=Path, default=None)
+    args = parser.parse_args(argv)
+
+    try:
+        import rapidgzip  # noqa: F401
+    except ImportError:
+        safe_print(
+            "rapidgzip not installed; cannot stress. Install archivey[seekable].",
+            file=sys.stderr,
+        )
+        return 2
+
+    scenarios = list(dict.fromkeys(args.scenarios))
+    return run_stress_matrix(
+        title="rapidgzip native stress",
+        scenarios=scenarios,
+        iterations=args.iterations,
+        timeout=args.timeout,
+        work_env=_WORK_ENV,
+        write_driver=_write_driver,
+        summary_path=args.summary,
+        footer=(
+            "Known issue: rapidgzip aborts if worker threads outlive `close()`; "
+            "also a leading suspect for intermittent Linux `[all]` suite heap "
+            "corruption. See `docs/internal/known-issues.md`."
+        ),
+        tmp_prefix="archivey-rapidgzip-stress-",
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_native_codec_stress.py
+++ b/tests/test_native_codec_stress.py
@@ -1,0 +1,99 @@
+"""Subprocess stress for rapidgzip / inflate64 natives (non-required CI).
+
+Excluded from the default suite via the ``native_codec_stress`` marker (selected
+only by the non-blocking native-codec stress workflow). See
+``docs/internal/known-issues.md``.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from tests.conftest import requires
+
+pytestmark = [
+    pytest.mark.native_codec_stress,
+]
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _iters(env_name: str) -> int:
+    return int(os.environ.get(env_name, "10"))
+
+
+def _run(
+    script: str, env_iters: str, *scenarios: str
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            str(_REPO_ROOT / "scripts" / script),
+            str(_iters(env_iters)),
+            "--scenarios",
+            *scenarios,
+        ],
+        cwd=str(_REPO_ROOT),
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+
+
+@requires("rapidgzip")
+def test_rapidgzip_minimal_surface_subprocess_stress() -> None:
+    """Fresh-process rapidgzip path + BytesIO close cycles (gzip + IndexedBzip2)."""
+    proc = _run(
+        "rapidgzip_native_stress.py",
+        "ARCHIVEY_RAPIDGZIP_STRESS_ITERS",
+        "raw_gzip_path_close",
+        "raw_gzip_bytesio_close",
+        "raw_bzip2_bytesio_close",
+        "archivey_gzip_bytesio",
+    )
+    assert proc.returncode == 0, (
+        "rapidgzip minimal-surface stress saw crashes/failures "
+        f"(rc={proc.returncode}).\n"
+        f"--- stdout ---\n{proc.stdout}\n--- stderr ---\n{proc.stderr}\n"
+    )
+
+
+@requires("rapidgzip")
+def test_rapidgzip_truncated_and_guard_subprocess_stress() -> None:
+    """Truncated gzip still closes cleanly; finalize-guard GC must not abort."""
+    proc = _run(
+        "rapidgzip_native_stress.py",
+        "ARCHIVEY_RAPIDGZIP_STRESS_ITERS",
+        "truncated_gzip_close",
+        "guard_cycle_gc",
+    )
+    assert proc.returncode == 0, (
+        "rapidgzip truncation/guard stress saw crashes/failures "
+        f"(rc={proc.returncode}).\n"
+        f"--- stdout ---\n{proc.stdout}\n--- stderr ---\n{proc.stderr}\n"
+    )
+
+
+@requires("inflate64")
+def test_inflate64_raw_and_bounded_subprocess_stress() -> None:
+    """Fresh-process inflate64 Inflater cycles + archivey budgeted read(1)."""
+    proc = _run(
+        "inflate64_native_stress.py",
+        "ARCHIVEY_INFLATE64_STRESS_ITERS",
+        "raw_inflate_roundtrip",
+        "raw_inflate_many_cycles",
+        "archivey_bounded_read1",
+        "truncated_flush",
+    )
+    assert proc.returncode == 0, (
+        "inflate64 stress saw crashes/failures "
+        f"(rc={proc.returncode}).\n"
+        f"--- stdout ---\n{proc.stdout}\n--- stderr ---\n{proc.stderr}\n"
+    )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds dedicated, **non-required** native stress coverage for `rapidgzip` and `inflate64`, mirroring the existing PPMd stress pattern. Leaves `ppmd-native-stress.yml` as-is.

## Inventory (also in `docs/internal/known-issues.md`)

| Library | Status | Notes |
|---------|--------|--------|
| `pyppmd` | already had stress | keep existing workflow |
| `rapidgzip` | **this PR** | shutdown abort + full-suite heap suspect |
| `inflate64` | **this PR** | unbounded inflate; early-warning soak |
| `brotli` | deferred (P2) | add when a flake appears |
| `lz4` / `pybcj` | deferred (P3) | low flake evidence |
| `cryptography`, `ncompress`, `pycdlib`, zstd | skip | not codec-abort targets |

Follow-up (called out in known-issues): a **mixed-natives soak** in one long child — the axis the Linux `[all]` suite corruption likely needs.

## What’s included

- `scripts/native_stress_common.py` — shared child loop / NTSTATUS / summaries
- `scripts/rapidgzip_native_stress.py` — path/BytesIO/archivey/truncated/guard scenarios
- `scripts/inflate64_native_stress.py` — raw Inflater cycles + budgeted `read(1)` / truncation (7z ZIP fixtures)
- `tests/test_native_codec_stress.py` — marker wrappers (`native_codec_stress`, excluded from default `addopts`)
- `.github/workflows/native-codec-stress.yml` — matrix over lib × OS/Python; **do not** make required

## Test plan

- [x] `python scripts/rapidgzip_native_stress.py 3`
- [x] `python scripts/inflate64_native_stress.py 2` (with `p7zip-full`)
- [x] `pytest -m native_codec_stress -o addopts=` (with low iter env)
- [x] Default collect excludes the new marker
- [ ] CI `Native codec stress` workflow green (non-blocking)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bcc1d485-4747-4216-88cb-30f08d333429"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bcc1d485-4747-4216-88cb-30f08d333429"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

