### PR TITLE
Investigate native PPMd/pyppmd heap corruption + add teardown mitigation & valgrind gate

### DIFF
--- a/.github/workflows/ppmd-native-stress.yml
+++ b/.github/workflows/ppmd-native-stress.yml
@@ -92,6 +92,21 @@ jobs:
           --repeat ${{ env.ARCHIVEY_PPMD_RAW_STREAMS_ITERS }}
           --summary ppmd-raw-streams-soak-${{ matrix.os }}-py${{ matrix.python-version }}.md
 
+      - name: Install valgrind (Linux)
+        if: runner.os == 'Linux' && steps.sync.outcome == 'success'
+        run: sudo apt-get update && sudo apt-get install -y valgrind
+
+      - name: Deterministic UAF gate (valgrind, Linux)
+        # Pins the output-buffer use-after-free (ThreadDecoder.c:134) deterministically.
+        # The archivey scenarios MUST be clean (a regression here is an archivey bug and
+        # fails the step); the bare-pyppmd overshoot reproducer is a detector run without
+        # --strict-pyppmd, so its expected-red on 1.3.x does not fail the step. Still
+        # non-required overall. See docs/internal/ppmd-native-investigation-results.md §J.
+        if: runner.os == 'Linux' && steps.sync.outcome == 'success'
+        run: >
+          uv run --python ${{ matrix.python-version }} --no-sync
+          python scripts/ppmd_uaf_valgrind.py --scenario all
+
       - name: Stress PPMd (pytest marker entry points)
         # Run even when the script step failed (crash signal), but not when setup/sync
         # never installed `uv` (avoids a misleading "uv: command not found").

--- a/docs/internal/known-issues.md
+++ b/docs/internal/known-issues.md
@@ -176,18 +176,30 @@ upstream (no issue filed there as of 2026-07-16 — ready-to-file draft in
 `docs/internal/pyppmd-upstream-report.md`). Linux and Windows both affected (different
 trigger shapes).** Not adversarial input — happy-path encode/decode of valid PPMd data.
 
-### Root cause (pinpointed from the 1.2.0 → 1.3.1 sdist diff)
+### Root cause (valgrind-confirmed; refined 2026-07-23)
 
-pyppmd runs `Ppmd7Decoder.decode` on a native worker thread. The 1.3.0 rewrite removed
-the worker loop's input-empty stop condition, and `_ppmdmodule.c` translates
+pyppmd runs `Ppmd7Decoder.decode` on a native worker thread. The 1.3.0 rewrite (#126)
+removed the worker loop's input-empty stop condition, and `_ppmdmodule.c` translates
 `max_length=-1` into an `INT_MAX` symbol budget — so on PPMd7 (no end mark) the worker
-decodes **past the true end of the stream**, walking the vendored 7-Zip model on a
-desynchronized range coder until the heap corrupts. The after-eof guard 1.3.0 added went
-to the cffi backend only; the C extension has none, so `decode(b"\0", -1)` after eof
-restarts the runaway worker on finished state (the hottest trigger). Sized decodes stop
-exactly at the payload boundary, which is why they never crash — and why py7zr (which
-always passes `max_length`) never sees this. Full analysis, crash-rate tables, and
-suggested upstream fixes: `docs/internal/pyppmd-upstream-report.md`.
+decodes **past the true end of the stream**, and when its input runs out it is left
+**blocked in the reader** rather than finishing. The **corrupting write itself is a
+use-after-free of pyppmd's own output buffer**: `OutputBuffer_Finish`
+(`_ppmdmodule.c:552`) frees the decode's output block while that blocked worker still
+holds a raw pointer into it, and a later wake (the next call, or `Ppmd7T_Free` at
+teardown) resumes the worker to free-run into the freed block at `ThreadDecoder.c:134`.
+Valgrind pins that as the first error in every crash family; the desynchronized 7-Zip
+model is the *source* of the garbage symbols, not the first out-of-bounds write. The
+after-eof guard 1.3.0 added went to the cffi backend only; the C extension has none, so
+`decode(b"\0", -1)` after eof restarts the runaway worker (a hot trigger). Sized decodes
+stop exactly at the payload boundary — the worker finishes and is joined — which is why
+they never crash, and why py7zr (which always passes `max_length`) never sees this.
+
+Full source-level analysis, valgrind evidence, the 1.2.0→1.3.0 regression window, and
+the corrected, ready-to-file upstream report are in
+`docs/internal/ppmd-native-investigation-results.md` (§D root cause, §J report). The
+older `docs/internal/pyppmd-upstream-report.md` is folded into a pointer to it (it had
+attributed the corruption to the model walk; §J corrects that to the output-buffer UAF).
+The deterministic valgrind gate is `scripts/ppmd_uaf_valgrind.py`.
 
 ### Windows: `STATUS_HEAP_CORRUPTION` on fresh PPMd children
 
@@ -382,13 +394,14 @@ ARCHIVEY_PPMD_STRESS_ITERS=30 uv run --no-sync python scripts/ppmd_native_stress
 
 **Status: partially mitigated (2026-07-23).** Separate fingerprint from the
 mid-decode / `warmup_codecs` / unbounded-`decode(..., -1)` bug above. The
-**decode-time overshoot** (large NUL flush on truncated streams) is fixed. The
-upstream **`Ppmd7T_Free` teardown race** on unfinished workers is **not**
-eliminated — subprocess isolation contains it so it cannot kill the parent
-pytest session, but children can still SIGSEGV after printing `ok`, and the
-parent process can still intermittently exit-after-green. Required CI therefore
-keeps `--allow-exit-after-green` for this module. Full lab notes:
-`docs/internal/ppmd-exit-after-green-exploration.md`.
+**decode-time overshoot** (large NUL flush on truncated streams) is fixed, and a
+**`quiesce-on-close`** step now drives a parked worker to `finished` before the
+decoder is freed so `Ppmd7T_Free` cannot resume it into the freed output block
+(the same UAF, at teardown). Both mitigations attack the same defect: never leave
+a native worker blocked at dispose. Required CI **still** keeps
+`--allow-exit-after-green` for this module — see the caveat below. Full lab notes:
+`docs/internal/ppmd-exit-after-green-exploration.md`; corrected root cause and the
+quiesce measurement: `docs/internal/ppmd-native-investigation-results.md` (§D, §I).
 
 ### Symptom (pre-mitigation)
 
@@ -411,12 +424,17 @@ Two stacked issues on pyppmd 1.3.x:
    same overshoot class as unbounded `decode(..., -1)` and corrupts the heap.
    Bare-`pyppmd` repro of that shape: **85/100** children SIGSEGV; with
    `max_length` capped to 64: **0/100**. Happy-path tests alone: **0/40**.
-2. **Upstream `Ppmd7T_Free` race (contained, not fixed):** tearing down a decoder
-   whose worker is still blocked on input can still poison the heap (documented in
-   `pyppmd-upstream-report.md`). Unfinished-decoder adversarial tests run in
-   **subprocess children** so a child abort cannot take down the parent session;
-   `_run_ppmd_child` accepts teardown signal death after a green `ok` body.
-   Parent-process exit-after-green remains possible → required CI soft-pass.
+2. **Upstream `Ppmd7T_Free` race (now mitigated in-process; still upstream):**
+   tearing down a decoder whose worker is still blocked on input lets
+   `Ppmd7T_Free` resume that worker into the output block already freed by the
+   previous `decode` — the same output-buffer UAF as the overshoot bug, just
+   reached at teardown (valgrind: `ThreadDecoder.c:134`; see the results doc §D).
+   `PpmdDecoder` now **quiesces** a parked worker before dispose (bounded
+   `decode(b"\0", 1)` until it exits on budget), wired through `Decoder.close()`
+   (called from `DecompressorStream.close()` and on seek/recreate) plus a `__del__`
+   safety net. Unfinished-decoder adversarial tests still run in **subprocess
+   children**; `_run_ppmd_child` still accepts teardown signal death after a green
+   `ok` body. See the caveat under *Residual*.
 
 ### Mitigation in archivey
 
@@ -444,15 +462,26 @@ Two stacked issues on pyppmd 1.3.x:
 - **Unsized PPMd8 gets no post-eof drain.** Its end mark terminates valid decodes; a
   drain without an ``unpack_size`` clamp only fabricates trailing bytes (measured: +3
   on an all-zero payload). Sized PPMd8 keeps the drain.
+- **Quiesce a parked worker before dispose** (`PpmdDecoder._quiesce_worker`, via
+  `close()` / `__del__`): drive it to `finished` with bounded `decode(b"\0", 1)` so
+  `Ppmd7T_Free` becomes a no-op. Deterministic evidence:
+  `scripts/ppmd_uaf_valgrind.py` — the archivey scenarios report **0** memcheck
+  errors, the bare-pyppmd overshoot reproducer reports the UAF.
 - Keep unfinished-decoder adversarial coverage in fresh subprocesses; tolerate
   child teardown abort after a successful body (`tests/test_ppmd_raw_streams.py`).
 
-**Residual:** (1) `Ppmd7T_Free` teardown race — required CI still uses
-`--allow-exit-after-green` for this module. (2) Declared-complete but internally
-corrupt sized packs can still fill toward `unpack_size` via empty drains (container
-CRC is the backstop). (3) `pack_size` must measure the same bytes `feed()` counts —
-see `PpmdDecoder` docstring invariant; the 7z plumbing satisfies it by construction
-(pack slice length / preceding coder output).
+**Residual:** (1) `Ppmd7T_Free` teardown race — quiesce-on-close removes the UAF on
+the shapes that reproduce it under valgrind, but it is **defense-in-depth**, not a
+proven elimination: the observable abort rate on archivey's own shapes was already
+~0 on Linux/CPython 3.11 here (child soak 400/400 clean at baseline), and the race
+is timing/platform-dependent (hotter on 3.12+/free-threaded/Windows). Required CI
+therefore **still** keeps `--allow-exit-after-green`; drop it only once the
+deterministic `ppmd_uaf_valgrind.py` gate runs green on the hot-race platforms, not
+on this host's soak alone. (2) Declared-complete but internally corrupt sized packs
+can still fill toward `unpack_size` via empty drains (container CRC is the backstop).
+(3) `pack_size` must measure the same bytes `feed()` counts — see `PpmdDecoder`
+docstring invariant; the 7z plumbing satisfies it by construction (pack slice length
+/ preceding coder output).
 
 ### Verification (this investigation)
 
@@ -461,9 +490,13 @@ see `PpmdDecoder` docstring invariant; the 7z plumbing satisfies it by construct
 | Bare half-pack + NUL(rem) | ~85/100 → **0/100** with cap 64 | n/a |
 | Adversarial tests in subprocess | Contained | Child may still SIGSEGV after `ok` |
 | Parent `test_ppmd_raw_streams` session | Soft-pass via `--allow-exit-after-green` | Intermittent exit-after-green possible |
+| `ppmd_uaf_valgrind.py` (deterministic) | archivey scenarios **0 errors** | quiesce-on-close: **0 errors** with fix; bare overshoot still reproduces |
 
-Do **not** claim the Free race is gone until teardown is deterministic or
-process-isolated by default. See also: exploration doc,
+Do **not** claim the Free race is gone until the deterministic
+`scripts/ppmd_uaf_valgrind.py` gate is green on the hot-race platforms
+(3.12+/free-threaded/Windows) or teardown is process-isolated by default;
+quiesce-on-close is defense-in-depth (see *Residual*). See also: exploration doc,
+`docs/internal/ppmd-native-investigation-results.md` (§D/§I/§J),
 `scripts/ci_run_native_modules.py`, `.github/workflows/ppmd-native-stress.yml`.
 
 ## Intermittent Linux full-suite heap corruption (`[all]` / Hypothesis late crash)

--- a/docs/internal/ppmd-native-investigation-results.md
+++ b/docs/internal/ppmd-native-investigation-results.md
@@ -1,0 +1,309 @@
+# PPMd / pyppmd native investigation — results
+
+**Brief:** `docs/internal/ppmd-native-investigation-brief.md`
+**Prior work:** `docs/internal/pyppmd-upstream-report.md`,
+`docs/internal/ppmd-exit-after-green-exploration.md`,
+`docs/internal/known-issues.md`, `scripts/pyppmd_crash_repro.py`
+**Date started:** 2026-07-23
+**Status:** live notebook — findings appended as experiments finish. Source
+citations are against **pyppmd `v1.3.1`** (the pinned wheel; git tag `v1.3.1`,
+commit `580b675`). The wheel installed in this env is `pyppmd 1.3.1`, CPython
+3.11.15, glibc 2.39, Linux 6.18.5.
+
+This report answers the brief from **native source + minimal repros**, not from
+archivey's mitigations. Where the archivey labs already measured a behaviour, it
+is cited and the *source-level cause* is added rather than re-measured.
+
+---
+
+## TL;DR verdict
+
+| Failure mode | 7-Zip / Pavlov PPMd core | pyppmd ThreadDecoder / binding | Caller contract |
+|--------------|--------------------------|--------------------------------|-----------------|
+| overshoot `max_length` (`-1` or `+65536`) | Memory-unsafe **primitive**: decodes garbage symbols past true EOF, suballocator writes wild `p->Base + offset` → heap corruption. But never *invoked* this way in real 7-Zip (exact unpack size always known). | **Root trigger:** 1.3.0 `#126` removed the input-empty stop; `-1 → INT_MAX` budget (`_ppmdmodule.c:521`) drives the core past EOF. | Never request more output than the true remaining payload. |
+| post-eof empty decode toward `unpack_size` | Same primitive once desynced. | No after-eof guard in the **C extension** `decode` (guard is cffi-only); restarts a runaway worker on finished range state. | Do not call `decode` after `eof` unless pack delivery is known complete. |
+| half-pack + large NUL | Same primitive (large budget over truncated stream). | Same removed stop + INT_MAX budget. | Cap the synthetic-NUL budget; do not chase `unpack_size` on short pack. |
+| `Ppmd7T_Free` while worker blocked | Not applicable (7-Zip is non-threaded here). | **pyppmd-only:** `Ppmd7T_Free` fakes "input available" (`tc->empty=False`) then cancels; reader does an OOB `src[pos++]` at `pos==size`. | n/a (teardown bug). |
+| omit-trailing-null / "extra byte" | **Container/reader convention**, not an encoder action. | pyppmd's reader **blocks** at EOF instead of returning 0, so the caller must feed `b"\0"` to emulate 7-Zip's over-read-zero. | Keep bounded NUL recovery for members produced by real 7-Zip. |
+
+Bottom line: the **memory-unsafety primitive lives in Igor Pavlov's vendored
+PPMd7 model/suballocator** (`Ppmd7.c`), which is safe *only* when the caller
+never decodes past the true payload length. **pyppmd 1.3.x's ThreadDecoder
+rewrite (#126) is what actually drives the core past EOF** by removing the
+input-exhausted stop condition and honouring an `INT_MAX`/oversized output
+budget, with no after-eof guard in the C extension. So it is an **interaction**,
+but the regression and the fix both belong to pyppmd; the core needs the caller
+to respect the length contract it has always required.
+
+---
+
+## A. Code map (which file owns what)
+
+Vendored tree under `pyppmd/src/`:
+
+| File | Provenance | Role |
+|------|-----------|------|
+| `lib/ppmd/Ppmd7.c`, `Ppmd7.h` | Igor Pavlov / 7-Zip (`2017-04-03 : Igor Pavlov : Public domain`, "based on PPMd var.H (2001): Dmitry Shkarin") | Model + **suballocator** (`InsertNode`/`RemoveNode`/`GlueFreeBlocks`/`AllocUnits`), range-dec vtable |
+| `lib/ppmd/Ppmd7Enc.c` | Pavlov / 7-Zip | Range encoder + `Ppmd7z_RangeEnc_FlushData`, `Ppmd7_EncodeSymbol` |
+| `lib/ppmd/Ppmd7Dec.c` | Pavlov / 7-Zip | Range decoder + `Ppmd7_DecodeSymbol` |
+| `lib/ppmd/Ppmd8*.c` | Pavlov / 7-Zip (var.I, RAR) | PPMd8 model/enc/dec (has a real end mark) |
+| `lib/buffer/ThreadDecoder.c/.h` | **pyppmd original** (`Created by miurahr 2021/08/07`) | Worker-thread wrapper, blocking reader, `Ppmd7T_decode`, `Ppmd7T_Free` |
+| `lib/buffer/Buffer.c/.h` | pyppmd original | `BufferReader`/`BufferWriter`, `InBuffer`/`OutBuffer`, growable output |
+| `ext/_ppmdmodule.c` | pyppmd original | Python `Ppmd7Encoder`/`Ppmd7Decoder` (+ Ppmd8), `eof`/`needs_input` state machine, `remains` budget |
+
+So the **algorithm** files (`Ppmd7*.c`) are untouched Pavlov code; the
+**threading, budget, and lifecycle** live entirely in pyppmd's own
+`ThreadDecoder.c` + `_ppmdmodule.c`. This division is what makes the verdict
+crisp.
+
+### How a decode byte flows
+
+`_ppmdmodule.c:335` wires the range decoder's input stream to the **blocking**
+reader: `bufferReader->Read = Ppmd_thread_Reader`. Every
+`IByteIn_Read(p->Stream)` inside `Ppmd7Dec.c` (`Range_Normalize`,
+`Ppmd7z_RangeDec_Init`) therefore calls `Ppmd_thread_Reader`
+(`ThreadDecoder.c:65`), which **blocks on `notEmpty` when input is exhausted**
+(`pos == size`) instead of returning a byte. The actual symbol loop runs on a
+separate worker thread (`Ppmd7T_decode_run`), decoupled from the Python call by
+condition variables.
+
+---
+
+## B. "Omit last null" / the extra input byte
+
+### What the encoder actually does
+
+`Ppmd7Encoder.flush()` (`_ppmdmodule.c:851`) optionally encodes an end-mark
+symbol **only if `endmark=True`** (default `False`), then unconditionally calls
+`Ppmd7z_RangeEnc_FlushData` (`Ppmd7Enc.c:67`):
+
+```c
+void Ppmd7z_RangeEnc_FlushData(CPpmd7z_RangeEnc *p) {
+  unsigned i;
+  for (i = 0; i < 5; i++)
+    RangeEnc_ShiftLow(p);   // always emits 5 range-coder bytes
+}
+```
+
+**There is no code that omits a trailing `0x00`.** The encoder writes exactly 5
+flush bytes, unconditionally. The README's
+
+> "The encoder will omit a last null (`b"\0"`) byte when last byte is `b"\0"`."
+
+is therefore **not a description of `Ppmd7Enc.c`** — pyppmd's own encoder omits
+nothing. This matches the archivey labs: `encode()+flush()` round-trips on 1.3.1
+need the synthetic NUL in **0/60768** trials.
+
+### Where the "extra byte" convention really comes from
+
+It is a **reader convention**, not an encoder action. Two facts from source:
+
+1. The PPMd7 range decoder does a **1-byte lookahead** at the tail. `Range_Normalize`
+   (`Ppmd7Dec.c:26`) reads a fresh byte whenever `Range < kTopValue`; near the
+   end of a stream it can demand one more byte than the payload strictly needed.
+2. pyppmd's reader **blocks** at EOF (`ThreadDecoder.c:70-81`) rather than
+   synthesising that lookahead byte.
+
+In stock **7-Zip**, the PPMd stream is read through an in-byte wrapper
+(`CByteInBufWrap`-style) whose `ReadByte` **returns `0` and bumps an
+"extra bytes" counter once the buffer is exhausted**, so the decoder's tail
+lookahead transparently reads zeros past end-of-input. That over-read-zero
+behaviour is exactly what lets 7-Zip *store* a PPMd pack stream with a trailing
+`0x00` trimmed — "omit last null" is a **container storage optimisation that
+depends on the decoder reader returning 0 past EOF**, not on the encoder
+dropping a byte.
+
+pyppmd's blocking reader does **not** return 0 past EOF, so the binding pushes
+that responsibility onto the caller: the README's
+`decode(b"\0", length - len(result))` is the caller **manually feeding the zero
+byte 7-Zip's reader would have synthesised**. Confirmation to run (Section G):
+feeding `b"\0"` unblocks a stream that `needs_input` at the tail, whereas the
+same stream stalls forever if you never feed it.
+
+**Implication for archivey:** keep bounded NUL recovery — it is required for
+members produced by real 7-Zip that were stored with a trimmed trailing zero,
+even though pyppmd's *own* encoder never produces such a stream. The cap must be
+bounded (not `unpack_size`) because the same `decode(b"\0", big)` call is the
+overshoot crash primitive (Section D).
+
+---
+
+## C. `max_length` and `eof` semantics
+
+### The budget
+
+`_ppmdmodule.c:521`:
+
+```c
+int remains = length >= 0 ? length : INT_MAX;   // <-- -1 becomes INT_MAX
+```
+
+The Python `length` (`max_length`) is a plain symbol budget. `-1` is not "decode
+to end mark" (PPMd7 has none) — it is "decode up to INT_MAX symbols". The output
+buffer grows on demand (`OutputBuffer_Grow`, `_ppmdmodule.c:534`), so nothing
+bounds the run except (a) the budget and (b) the worker's `outbuf_full` check.
+
+### The worker's stop condition (the #126 regression)
+
+`Ppmd7T_decode_run` (`ThreadDecoder.c:110-137`):
+
+```c
+while (i < max_length) {
+    Bool outbuf_full = threadInfo->out->size == threadInfo->out->pos;
+    /* Only stop when output buffer is full. Do NOT stop just because
+       input buffer appears empty ... */
+    if (outbuf_full) break;
+    int c = Ppmd7_DecodeSymbol(cPpmd7, rc);   // may block in reader, or run on stale state
+    ...
+}
+```
+
+Pre-1.3.0, the loop also broke when input was exhausted. #126 removed that,
+commenting that the reader will block instead. That is true **only while more
+real input is coming**. When the whole pack has been fed in one `decode` call
+and `max_length` exceeds the payload, the range coder still has its 5 flush
+bytes + code register, so `Ppmd7_DecodeSymbol` keeps **returning symbols without
+reading input** — it walks the model on a desynchronised range coder, emitting
+garbage, until it either finally demands a byte (reader blocks) or the model
+throws `-1`/`-2`. With `INT_MAX`/oversized budget that window is effectively
+unbounded. This is the mechanism behind `overshoot` and `oversized`
+(`scripts/pyppmd_crash_repro.py`), and behind half-pack + large NUL.
+
+### Premature `eof`
+
+`_ppmdmodule.c:553`:
+
+```c
+if (Ppmd7z_RangeDec_IsFinishedOK(self->rangeDec)) self->eof = True;
+```
+
+and `Ppmd7.h:107`:
+
+```c
+#define Ppmd7z_RangeDec_IsFinishedOK(p) ((p)->Code == 0)
+```
+
+`eof` is set **whenever the range-coder `Code` register is 0 at the end of a
+decode call** — not when the stream is genuinely finished. On highly
+compressible data decoded with a small `max_length`, the `Code` register
+transiently hits 0 after the first ~64 output bytes, so `eof=True` is reported
+even though `unpack_size` is far larger. That is the "premature eof" the brief
+asks about, and it is a direct consequence of using `Code == 0` as an
+end-of-stream proxy. The register returning to a non-zero value on the next
+symbol is why *ignoring* the premature eof and continuing with `decode(b"", n)`
+can still complete a **valid** stream (the archivey chunked-drain observation) —
+and why the same continuation on a **truncated** stream runs the overshoot
+primitive into the ground.
+
+`needs_input` is set (`_ppmdmodule.c:541`) when the worker returned `0`
+(reader blocked / input exhausted), i.e. `Ppmd7T_decode` took the `inempty`
+path (`ThreadDecoder.c:189`). So the state machine is:
+
+- worker fills output → `result = i > 0`, loop continues / stops on budget;
+- reader blocks (input empty) → `result = 0` → `needs_input = True`;
+- `Ppmd7_DecodeSymbol` returns `-1` → `result = -1` → `eof = True`;
+- returns `-2` → `ValueError("Corrupted input data")`;
+- after any call, `Code == 0` → `eof = True` (the premature-eof path).
+
+---
+
+## D. Corruption mechanism (root cause function)
+
+The heap-corruption abort (`malloc(): invalid size (unsorted)` / SIGABRT /
+SIGSEGV, Windows `STATUS_HEAP_CORRUPTION 0xC0000374`) is a **wild write inside
+the PPMd7 suballocator**, driven by decoding past true EOF.
+
+The entire PPMd7 model lives in one allocation `p->Base` (`Ppmd7.c:96-113`), and
+every node is addressed by a byte offset into it:
+
+```c
+#define REF(ptr)   ((UInt32)((Byte *)(ptr) - (p)->Base))   // Ppmd7.c:22
+#define NODE(offs) ((CPpmd7_Node *)(p->Base + (offs)))       // Ppmd7.c:55
+```
+
+After the range coder desyncs (Section C), `Ppmd7_DecodeSymbol` returns garbage
+symbols and calls `Ppmd7_Update1/Update2/UpdateBin` → `Ppmd7_Rescale`,
+`CreateSuccessors`, `AllocContext` → the suballocator (`InsertNode` `Ppmd7.c:120`,
+`RemoveNode` `:126`, `GlueFreeBlocks` `:145`, `AllocUnits` `:243`). With garbage
+`NumStats` / `SummFreq` / `Successor` refs, these compute **offsets that fall
+outside the `Base` allocation**, and `p->FreeList[indx] = REF(node)` /
+`NODE(offs)->Next = ...` then write to `Base + wild_offset` — arbitrary heap
+addresses, which corrupts glibc chunk metadata and aborts on the next `malloc`.
+
+This is **Pavlov's code**, and it is memory-unsafe *by design assumption*: PPMd7
+has no end mark and the decoder trusts that the caller stops at the exact
+declared unpack size (7-Zip always knows it from the archive header, so 7-Zip
+never runs the model past EOF). The bug is not that `Ppmd7.c` lacks bounds
+checks — it never claimed to have them; the bug is that **pyppmd hands it an
+`INT_MAX`/oversized budget and no input-empty stop**, so the model *is* run past
+EOF through a documented Python API.
+
+Secondary teardown hazard (`Ppmd7T_Free`, `ThreadDecoder.c:193`): when the
+worker is blocked in the reader, `Free` sets `tc->empty = False` and broadcasts
+`notEmpty` **before** `pthread_cancel`. The woken reader leaves its wait loop and
+executes `return *((const Byte *)inBuffer->src + inBuffer->pos++)` with
+`pos == size` — an **out-of-bounds read one past the input buffer** (whose
+backing Python bytes may already be released), decoding one more garbage symbol
+into a possibly-finished output block before deferred cancellation lands at the
+next cancellation point. Compounded by the reader's empty check being
+`pos == size` (`ThreadDecoder.c:70`) rather than `pos >= size`, so once `pos`
+overshoots by one it never blocks again. This is the `Ppmd7T_Free` /
+exit-after-green race, and it is **pyppmd-only** (7-Zip's non-threaded decoder
+has no such teardown).
+
+*(Backtrace attribution under a debug allocator is pending — Section G/task 4.)*
+
+---
+
+## E. Ppmd8 parity note (pending measurement)
+
+PPMd8 (var.I / RAR) **does** have a real end mark: `Ppmd8_DecodeSymbol` returns
+`-1` at the EndMarker (`Ppmd8.h:124`), and the same `ThreadDecoder.c`
+`Ppmd8T_decode_run` translates it to `PPMD_RESULT_EOF`. So an unsized PPMd8
+decode terminates on the end mark rather than needing an external size — which is
+why archivey performs no post-eof drain for unsized PPMd8. Whether the same
+overshoot / Free-race primitives reproduce on `Ppmd8Decoder` is still to be
+measured (task 5); the `Ppmd8T_*` wrapper shares the exact structure of the
+Ppmd7 one (same removed stop, same `INT_MAX` budget at `_ppmdmodule.c:1264`, same
+`Free` fake-input-then-cancel at `:302`), so the primitives are expected to
+carry over except that the end mark gives valid streams a clean stop.
+
+---
+
+## F. Answers to the brief's four questions (interim)
+
+1. **Omit-null:** pyppmd's encoder omits nothing (5 unconditional flush bytes,
+   `Ppmd7Enc.c:67`); the "extra byte" is a 7-Zip *reader* convention (return 0
+   past EOF) that pyppmd's *blocking* reader does not implement, so the caller
+   must feed `b"\0"`. Archivey must keep bounded NUL recovery for real-7-Zip
+   members, but never with an `unpack_size` budget.
+2. **`max_length`/`eof`:** `-1 → INT_MAX` (`:521`); `eof` is `Code == 0`
+   (`Ppmd7.h:107`), a proxy that fires prematurely on compressible data under a
+   small cap; retained-input semantics let a valid stream continue past that
+   premature eof but let a truncated stream run the overshoot primitive.
+3. **Corruption:** wild write in the PPMd7 suballocator (`Ppmd7.c` `InsertNode` /
+   `GlueFreeBlocks` via `NODE(offs)` on garbage offsets) after the range coder
+   desyncs from decoding past EOF — Pavlov's memory-unsafe-past-EOF core, invoked
+   past EOF by pyppmd's unbounded ThreadDecoder budget.
+4. **Separability:** the teardown OOB and the removed stop are **pyppmd-only**;
+   the model wild-write is **shared** but never reached by real 7-Zip because
+   7-Zip always decodes to the exact known size. Direct 7-Zip-API overshoot
+   comparison is task E of the brief (see Section G plan).
+
+---
+
+## G. Empirical plan (in progress)
+
+- [ ] Premature-eof repro: `decode(packed, 64)` on `b"a"*4096`, show `eof=True`
+      with `Code == 0` while output ≪ payload; then `decode(b"", 64)` completes.
+- [ ] Corruption backtrace: run `pyppmd_crash_repro.py --mode overshoot/oversized`
+      and half-pack+large-NUL under `MALLOC_CHECK_=3` / glibc malloc debug +
+      `faulthandler`, capture the faulting frame (expect `Ppmd7.c` suballocator).
+- [ ] Reader-blocks vs feed-zero: show a tail-`needs_input` stream completes when
+      fed `b"\0"` and stalls otherwise (emulating 7-Zip's over-read-zero).
+- [ ] Ppmd8 parity: overshoot / post-eof / Free-race on `Ppmd8Decoder`; confirm
+      end-mark makes unsized drains unnecessary.
+- [ ] Version delta 1.2.0 vs 1.3.1 on the same overshoot (if a 1.2.0 wheel builds
+      in-env), to nail the #126 regression window.
+
+Findings and the concrete upstream-fix refinement will be appended as each runs.

--- a/docs/internal/ppmd-native-investigation-results.md
+++ b/docs/internal/ppmd-native-investigation-results.md
@@ -498,15 +498,61 @@ cycles):
 | `while dec.needs_input: dec.decode(b"\0", 1)` (≤4×), then `del` | **0** |
 
 So archivey can add a **"quiesce on close"** step to `PpmdDecoder` /
-`DecompressorStream.close()`: while `needs_input` (worker parked), issue a bounded
-`decode(b"\0", 1)` (cap the loop at a few iterations) to force the worker to
-`finished` before releasing the decoder. This is the deterministic-dispose spike
-the brief's review addendum asked for (gap #1), and if it holds under the full
-adversarial soak it would let required CI **drop `--allow-exit-after-green`** for
-the PPMd module. It needs validating against the existing subprocess-isolated
-adversarial tests (and on 3.12+/free-threaded per gap #4) before being relied on;
-the mechanism and the single-shape measurement above are promising but not yet a
-full soak.
+`DecompressorStream.close()`: while a worker is parked, issue a bounded
+`decode(b"\0", 1)` (cap the loop at a few iterations) to force it to `finished`
+before releasing the decoder. This is the deterministic-dispose spike the brief's
+review addendum asked for (gap #1).
+
+#### Prototype implemented (2026-07-23)
+
+Landed on this branch as `PpmdDecoder._quiesce_worker()`, wired through both an
+explicit `close()` (new no-op `Decoder.close()` on the protocol / `BaseDecoder`,
+called from `DecompressorStream.close()`) and a `__del__` GC safety net, and
+gated on `not self.finished` so a fully-decoded member's close costs nothing.
+All 26 `tests/test_ppmd_raw_streams.py` + 7z reader tests pass; both type-checkers
+clean.
+
+**What is proven, and what is not:**
+
+- **The quiesce mechanism works** — valgrind on the raw shape that reproduces the
+  UAF (bare `pyppmd`, a large-budget `decode` over truncated input, 6 cycles):
+
+  | Disposal policy | Invalid writes at `ThreadDecoder.c:134` |
+  |-----------------|------------------------------------------|
+  | `del dec` directly (worker left blocked) | **8 154** |
+  | `while parked: dec.decode(b"\0", 1)` (≤4×), then `del` | **0** |
+
+  Through the archivey `PpmdDecoder` (truncated PPMd7 via the stream `close()`
+  path and via `__del__`): **0** valgrind errors with the fix.
+
+- **On archivey's own shapes in this env, the baseline was already ~0**, so the
+  fix could not be shown to move a nonzero crash count *here*:
+  - Child-level soak (archivey truncated PPMd7 flush + dispose, fracs
+    0.25/0.5/0.7/0.9, 100 fresh processes each): **0 teardown aborts** *without*
+    the fix. archivey's capped single NUL (`_PPMD_EXTRA_NUL_MAX_OUTPUT = 64`)
+    already limits any teardown free-run to ≤64 writes, which rarely aborts — the
+    doc's historical ~15% was the *uncapped* bare-`pyppmd` shape, not archivey's.
+  - Module soak (`ci_run_native_modules.py --repeat 30/40`, no
+    `--allow-exit-after-green`): **all iterations PASSED** both with and without
+    the fix — the in-process adversarial shapes are already subprocess-isolated,
+    so the parent session does not abort here.
+  - Under valgrind's deterministic thread scheduling, the small-budget teardown
+    *race* does not reproduce at all (baseline and fixed both 0) — `pthread_cancel`
+    wins at the reader's `cond_wait` cancellation point before the OOB
+    read/write. The 8 154→0 result reproduces only with a **large** budget
+    (long free-run), which archivey mostly avoids (the one large-budget archivey
+    path is unsized PPMd8's 64 KiB chunk; it too was 0/0 here because its end mark
+    exits the worker on valid data).
+
+**Verdict on the prototype:** sound, zero-overhead on the happy path,
+valgrind-proven to remove the UAF on the shape that exhibits it, and the right
+structural fix for gap #1 — but in the current archivey code + this Linux/CPython
+3.11 host the teardown residual is already ~0, so it is **defense-in-depth**, not
+a fix for a locally-reproducible archivey crash. Dropping required CI's
+`--allow-exit-after-green` should be gated on a **deterministic** check (a
+valgrind driver like Section D's, run in the PPMd-native-stress workflow) and on
+the hot-race platforms (3.12+/free-threaded/Windows, gap #4), not on this host's
+already-green soak.
 
 ### 3. What cannot be closed in-process
 
@@ -527,5 +573,5 @@ full soak.
 | Case | In-process safety today | Lever |
 |------|------------------------|-------|
 | Valid member (known `unpack_size`, complete pack) | **Safe** (0 valgrind errors) | Existing bound-every-call + `pack_size` gate |
-| Truncated member | Intermittent teardown abort | **Quiesce-on-close** (measured 8154→0) — validate then drop allow-exit-after-green |
+| Truncated member | Teardown abort already ~0 here (capped NUL); a large-budget worker would UAF | **Quiesce-on-close** prototype (bare-shape 8154→0; defense-in-depth) — gate CI allowance-drop on a valgrind check + hot-race platforms |
 | Corrupt full-length pack | Residual | Quiesce-on-close neutralises teardown; forbid in-call overshoot; process isolation for full guarantee |

--- a/docs/internal/ppmd-native-investigation-results.md
+++ b/docs/internal/ppmd-native-investigation-results.md
@@ -398,48 +398,28 @@ requests more than the member contains.
 
 ---
 
-## H. Concrete upstream fix (refines `pyppmd-upstream-report.md`)
+## H. Concrete upstream fix (summary)
 
-The prior report's four fixes still apply, but the root-cause finding sharpens
-the priority: **the corrupting write is the output-buffer UAF, so the primary fix
-is worker/output lifetime, not (only) budget clamping.**
+The full, paste-able fix list and reproduction are the ready-to-file report in
+**§J** below (which supersedes the root-cause analysis in
+`pyppmd-upstream-report.md`). In short, the root-cause finding sharpens the
+priority over the earlier draft: **the corrupting write is the output-buffer UAF,
+so the primary fix is worker/output lifetime, not (only) budget clamping.**
 
-1. **Never free the output block while a worker may still write to it
-   (primary).** Before `OutputBuffer_Finish` / any `Py_DECREF(buffer->list)` in
-   `Ppmd7Decoder_decode` (`_ppmdmodule.c:552`) and `Ppmd8Decoder_decode`
-   (`:~1300`), ensure the worker is quiescent — either it `finished`, or it is
-   parked in the reader wait with `out->dst` guaranteed not to be dereferenced
-   until re-entry. Equivalently, do not hand the worker a raw pointer into a
-   Python-owned block that the controller can free while the worker is only
-   *paused*. This alone removes the UAF that valgrind flags.
-2. **Restore a stop condition for input-exhausted decodes.** Re-add the 1.2.0
-   input-empty break *without* reintroducing its chunked-truncation bug: stop the
-   symbol loop when the range coder would need a byte that is not available
-   (park), rather than spinning on stale range state. Bound the loop by what the
-   input can actually support instead of `INT_MAX` (`_ppmdmodule.c:521/1264`).
-3. **Fix the reader's empty check:** `pos >= size` (not `== size`) in
-   `Ppmd_thread_Reader` (`ThreadDecoder.c:70`), so an overshoot of one cannot
-   turn into an unbounded free-run.
-4. **Signal termination explicitly in `Ppmd7T_Free`/`Ppmd8T_Free`.** Use a
-   dedicated "terminate" flag the reader re-checks after wakeup instead of faking
-   `tc->empty = False` with no data (`ThreadDecoder.c:198/307`); the reader must
-   return/park on termination rather than reading `src[pos++]`.
-5. **Port the cffi `_eof` guard to the C extension:** `decode` after `eof`
-   returns `b""` without starting a worker (`_ppmdmodule.c:396`, add the early
-   return the cffi backend already has).
+1. **Primary — never free the output block while a worker may still write to it**
+   (`OutputBuffer_Finish` at `_ppmdmodule.c:552`): quiesce the worker first. This
+   alone removes the UAF valgrind flags.
+2. Restore an input-exhausted stop (bound the loop by available input, not
+   `INT_MAX`, `:521/1264`) without 1.2.0's chunked-truncation bug.
+3. Reader empty check `pos >= size`, not `== size` (`ThreadDecoder.c:70`).
+4. Explicit terminate flag in `Ppmd7T_Free`/`Ppmd8T_Free` instead of faking
+   `tc->empty = False` (`:198/307`).
+5. Port the cffi `_eof` guard to the C extension (`_ppmdmodule.c:396`).
 
-Fixes 2–5 are defence-in-depth; **fix 1 is the one the valgrind evidence
-demands**. Until a fixed release ships, archivey's discipline (never overshoot;
-require `unpack_size`/`pack_size`; bounded single NUL; no post-eof drain unless
-pack delivery is known complete) is the correct in-process mitigation, and the
-`Ppmd7T_Free` residual remains the reason PPMd adversarial tests are
-subprocess-isolated.
-
-### Verification when a fixed release ships
-
-Re-run all `scripts/pyppmd_crash_repro.py` modes (`extra-null`, `overshoot`,
-`oversized`, `warmup-overshoot`) plus the valgrind driver of Section D; all must
-report **0 memory errors** and 0 crashes, including under teardown (`del dec`).
+Until a fixed release ships, archivey's discipline (never overshoot; require
+`unpack_size`/`pack_size`; bounded single NUL; no post-eof drain unless pack
+delivery is known complete; **quiesce-on-close** for teardown, §I) is the correct
+in-process mitigation.
 
 ---
 
@@ -575,3 +555,141 @@ already-green soak.
 | Valid member (known `unpack_size`, complete pack) | **Safe** (0 valgrind errors) | Existing bound-every-call + `pack_size` gate |
 | Truncated member | Teardown abort already ~0 here (capped NUL); a large-budget worker would UAF | **Quiesce-on-close** prototype (bare-shape 8154→0; defense-in-depth) — gate CI allowance-drop on a valgrind check + hot-race platforms |
 | Corrupt full-length pack | Residual | Quiesce-on-close neutralises teardown; forbid in-call overshoot; process isolation for full guarantee |
+
+---
+
+## J. Upstream report (ready to file against miurahr/pyppmd)
+
+This section is the self-contained, paste-able bug report. It **supersedes the
+root-cause analysis** in `docs/internal/pyppmd-upstream-report.md` (that draft
+attributed the corruption to the vendored 7-Zip model being walked on a
+desynchronised range coder; valgrind shows the *first* corrupting write is an
+output-buffer use-after-free in pyppmd's own `ThreadDecoder.c`). The two describe
+the **same defect** — 1.3.x heap corruption decoding valid/overshot PPMd7 — and
+that file now points here.
+
+### Title
+
+> 1.3.x: heap corruption / SIGSEGV / SIGABRT decoding PPMd7 whenever a `decode`
+> requests more output than the fed input can produce — root cause is a
+> use-after-free of the decode output buffer by the worker thread
+> (`ThreadDecoder.c:134`), not the PPMd model. Regression from the 1.3.0
+> ThreadDecoder rewrite (#126).
+
+### Summary
+
+Since **1.3.0**, `Ppmd7Decoder.decode` intermittently corrupts the heap on
+**valid** PPMd7 data whenever the requested output exceeds what the stream can
+still produce — `max_length=-1`, an oversized sized bound (≳64 KiB past the true
+payload), any `decode` after `eof`, or a large NUL/empty budget over a truncated
+member. Symptoms: `malloc(): invalid size` / `corrupted size vs. prev_size` /
+SIGSEGV on Linux, `STATUS_HEAP_CORRUPTION (0xC0000374)` on Windows. 1.1.1/1.2.0
+do not corrupt on these inputs. `Ppmd8Decoder` shares the wrapper and the same
+defect past its end mark.
+
+### Root cause (valgrind-confirmed)
+
+The worker thread's output write is a **use-after-free**. Valgrind memcheck
+reports one context for `overshoot`/`oversized`/after-eof:
+
+```
+Invalid write of size 1  at Ppmd7T_decode_run (ThreadDecoder.c:134)
+Address ... free'd by  OutputBuffer_Finish (blockoutput.h:253)  <- Py_DECREF(buffer->list)
+                       Ppmd7Decoder_decode (_ppmdmodule.c:552)
+Block alloc'd at        OutputBuffer_InitAndGrow (blockoutput.h:79) / _ppmdmodule.c:504
+```
+
+Three compounding defects, all in pyppmd-original code, introduced by #126:
+
+1. **#126 removed the input-empty stop.** 1.2.0's `Ppmd7T_decode_run` broke out of
+   the symbol loop when the input buffer was consumed:
+   `if (inbuf_empty && reader->inBuffer->size > 0) break;`. 1.3.0 removed it, so
+   with a budget larger than the payload the worker keeps decoding past logical
+   EOF and, when it finally needs a byte, **blocks in the reader**
+   (`Ppmd_thread_Reader`, `ThreadDecoder.c:77`). The controller returns to Python
+   via the `inempty` path (`:189`) **without joining** the still-blocked worker.
+
+2. **`OutputBuffer_Finish` frees the output block under the blocked worker.** Back
+   in `Ppmd7Decoder_decode`, the loop breaks on `result == 0` (`_ppmdmodule.c:530`)
+   and `OutputBuffer_Finish` (`:552`) does `Py_DECREF(buffer->list)`
+   (`blockoutput.h:253`), freeing the PyBytes block that the worker's `out->dst`
+   still points at. No worker-quiescence precedes the free.
+
+3. **The blocked worker is resumed with no input and free-runs.** The next
+   `decode` or `Ppmd7T_Free` at teardown (`:198`) broadcasts `notEmpty`; the
+   reader does an OOB `*(src + pos++)` at `pos == size`, and because the empty
+   check is `pos == size` (not `pos >= size`, `:70`) it **never blocks again** and
+   free-runs — each iteration writing one byte into the freed block
+   (`ThreadDecoder.c:134`) for thousands of iterations until the heap aborts.
+
+**Control:** exact-sized `decode(packed, len(data))` is **0 valgrind errors** — the
+worker's budget ends at the payload boundary, it returns, is joined
+(`finished == True`), and `Ppmd7T_Free` no-ops. This is why py7zr (always passes a
+size) and any caller that never overshoots are safe.
+
+The vendored 7-Zip model (`Ppmd7.c`) is memory-unsafe *if driven past EOF* (its
+suballocator addresses nodes by unchecked `p->Base + offset`), but that is a
+latent property the caller must respect; it is **not** the first corrupting write
+here, and real 7-Zip never trips it because it always decodes to the exact known
+unpack size.
+
+### Reproduction
+
+```bash
+pip install 'pyppmd==1.3.1'
+# Probabilistic crash-rate (fresh subprocess children):
+python scripts/pyppmd_crash_repro.py 30 --mode overshoot   # crashes
+python scripts/pyppmd_crash_repro.py 30 --mode oversized   # crashes, no -1
+python scripts/pyppmd_crash_repro.py 30 --mode sized-safe  # control, clean
+# Deterministic (valgrind memcheck; pins the UAF every run):
+python scripts/ppmd_uaf_valgrind.py --scenario pyppmd-overshoot --strict-pyppmd
+```
+
+`ppmd_uaf_valgrind.py` reports the `Invalid write ... ThreadDecoder.c:134` context
+deterministically; a fixed release must make it 0.
+
+### Suggested fixes (priority order)
+
+1. **Do not free the output block while a worker may still write to it (primary).**
+   Before `OutputBuffer_Finish` / any `Py_DECREF(buffer->list)` in
+   `Ppmd7Decoder_decode` (`_ppmdmodule.c:552`) and `Ppmd8Decoder_decode`, ensure
+   the worker is quiescent (finished, or parked in a way that guarantees it will
+   not dereference `out->dst` until re-entry). Equivalently, never hand the worker
+   a raw pointer into a Python-owned block the controller can free while the worker
+   is only paused.
+2. **Restore an input-exhausted stop** without reintroducing 1.2.0's
+   chunked-truncation bug: stop/park when the range coder needs a byte the input
+   cannot supply, and bound the loop by what the input supports instead of
+   `INT_MAX` (`:521`/`:1264`).
+3. **Fix the reader's empty check** to `pos >= size` (`ThreadDecoder.c:70`) so a
+   one-byte overshoot cannot become an unbounded free-run.
+4. **Signal termination explicitly in `Ppmd7T_Free`/`Ppmd8T_Free`** via a flag the
+   reader re-checks after wakeup, instead of faking `tc->empty = False` with no
+   data (`:198`/`:307`); the reader must park/return on termination, not read
+   `src[pos++]`.
+5. **Port the cffi `_eof` guard to the C extension:** `decode` after `eof` returns
+   `b""` without starting a worker (`_ppmdmodule.c:396`).
+
+Fixes 2–5 are defence-in-depth; **fix 1 is the one valgrind demands.**
+
+### Caller-side workaround (what archivey ships)
+
+Never overshoot: require the exact `unpack_size`; bound every `decode` to
+`min(chunk, unpack_size - produced)`; never `-1`; `pack_size` gate on post-eof
+drains; a single capped extra NUL. Plus **quiesce-on-close** — drive a parked
+worker to `finished` with bounded `decode(b"\0", 1)` before disposal so
+`Ppmd7T_Free` cannot resume it into freed memory (`PpmdDecoder._quiesce_worker`,
+§I). See `docs/internal/known-issues.md`.
+
+### Verification checklist for a fixed release
+
+All must be **0 crashes / 0 memcheck errors**:
+
+```bash
+python scripts/pyppmd_crash_repro.py 50 --mode extra-null
+python scripts/pyppmd_crash_repro.py 50 --mode overshoot
+python scripts/pyppmd_crash_repro.py 50 --mode oversized
+python scripts/pyppmd_crash_repro.py 50 --mode warmup-overshoot
+python scripts/ppmd_uaf_valgrind.py --scenario all --strict-pyppmd
+uv run --no-sync pytest tests/test_ppmd_raw_streams.py -q
+```

--- a/docs/internal/ppmd-native-investigation-results.md
+++ b/docs/internal/ppmd-native-investigation-results.md
@@ -5,7 +5,8 @@
 `docs/internal/ppmd-exit-after-green-exploration.md`,
 `docs/internal/known-issues.md`, `scripts/pyppmd_crash_repro.py`
 **Date started:** 2026-07-23
-**Status:** live notebook — findings appended as experiments finish. Source
+**Status:** complete (empirical + source). Findings appended as experiments
+finished. Source
 citations are against **pyppmd `v1.3.1`** (the pinned wheel; git tag `v1.3.1`,
 commit `580b675`). The wheel installed in this env is `pyppmd 1.3.1`, CPython
 3.11.15, glibc 2.39, Linux 6.18.5.
@@ -18,22 +19,34 @@ is cited and the *source-level cause* is added rather than re-measured.
 
 ## TL;DR verdict
 
+The heap corruption is **not** primarily the Pavlov suballocator — valgrind's
+*first* memory error in every crash family is a **use-after-free of pyppmd's own
+output buffer** at `ThreadDecoder.c:134`, on a block already freed by
+`OutputBuffer_Finish` (`_ppmdmodule.c:552`). Every failure mode below reduces to
+that one bug, gated by one condition: **did the worker finish, or is it left
+blocked in the reader past logical EOF?**
+
 | Failure mode | 7-Zip / Pavlov PPMd core | pyppmd ThreadDecoder / binding | Caller contract |
 |--------------|--------------------------|--------------------------------|-----------------|
-| overshoot `max_length` (`-1` or `+65536`) | Memory-unsafe **primitive**: decodes garbage symbols past true EOF, suballocator writes wild `p->Base + offset` → heap corruption. But never *invoked* this way in real 7-Zip (exact unpack size always known). | **Root trigger:** 1.3.0 `#126` removed the input-empty stop; `-1 → INT_MAX` budget (`_ppmdmodule.c:521`) drives the core past EOF. | Never request more output than the true remaining payload. |
-| post-eof empty decode toward `unpack_size` | Same primitive once desynced. | No after-eof guard in the **C extension** `decode` (guard is cffi-only); restarts a runaway worker on finished range state. | Do not call `decode` after `eof` unless pack delivery is known complete. |
-| half-pack + large NUL | Same primitive (large budget over truncated stream). | Same removed stop + INT_MAX budget. | Cap the synthetic-NUL budget; do not chase `unpack_size` on short pack. |
-| `Ppmd7T_Free` while worker blocked | Not applicable (7-Zip is non-threaded here). | **pyppmd-only:** `Ppmd7T_Free` fakes "input available" (`tc->empty=False`) then cancels; reader does an OOB `src[pos++]` at `pos==size`. | n/a (teardown bug). |
+| overshoot `max_length` (`-1` or `+65536`) | Not the fault site. The desynced model only *generates the garbage symbols*; it does not write outside its own `p->Base` arena first. | **Root cause (pyppmd):** worker left blocked-in-reader (1.3.0 `#126` removed the input-empty stop) while `OutputBuffer_Finish` frees the output block → later wake ⇒ **UAF write, free-running** (reader `pos==size` bug). Valgrind: 33 423 writes at `ThreadDecoder.c:134`. | Never request more output than the true remaining payload. |
+| post-eof empty decode toward `unpack_size` | Not the fault site. | Same UAF. No after-eof guard in the **C extension** `decode` (guard is cffi-only) restarts a runaway worker. | Do not `decode` after `eof` unless pack delivery is known complete. |
+| half-pack + large NUL / after-eof NUL | Not the fault site. | Same UAF (valgrind: 59 522 writes at `ThreadDecoder.c:134`, same single context). | Cap the synthetic-NUL budget; do not chase `unpack_size` on short pack. |
+| `Ppmd7T_Free` while worker blocked | Not applicable (7-Zip is non-threaded here). | **pyppmd-only:** `Ppmd7T_Free` fakes "input available" (`tc->empty=False`) then cancels; that wake is *what drives the UAF above*, and the reader also does an OOB `src[pos++]` at `pos==size`. | n/a (teardown bug). |
 | omit-trailing-null / "extra byte" | **Container/reader convention**, not an encoder action. | pyppmd's reader **blocks** at EOF instead of returning 0, so the caller must feed `b"\0"` to emulate 7-Zip's over-read-zero. | Keep bounded NUL recovery for members produced by real 7-Zip. |
 
-Bottom line: the **memory-unsafety primitive lives in Igor Pavlov's vendored
-PPMd7 model/suballocator** (`Ppmd7.c`), which is safe *only* when the caller
-never decodes past the true payload length. **pyppmd 1.3.x's ThreadDecoder
-rewrite (#126) is what actually drives the core past EOF** by removing the
-input-exhausted stop condition and honouring an `INT_MAX`/oversized output
-budget, with no after-eof guard in the C extension. So it is an **interaction**,
-but the regression and the fix both belong to pyppmd; the core needs the caller
-to respect the length contract it has always required.
+Control that pins it: **exact-sized `decode(packed, len(data))` is 0 valgrind
+errors** — the worker's budget runs out exactly at the payload boundary, it
+returns and is joined, `finished=True`, and `Ppmd7T_Free` never wakes it. Any
+overshoot leaves it blocked-in-reader instead, and the freed output block is then
+written by the resumed worker.
+
+Bottom line: this is a **pyppmd binding bug** — three compounding defects, all in
+`ThreadDecoder.c` / `_ppmdmodule.c` / `blockoutput.h` (Section D), introduced by
+the 1.3.0 `#126` rewrite. Igor Pavlov's `Ppmd7.c` is *memory-unsafe if driven
+past EOF*, but that is a latent property the caller must respect (real 7-Zip
+always decodes to the exact known unpack size and never trips it); it is **not**
+the first corrupting write here. The regression and the fix both belong to
+pyppmd.
 
 ---
 
@@ -166,7 +179,9 @@ bytes + code register, so `Ppmd7_DecodeSymbol` keeps **returning symbols without
 reading input** — it walks the model on a desynchronised range coder, emitting
 garbage, until it either finally demands a byte (reader blocks) or the model
 throws `-1`/`-2`. With `INT_MAX`/oversized budget that window is effectively
-unbounded. This is the mechanism behind `overshoot` and `oversized`
+unbounded — and, crucially, it usually ends with the worker **blocked in the
+reader** rather than finished, which is the precondition for the output-buffer
+UAF (Section D). This is the mechanism behind `overshoot` and `oversized`
 (`scripts/pyppmd_crash_repro.py`), and behind half-pack + large NUL.
 
 ### Premature `eof`
@@ -207,66 +222,118 @@ path (`ThreadDecoder.c:189`). So the state machine is:
 
 ---
 
-## D. Corruption mechanism (root cause function)
+## D. Corruption mechanism (root cause — valgrind-confirmed)
 
-The heap-corruption abort (`malloc(): invalid size (unsorted)` / SIGABRT /
-SIGSEGV, Windows `STATUS_HEAP_CORRUPTION 0xC0000374`) is a **wild write inside
-the PPMd7 suballocator**, driven by decoding past true EOF.
+The heap-corruption abort (`corrupted size vs. prev_size` / `malloc(): invalid
+size` / SIGABRT / SIGSEGV, Windows `STATUS_HEAP_CORRUPTION 0xC0000374`) is a
+**use-after-free of pyppmd's output buffer**, *not* (primarily) a Pavlov
+suballocator wild-write. Valgrind (memcheck) reports the same single error
+context for `overshoot`, `oversized`, and after-eof `extra-null`:
 
-The entire PPMd7 model lives in one allocation `p->Base` (`Ppmd7.c:96-113`), and
-every node is addressed by a byte offset into it:
-
-```c
-#define REF(ptr)   ((UInt32)((Byte *)(ptr) - (p)->Base))   // Ppmd7.c:22
-#define NODE(offs) ((CPpmd7_Node *)(p->Base + (offs)))       // Ppmd7.c:55
+```
+Invalid write of size 1
+   at 0x...: Ppmd7T_decode_run (ThreadDecoder.c:134)
+   by ...: start_thread (pthread_create.c:447)
+ Address 0x... is 1,838 bytes inside a block of size 32,801 free'd
+   at ...: free
+   by ...: OutputBuffer_Finish (blockoutput.h:253)
+   by ...: Ppmd7Decoder_decode (_ppmdmodule.c:552)
+ Block was alloc'd at
+   by ...: OutputBuffer_InitAndGrow (blockoutput.h:79) / Ppmd7Decoder_decode:504
 ```
 
-After the range coder desyncs (Section C), `Ppmd7_DecodeSymbol` returns garbage
-symbols and calls `Ppmd7_Update1/Update2/UpdateBin` → `Ppmd7_Rescale`,
-`CreateSuccessors`, `AllocContext` → the suballocator (`InsertNode` `Ppmd7.c:120`,
-`RemoveNode` `:126`, `GlueFreeBlocks` `:145`, `AllocUnits` `:243`). With garbage
-`NumStats` / `SummFreq` / `Successor` refs, these compute **offsets that fall
-outside the `Base` allocation**, and `p->FreeList[indx] = REF(node)` /
-`NODE(offs)->Next = ...` then write to `Base + wild_offset` — arbitrary heap
-addresses, which corrupts glibc chunk metadata and aborts on the next `malloc`.
+`ThreadDecoder.c:134` is the worker's output write
+`*((Byte *)threadInfo->out->dst + threadInfo->out->pos++) = (Byte) c;`. The block
+it writes into was freed by `OutputBuffer_Finish`'s `Py_DECREF(buffer->list)`
+(`blockoutput.h:253`, reached from `_ppmdmodule.c:552`). So a **worker thread is
+still alive and writing after the Python `decode` call freed the output block.**
 
-This is **Pavlov's code**, and it is memory-unsafe *by design assumption*: PPMd7
-has no end mark and the decoder trusts that the caller stops at the exact
-declared unpack size (7-Zip always knows it from the archive header, so 7-Zip
-never runs the model past EOF). The bug is not that `Ppmd7.c` lacks bounds
-checks — it never claimed to have them; the bug is that **pyppmd hands it an
-`INT_MAX`/oversized budget and no input-empty stop**, so the model *is* run past
-EOF through a documented Python API.
+### The exact causal chain (three compounding defects, all pyppmd-original)
 
-Secondary teardown hazard (`Ppmd7T_Free`, `ThreadDecoder.c:193`): when the
-worker is blocked in the reader, `Free` sets `tc->empty = False` and broadcasts
-`notEmpty` **before** `pthread_cancel`. The woken reader leaves its wait loop and
-executes `return *((const Byte *)inBuffer->src + inBuffer->pos++)` with
-`pos == size` — an **out-of-bounds read one past the input buffer** (whose
-backing Python bytes may already be released), decoding one more garbage symbol
-into a possibly-finished output block before deferred cancellation lands at the
-next cancellation point. Compounded by the reader's empty check being
-`pos == size` (`ThreadDecoder.c:70`) rather than `pos >= size`, so once `pos`
-overshoots by one it never blocks again. This is the `Ppmd7T_Free` /
-exit-after-green race, and it is **pyppmd-only** (7-Zip's non-threaded decoder
-has no such teardown).
+1. **`#126` removed the input-empty stop** (`ThreadDecoder.c`, 1.3.0). In 1.2.0,
+   `Ppmd7T_decode_run` broke out of the symbol loop when the input buffer was
+   consumed:
 
-*(Backtrace attribution under a debug allocator is pending — Section G/task 4.)*
+   ```c
+   // v1.2.0 src/lib/buffer/ThreadDecoder.c
+   Bool inbuf_empty = reader->inBuffer->size == reader->inBuffer->pos;
+   ...
+   if (inbuf_empty && reader->inBuffer->size > 0) { break; }  // <-- REMOVED in 1.3.0
+   ```
+
+   With the whole pack fed in one `decode` call and `max_length` exceeding the
+   payload, the 1.3.x worker no longer stops at input-empty; it keeps decoding
+   (garbage) symbols until the range coder finally needs a byte, then **blocks in
+   the reader** (`pthread_cond_wait(notEmpty)`, `ThreadDecoder.c:77`). The
+   controller's `inempty` path (`ThreadDecoder.c:189`) returns 0 to Python
+   **without joining the still-blocked worker**.
+
+2. **`OutputBuffer_Finish` frees the output block while the worker holds a raw
+   pointer into it.** Back in Python land, `Ppmd7Decoder_decode` breaks its loop
+   on `result == 0` (`_ppmdmodule.c:530`), sets `needs_input`, and calls
+   `OutputBuffer_Finish` (`:552`), whose `Py_DECREF(buffer->list)` frees the
+   PyBytes blocks — including the one `out->dst` still points at. There is **no
+   worker-quiescence step** before the free.
+
+3. **The blocked worker is later resumed with no new input, and free-runs.** The
+   only things that broadcast `notEmpty` are the next `decode` call or
+   `Ppmd7T_Free` at teardown (`:198`). When woken, the reader
+   (`Ppmd_thread_Reader`, `ThreadDecoder.c:81`) executes
+   `return *((const Byte *)inBuffer->src + inBuffer->pos++)` with `pos == size`
+   — an OOB read — advancing `pos` to `size+1`. Because the empty check is
+   `pos == size` (`:70`) and **not** `pos >= size`, the reader **never blocks
+   again**, so the worker free-runs: each iteration decodes a garbage symbol and
+   writes it to the freed `out->dst` (`:134`) — thousands of UAF writes
+   (valgrind counted 33 423 / 59 522 in 6-cycle runs) until the corrupted glibc
+   metadata aborts, a wild read SIGSEGVs, or the deferred `pthread_cancel` lands.
+
+### Why the controls are clean
+
+Exact-sized `decode(packed, len(data))` is **0 valgrind errors**: the worker's
+budget (`i < max_length`) runs out at exactly the payload boundary, the worker
+returns `i`, sets `finished = True`, and is `pthread_join`-ed by the controller's
+`finished` path (`ThreadDecoder.c:185`). No worker is ever left blocked, so
+`Ppmd7T_Free` sees `finished` and does nothing, and `out->dst` is never written
+after the free. This is precisely the measured safe/unsafe split (sized-safe 0%,
+overshoot/oversized/extra-null high-rate).
+
+### Where the Pavlov suballocator fits
+
+The desynced model (`Ppmd7_DecodeSymbol` on a range coder past EOF) is what
+*produces* the garbage symbols the worker then writes, and in principle its
+suballocator (`InsertNode`/`GlueFreeBlocks` via `NODE(offs)`, `Ppmd7.c:120/145/55`)
+can also compute out-of-`Base` offsets. But valgrind's **first** error is always
+the output-buffer UAF in pyppmd's own `ThreadDecoder.c:134`, not a write inside
+`Ppmd7.c`. So the corruption the earlier `pyppmd-upstream-report.md` attributed
+to "walking the native model on a desynchronized range coder" is more precisely a
+**pyppmd output-buffer lifetime bug**; the model walk is the garbage *source*, the
+UAF is the corrupting *write*. Both are enabled by the same removed stop + oversized
+budget.
 
 ---
 
-## E. Ppmd8 parity note (pending measurement)
+## E. Ppmd8 parity (measured)
 
 PPMd8 (var.I / RAR) **does** have a real end mark: `Ppmd8_DecodeSymbol` returns
-`-1` at the EndMarker (`Ppmd8.h:124`), and the same `ThreadDecoder.c`
-`Ppmd8T_decode_run` translates it to `PPMD_RESULT_EOF`. So an unsized PPMd8
-decode terminates on the end mark rather than needing an external size — which is
-why archivey performs no post-eof drain for unsized PPMd8. Whether the same
-overshoot / Free-race primitives reproduce on `Ppmd8Decoder` is still to be
-measured (task 5); the `Ppmd8T_*` wrapper shares the exact structure of the
-Ppmd7 one (same removed stop, same `INT_MAX` budget at `_ppmdmodule.c:1264`, same
-`Free` fake-input-then-cancel at `:302`), so the primitives are expected to
-carry over except that the end mark gives valid streams a clean stop.
+`-1` at the EndMarker (`Ppmd8.h:124`), and `Ppmd8T_decode_run` translates it to
+`PPMD_RESULT_EOF` (`ThreadDecoder.c:235`), which the module maps to `eof=True`.
+
+Measured (this env, 1.3.1): an **unsized** PPMd8 decode of `b"a"*2000`,
+`b"\x00"*2000`, and `"hello world "*100` terminates on the end mark with
+`eof=True` and **overshoot = 0** in each case (drove `decode(b"", 4096)` to
+completion; no fabricated trailing bytes). This confirms archivey's decision to
+perform **no** post-eof drain for unsized PPMd8: the end mark flushes the final
+symbols with no residual buffered output, so skipping the drain cannot truncate a
+valid member (brief gap #8).
+
+The `Ppmd8T_*` wrapper shares the Ppmd7 structure exactly — same removed
+input-empty stop, same `INT_MAX` budget (`_ppmdmodule.c:1264`), same
+`OutputBuffer_Finish` free, same `Ppmd8T_Free` fake-input-then-cancel (`:302`) —
+so **overshooting past the end mark** (an oversized budget on truncated/corrupt
+PPMd8, or empty drains past `eof` toward an inflated `unpack_size`) reproduces the
+identical output-buffer UAF. The end mark only protects *valid* unsized streams
+by giving the worker a clean stop; it does not protect against a caller that
+requests more than the member contains.
 
 ---
 
@@ -281,29 +348,95 @@ carry over except that the end mark gives valid streams a clean stop.
    (`Ppmd7.h:107`), a proxy that fires prematurely on compressible data under a
    small cap; retained-input semantics let a valid stream continue past that
    premature eof but let a truncated stream run the overshoot primitive.
-3. **Corruption:** wild write in the PPMd7 suballocator (`Ppmd7.c` `InsertNode` /
-   `GlueFreeBlocks` via `NODE(offs)` on garbage offsets) after the range coder
-   desyncs from decoding past EOF — Pavlov's memory-unsafe-past-EOF core, invoked
-   past EOF by pyppmd's unbounded ThreadDecoder budget.
-4. **Separability:** the teardown OOB and the removed stop are **pyppmd-only**;
-   the model wild-write is **shared** but never reached by real 7-Zip because
-   7-Zip always decodes to the exact known size. Direct 7-Zip-API overshoot
-   comparison is task E of the brief (see Section G plan).
+3. **Corruption:** use-after-free of pyppmd's output block at
+   `ThreadDecoder.c:134` (freed by `OutputBuffer_Finish`, `_ppmdmodule.c:552`),
+   because the overshooting worker is left blocked-in-reader and later resumed to
+   free-run (reader `pos==size` bug). Valgrind-confirmed as the first error in
+   overshoot / oversized / after-eof families; the Pavlov suballocator supplies
+   the garbage symbols but is not the first faulting write.
+4. **Separability:** the whole crash family is **pyppmd-only** — it is a binding
+   lifetime/threading bug (`ThreadDecoder.c` + `_ppmdmodule.c` + `blockoutput.h`),
+   introduced by `#126` (the input-empty stop existed in 1.2.0, source-confirmed).
+   The Pavlov core's memory-unsafety-past-EOF is real but latent: real 7-Zip
+   decodes to the exact known unpack size and never trips it, and it is not the
+   first corrupting write in pyppmd either.
 
 ---
 
-## G. Empirical plan (in progress)
+## G. Empirical results (this env: pyppmd 1.3.1, CPython 3.11.15, glibc 2.39)
 
-- [ ] Premature-eof repro: `decode(packed, 64)` on `b"a"*4096`, show `eof=True`
-      with `Code == 0` while output ≪ payload; then `decode(b"", 64)` completes.
-- [ ] Corruption backtrace: run `pyppmd_crash_repro.py --mode overshoot/oversized`
-      and half-pack+large-NUL under `MALLOC_CHECK_=3` / glibc malloc debug +
-      `faulthandler`, capture the faulting frame (expect `Ppmd7.c` suballocator).
-- [ ] Reader-blocks vs feed-zero: show a tail-`needs_input` stream completes when
-      fed `b"\0"` and stalls otherwise (emulating 7-Zip's over-read-zero).
-- [ ] Ppmd8 parity: overshoot / post-eof / Free-race on `Ppmd8Decoder`; confirm
-      end-mark makes unsized drains unnecessary.
-- [ ] Version delta 1.2.0 vs 1.3.1 on the same overshoot (if a 1.2.0 wheel builds
-      in-env), to nail the #126 regression window.
+- [x] **Premature-eof:** `decode(b"a"*4096, 64)` → `out=64`, `eof=True`,
+      `needs_input=False` after only 64 of 4096 bytes. `eof` here is the
+      `Ppmd7z_RangeDec_IsFinishedOK` (`Code == 0`, `Ppmd7.h:107`) path at
+      `_ppmdmodule.c:553` (not an end mark — PPMd7 has none). Ignoring it and
+      continuing with `decode(b"", 64)` recovered all 4096 bytes over 63 calls
+      (`match_full=True`). Confirms premature eof is a `Code == 0` proxy artefact,
+      and that continued empty decode is valid *on a complete stream*.
+- [x] **Corruption:** valgrind pins the first error to the output-buffer UAF at
+      `ThreadDecoder.c:134` for `overshoot` (`-1`), `oversized`, and after-eof
+      `extra-null`; exact-sized decode is 0 errors (Section D). gdb on the raw
+      `overshoot` repro aborts with `corrupted size vs. prev_size` at
+      `Ppmd7Decoder_dealloc` (`_ppmdmodule.c:222`) — i.e. corrupted metadata is
+      only *detected* at teardown free, consistent with an earlier UAF.
+      `scripts/pyppmd_crash_repro.py 20 --mode overshoot` → 16/20 crashes here.
+- [x] **Omit-null / reader-blocks:** no `encode()+flush()` stream reports
+      tail-`needs_input` (encoder omits nothing; `Ppmd7Enc.c:67` writes 5
+      unconditional flush bytes). Flushed packs commonly end in `0x00` (that byte
+      is load-bearing compressed data). The "extra byte" is the caller manually
+      feeding the zero that 7-Zip's over-read-zero reader would synthesise, which
+      pyppmd's blocking reader (`ThreadDecoder.c:70-81`) does not.
+- [x] **Ppmd8 parity:** unsized decode terminates on the end mark with
+      overshoot = 0 (Section E). Structural overshoot-past-end-mark shares the
+      Ppmd7 UAF.
+- [x] **Version delta (source-confirmed):** the input-empty stop
+      `if (inbuf_empty && reader->inBuffer->size > 0) break;` is present in
+      `v1.2.0:src/lib/buffer/ThreadDecoder.c` and **absent** in `v1.3.1`
+      (removed by `#126`). 1.2.0's own trade-off bug: that same early break
+      truncates chunked decodes that must keep producing without new input —
+      which is what `#126` set out to fix, swapping a correctness bug for this
+      memory-safety bug.
 
-Findings and the concrete upstream-fix refinement will be appended as each runs.
+---
+
+## H. Concrete upstream fix (refines `pyppmd-upstream-report.md`)
+
+The prior report's four fixes still apply, but the root-cause finding sharpens
+the priority: **the corrupting write is the output-buffer UAF, so the primary fix
+is worker/output lifetime, not (only) budget clamping.**
+
+1. **Never free the output block while a worker may still write to it
+   (primary).** Before `OutputBuffer_Finish` / any `Py_DECREF(buffer->list)` in
+   `Ppmd7Decoder_decode` (`_ppmdmodule.c:552`) and `Ppmd8Decoder_decode`
+   (`:~1300`), ensure the worker is quiescent — either it `finished`, or it is
+   parked in the reader wait with `out->dst` guaranteed not to be dereferenced
+   until re-entry. Equivalently, do not hand the worker a raw pointer into a
+   Python-owned block that the controller can free while the worker is only
+   *paused*. This alone removes the UAF that valgrind flags.
+2. **Restore a stop condition for input-exhausted decodes.** Re-add the 1.2.0
+   input-empty break *without* reintroducing its chunked-truncation bug: stop the
+   symbol loop when the range coder would need a byte that is not available
+   (park), rather than spinning on stale range state. Bound the loop by what the
+   input can actually support instead of `INT_MAX` (`_ppmdmodule.c:521/1264`).
+3. **Fix the reader's empty check:** `pos >= size` (not `== size`) in
+   `Ppmd_thread_Reader` (`ThreadDecoder.c:70`), so an overshoot of one cannot
+   turn into an unbounded free-run.
+4. **Signal termination explicitly in `Ppmd7T_Free`/`Ppmd8T_Free`.** Use a
+   dedicated "terminate" flag the reader re-checks after wakeup instead of faking
+   `tc->empty = False` with no data (`ThreadDecoder.c:198/307`); the reader must
+   return/park on termination rather than reading `src[pos++]`.
+5. **Port the cffi `_eof` guard to the C extension:** `decode` after `eof`
+   returns `b""` without starting a worker (`_ppmdmodule.c:396`, add the early
+   return the cffi backend already has).
+
+Fixes 2–5 are defence-in-depth; **fix 1 is the one the valgrind evidence
+demands**. Until a fixed release ships, archivey's discipline (never overshoot;
+require `unpack_size`/`pack_size`; bounded single NUL; no post-eof drain unless
+pack delivery is known complete) is the correct in-process mitigation, and the
+`Ppmd7T_Free` residual remains the reason PPMd adversarial tests are
+subprocess-isolated.
+
+### Verification when a fixed release ships
+
+Re-run all `scripts/pyppmd_crash_repro.py` modes (`extra-null`, `overshoot`,
+`oversized`, `warmup-overshoot`) plus the valgrind driver of Section D; all must
+report **0 memory errors** and 0 crashes, including under teardown (`del dec`).

--- a/docs/internal/ppmd-native-investigation-results.md
+++ b/docs/internal/ppmd-native-investigation-results.md
@@ -440,3 +440,92 @@ subprocess-isolated.
 Re-run all `scripts/pyppmd_crash_repro.py` modes (`extra-null`, `overshoot`,
 `oversized`, `warmup-overshoot`) plus the valgrind driver of Section D; all must
 report **0 memory errors** and 0 crashes, including under teardown (`del dec`).
+
+---
+
+## I. What archivey can do until pyppmd is fixed
+
+The root cause reframes the whole mitigation story around **one invariant**:
+
+> **A `PpmdDecoder` must never be left with a worker blocked in the reader —
+> not between calls, and above all not at disposal.** The worker is left blocked
+> exactly when a `decode` call requests more output symbols than the *currently
+> fed* input can produce. A worker that instead exhausts its `max_length` budget
+> returns and is `pthread_join`-ed (`finished=True`), and `Ppmd7T_Free` then
+> no-ops — no resume, no use-after-free.
+
+### 1. For valid members: already fully safe in-process (no change needed)
+
+The shipped discipline *is* this invariant, and the investigation now proves it:
+
+- **Require `unpack_size`; bound every call to `min(chunk, unpack_size - produced)`;
+  stop exactly at `unpack_size`; never `-1`; never `decode` after `eof` unless the
+  pack is known complete; single capped NUL.**
+
+Exact-sized `decode(packed, len(data))` is **0 valgrind errors** (Section D).
+Chunked reads of a valid member are clean for the same reason: each call's budget
+(e.g. 64) is reached *before* the range coder needs a byte past what was fed, so
+the worker finishes every call and `needs_input` never latches at the end. Nothing
+to add here — the existing `pack_size` gate + bounded calls cover every
+well-formed 7z/PPMd member.
+
+### 2. For truncated / corrupt members: the residual, and a concrete new fix
+
+A member that genuinely contains fewer symbols than its header claims (truncated
+pack, or a corrupt full-length pack) **will** exhaust the fed input mid-budget on
+some call, latch `needs_input=True`, and leave the worker blocked. archivey
+detects this and raises `TruncatedError` — but by then the decoder is already in
+the blocked-worker state, and `OutputBuffer_Finish` has already freed the last
+output block. When that `PpmdDecoder` is later garbage-collected, `Ppmd7T_Free`
+resumes the blocked worker into the freed block → the intermittent
+"exit-after-green" abort. Bounding `max_length` shrinks the blast radius (a small
+budget makes the free-run short) but does **not** remove the dangling pointer.
+
+**New, measured lever — quiesce the worker before disposal.** Because the UAF
+needs the blocked worker to be *resumed*, driving it to `finished` **before** the
+decoder is freed removes the resume entirely. One bounded `decode` per outstanding
+`needs_input` does it: the worker wakes via the *decode* path (which allocates a
+fresh output block **before** resuming, so the 1-symbol write lands in live
+memory), hits its 1-symbol budget, and exits `finished`. `Ppmd7T_Free` then
+no-ops.
+
+Measured (valgrind, truncated pack + sized decode that blocks the worker, 6
+cycles):
+
+| Disposal policy | Invalid writes at `ThreadDecoder.c:134` |
+|-----------------|------------------------------------------|
+| `del dec` directly (worker left blocked) | **8 154** |
+| `while dec.needs_input: dec.decode(b"\0", 1)` (≤4×), then `del` | **0** |
+
+So archivey can add a **"quiesce on close"** step to `PpmdDecoder` /
+`DecompressorStream.close()`: while `needs_input` (worker parked), issue a bounded
+`decode(b"\0", 1)` (cap the loop at a few iterations) to force the worker to
+`finished` before releasing the decoder. This is the deterministic-dispose spike
+the brief's review addendum asked for (gap #1), and if it holds under the full
+adversarial soak it would let required CI **drop `--allow-exit-after-green`** for
+the PPMd module. It needs validating against the existing subprocess-isolated
+adversarial tests (and on 3.12+/free-threaded per gap #4) before being relied on;
+the mechanism and the single-shape measurement above are promising but not yet a
+full soak.
+
+### 3. What cannot be closed in-process
+
+- A **corrupt but full-length** pack (`fed >= pack_size`, right length, wrong
+  bytes) can still desync the model and report `needs_input`/premature `eof` with
+  large remaining `unpack_size`; `pack_size` cannot tell "wrong bytes" from "right
+  bytes", so the gate would permit exactly the blocked-worker state. Quiesce-on-
+  close (2) would still neutralise its *teardown*, but any in-call overshoot must
+  remain forbidden.
+- **True containment for hostile inputs** remains process isolation (exploration
+  doc Option D) or the upstream fix (Section H). Quiesce-on-close is a strong
+  in-process *reduction* of the teardown residual, not a guarantee against a
+  worker that faults *inside* `Ppmd7_DecodeSymbol` on a maximally-corrupt model
+  before it can return.
+
+### Summary
+
+| Case | In-process safety today | Lever |
+|------|------------------------|-------|
+| Valid member (known `unpack_size`, complete pack) | **Safe** (0 valgrind errors) | Existing bound-every-call + `pack_size` gate |
+| Truncated member | Intermittent teardown abort | **Quiesce-on-close** (measured 8154→0) — validate then drop allow-exit-after-green |
+| Corrupt full-length pack | Residual | Quiesce-on-close neutralises teardown; forbid in-call overshoot; process isolation for full guarantee |

--- a/docs/internal/pyppmd-upstream-report.md
+++ b/docs/internal/pyppmd-upstream-report.md
@@ -1,163 +1,66 @@
 # pyppmd upstream report — 1.3.x native heap corruption on valid PPMd7 data
 
-Status: **not yet filed** (as of 2026-07-16 there is no matching issue at
-<https://github.com/miurahr/pyppmd/issues>). This document is a ready-to-file
-issue draft plus the supporting analysis. File it against
-[miurahr/pyppmd](https://github.com/miurahr/pyppmd) and attach
-`scripts/pyppmd_crash_repro.py` (self-contained: `pyppmd` + stdlib only).
+Status: **not yet filed** (no matching issue at
+<https://github.com/miurahr/pyppmd/issues> as of 2026-07-23).
 
-Archivey context (what we ship regardless of the upstream fix) lives in
-`docs/internal/known-issues.md` → “Intermittent `pyppmd` native aborts”.
+> **Consolidated 2026-07-23.** The canonical, ready-to-file report now lives in
+> [`ppmd-native-investigation-results.md` §J](ppmd-native-investigation-results.md)
+> — it is self-contained (title, summary, reproduction, root cause, fixes,
+> verification checklist) and paste-able into a GitHub issue. That investigation
+> **corrected the root cause** of this same defect: the first corrupting write is a
+> **use-after-free of the decode output buffer** by the worker thread
+> (`ThreadDecoder.c:134`, on a block freed by `OutputBuffer_Finish` /
+> `_ppmdmodule.c:552`) — **not** the vendored 7-Zip model being walked on a
+> desynchronised range coder, as the earlier draft below hypothesised. The rest of
+> the earlier analysis (the 1.3.0 `#126` ThreadDecoder rewrite removing the
+> input-empty stop, the `INT_MAX` budget, the missing after-eof guard in the C
+> extension, the `Ppmd7T_Free` teardown race) stands and is folded into §J.
+
+File it against [miurahr/pyppmd](https://github.com/miurahr/pyppmd) using §J, and
+attach both repro scripts:
+
+- `scripts/pyppmd_crash_repro.py` — probabilistic crash-rate (self-contained:
+  `pyppmd` + stdlib), modes `overshoot` / `oversized` / `extra-null` / `sized-safe`.
+- `scripts/ppmd_uaf_valgrind.py` — **deterministic** valgrind memcheck gate that
+  pins the `Invalid write … ThreadDecoder.c:134` context every run (the evidence a
+  fixed release must clear, and the check CI should gate on before retiring
+  `--allow-exit-after-green`).
+
+Archivey context (what we ship regardless of the upstream fix — bounded decodes,
+`unpack_size`/`pack_size` requirement, single capped NUL, and the
+`quiesce-on-close` teardown fix) lives in `docs/internal/known-issues.md` →
+“Intermittent `pyppmd` native aborts” and in `ppmd-native-investigation-results.md`
+§I.
 
 ---
 
-## Suggested issue draft
+## Crash-shape reference (still valid)
 
-> **Title:** 1.3.x regression: heap corruption / SIGSEGV decoding *valid* PPMd7
-> data whenever the decode request exceeds the remaining payload — `-1`,
-> after-eof, or plain oversized `max_length` (ThreadDecoder.c input-empty stop
-> condition removed in #126)
+Measured with `scripts/pyppmd_crash_repro.py` (fresh subprocess children, ~5
+encode/decode cycles each) on pyppmd 1.3.1 (Linux, x86_64):
 
-### Summary
-
-Since pyppmd **1.3.0**, `Ppmd7Decoder.decode` intermittently aborts the
-process on **valid** PPMd7 data whenever the requested output materially
-exceeds what the stream can still produce — via `max_length=-1`, via any
-`decode` call issued after `eof`, or via a plain sized request ≳64 KiB past
-the true payload (no `-1` involved). Symptoms: `malloc(): invalid size
-(unsorted)` / SIGSEGV / SIGABRT on Linux, `STATUS_HEAP_CORRUPTION`
-(`0xC0000374`) on Windows. 1.1.1 and 1.2.0 do not crash on the same inputs
-(they have a different bug: short/incorrect output on chunked decodes, which
-#126 was fixing).
-
-Measured with the attached single-file repro (fresh subprocess children,
-5 encode/decode cycles each):
-
-| mode | pattern | pyppmd 1.3.1 (Linux A) | (Linux B) |
-|------|---------|------------------------|-----------|
-| `extra-null` | sized decode to `eof`, then `decode(b"\0", -1)` | ~40% of children | **30/30** |
-| `overshoot` | single `decode(packed, -1)` (no second call) | ~15–25% | **19/30** |
-| `oversized` | single **sized** `decode(packed, len(data) + 65536)` — no `-1` anywhere | — | **10–13/20** |
-| `sized-safe` | `decode(packed, len(data))` only | 0% | 0/30 |
-| `underfed-sized` | sized decode, half the input, then dealloc | 0% | 0/20 |
-| `hostile-tail` | sized decode to eof, then small bounded decode of garbage | 0% | 0/20 |
+| mode | pattern | 1.3.1 |
+|------|---------|-------|
+| `extra-null` | sized decode to `eof`, then `decode(b"\0", -1)` | crashes (~30–40%) |
+| `overshoot` | single `decode(packed, -1)` | crashes (~15–25%) |
+| `oversized` | single **sized** `decode(packed, len(data) + 65536)` — no `-1` | crashes (~50–65%) |
+| `sized-safe` | `decode(packed, len(data))` only | **0%** (control) |
 
 The `oversized` row is the sharpest datapoint: the crash does **not** require the
 `-1` sentinel. Requesting materially more output than the stream's true remaining
-payload is what crashes — `len(data) + 64` and `len(data) + 4096` over-requests were
-0/20 each, `+65536` crashed 13/20 (and an equivalent shape through a 64 KiB-chunked
-wrapper crashed 9/20). Requesting exactly the remaining output is safe at any size
-(a 1.2 MB payload decoded in 64 KiB input chunks with the exact total bound: 0/20
-across 60 full decodes).
-
-Linux A: the original CI investigation (x86_64, CPython 3.11/3.14).
-Linux B: independent re-run (x86_64, CPython 3.11.15, glibc 2.39,
-Linux 6.18.5). Rates vary with allocator layout — runs that exercise other
-codecs first crash more often — but the safe/unsafe split is stable.
-
-```bash
-pip install 'pyppmd==1.3.1'
-python pyppmd_crash_repro.py 30 --mode extra-null   # crashes
-python pyppmd_crash_repro.py 30 --mode overshoot    # crashes
-python pyppmd_crash_repro.py 30 --mode oversized    # crashes, no -1 involved
-python pyppmd_crash_repro.py 30 --mode sized-safe   # control, clean
-```
-
-`faulthandler` places the abort **inside the `decode` call** (not at object
-teardown), typically after the call has already returned thousands of bytes
-that were never in the encoded stream.
-
-### Root cause analysis (from the 1.2.0 → 1.3.1 sdist diff)
-
-The regression is the `src/lib/buffer/ThreadDecoder.c` rewrite that shipped in
-**1.3.0** (PR #126, “Fix several issues in ThreadDecoder.c”). Three pieces
-interact:
-
-1. **The worker no longer stops when input is exhausted.** In 1.2.0,
-   `Ppmd7T_decode_run` / `Ppmd8T_decode_run` broke out of the symbol loop on
-   `inbuf_empty && size > 0`. 1.3.0 removed that check (“Only stop when output
-   buffer is full”), relying on `Ppmd_thread_Reader` to block on the
-   `notEmpty` condition when `pos == size`.
-
-2. **`max_length=-1` gives the worker an unbounded budget.** In
-   `_ppmdmodule.c`, `remains = length >= 0 ? length : INT_MAX`, and the
-   output buffer grows on demand. PPMd7 has **no end mark**, so nothing in the
-   data tells the worker where the payload ends. Once the true stream is
-   consumed, the worker keeps calling `Ppmd7_DecodeSymbol` on a
-   **desynchronized range coder**, walking the PPMd model with garbage — the
-   vendored 7-Zip model code is not memory-safe in that state, and the heap
-   corrupts. That is the `overshoot` mode. In 1.2.0 the per-symbol
-   input-empty check made this window one symbol wide; in 1.3.x it is
-   unbounded.
-
-3. **The after-eof guard was only added to the cffi backend.** 1.3.0 added an
-   `_eof` early-return to `cffi_ppmd.py`’s `decode`, but `_ppmdmodule.c` (the
-   C extension virtually all wheels use — crash dumps show `pyppmd.c._ppmd`)
-   has no such guard. `decode(b"\0", -1)` after `eof` therefore starts a fresh
-   `INT_MAX`-budget worker on finished range-coder state: pure garbage
-   decoding, the hottest trigger (`extra-null`).
-
-Two secondary hazards in the same file (not the observed crash site, but
-worth fixing while there):
-
-- **`Ppmd7T_Free` wakes the blocked worker without giving it input.** It sets
-  `tc->empty = False` and broadcasts `notEmpty` before `pthread_cancel`. A
-  worker parked in `Ppmd_thread_Reader` then leaves the wait loop and executes
-  `*((const Byte *)inBuffer->src + inBuffer->pos++)` with `pos == size` — an
-  out-of-bounds read of a buffer whose backing memory (the Python-level input)
-  may already be released — and, because cancellation is deferred and the
-  symbol loop has no cancellation points, it can decode into the previous
-  call's finished output block before the cancel lands at the next blocking
-  read.
-- **`Ppmd_thread_Reader` only blocks on `pos == size`**, so once `pos`
-  overshoots by one it never blocks again and free-runs past the buffer.
-  The check should be `pos >= size`.
-
-### Why exact-sized decodes are safe (and py7zr never sees this)
-
-With `max_length` equal to the remaining declared output, the worker’s budget
-runs out exactly at the payload boundary and it exits cleanly — the model
-never runs past the end of stream. py7zr always passes `max_length` to
-`decompress`, which is why it doesn't exhibit the crash. Callers can use the
-same discipline as a workaround (this is what archivey now does), but the
-library-level behavior is still a crash on valid data through a documented
-API — and per the `oversized` row, a caller who innocently over-requests
-(e.g. asks for a full read-buffer's worth near end of stream) hits the same
-corruption with no `-1` involved, so the sized API is only safe when the
-caller already knows the exact payload size. For end-markless PPMd7 that
-makes safe use impossible without external size information.
-
-### Suggested fixes
-
-1. Restore a stop condition for unbounded decodes: when input is exhausted
-   and the range coder would need another byte, park/return instead of
-   decoding further symbols (or bound the budget by what the input can
-   support).
-2. Port the cffi `_eof` guard to `_ppmdmodule.c`: `decode` after `eof`
-   returns `b""` without touching native state.
-3. In `Ppmd7T_Free` / `Ppmd8T_Free`, signal termination through a dedicated
-   flag the reader re-checks after wakeup instead of faking “input available”
-   (`tc->empty = False`) with no data.
-4. Change the reader’s empty check to `pos >= size`.
-
----
+payload is what corrupts the heap; the exact remaining size is the safe contract.
+1.1.1 / 1.2.0 do not crash on these inputs (they have a different bug — short
+output on chunked bounded decodes, which `#126` was fixing).
 
 ## Verification checklist for a fixed release
 
-When an upstream fix ships, re-run (all should be 0 crashes):
+All must be **0 crashes / 0 memcheck errors** (see §J for the same list):
 
 ```bash
 python scripts/pyppmd_crash_repro.py 50 --mode extra-null
 python scripts/pyppmd_crash_repro.py 50 --mode overshoot
 python scripts/pyppmd_crash_repro.py 50 --mode oversized
 python scripts/pyppmd_crash_repro.py 50 --mode warmup-overshoot
-python scripts/pyppmd_crash_repro.py 30 --mode underfed-sized
-python scripts/pyppmd_crash_repro.py 30 --mode hostile-tail
-uv run --no-sync python scripts/ppmd_native_stress.py 30 --scenarios warmup_codecs
+python scripts/ppmd_uaf_valgrind.py --scenario all --strict-pyppmd
 uv run --no-sync pytest tests/test_ppmd_raw_streams.py -q
 ```
-
-The non-blocking **PPMd native stress** workflow runs the same scenarios on
-every PR (Linux + Windows × py3.11/3.14) and will catch a regression on
-either side; the deterministic adversarial shapes (truncation, early close,
-hostile tails) are pinned in `tests/test_ppmd_raw_streams.py`.

--- a/scripts/ppmd_uaf_valgrind.py
+++ b/scripts/ppmd_uaf_valgrind.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""Deterministic valgrind gate for the pyppmd output-buffer use-after-free.
+
+Background
+----------
+On pyppmd 1.3.x the native decode worker thread is left blocked in its input
+reader whenever a ``decode`` requests more output than the fed input can produce
+(``max_length=-1``, an oversized bound, or a large post-eof / NUL budget over a
+truncated stream). ``OutputBuffer_Finish`` then frees the decode's output block
+while that worker still holds a raw pointer into it, and the worker is later
+resumed (by the next call or by ``Ppmd7T_Free`` at teardown) to free-run into the
+freed block — a use-after-free write at ``ThreadDecoder.c:134``. Root-cause
+analysis, valgrind evidence, and the 1.2.0→1.3.0 (#126) regression window are in
+``docs/internal/ppmd-native-investigation-results.md`` (§D, §J).
+
+Unlike the crash-rate soak in ``scripts/pyppmd_crash_repro.py`` (a probabilistic
+race whose rate swings with allocator layout and Python/GIL mode), this driver is
+**deterministic**: valgrind's memcheck reports the invalid write on the shape that
+reproduces it every run, so it can gate CI. A green run here on a fixed pyppmd —
+or archivey's ``quiesce-on-close`` mitigation for the archivey scenarios — is the
+evidence needed to retire ``--allow-exit-after-green`` for the PPMd module.
+
+Scenarios
+---------
+* ``pyppmd-overshoot`` — bare ``pyppmd``: ``decode(packed, -1)`` over a truncated
+  stream. The canonical reproducer; **expected to fail (nonzero) on 1.3.x**, pass
+  on a fixed release. Use it as a pyppmd-regression / fixed-release detector.
+* ``archivey-truncated`` — archivey ``PpmdDecoder``: truncated PPMd7 fed + flushed
+  then disposed via ``__del__``. Exercises the shipped mitigations + the
+  ``quiesce-on-close`` fix; expected **clean**. A failure here is an archivey bug.
+* ``archivey-stream`` — same, driven through ``PpmdDecompressorStream`` so disposal
+  runs the explicit ``close()`` path. Expected **clean**.
+
+Usage
+-----
+::
+
+    python scripts/ppmd_uaf_valgrind.py                       # all archivey scenarios
+    python scripts/ppmd_uaf_valgrind.py --scenario archivey-truncated
+    python scripts/ppmd_uaf_valgrind.py --scenario pyppmd-overshoot  # pyppmd detector
+    python scripts/ppmd_uaf_valgrind.py --scenario all --cycles 8
+
+Exit code is nonzero if valgrind reports any memcheck error in a scenario that is
+expected to be clean (the ``pyppmd-overshoot`` detector is reported but does not
+fail the run unless ``--strict-pyppmd`` is passed). Requires ``valgrind`` on PATH.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import textwrap
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Highly compressible payload: a small mid-stream cut still leaves the worker
+# wanting many more symbols than the truncated input can produce, so it parks past
+# logical EOF — the precondition for the UAF.
+_PREAMBLE = textwrap.dedent(
+    """\
+    import os, sys
+    sys.path.insert(0, os.path.join({repo!r}, "src"))
+    sys.path.insert(0, {repo!r})
+    import pyppmd
+
+    ORDER, MEM = 6, 1 << 20
+    CONTENT = (b"the quick brown fox jumps over the lazy dog\\n" * 200)
+    _e = pyppmd.Ppmd7Encoder(ORDER, MEM)
+    PACKED = _e.encode(CONTENT) + _e.flush()
+    CYCLES = int(os.environ.get("PPMD_UAF_CYCLES", "6"))
+    """
+)
+
+_SCENARIOS: dict[str, str] = {
+    # Bare pyppmd, the canonical reproducer (fails on 1.3.x, passes when fixed).
+    "pyppmd-overshoot": _PREAMBLE
+    + textwrap.dedent(
+        """\
+        for _ in range(CYCLES):
+            dec = pyppmd.Ppmd7Decoder(ORDER, MEM)
+            out = dec.decode(PACKED[: len(PACKED) // 2], -1)  # INT_MAX budget, truncated
+            del dec
+        print("ok", flush=True)
+        """
+    ),
+    # archivey PpmdDecoder, truncated PPMd7, disposed via __del__.
+    "archivey-truncated": _PREAMBLE
+    + textwrap.dedent(
+        """\
+        from archivey.internal.streams.decompress import PpmdDecoder
+        for _ in range(CYCLES):
+            dec = PpmdDecoder(order=ORDER, mem_size=MEM, variant=7,
+                              unpack_size=len(CONTENT), pack_size=len(PACKED))
+            dec.feed(PACKED[: len(PACKED) // 2], len(CONTENT))
+            try:
+                dec.flush()
+            except Exception:
+                pass
+            del dec
+        print("ok", flush=True)
+        """
+    ),
+    # archivey stream, disposal via the explicit close() path (context manager).
+    "archivey-stream": _PREAMBLE
+    + textwrap.dedent(
+        """\
+        import io
+        from archivey.exceptions import TruncatedError
+        from archivey.internal.streams.decompress import PpmdDecompressorStream
+        for _ in range(CYCLES):
+            with PpmdDecompressorStream(
+                io.BytesIO(PACKED[: len(PACKED) // 2]),
+                order=ORDER, mem_size=MEM, variant=7,
+                unpack_size=len(CONTENT), pack_size=len(PACKED),
+            ) as stream:
+                try:
+                    stream.read()
+                except TruncatedError:
+                    pass
+        print("ok", flush=True)
+        """
+    ),
+}
+
+# Scenarios expected to be clean (a memcheck error fails the run). The bare-pyppmd
+# reproducer is a detector: on 1.3.x it is *expected* to error, so it does not fail
+# the run unless --strict-pyppmd is given.
+_EXPECT_CLEAN = {"archivey-truncated", "archivey-stream"}
+
+_ERROR_SUMMARY = re.compile(r"ERROR SUMMARY:\s+(\d+)\s+errors")
+
+
+def _run_scenario(name: str, cycles: int, timeout: float) -> tuple[int, bool, str]:
+    """Return (memcheck_error_count, body_ok, tail_of_output)."""
+    script = _SCENARIOS[name]
+    env = dict(os.environ)
+    env["PPMD_UAF_CYCLES"] = str(cycles)
+    with tempfile.TemporaryDirectory(prefix="ppmd-uaf-") as tmp:
+        driver = Path(tmp) / f"{name}.py"
+        driver.write_text(script.format(repo=str(_REPO_ROOT)), encoding="utf-8")
+        cmd = [
+            "valgrind",
+            "--error-exitcode=0",  # we parse ERROR SUMMARY ourselves
+            "--num-callers=6",
+            "--smc-check=all",
+            sys.executable,
+            str(driver),
+        ]
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=timeout,
+            check=False,
+        )
+    combined = (proc.stdout or "") + (proc.stderr or "")
+    body_ok = any(line.strip() == "ok" for line in (proc.stdout or "").splitlines())
+    match = _ERROR_SUMMARY.search(combined)
+    errors = int(match.group(1)) if match else -1
+    tail = "\n".join(combined.strip().splitlines()[-8:])
+    return errors, body_ok, tail
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--scenario",
+        choices=[*sorted(_SCENARIOS), "all", "archivey"],
+        default="archivey",
+        help="Scenario to run ('archivey' = both archivey scenarios; 'all' = every scenario).",
+    )
+    parser.add_argument(
+        "--cycles",
+        type=int,
+        default=6,
+        help="Decode/dispose cycles per child (default 6).",
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=400.0,
+        help="Per-scenario valgrind timeout (s).",
+    )
+    parser.add_argument(
+        "--strict-pyppmd",
+        action="store_true",
+        help="Also fail the run if the bare-pyppmd reproducer reports errors (i.e. require a fixed pyppmd).",
+    )
+    args = parser.parse_args(argv)
+
+    if shutil.which("valgrind") is None:
+        print("valgrind not found on PATH (apt-get install valgrind)", file=sys.stderr)
+        return 2
+    try:
+        import pyppmd  # noqa: F401
+    except ImportError:
+        print("pyppmd is not installed (pip install 'pyppmd>=1.3.1')", file=sys.stderr)
+        return 2
+
+    if args.scenario == "all":
+        names = sorted(_SCENARIOS)
+    elif args.scenario == "archivey":
+        names = ["archivey-truncated", "archivey-stream"]
+    else:
+        names = [args.scenario]
+
+    failed = False
+    print(f"ppmd_uaf_valgrind: scenarios={names} cycles={args.cycles}")
+    for name in names:
+        errors, body_ok, tail = _run_scenario(name, args.cycles, args.timeout)
+        expect_clean = name in _EXPECT_CLEAN or (
+            name == "pyppmd-overshoot" and args.strict_pyppmd
+        )
+        status = "OK" if errors == 0 else ("DETECTED" if not expect_clean else "FAIL")
+        if errors != 0 and expect_clean:
+            failed = True
+        if errors < 0:
+            status = "UNKNOWN"
+            failed = failed or expect_clean
+        note = "" if body_ok else " [body did not print ok]"
+        print(f"  {name:<20} memcheck_errors={errors:<6} {status}{note}")
+        if errors != 0 or not body_ok:
+            print(textwrap.indent(tail, "      "))
+
+    print()
+    print("PASS" if not failed else "FAIL")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ppmd_uaf_valgrind.py
+++ b/scripts/ppmd_uaf_valgrind.py
@@ -16,9 +16,12 @@ analysis, valgrind evidence, and the 1.2.0→1.3.0 (#126) regression window are 
 Unlike the crash-rate soak in ``scripts/pyppmd_crash_repro.py`` (a probabilistic
 race whose rate swings with allocator layout and Python/GIL mode), this driver is
 **deterministic**: valgrind's memcheck reports the invalid write on the shape that
-reproduces it every run, so it can gate CI. A green run here on a fixed pyppmd —
-or archivey's ``quiesce-on-close`` mitigation for the archivey scenarios — is the
-evidence needed to retire ``--allow-exit-after-green`` for the PPMd module.
+reproduces it every run. It runs in the non-required ``PPMd native stress``
+workflow (Linux). A green run here on a fixed pyppmd — or archivey's
+``quiesce-on-close`` mitigation for the archivey scenarios — across the hot-race
+platforms is the evidence needed to retire ``--allow-exit-after-green`` for the
+PPMd module; it is **not** on its own sufficient on a single host (the observable
+teardown abort is already ~0 there).
 
 Scenarios
 ---------
@@ -141,6 +144,10 @@ def _run_scenario(name: str, cycles: int, timeout: float) -> tuple[int, bool, st
     script = _SCENARIOS[name]
     env = dict(os.environ)
     env["PPMD_UAF_CYCLES"] = str(cycles)
+    # Keep pymalloc (do NOT set PYTHONMALLOC=malloc): the UAF'd output blocks are
+    # large PyBytes that pymalloc routes to raw malloc, so valgrind already tracks
+    # them; forcing libc malloc for every allocation instead floods the report with
+    # CPython-interpreter false positives (measured ~984 errors on a clean run).
     with tempfile.TemporaryDirectory(prefix="ppmd-uaf-") as tmp:
         driver = Path(tmp) / f"{name}.py"
         driver.write_text(script.format(repo=str(_REPO_ROOT)), encoding="utf-8")
@@ -218,18 +225,28 @@ def main(argv: list[str] | None = None) -> int:
     print(f"ppmd_uaf_valgrind: scenarios={names} cycles={args.cycles}")
     for name in names:
         errors, body_ok, tail = _run_scenario(name, args.cycles, args.timeout)
-        expect_clean = name in _EXPECT_CLEAN or (
+        # `pyppmd-overshoot` is a detector: memcheck errors are the *expected*
+        # outcome on 1.3.x and do not fail the run unless --strict-pyppmd requires
+        # a fixed pyppmd. Every other scenario must be clean.
+        clean_required = name in _EXPECT_CLEAN or (
             name == "pyppmd-overshoot" and args.strict_pyppmd
         )
-        status = "OK" if errors == 0 else ("DETECTED" if not expect_clean else "FAIL")
-        if errors != 0 and expect_clean:
-            failed = True
-        if errors < 0:
-            status = "UNKNOWN"
-            failed = failed or expect_clean
-        note = "" if body_ok else " [body did not print ok]"
-        print(f"  {name:<20} memcheck_errors={errors:<6} {status}{note}")
-        if errors != 0 or not body_ok:
+        # A scenario that never ran its body (import error, early crash, wrong env)
+        # or produced no parseable valgrind summary is a failure regardless: a
+        # "0 errors" from a body that never executed the repro is a false PASS.
+        if not body_ok:
+            status, scenario_failed = "FAIL (body did not run)", True
+        elif errors < 0:
+            status, scenario_failed = "FAIL (no valgrind summary)", True
+        elif errors == 0:
+            status, scenario_failed = "OK", False
+        elif clean_required:
+            status, scenario_failed = "FAIL", True
+        else:
+            status, scenario_failed = "DETECTED", False  # detector, expected
+        failed = failed or scenario_failed
+        print(f"  {name:<20} memcheck_errors={errors:<6} {status}")
+        if scenario_failed or errors != 0:
             print(textwrap.indent(tail, "      "))
 
     print()

--- a/src/archivey/internal/streams/decompress.py
+++ b/src/archivey/internal/streams/decompress.py
@@ -684,8 +684,12 @@ class PpmdDecoder(BaseDecoder):
             if self.finished:
                 return
             for _ in range(_PPMD_QUIESCE_MAX_CALLS):
-                # ``eof`` or ``needs_input`` False ⇒ the last call exited on budget
-                # or the end mark; the worker is not parked and Free is a no-op.
+                # ``not needs_input`` is the "worker not parked" signal — the last
+                # call exited on budget, so Free is already a no-op. The ``eof``
+                # short-circuit is deliberately kept ahead of it: at native eof the
+                # worker is finished AND feeding a NUL here would be a decode-after-eof
+                # (the unbounded form of which is itself a crash path on 1.3.x), so
+                # never issue one — skip instead.
                 if decomp.eof or not getattr(decomp, "needs_input", False):
                     return
                 # One-symbol budget: the worker resumes, consumes the NUL, and

--- a/src/archivey/internal/streams/decompress.py
+++ b/src/archivey/internal/streams/decompress.py
@@ -381,6 +381,12 @@ _PPMD_UNSIZED_DECODE_CHUNK = 65536
 # otherwise). See ``docs/internal/ppmd-exit-after-green-exploration.md``.
 _PPMD_EXTRA_NUL_MAX_OUTPUT = 64
 
+# Bounded number of single-symbol NUL decodes used to quiesce a parked native
+# worker before the decoder is freed (see ``PpmdDecoder._quiesce_worker``). A
+# parked worker only needs the range coder's few-byte tail lookahead satisfied to
+# reach its 1-symbol budget and exit; 8 is a safe cushion over the observed need.
+_PPMD_QUIESCE_MAX_CALLS = 8
+
 
 class PpmdDecoder(BaseDecoder):
     """Decode a PPMd stream via ``pyppmd``.
@@ -649,6 +655,56 @@ class PpmdDecoder(BaseDecoder):
     @property
     def needs_input(self) -> bool:
         return bool(getattr(self._decomp, "needs_input", True))
+
+    def _quiesce_worker(self) -> None:
+        """Drive a parked native decode worker to exit before the decoder is freed.
+
+        On pyppmd 1.3.x the decode worker thread is left blocked in the reader
+        whenever a ``decode`` requested more output than the fed input could
+        produce (a truncated or abandoned member). ``Ppmd7T_Free`` — run from the
+        pyppmd decoder's ``dealloc`` — then wakes that worker with no new input,
+        and it free-runs into the output block already released by the previous
+        ``decode`` call: a use-after-free that intermittently aborts the process
+        at GC (the "exit-after-green" residual in ``known-issues.md``).
+
+        Feeding one bounded single-symbol NUL makes the worker consume its tail
+        lookahead and exit on its own 1-symbol budget, so ``Ppmd7T_Free`` sees a
+        finished worker and becomes a no-op. Measured: valgrind 8154 → 0 invalid
+        writes on a truncated-pack teardown. Best-effort and idempotent; safe to
+        call more than once. See ``docs/internal/ppmd-native-investigation-results.md``
+        (§D root cause, §I mitigation).
+        """
+        decomp = getattr(self, "_decomp", None)
+        if decomp is None:
+            return
+        try:
+            # A fully-decoded member exited its worker on budget / the end mark;
+            # only an incomplete (truncated / abandoned) decode can leave one
+            # parked. Skip the happy path so valid closes cost nothing.
+            if self.finished:
+                return
+            for _ in range(_PPMD_QUIESCE_MAX_CALLS):
+                # ``eof`` or ``needs_input`` False ⇒ the last call exited on budget
+                # or the end mark; the worker is not parked and Free is a no-op.
+                if decomp.eof or not getattr(decomp, "needs_input", False):
+                    return
+                # One-symbol budget: the worker resumes, consumes the NUL, and
+                # exits on budget (returns the byte), or blocks needing one more
+                # tail byte — the next iteration feeds it. A non-empty return means
+                # the worker hit its budget and exited, so it will not be resumed.
+                if decomp.decode(b"\0", 1):
+                    return
+        except Exception:  # noqa: BLE001 - teardown hygiene; never raise from close()/__del__
+            pass
+
+    def close(self) -> None:
+        self._quiesce_worker()
+
+    def __del__(self) -> None:
+        # GC safety net: quiesce even when the owning stream's close() did not run
+        # (decoder used directly, or stream leaked). Runs before self._decomp is
+        # dropped, so the native worker is finished before Ppmd7T_Free executes.
+        self._quiesce_worker()
 
 
 class BcjDecoder(BaseDecoder):

--- a/src/archivey/internal/streams/decompressor_stream.py
+++ b/src/archivey/internal/streams/decompressor_stream.py
@@ -104,6 +104,16 @@ class Decoder(Protocol):
         """Clear :attr:`pending_error` after the stream has raised it (or on seek reset)."""
         ...
 
+    def close(self) -> None:
+        """Release decoder-owned native resources deterministically.
+
+        Optional teardown hook: most decoders need nothing here (GC frees the
+        underlying object), but a decoder holding a native worker whose lifetime
+        is unsafe under GC (PPMd) uses this to reach a clean state before it is
+        dropped. Idempotent; never raises.
+        """
+        ...
+
     def build_index(
         self, inner: BinaryIO, last_known: SeekPoint
     ) -> tuple[list[SeekPoint], int | None]: ...
@@ -131,6 +141,9 @@ class BaseDecoder:
     @property
     def needs_input(self) -> bool:
         return True
+
+    def close(self) -> None:
+        """No-op teardown hook (see :meth:`Decoder.close`); overridden by PPMd."""
 
     def build_index(
         self, inner: BinaryIO, last_known: SeekPoint
@@ -443,6 +456,9 @@ class DecompressorStream(ReadOnlyIOStream):
         return data
 
     def close(self) -> None:
+        # Quiesce any decoder-owned native worker before dropping references, so a
+        # blocked PPMd worker cannot be resumed into freed memory at GC.
+        self._decoder.close()
         if self._should_close:
             self._inner.close()
         super().close()

--- a/src/archivey/internal/streams/decompressor_stream.py
+++ b/src/archivey/internal/streams/decompressor_stream.py
@@ -375,7 +375,14 @@ class DecompressorStream(ReadOnlyIOStream):
 
     def _reset_to_seek_point(self, point: SeekPoint) -> None:
         self._inner.seek(point.compressed_offset)
-        self._decoder = self._decoder.recreate(point, self._inner)
+        # Dispose the outgoing decoder deterministically before dropping it:
+        # mid-member a PPMd decode can leave its native worker parked, and relying
+        # on __del__/GC timing to quiesce it is exactly what close() exists to avoid
+        # (no-op for every other codec). recreate() builds a fresh decoder from the
+        # config, not from the old native state, so closing first is safe.
+        old_decoder = self._decoder
+        old_decoder.close()
+        self._decoder = old_decoder.recreate(point, self._inner)
         self._decoder.clear_pending_error()
         self._buffer.clear()
         self._eof = False

--- a/tests/test_ppmd_raw_streams.py
+++ b/tests/test_ppmd_raw_streams.py
@@ -362,6 +362,139 @@ def test_archivey_ppmd7_repeated_construct_destroy() -> None:
 
 
 # ---------------------------------------------------------------------------
+# quiesce-on-close wiring + logic (deterministic; no native abort dependency)
+#
+# The teardown use-after-free (docs/internal/ppmd-native-investigation-results.md
+# §D/§I) is a race that does not reproduce reliably in-process, so these tests
+# assert the *mechanism* — that a parked worker is driven to exit on dispose and
+# the happy path is skipped — with fakes, not by trying to provoke a crash.
+# ---------------------------------------------------------------------------
+
+
+class _FakeDecomp:
+    """Stand-in for ``pyppmd.Ppmd7Decoder`` recording ``decode`` calls."""
+
+    def __init__(self, *, needs_input: bool, eof: bool, returns: list[bytes]) -> None:
+        self.needs_input = needs_input
+        self.eof = eof
+        self._returns = list(returns)
+        self.calls: list[tuple[bytes, int]] = []
+
+    def decode(self, data: bytes, length: int) -> bytes:
+        self.calls.append((data, length))
+        return self._returns.pop(0) if self._returns else b""
+
+
+def _ppmd7_with_fake(fake: _FakeDecomp, *, produced: int) -> PpmdDecoder:
+    dec = PpmdDecoder(
+        order=_ORDER, mem_size=_MEM, variant=7, unpack_size=100, pack_size=50
+    )
+    dec._decomp = fake  # type: ignore[assignment]  # test double for the native decoder
+    dec._produced = produced
+    return dec
+
+
+def test_ppmd7_close_quiesces_parked_worker() -> None:
+    """Incomplete member with a parked worker: close() feeds bounded NUL(s) until
+    the worker exits on budget (a non-empty return)."""
+    fake = _FakeDecomp(needs_input=True, eof=False, returns=[b"", b"x"])
+    dec = _ppmd7_with_fake(fake, produced=0)  # not finished
+    dec.close()
+    # First NUL returns b"" (worker blocked again) -> feed once more; second returns
+    # a byte (worker hit its 1-symbol budget and exited) -> stop.
+    assert fake.calls == [(b"\0", 1), (b"\0", 1)]
+
+
+def test_ppmd7_close_skips_finished_decoder() -> None:
+    """A completed member (produced >= unpack_size) must not decode on close."""
+    fake = _FakeDecomp(needs_input=True, eof=False, returns=[b"x"])
+    dec = _ppmd7_with_fake(fake, produced=100)  # finished
+    dec.close()
+    assert fake.calls == []
+
+
+def test_ppmd7_close_skips_at_native_eof() -> None:
+    """At native eof the worker is not parked and a decode-after-eof is unsafe;
+    close() must issue nothing."""
+    fake = _FakeDecomp(needs_input=True, eof=True, returns=[b"x"])
+    dec = _ppmd7_with_fake(fake, produced=0)
+    dec.close()
+    assert fake.calls == []
+
+
+class _SpyDecoder:
+    """Minimal :class:`Decoder` that records ``close()`` and re-registers on recreate."""
+
+    def __init__(self, log: list["_SpyDecoder"]) -> None:
+        self._log = log
+        self.closed = 0
+        log.append(self)
+
+    def recreate(self, point, inner):  # type: ignore[no-untyped-def]
+        return _SpyDecoder(self._log)
+
+    def feed(self, chunk: bytes, max_length: int = -1):  # type: ignore[no-untyped-def]
+        from archivey.internal.streams.decompressor_stream import DecodeOut
+
+        return DecodeOut(b"")
+
+    def flush(self):  # type: ignore[no-untyped-def]
+        from archivey.internal.streams.decompressor_stream import DecodeOut
+
+        return DecodeOut(b"")
+
+    @property
+    def finished(self) -> bool:
+        return True
+
+    @property
+    def pending_error(self):  # type: ignore[no-untyped-def]
+        return None
+
+    def clear_pending_error(self) -> None:
+        pass
+
+    @property
+    def needs_input(self) -> bool:
+        return True
+
+    def build_index(self, inner, last_known):  # type: ignore[no-untyped-def]
+        return [], None
+
+    def close(self) -> None:
+        self.closed += 1
+
+
+def test_decompressor_stream_close_closes_decoder() -> None:
+    """DecompressorStream.close() disposes its decoder (the close() wiring)."""
+    from archivey.internal.streams.decompressor_stream import DecompressorStream
+
+    log: list[_SpyDecoder] = []
+    stream = DecompressorStream(
+        io.BytesIO(b""), make_decoder=lambda _p, _i: _SpyDecoder(log)
+    )
+    stream.close()
+    assert log[0].closed == 1
+
+
+def test_decompressor_stream_seek_recreate_closes_old_decoder() -> None:
+    """Seek/recreate disposes the outgoing decoder before replacing it."""
+    from archivey.internal.streams.decompressor_stream import (
+        DecompressorStream,
+        SeekPoint,
+    )
+
+    log: list[_SpyDecoder] = []
+    stream = DecompressorStream(
+        io.BytesIO(b""), make_decoder=lambda _p, _i: _SpyDecoder(log)
+    )
+    old = log[0]
+    stream._reset_to_seek_point(SeekPoint(0, 0))
+    assert old.closed == 1  # outgoing decoder disposed deterministically
+    assert stream._decoder is log[1] and stream._decoder is not old
+
+
+# ---------------------------------------------------------------------------
 # Adversarial-input regression tests (pyppmd 1.3.x native aborts)
 #
 # pyppmd 1.3.x heap corruption fires when the native decoder runs past the true


### PR DESCRIPTION
Performs the investigation in `docs/internal/ppmd-native-investigation-brief.md`,
adds the results doc, and lands a defense-in-depth mitigation + a deterministic CI
gate for the pyppmd heap corruption.

## Investigation (docs)

`docs/internal/ppmd-native-investigation-results.md` — source-level + empirical
study (pyppmd `v1.3.1`).

**Headline (corrects the prior upstream report):** the heap corruption is **not**
primarily Igor Pavlov's PPMd7 suballocator. Valgrind pins the first memory error
in every crash family to a **use-after-free of pyppmd's own output buffer** at
`ThreadDecoder.c:134`, on a block freed by `OutputBuffer_Finish`
(`_ppmdmodule.c:552`) while an overshooting worker is left blocked in the reader
and later resumed to free-run (reader `pos==size` bug). Three compounding defects,
all pyppmd-original, introduced by the 1.3.0 `#126` rewrite (input-empty stop
existed in 1.2.0, source-confirmed). Control: exact-sized decode = **0 valgrind
errors**.

Also answered: omit-null is a 7-Zip *reader* convention (not an encoder action);
premature `eof` is `Code == 0` (`Ppmd7.h:107`); Ppmd8 end mark → unsized
overshoot = 0.

## Mitigation (code) — `quiesce-on-close`

`PpmdDecoder._quiesce_worker()` drives a parked native worker to `finished` with
bounded `decode(b"\0", 1)` before disposal, so `Ppmd7T_Free` cannot resume it into
freed memory. Wired through a new no-op `Decoder.close()` (protocol + `BaseDecoder`,
called from `DecompressorStream.close()`) and a `__del__` safety net; gated on
`not self.finished` (zero happy-path cost).

**Honest scope:** valgrind proves the mechanism on the reproducing shape
(bare-pyppmd 8154→0); archivey's own truncated paths are 0 with the fix. But
archivey's existing capped-NUL already keeps the observable teardown-abort rate
~0 here (child soak 400/400 clean at baseline), so this is **defense-in-depth**,
not a fix for a locally-reproducible crash. Dropping CI's
`--allow-exit-after-green` should be gated on the deterministic valgrind check
below + hot-race platforms (3.12+/free-threaded/Windows), not this host's soak.

## Deterministic gate (script)

`scripts/ppmd_uaf_valgrind.py` — valgrind memcheck driver that pins the UAF every
run (vs the probabilistic `pyppmd_crash_repro.py`). Scenarios: `pyppmd-overshoot`
(bare detector — DETECTED 47467 errors on 1.3.1), `archivey-truncated` /
`archivey-stream` (exercise the shipped mitigations + fix — **0 errors**).

## Report consolidation

Added a self-contained, paste-able **§J "Upstream report (ready to file)"** to the
results doc (corrected root cause, reproduction, prioritised fixes, verification
checklist). `docs/internal/pyppmd-upstream-report.md` is the same defect — folded
into a pointer to §J (keeping its crash-shape table + verification checklist).

## Validation
- 26 PPMd raw-stream + 7z reader tests pass; 178 codec/stream contract tests pass.
- pyrefly + ty clean; ruff clean.
- valgrind: archivey scenarios 0 errors; bare-pyppmd detector fires.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NdwM38UPEAsxX2uea9Ef9Q