### PR TITLE
docs: mark perf peer bands aspirational; publish measured ratios (refresh #172)

### DIFF
--- a/IDEAS.md
+++ b/IDEAS.md
@@ -303,11 +303,12 @@
   `--raw` hatch for scripts that need exact names before `--json` exists is
   additive. Parked as debt-ledger DD8.
 - **Lazy `ArchiveMember` derivation (perf L5)** — only named lever to bring
-  many-small ZIP open+list from ~3.7–4× into the aspirational 2–3× peer band
-  (`review/performance/listing-attribution.md`). Touches equality / accounting /
-  listing contract → needs its own OpenSpec. **Deferred past 0.2.0** when deciding
-  debt-ledger Q2 (2026-07-20): bands are aspirational; measured ratios are good
-  enough for everyday use. Same story for 7z listing ~2× vs ~1.25× native-par.
+  ZIP open+list from ~4.4× (nightly realistic, 2026-07-23) into the aspirational
+  2–3× peer band (`review/performance/listing-attribution.md`). Touches equality
+  / accounting / listing contract → needs its own OpenSpec. **Deferred past
+  0.2.0** when deciding debt-ledger Q2 (2026-07-20): bands are aspirational;
+  measured ratios are good enough for everyday use. Same story for 7z listing
+  ~2.1× / RAR ~2.4× vs ~1.25× native-par.
 
 ## Strategy & adoption (2026-07 review backlog)
 

--- a/IDEAS.md
+++ b/IDEAS.md
@@ -302,6 +302,12 @@
   recommended style (escape everywhere, backslash) already applied; optional
   `--raw` hatch for scripts that need exact names before `--json` exists is
   additive. Parked as debt-ledger DD8.
+- **Lazy `ArchiveMember` derivation (perf L5)** — only named lever to bring
+  many-small ZIP open+list from ~3.7–4× into the aspirational 2–3× peer band
+  (`review/performance/listing-attribution.md`). Touches equality / accounting /
+  listing contract → needs its own OpenSpec. **Deferred past 0.2.0** when deciding
+  debt-ledger Q2 (2026-07-20): bands are aspirational; measured ratios are good
+  enough for everyday use. Same story for 7z listing ~2× vs ~1.25× native-par.
 
 ## Strategy & adoption (2026-07 review backlog)
 

--- a/VISION.md
+++ b/VISION.md
@@ -73,13 +73,29 @@ That origin story encodes priorities that remain core:
 
 ## Performance budget
 
-- Target: **≤ 1.3×** stdlib wall-time for the common paths (open/list/read/extract on
-  ZIP and TAR); up to ~2× acceptable where a safety or correctness feature justifies it.
-- The bottleneck in real workloads is data movement and *re*-decompression, not header
-  parsing. So the benchmark suite must track **bytes decompressed and seek patterns**,
-  not just wall time — an implementation that re-reads a solid block fails the
-  benchmark even if a small test corpus hides it.
-- Benchmarks become a CI gate like the type checkers (backlog until stood up).
+Wall-time targets are **aspirational peer-ratio bands**, not a claim that every
+path meets them today. Measured ratios live in [`docs/costs.md`](docs/costs.md)
+(and the nightly harness report); re-run
+`python -m benchmarks.harness --mode full --scale realistic` to check on your host.
+
+- **Decompression-dominated** common paths (large-member ZIP/TAR/gzip read):
+  target **≤ 1.3×** the relevant stdlib peer; up to ~**2×** where safety or
+  correctness features justify it (e.g. extract with path/symlink guards).
+  Large-member ZIP read and realistic extract are in or near these bands today;
+  many-small member machinery tracks the listing story below.
+- **Metadata / listing** (open+list): aspirational peer ratios — ZIP/TAR at most
+  **2–3×** vs `zipfile`/`tarfile`; native 7z/RAR **≈parity** (~1.25×) with
+  `py7zr`/`rarfile`. Measured many-small ZIP listing is ~3.7–4× and 7z listing
+  ~2× — fine for everyday use; closing the residual (lazy `ArchiveMember`
+  derivation) is a named follow-up, not a release blocker.
+- The bottleneck in real workloads is data movement and *re*-decompression, not
+  header parsing. The benchmark suite tracks **bytes decompressed and seek
+  patterns**, not just wall time — an implementation that re-reads a solid block
+  fails the structural gate even if a small test corpus hides it.
+- **CI:** structural axes (bytes decompressed, seeks, solid decode-once) gate
+  every PR. Absolute wall bands are **not** PR-gated (shared-runner noise). The
+  change-guarded nightly (`benchmark-wall.yml`) measures and publishes wall
+  ratios vs peers.
 
 ## Quality scaffolding over promises
 

--- a/VISION.md
+++ b/VISION.md
@@ -81,13 +81,14 @@ path meets them today. Measured ratios live in [`docs/costs.md`](docs/costs.md)
 - **Decompression-dominated** common paths (large-member ZIP/TAR/gzip read):
   target **≤ 1.3×** the relevant stdlib peer; up to ~**2×** where safety or
   correctness features justify it (e.g. extract with path/symlink guards).
-  Large-member ZIP read and realistic extract are in or near these bands today;
-  many-small member machinery tracks the listing story below.
+  Nightly realistic (2026-07-23): gzip / tar.bz2 ~parity, tar.gz accel-off
+  ~1.3×, ZIP read-all ~1.9× (under the ~2× safety band); ZIP extract ~2.4×
+  (slightly above). Per-member machinery tracks the listing story below.
 - **Metadata / listing** (open+list): aspirational peer ratios — ZIP/TAR at most
   **2–3×** vs `zipfile`/`tarfile`; native 7z/RAR **≈parity** (~1.25×) with
-  `py7zr`/`rarfile`. Measured many-small ZIP listing is ~3.7–4× and 7z listing
-  ~2× — fine for everyday use; closing the residual (lazy `ArchiveMember`
-  derivation) is a named follow-up, not a release blocker.
+  `py7zr`/`rarfile`. Measured realistic ZIP listing is ~4.4×, 7z ~2.1×, RAR
+  ~2.4× — fine for everyday use; closing the ZIP residual (lazy
+  `ArchiveMember` derivation) is a named follow-up, not a release blocker.
 - The bottleneck in real workloads is data movement and *re*-decompression, not
   header parsing. The benchmark suite tracks **bytes decompressed and seek
   patterns**, not just wall time — an implementation that re-reads a solid block

--- a/docs/costs.md
+++ b/docs/costs.md
@@ -3,6 +3,28 @@
 Archivey’s defaults keep the common path cheap and fail loudly when you ask for something
 expensive. This page is the “how not to shoot yourself in the foot” guide.
 
+## Wall-time bands (aspirational)
+
+These are **targets**, not CI hard-fails. Absolute ratios vary by host; the PR gate
+enforces structural invariants (bytes decompressed, seeks, solid decode-once) instead.
+The change-guarded nightly publishes full wall ratios — re-run locally with:
+
+```bash
+uv run --extra all python -m benchmarks.harness --mode full --scale realistic
+```
+
+| Workload | Aspirational band | Measured (review host, post-#143/#146/#139) |
+| --- | --- | --- |
+| Large-member ZIP/TAR/gzip **read** (decompression-dominated) | ≤ **1.3×** stdlib peer | ZIP read-all ~**1.2×**; gzip / tar.bz2 ~parity; tar.gz accel-off ~1.3× |
+| ZIP/TAR **extract** (safety floor) | ≤ ~**2×** stdlib peer | realistic extract ~**1.9×** |
+| ZIP/TAR **open+list** (wraps stdlib) | ≤ **2–3×** `zipfile` / `tarfile` | many-small ZIP ~**3.7–4×** |
+| 7z/RAR **open+list** (native parsers) | ≈parity (~**1.25×**) vs `py7zr` / `rarfile` | 7z ~**2.0–2.2×**; RAR harness ratio still fixture-limited |
+
+Everyday listing and extract at these measured ratios are fine. The residual listing
+gap is mostly per-member derivation cost; **lazy `ArchiveMember` derivation (L5)** is
+the named follow-up to move ZIP toward the 2–3× band — deferred past the first public
+release (see `IDEAS.md`).
+
 ## Read `reader.cost`
 
 Every open archive exposes a machine-readable receipt:

--- a/docs/costs.md
+++ b/docs/costs.md
@@ -13,17 +13,24 @@ The change-guarded nightly publishes full wall ratios — re-run locally with:
 uv run --extra all python -m benchmarks.harness --mode full --scale realistic
 ```
 
-| Workload | Aspirational band | Measured (review host, post-#143/#146/#139) |
-| --- | --- | --- |
-| Large-member ZIP/TAR/gzip **read** (decompression-dominated) | ≤ **1.3×** stdlib peer | ZIP read-all ~**1.2×**; gzip / tar.bz2 ~parity; tar.gz accel-off ~1.3× |
-| ZIP/TAR **extract** (safety floor) | ≤ ~**2×** stdlib peer | realistic extract ~**1.9×** |
-| ZIP/TAR **open+list** (wraps stdlib) | ≤ **2–3×** `zipfile` / `tarfile` | many-small ZIP ~**3.7–4×** |
-| 7z/RAR **open+list** (native parsers) | ≈parity (~**1.25×**) vs `py7zr` / `rarfile` | 7z ~**2.0–2.2×**; RAR harness ratio still fixture-limited |
+Measured column from the latest full nightly
+([run 29992136861](https://github.com/davitf/archivey-2/actions/runs/29992136861),
+`2026-07-23`, `main` @ `89720de`, realistic corpus: 64 × 256 KiB members /
+32 MiB gzip). Ratios are host-dependent — treat as directional.
 
-Everyday listing and extract at these measured ratios are fine. The residual listing
-gap is mostly per-member derivation cost; **lazy `ArchiveMember` derivation (L5)** is
-the named follow-up to move ZIP toward the 2–3× band — deferred past the first public
-release (see `IDEAS.md`).
+| Workload | Aspirational band | Measured (nightly realistic) |
+| --- | --- | --- |
+| Large-member ZIP/TAR/gzip **read** (decompression-dominated) | ≤ **1.3×** stdlib peer | ZIP read-all **1.87×**; gzip **1.03×**; tar.bz2 **1.03×**; tar.gz accel-off **1.27×** (accel-on **0.45×**) |
+| ZIP/TAR **extract** (safety floor) | ≤ ~**2×** stdlib peer | ZIP extract **2.38×** (above band) |
+| ZIP/TAR **open+list** (wraps stdlib) | ≤ **2–3×** `zipfile` / `tarfile` | ZIP **4.44×**; TAR **1.41×** |
+| 7z/RAR **open+list** (native parsers) | ≈parity (~**1.25×**) vs `py7zr` / `rarfile` | 7z **2.13×**; RAR **2.39×** |
+
+Plain uncompressed TAR **read-all** is **1.90×** on the same run — metadata /
+per-member overhead, not a codec story. Everyday listing and extract at these
+ratios are still fine for most callers. The residual ZIP listing gap is mostly
+per-member derivation cost; **lazy `ArchiveMember` derivation (L5)** is the
+named follow-up to move ZIP toward the 2–3× band — deferred past the first
+public release (see `IDEAS.md`).
 
 ## Read `reader.cost`
 

--- a/docs/philosophy.md
+++ b/docs/philosophy.md
@@ -67,6 +67,10 @@ evidence-based (magic first). Access cost is queryable (`reader.cost`). Prefer
 `stream_members()` when order matters. Prefer stored hashes (`member.hashes`) when you
 only need integrity fingerprints.
 
+Wall-time expectations are **aspirational peer-ratio bands** (not a silent promise):
+see [Access costs — wall-time bands](costs.md#wall-time-bands-aspirational). Re-run the
+harness if you want numbers on your machine.
+
 ## What this is not
 
 - Not an everything-tool (no in-place modify, no async in v1)

--- a/review/README.md
+++ b/review/README.md
@@ -22,8 +22,8 @@ Round commissioned 2026-07-17 — the **non-security** pass toward the first pub
 
 | Dir | Review | Status |
 |-----|--------|--------|
-| `debt-ledger/` | The pre-`0.2.0` **debt ledger** (backlog Topics 4+5: test-strategy + structural cleanliness) — every shortcut/duplication/drift/deferred-decision/test-hole with a pay-or-keep verdict, ranked by freezes-at-release cost | Findings in (2026-07-20); pay-list (D5/D6 done) + `QUESTIONS.md` Q1–Q5 open |
-| `performance/` | The ≤1.3× stdlib perf budget — benchmark-gate efficacy + the real traps | Listing L0–L3 + peers (#143/#146/#148); residual band miss; **Q2/Q4** still open |
+| `debt-ledger/` | The pre-`0.2.0` **debt ledger** (backlog Topics 4+5: test-strategy + structural cleanliness) — every shortcut/duplication/drift/deferred-decision/test-hole with a pay-or-keep verdict, ranked by freezes-at-release cost | Findings in (2026-07-20); **D1/D5/D6 done**; Q1–Q4 decided; Q5 + remaining pay-list open |
+| `performance/` | The ≤1.3× stdlib perf budget — benchmark-gate efficacy + the real traps | Listing L0–L3 + peers; residual band miss accepted as aspirational (debt-ledger Q2); wall-enforcement Q2 decided (a); **Q4** still open |
 
 **Live triage:** [`STATUS.md`](STATUS.md).
 

--- a/review/STATUS.md
+++ b/review/STATUS.md
@@ -7,8 +7,8 @@ Triage after archiving `cli-product/` and OpenSpec `stop-on-failure-not-policy`
 
 | Review | Findings delivered? | Code/docs follow-ups | Ready to archive? |
 |--------|---------------------|----------------------|-------------------|
-| `debt-ledger/` | yes (2026-07-20) | pay-list D1/D2/D3/T1/T2/T3/D4/T7 + **DD4/rapidgzip-truncation** open; **D5/D6 done**; **Q1/Q3/Q4 decided**; Q2/Q5 open | no |
-| `performance/` | yes (#134 + follow-ups) | P3–P5 done; listing L0–L3 + peers (#143/#146/#148); residual band miss; **Q2 decided** (drift gate); **Q4 open** | no |
+| `debt-ledger/` | yes (2026-07-20) | pay-list D2/D3/T1/T2/T3/D4/T7 + **DD4/rapidgzip-truncation** open; **D1/D5/D6 done**; **Q1–Q4 decided**; Q5 open | no |
+| `performance/` | yes (#134 + follow-ups) | P3–P5 done; listing L0–L3 + peers; residual band miss **accepted as aspirational** (debt-ledger Q2 (b)); wall enforcement **Q2 decided** (drift gate #171); **Q4 open** | no |
 
 Archived this pass: `archive/2026-07-19-api-coherence/`,
 `archive/2026-07-19-stream-layering/`, `archive/2026-07-20-cli-product/`.
@@ -22,7 +22,6 @@ OpenSpec archived: `archive/2026-07-20-stop-on-failure-not-policy/`.
 
 | ID | Action |
 |----|--------|
-| **D1** | Re-word VISION/philosophy/costs ≤1.3× claim to peer-ratio bands (after Q1/Q2). |
 | **D2** | Write `SECURITY.md` / disclosure process. |
 | **D3** | Start `CHANGELOG.md` (Q5 form). |
 | **T1 / T2** | Solid-RAR mutation net; parametrize seek-interleaving over lzip/`.Z`. |
@@ -34,9 +33,8 @@ OpenSpec archived: `archive/2026-07-20-stop-on-failure-not-policy/`.
 
 | ID | Action |
 |----|--------|
-| **P7 residual** | ZIP many-small ~3.7× (above 2–3×); 7z ~2.0–2.2× (above 1.25×). Next: **L3** large RAR listing fixture; **L5** lazy derivation (needs OpenSpec) — or publish honest numbers (debt-ledger Q2). |
+| **P7 residual** | **Accepted** — peer bands aspirational; measured ZIP ~3.7–4× / 7z ~2× published in `docs/costs.md`; **L5** → `IDEAS.md` (debt-ledger Q2 (b)). Optional: **L3** large RAR listing fixture. |
 | **P6 remainder** | RAR / encrypted / accelerator *data* harness cases still missing (= debt-ledger T3). |
-| **VISION/docs** | Re-word ≤1.3× claim to match Q1 now that **Q2** is (a) (= debt-ledger D1). |
 
 ---
 
@@ -47,7 +45,7 @@ OpenSpec archived: `archive/2026-07-20-stop-on-failure-not-policy/`.
 | Q | Finding | Status |
 |---|---------|--------|
 | **Q1** | Perf wall-budget enforcement (perf Q2) | **decided** — nightly drift vs previous JSON (a); absolute bands informational |
-| **Q2** | ZIP listing above band: L5 pre-release vs publish honest number | lean: publish honest number; L5 follow-up |
+| **Q2** | ZIP listing above band: L5 pre-release vs publish honest number | **decided** — (b) aspirational bands + measured table; L5 → `IDEAS.md` |
 | **Q3** | S2+S3: entry gate vs pay pre-release | **decided** — (b) pay now; OpenSpec `unify-pass-driver` |
 | **Q4** | rapidgzip-truncation rides past 0.2.0? | **decided** — PAY before 0.2.0; implement later |
 | **Q5** | CHANGELOG form | lean: committed `CHANGELOG.md` |
@@ -56,7 +54,7 @@ OpenSpec archived: `archive/2026-07-20-stop-on-failure-not-policy/`.
 
 | Q | Finding | Status |
 |---|---------|--------|
-| **Q2** | **P1** wall-budget enforcement | **decided** (= debt-ledger Q1 (a)) |
+| **Q2** | **P1** wall-budget enforcement | **decided** (= debt-ledger Q1 (a); landed #171) |
 | **Q4** | Verify-skip knob (lean leave-as-is; close when archiving) | open |
 
 ---
@@ -68,7 +66,7 @@ OpenSpec archived: `archive/2026-07-20-stop-on-failure-not-policy/`.
 | **P8** | rapidgzip AUTO threshold may be conservative for seek. |
 | **P9** | Measurement blind spots (7z password-confirm; RAR solid rewind). |
 | Extract residual | Safety floor; realistic ~1.9× already in band. |
-| **L5** | Lazy `ArchiveMember` derivation — OpenSpec when commissioned. |
+| **L5** | Lazy `ArchiveMember` derivation — **deferred** → `IDEAS.md` (debt-ledger Q2 (b)). |
 | Topic 6 | Decode-engine performance — `backlog.md` (includes stream Q4). |
 
 ---
@@ -102,3 +100,5 @@ Full table also in `backlog.md` → "Parked from archived deep reviews".
 | Perf P3–P5, decode-feed, O8 | #136/#139/#141 |
 | cli-product P1–P3/P5–P14/D1 | #144 follow-ups + #163/#165 |
 | OpenSpec `stop-on-failure-not-policy` | #165 → archived 2026-07-20 |
+| Nightly wall-ratio drift gate | #171 |
+| D1 VISION/costs/philosophy peer bands (debt-ledger Q2 (b)) | this PR (refresh of #172) |

--- a/review/STATUS.md
+++ b/review/STATUS.md
@@ -33,7 +33,7 @@ OpenSpec archived: `archive/2026-07-20-stop-on-failure-not-policy/`.
 
 | ID | Action |
 |----|--------|
-| **P7 residual** | **Accepted** — peer bands aspirational; measured ZIP ~3.7–4× / 7z ~2× published in `docs/costs.md`; **L5** → `IDEAS.md` (debt-ledger Q2 (b)). Optional: **L3** large RAR listing fixture. |
+| **P7 residual** | **Accepted** — peer bands aspirational; nightly realistic (2026-07-23) ZIP open+list **4.44×** / 7z **2.13×** / RAR **2.39×** published in `docs/costs.md`; **L5** → `IDEAS.md` (debt-ledger Q2 (b)). |
 | **P6 remainder** | RAR / encrypted / accelerator *data* harness cases still missing (= debt-ledger T3). |
 
 ---

--- a/review/STATUS.md
+++ b/review/STATUS.md
@@ -65,7 +65,7 @@ OpenSpec archived: `archive/2026-07-20-stop-on-failure-not-policy/`.
 |----|-------|
 | **P8** | rapidgzip AUTO threshold may be conservative for seek. |
 | **P9** | Measurement blind spots (7z password-confirm; RAR solid rewind). |
-| Extract residual | Safety floor; realistic ~1.9× already in band. |
+| Extract residual | Safety floor; nightly realistic ZIP extract **2.38×** (slightly above ~2×). |
 | **L5** | Lazy `ArchiveMember` derivation — **deferred** → `IDEAS.md` (debt-ledger Q2 (b)). |
 | Topic 6 | Decode-engine performance — `backlog.md` (includes stream Q4). |
 

--- a/review/debt-ledger/QUESTIONS.md
+++ b/review/debt-ledger/QUESTIONS.md
@@ -27,8 +27,9 @@ absolute-ratio flake and catches regressions, which is what the claim needs.
 
 **Decision: (b).** Peer-ratio bands are **aspirational**; publish measured
 numbers in `docs/costs.md` / VISION; L5 (lazy `ArchiveMember` derivation) is a
-named post-0.2.0 follow-up in `IDEAS.md`. Measured many-small ZIP ~3.7–4× and
-7z ~2× are good enough for everyday use — do not block the release on L5.
+named post-0.2.0 follow-up in `IDEAS.md`. Nightly realistic (2026-07-23) ZIP
+open+list **4.44×** / 7z **2.13×** / RAR **2.39×** are good enough for
+everyday use — do not block the release on L5.
 
 Post-#143/#146, ZIP open+list sits ~3.7–4× vs the Q1-direction band of 2–3×;
 7z ~2.0–2.2× vs ≈1.25× native-par. Two honest paths were:

--- a/review/debt-ledger/QUESTIONS.md
+++ b/review/debt-ledger/QUESTIONS.md
@@ -23,10 +23,15 @@ informational. **A choice — any choice — is needed before the VISION/costs
 re-wording can be finished.** Recommendation: (a), it dodges shared-runner
 absolute-ratio flake and catches regressions, which is what the claim needs.
 
-## Q2 — ZIP open+list is above the maintainer's own re-scoped band: land L5 pre-release, or publish the real number?
+## Q2 — ZIP open+list is above the maintainer's own re-scoped band: land L5 pre-release, or publish the real number? — **DECIDED (2026-07-20)**
+
+**Decision: (b).** Peer-ratio bands are **aspirational**; publish measured
+numbers in `docs/costs.md` / VISION; L5 (lazy `ArchiveMember` derivation) is a
+named post-0.2.0 follow-up in `IDEAS.md`. Measured many-small ZIP ~3.7–4× and
+7z ~2× are good enough for everyday use — do not block the release on L5.
 
 Post-#143/#146, ZIP open+list sits ~3.7–4× vs the Q1-direction band of 2–3×;
-7z ~2.0–2.2× vs ≈1.25× native-par. Two honest paths:
+7z ~2.0–2.2× vs ≈1.25× native-par. Two honest paths were:
 
 - **(a)** Commission **L5** (lazy `ArchiveMember` derivation — needs an
   OpenSpec change; the remaining cost is `_to_member` + registration per the
@@ -35,10 +40,7 @@ Post-#143/#146, ZIP open+list sits ~3.7–4× vs the Q1-direction band of 2–3�
   measured numbers published beside it (costs.md table), L5 as the named
   follow-up.
 
-Recommendation: **(b)**. L5 restructures the hottest member-model path right
-before release; the honest-number option costs nothing and the claim stays
-falsifiable-but-true. But this is a positioning call — VISION is the
-maintainer's document.
+**(b) landed** with this change (refreshed onto main 2026-07-24).
 
 ## Q3 — S2+S3 unification: accept "entry gate for the next backend", or pay pre-release? — **DECIDED (2026-07-20)**
 

--- a/review/debt-ledger/SUMMARY.md
+++ b/review/debt-ledger/SUMMARY.md
@@ -35,9 +35,9 @@ stable over time.
 
 | # | Item | Where | Freeze | Verdict |
 |---|------|-------|--------|---------|
-| **D1** | VISION/philosophy/costs still publish **≤1.3× for open/list** — falsified by own measurements; maintainer's Q1 re-scoping (peer-ratio bands) never reached the docs | `VISION.md:74-76`; `review/performance/QUESTIONS.md` Q1 | **F3** | **PAY** — re-word before release; band honesty doesn't wait on Q2 |
+| **D1** | VISION/philosophy/costs still publish **≤1.3× for open/list** — falsified by own measurements; maintainer's Q1 re-scoping (peer-ratio bands) never reached the docs | `VISION.md`; `review/performance/QUESTIONS.md` Q1 | **F3** | **DONE** (2026-07-20 / refreshed 2026-07-24) — aspirational peer bands + measured table in `docs/costs.md` (Q2 (b)); L5 → `IDEAS.md` |
 | **D2** | No `SECURITY.md` / disclosure process — gates the "safe" positioning per threat-model O5.4 + PLAN | `docs/internal/threat-model.md` O5 | **F3** | **PAY** (SECURITY.md); OSS-Fuzz may trail |
-| **DD1/DD3** | Perf **Q2** (wall enforcement) + ZIP listing above its own band (L5 or honest number) | `review/performance/` | **F3** | **DECIDE** — `QUESTIONS.md` Q1/Q2 |
+| **DD1/DD3** | Perf **Q2** (wall enforcement) + ZIP listing above its own band (L5 or honest number) | `review/performance/` | **F3** | **DECIDED** — Q1 (a) drift (#171); Q2 (b) aspirational bands |
 | **D3** | No `CHANGELOG`; `0.2.0.dev0` sets the record at release | `pyproject.toml:7` | **F3** | **PAY** (cheap; form → Q5) |
 | **DD6** | Salvage mode absent though it's the founding use case | PLAN / IDEAS / reserved `--salvage` | **F3**→ok | **KEEP** — sequencing decision already recorded; docs verified honest |
 | **T1** | Mutation-fuzz + conformance sweep cover only declarative `CORPUS`; **solid-RAR demux** (where RAR-review bugs lived) has no generative net | `tests/test_mutation_fuzz.py:118`; `rar_reader.py:578-649` | **F2** | **PAY** — mutate static fixtures / build solid RAR into corpus |
@@ -58,7 +58,7 @@ stable over time.
 
 ## The pre-0.2.0 pay list, in order
 
-1. **D1** — re-word the perf claim (after deciding Q1/Q2 in `QUESTIONS.md`).
+1. ~~**D1** — re-word the perf claim~~ **done** (Q1/Q2 decided; VISION/costs/philosophy updated).
 2. **D2** — write `SECURITY.md`.
 3. **D3** — start `CHANGELOG.md`.
 4. **T1 + T2** — widen the generative nets (solid-RAR mutation; lzip/`.Z`

--- a/review/debt-ledger/drift-and-decisions.md
+++ b/review/debt-ledger/drift-and-decisions.md
@@ -6,29 +6,18 @@ All references: `main` @ `7bb862b`. Mechanical baseline: `openspec validate
 `rapidgzip-truncation-investigation 1/11`. (**D5** archived that complete change
 on 2026-07-20.)
 
-## D1 — the VISION ≤1.3× performance claim no longer matches either the measurements or the maintainer's own re-scoping (PAY — top of the ledger)
+## D1 — the VISION ≤1.3× performance claim no longer matches either the measurements or the maintainer's own re-scoping — **DONE (2026-07-20 / refreshed 2026-07-24)**
 
-`VISION.md:74-76` still states the budget as "**≤ 1.3×** stdlib wall-time for
-the common paths (open/list/read/extract…)". The performance review measured
-ZIP open+list at ~3.7–4× post-optimization, 7z listing ~2.0–2.2× vs py7zr,
-ZIP many-small extract ~3.7× (`review/performance/QUESTIONS.md` Q1,
-`budget-table.md`), and the maintainer **already re-scoped the claim** (Q1
-direction, 2026-07-18): metadata ops get *ratio bands vs the relevant peer*
-(ZIP/TAR listing ≤2–3×, native 7z/RAR ≈ par), decompression-dominated paths
-keep ≤1.3×. None of that re-scoping has reached `VISION.md`, `docs/philosophy.md`,
-or `docs/costs.md` — and `philosophy.md` explicitly invites skeptics to
-benchmark. Shipping 0.2.0 with the old sentence publishes a falsifiable claim
-the project's own numbers falsify.
+Paid with debt-ledger Q1/Q2: `VISION.md` / `docs/philosophy.md` /
+`docs/costs.md` now state **aspirational peer-ratio bands** plus a measured
+table; L5 parked in `IDEAS.md`. Absolute bands are not PR-gated; structural
+axes remain the PR gate. Nightly wall-ratio *drift* (#171) enforces
+regressions without claiming absolute ≤1.3×.
 
-This is the highest freezes-at-release item on the ledger: a public claim,
-quoted in announcement posts and package metadata, is the single hardest thing
-to walk back. **PAY before 0.2.0**: re-word VISION + philosophy + costs to the
-Q1 band structure. Only the *enforcement* wording (is the band CI-gated or
-measured-and-published?) waits on performance Q2 — the band honesty does not.
-Residual: ZIP open+list is still **above** its own re-scoped 2–3× band; either
-L5 (lazy `ArchiveMember` derivation, needs an OpenSpec) lands pre-release or
-the published band must say where ZIP actually sits today (see `QUESTIONS.md`
-Q1/Q2).
+Previously `VISION.md` published a single "**≤ 1.3×** stdlib" open/list/read/extract
+claim that the project's own measurements falsified (ZIP open+list ~3.7–4×,
+7z listing ~2.0–2.2×). Q1 direction (2026-07-18) already re-scoped metadata ops
+to peer-ratio bands; this change is the docs landing of that decision plus Q2 (b).
 
 ## D2 — no SECURITY.md / disclosure process, and it gates the release's own marketing (PAY)
 
@@ -105,7 +94,7 @@ Archived to `review/archive/2026-07-20-cli-product/`. Parked leftovers:
 |---|---|---|---|
 | **DD1** | Performance **Q2** — where the wall budget is enforced (nightly-vs-previous JSON, 2× band on read_all, or informational) | `review/performance/QUESTIONS.md` Q2 | **DECIDED (2026-07-20)** — (a) nightly wall-ratio drift vs previous successful JSON; skip re-publish + ≥30d forced re-measure; absolute bands informational. |
 | DD2 | Performance **Q4** — verify-skip knob | same, Q4 | **KEEP** (lean leave-as-is already recorded; perf case ~nil post-#137). Record as closed-no-knob. |
-| DD3 | ZIP listing above its own band — land **L5** or publish the honest number | STATUS "residual band miss" | **DECIDE pre-0.2.0** (part of D1; `QUESTIONS.md` Q2). |
+| DD3 | ZIP listing above its own band — land **L5** or publish the honest number | STATUS "residual band miss" | **DECIDED (2026-07-20)** — (b) aspirational bands + measured table; L5 → `IDEAS.md`. |
 | DD4 | `rapidgzip-truncation-investigation` (1/11) — the shipped ISIZE backstop is a heuristic built on admittedly incomplete knowledge (`proposal.md`) | in-flight change | **DECIDED (2026-07-20)** — **PAY before 0.2.0** (debt-ledger Q4). Enrichment in change `design.md`; implement in a later PR. Rejected: ride past release because accelerators are opt-in. |
 | DD5 | `seekable-gzip-and-block-writing` (0/24, spec-only, Phase 8) | in-flight change | **KEEP** — post-0.2.0 feature by plan; additive. |
 | DD6 | Salvage / best-effort read mode — the founding use case, unbuilt; reads are all-or-error | `backlog.md`, `IDEAS.md`, reserved `--salvage` | **KEEP for 0.2.0** — already an explicit, recorded sequencing decision (PLAN: post-0.2.0); CLI grammar + `members_report()` shape keep it additive. Confirm `docs`/README don't over-promise it (checked: gotchas/philosophy phrase it as recoverable-prefix + honest error, which #157 delivers). |

--- a/review/performance/QUESTIONS.md
+++ b/review/performance/QUESTIONS.md
@@ -41,9 +41,11 @@ Consequences to implement:
 2. ZIP open+list: measured **~3.7–4×** after #143 model-build + L2
    (`slots=True` / trimmed kwargs) — still above 2–3×. Remaining cost is
    `_to_member` derivation (~3.3 µs/member) + registration (~1.3 µs); further
-   gains need L5 lazy derivation (OpenSpec). 7z open+list after L1 bulk name
+   gains need L5 lazy derivation (OpenSpec). **Debt-ledger Q2 (2026-07-20):
+   bands are aspirational; measured numbers published; L5 deferred** →
+   `IDEAS.md` / `docs/costs.md`. 7z open+list after L1 bulk name
    decode: probe **~2.0×** / harness ~**2.2×** vs py7zr (was ~3.4×); still
-   above the 1.25× native band. RAR harness ratio remains a small-fixture
+   above the 1.25× native band (same aspirational treatment). RAR harness ratio remains a small-fixture
    artifact until a larger listing fixture exists (L3).
 3. Read/extract regimes stay as previously framed: decompression-dominated
    ≤1.3× (met for large-member ZIP after #139), extract inside the ~2× safety

--- a/review/performance/QUESTIONS.md
+++ b/review/performance/QUESTIONS.md
@@ -39,18 +39,18 @@ Consequences to implement:
    report labels use Q1 bands (ZIP/TAR ≤3×, native ≈1.25×). Still asserted the
    same way the wall budget ends up asserted (Q2 — informational only today).
 2. ZIP open+list: measured **~3.7–4×** after #143 model-build + L2
-   (`slots=True` / trimmed kwargs) — still above 2–3×. Remaining cost is
-   `_to_member` derivation (~3.3 µs/member) + registration (~1.3 µs); further
-   gains need L5 lazy derivation (OpenSpec). **Debt-ledger Q2 (2026-07-20):
-   bands are aspirational; measured numbers published; L5 deferred** →
-   `IDEAS.md` / `docs/costs.md`. 7z open+list after L1 bulk name
-   decode: probe **~2.0×** / harness ~**2.2×** vs py7zr (was ~3.4×); still
-   above the 1.25× native band (same aspirational treatment). RAR harness ratio remains a small-fixture
-   artifact until a larger listing fixture exists (L3).
-3. Read/extract regimes stay as previously framed: decompression-dominated
-   ≤1.3× (met for large-member ZIP after #139), extract inside the ~2× safety
-   band (met at realistic scale), many-small read_all follows the listing
-   story (its cost *is* per-member machinery).
+   (`slots=True` / trimmed kwargs); nightly realistic **2026-07-23** is
+   **4.44×** — still above 2–3×. Remaining cost is `_to_member` derivation
+   (~3.3 µs/member) + registration (~1.3 µs); further gains need L5 lazy
+   derivation (OpenSpec). **Debt-ledger Q2 (2026-07-20): bands are
+   aspirational; measured numbers published; L5 deferred** → `IDEAS.md` /
+   `docs/costs.md`. 7z open+list after L1: nightly **2.13×** vs py7zr; RAR
+   open+list nightly **2.39×** vs rarfile (same aspirational treatment).
+3. Read/extract regimes: decompression-dominated ≤1.3× is met for gzip /
+   tar.bz2 / tar.gz accel-off; ZIP read-all nightly **1.87×** (under ~2×
+   safety, above 1.3×). ZIP extract nightly **2.38×** (slightly above the
+   ~2× safety band). Many-small / listing cost still dominates small-member
+   read_all.
 
 ## Q2 — Where should the wall budget be *enforced*? — **DECIDED (2026-07-20)**
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Refresh of conflicting **#172** onto current `main`. Pays debt-ledger **D1** and decides **Q2 = (b)**.

### Product docs
- **VISION** / **philosophy**: wall-time targets are aspirational peer-ratio bands (not a silent ≤1.3× open/list claim).
- **`docs/costs.md`**: measured-ratio table, refreshed from nightly realistic **2026-07-23** ([run 29992136861](https://github.com/davitf/archivey-2/actions/runs/29992136861) @ `89720de`):
  - ZIP read-all **1.87×**, extract **2.38×**, open+list **4.44×**
  - gzip / tar.bz2 ~**1.03×**; tar.gz accel-off **1.27×**
  - 7z open+list **2.13×**; RAR **2.39×**; TAR open+list **1.41×**
- **`IDEAS.md`**: L5 lazy `ArchiveMember` derivation deferred past 0.2.0.

### Review triage
- Mark D1 / DD3 / Q2 **DONE**; keep later Q3/Q4 decisions already on `main` intact.
- Align STATUS / performance QUESTIONS with the nightly numbers.

### Supersedes
Replaces [**#172**](https://github.com/davitf/archivey-2/pull/172) (was `CONFLICTING` after #174–#189).

Docs-only; `mkdocs build --strict` green.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a4f19563-a02d-4243-abcc-5b17b8330f53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a4f19563-a02d-4243-abcc-5b17b8330f53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

