### PR TITLE
docs: add CHANGELOG.md and every-release checklist (refresh #176)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,52 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+How to update this file for a release: see
+[`docs/internal/release-checklist.md`](docs/internal/release-checklist.md)
+(commit walk since the previous tag + performance numbers vs that release).
+
+## [Unreleased]
+
+First public release will be **0.2.0**. Until then, notable work accumulates here;
+at cut time the checklist moves this section under a dated `## [0.2.0]` heading.
+
+### Added
+
+- Unified archive reading for ZIP, TAR, RAR, 7z, ISO, directory trees, and
+  single-file compressed streams (gzip / bzip2 / xz / lzip / zstd / lz4 / compress).
+- Safe extraction defaults (`archivey.extract`) with policy-driven path and
+  overwrite controls; CLI (`archivey list|test|extract`) as a safer unzip demo.
+- Native 7z and RAR metadata readers (stdlib codecs for common 7z filters;
+  external `unrar` for RAR member data).
+- Optional extras: `[seekable]` (rapidgzip), `[crypto]`, `[7z]` (PPMd / Deflate64),
+  and related packaging matrix — see `docs/formats.md`.
+- Declarative corpus + mutation / Hypothesis / Atheris testing contract;
+  three-configuration CI (`[all]`, `[all-lowest]`, `[core-only]`).
+- Benchmark harness: PR structural gate + change-guarded nightly wall-ratio drift.
+
+### Changed
+
+- Performance claims are **aspirational peer-ratio bands** with a published
+  measured table in `docs/costs.md` / `VISION.md` (nightly realistic ratios;
+  refresh at release time per the checklist).
+
+### Security
+
+- Threat model and open residuals: `docs/internal/threat-model.md`.
+- Disclosure process: add `SECURITY.md` before the public “safe” claim
+  (debt-ledger D2 — still open at changelog creation).
+
+<!--
+After 0.2.0 is tagged, add:
+
+## [0.2.0] - YYYY-MM-DD
+
+…and link compare URLs at the bottom, e.g.:
+
+[Unreleased]: https://github.com/davitf/archivey/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/davitf/archivey/releases/tag/v0.2.0
+-->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,6 +75,14 @@ macOS/Windows). Repo `.python-version` pins the default local env to 3.11, so th
 workflow must pass `--python <matrix>` (and `UV_PYTHON`) on every `uv sync` /
 `uv run` in the test job — otherwise newer-version legs silently re-test 3.11.
 
+## Cutting a release
+
+See [`docs/internal/release-checklist.md`](docs/internal/release-checklist.md)
+(CHANGELOG triage, perf vs previous tag, docs, three-config tests, version bump,
+tag, publish). One-time repo rename / PyPI setup:
+[`docs/internal/release-repo-cutover.md`](docs/internal/release-repo-cutover.md).
+User-facing history lives in [`CHANGELOG.md`](CHANGELOG.md).
+
 ## Tooling decisions
 
 - **Type-checking is Pyrefly + ty** — the library is kept clean on **both**. We do

--- a/PLAN.md
+++ b/PLAN.md
@@ -108,8 +108,9 @@ Recently archived stream-layer / refactor follow-ons: `codec-descriptor-refactor
    (extras→capability, PyPI metadata, drop `0.2.0.dev0`); **doc sweep + migration guide**
    (`zipfile`/`tarfile`/`shutil.unpack_archive`/`patool` → archivey); **`SECURITY.md` +
    disclosure process** and an **explicit free-threading support statement** (the `3.13t`
-   job runs core-only — document the matrix rather than leaving it implicit). Tag `0.2.0`
-   after this.
+   job runs core-only — document the matrix rather than leaving it implicit). Recurring
+   cut steps (CHANGELOG, perf vs previous tag, tests, tag, publish):
+   `docs/internal/release-checklist.md`. Tag `0.2.0` after this.
 
 **Deferred to a later version (not `0.2.0`):**
 - **Salvage / best-effort read mode** — the founding use case (index truncated/corrupt

--- a/README.md
+++ b/README.md
@@ -10,3 +10,5 @@ Python library for reading, streaming, and safely extracting archives (ZIP, TAR,
 - **[Threat model](docs/internal/threat-model.md)** — trust boundaries and open gaps
 - **[PLAN.md](PLAN.md)** — phased roadmap · **[IDEAS.md](IDEAS.md)** — backlog
 - Authoritative contracts: `openspec/specs/`
+- **[CHANGELOG.md](CHANGELOG.md)** — notable changes · **[Release checklist](docs/internal/release-checklist.md)** — how to cut a version
+- **[CONTRIBUTING.md](CONTRIBUTING.md)** — coding / testing standards

--- a/docs/internal/index.md
+++ b/docs/internal/index.md
@@ -8,6 +8,8 @@ Maintainer / contributor material. Not the primary user guide.
 | [Open issues (gotchas triage)](open-issues.md) | Fixable leftovers vs irreducible user gotchas; docs/spec drift |
 | [Compression-library analysis](library-analysis.md) | Per-codec backend choice and rationale |
 | [Known issues](known-issues.md) | Accelerator lifecycle / macOS coexistence notes |
+| [Release checklist](release-checklist.md) | Every-release loop: CHANGELOG, perf vs prior tag, docs, tag/publish |
+| [Release-repo cutover](release-repo-cutover.md) | One-time rename / PyPI / Pages before the first public tag |
 
 Normative behavior remains in `openspec/specs/`. Product framing: `VISION.md` at the
 repository root. Decision summaries: [decision log](../decisions/index.md).

--- a/docs/internal/release-checklist.md
+++ b/docs/internal/release-checklist.md
@@ -1,0 +1,214 @@
+# Release checklist
+
+Maintainer runbook for cutting a versioned release (`vX.Y.Z`). Work top to bottom;
+check boxes in the PR that prepares the release (or keep a local copy).
+
+One-time **repo rename / PyPI Trusted Publishing / Pages** steps live in
+[`release-repo-cutover.md`](release-repo-cutover.md) — do those before the first
+public tag from the canonical `archivey` name. This page is the **every release**
+loop.
+
+Package version is the static `[project].version` in `pyproject.toml` (not derived
+from the git tag). `publish.yml` fails if the tag and packaged version disagree.
+
+---
+
+## 0. Preconditions
+
+- [ ] Default branch green (CI + recent nightly wall job not in unexplained fail).
+- [ ] No open “must land before this tag” items on `review/STATUS.md` /
+      debt-ledger pay-list / in-flight OpenSpec changes you intended for this
+      version (for `0.2.0`, that includes D2 `SECURITY.md`, DD4 rapidgzip
+      characterization, and any other recorded pay-befores).
+- [ ] First public release only: cutover runbook complete (or consciously
+      releasing to TestPyPI from `archivey-2` while still pre-rename).
+
+---
+
+## 1. Gather user-visible changes (CHANGELOG)
+
+Previous release tag: `PREV=$(git describe --tags --abbrev=0 2>/dev/null || true)`  
+(If there is no tag yet — first release — use the empty range / whole history and
+write the entry-zero under `## [0.2.0]` from `[Unreleased]`.)
+
+- [ ] List commits / merged PRs since `PREV`:
+
+  ```bash
+  git log --first-parent --oneline "${PREV:-$(git rev-list --max-parents=0 HEAD)}..HEAD"
+  # Optional PR-oriented view (GitHub CLI):
+  gh pr list --state merged --base main --search "merged:>$(git log -1 --format=%cI "$PREV" 2>/dev/null || echo 2020-01-01)" --limit 100
+  ```
+
+- [ ] Triage into Keep a Changelog buckets in `CHANGELOG.md`:
+  **Added** / **Changed** / **Deprecated** / **Removed** / **Fixed** / **Security**.
+  Prefer user-facing behavior over internal refactors. Omit chore-only / review-doc
+  noise unless it changes a published claim.
+- [ ] Move `[Unreleased]` items into a new `## [X.Y.Z] - YYYY-MM-DD` section; leave
+  a fresh empty `[Unreleased]` above it.
+- [ ] Add / update the compare links at the bottom of `CHANGELOG.md` once the tag
+  name is known (repo may still be `archivey-2` pre-cutover).
+
+---
+
+## 2. Performance numbers for the CHANGELOG
+
+Goal: a short, honest table (or bullet list) of peer wall ratios **for this
+release**, plus a note vs the **previous release** when one exists. Absolute
+VISION bands stay informational; do not claim CI hard-fails on ≤1.3×.
+
+- [ ] On a quiet machine (or after pulling the latest successful
+      `benchmark-wall-realistic` artifact), measure current `main`:
+
+  ```bash
+  uv sync --group dev --extra all
+  uv run --no-sync python -m benchmarks.harness \
+    --mode full --scale realistic --warmup \
+    --json-out /tmp/archivey-wall-current.json \
+    --text-out /tmp/archivey-wall-current.md
+  ```
+
+- [ ] **Vs previous release** (skip on first release): check out the previous
+      tag in a worktree or second clone, run the same harness command to
+      `/tmp/archivey-wall-prev.json`, then compare overlapping `wall_ratio`
+      cases (higher = slower vs peer):
+
+  ```bash
+  # Example: previous tag v0.2.0
+  git worktree add /tmp/archivey-prev v0.2.0
+  ( cd /tmp/archivey-prev && uv sync --group dev --extra all && \
+    uv run --no-sync python -m benchmarks.harness \
+      --mode full --scale realistic --warmup \
+      --json-out /tmp/archivey-wall-prev.json \
+      --text-out /tmp/archivey-wall-prev.md )
+  # Drift helper against the previous JSON (same relative gates as nightly)
+  uv run --no-sync python -m benchmarks.harness \
+    --mode full --scale realistic --warmup \
+    --wall-drift-baseline /tmp/archivey-wall-prev.json \
+    --json-out /tmp/archivey-wall-current.json \
+    --text-out /tmp/archivey-wall-current.md
+  ```
+
+  Alternatively download the nightly artifact that corresponds to the previous
+  tag’s era if you trust that host more than a local rerun — record which host /
+  artifact you used.
+
+- [ ] Paste a compact summary into the CHANGELOG entry (and refresh
+      `docs/costs.md` / VISION measured tables if numbers moved materially).
+      Note measurement host / core count (see `benchmarks/RESULTS.md`).
+- [ ] Confirm PR structural gate still passes:
+
+  ```bash
+  uv run --no-sync python -m benchmarks.harness --mode structural --scale ci
+  ```
+
+---
+
+## 3. Docs and claims
+
+- [ ] End-user docs still match behavior: `docs/usage.md`, `formats.md`,
+      `safe-extraction.md`, `gotchas.md`, `api.md`, `philosophy.md`, `costs.md`.
+- [ ] `VISION.md` performance / safety sentences still match what you are willing
+      to ship (no falsifiable over-claim).
+- [ ] `docs/internal/threat-model.md` open items: either fixed, consciously
+      deferred with wording, or called out in SECURITY / gotchas.
+- [ ] `docs/internal/open-issues.md` not contradicting shipped decisions (stale
+      rows fixed or moved to Closed).
+- [ ] MkDocs builds clean:
+
+  ```bash
+  uv run --group docs mkdocs build --strict
+  ```
+
+- [ ] README install / quickstart / doc links still accurate.
+- [ ] First release: migration notes if promising a path from
+      `zipfile`/`tarfile`/`shutil.unpack_archive`/`patool` (PLAN release bundle).
+
+---
+
+## 4. Security and packaging
+
+- [ ] `SECURITY.md` present with a disclosure path (required before any public
+      “safe extraction” marketing).
+- [ ] `pyproject.toml` metadata: name, description, classifiers, URLs, extras ↔
+      capabilities (`packaging-and-extras` spec).
+- [ ] Free-threading / platform support statement matches CI (core-only `3.13t`
+      job — document honestly).
+- [ ] Optional: OSS-Fuzz onboarding status noted (may trail the first tag).
+
+---
+
+## 5. Quality gate (same bar as “before pushing”)
+
+From `CONTRIBUTING.md` — all three dependency configs:
+
+```bash
+# 1. Current [all]
+uv sync --group dev --extra all && uv run --no-sync pytest
+
+# 2. Lowest direct
+uv sync --group dev --extra all --resolution lowest-direct && uv run --no-sync pytest
+
+# 3. Core-only
+uv sync --no-dev && uv run --no-sync python tests/check_zero_dep_core.py \
+  && uv run --no-sync --with pytest --with pytest-timeout --with pytest-cov pytest tests/ -q
+
+# Restore everyday env
+uv sync --group dev --extra all
+```
+
+Also:
+
+- [ ] `uv run --no-sync ruff check` + `ruff format --check` over
+      `src/ tests/ scripts/ benchmarks/`
+- [ ] `uv run --no-sync pyrefly check` and `uv run --no-sync ty check`
+- [ ] `openspec validate --all`
+- [ ] Spot-check: `unrar` / `p7zip-full` present if you are asserting RAR data /
+      encrypted-ZIP fixture coverage in this release’s story
+
+---
+
+## 6. Version bump and tag
+
+- [ ] Set `[project].version` in `pyproject.toml` to `X.Y.Z` (**drop** any
+      `.devN` suffix).
+- [ ] Commit on a release PR: `CHANGELOG.md`, version bump, doc/number updates;
+      merge to the default branch.
+- [ ] Tag and push (annotated preferred):
+
+  ```bash
+  git checkout main && git pull
+  git tag -a "vX.Y.Z" -m "archivey X.Y.Z"
+  git push origin "vX.Y.Z"
+  ```
+
+- [ ] Confirm `publish.yml` built distributions and published to the expected
+      index (TestPyPI while repo is `archivey-2`; PyPI after cutover to
+      `archivey`). See cutover runbook for Trusted Publishing setup.
+- [ ] Create a GitHub Release for `vX.Y.Z` whose body **mirrors** the CHANGELOG
+      section (generated notes are optional; the committed file remains
+      authoritative).
+
+---
+
+## 7. Post-release
+
+- [ ] Bump `[project].version` to the next `X.Y.(Z+1).dev0` (or minor/major
+      `.dev0`) on `main` so installs from the default branch stay distinguishable
+      from the tag.
+- [ ] Leave `[Unreleased]` ready for the next cycle.
+- [ ] If docs site is Pages-published, confirm the workflow ran on the tag /
+      default branch as configured.
+- [ ] Announce as you prefer (not required by the tooling).
+
+---
+
+## Quick command cheat sheet
+
+| Step | Command |
+| --- | --- |
+| Commits since last tag | `git log --first-parent --oneline "$(git describe --tags --abbrev=0)"..HEAD` |
+| Structural bench | `uv run --no-sync python -m benchmarks.harness --mode structural --scale ci` |
+| Realistic wall + JSON | `uv run --no-sync python -m benchmarks.harness --mode full --scale realistic --warmup --json-out /tmp/wall.json --text-out /tmp/wall.md` |
+| Docs | `uv run --group docs mkdocs build --strict` |
+| Build only | `uv build` then inspect `dist/` |
+| Version source | `pyproject.toml` → `[project].version` |

--- a/docs/internal/release-repo-cutover.md
+++ b/docs/internal/release-repo-cutover.md
@@ -63,8 +63,11 @@ Do these in order — the `archivey` name must be free before this repo can take
 
 ## Releasing after the cutover
 
-The package version is a **static literal** (`[project].version` in `pyproject.toml`),
-not derived from the tag. To cut a release:
+For the recurring release loop (CHANGELOG, perf vs previous tag, docs, tests,
+version bump, tag, publish), use
+[`release-checklist.md`](release-checklist.md).
+
+Minimum mechanical steps once that checklist is satisfied:
 
 1. Bump `[project].version` (drop any `.devN` suffix), commit, merge to `main`.
 2. Tag `vX.Y.Z` and push the tag. `publish.yml` builds, verifies the tag matches the

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,6 +33,7 @@ nav:
       - Open issues (gotchas triage): internal/open-issues.md
       - Compression-library analysis: internal/library-analysis.md
       - Known issues: internal/known-issues.md
+      - Release checklist: internal/release-checklist.md
       - Release-repo cutover: internal/release-repo-cutover.md
   - Grab-bag:
       - Overview: grab-bag/index.md

--- a/review/STATUS.md
+++ b/review/STATUS.md
@@ -7,7 +7,7 @@ Triage after archiving `cli-product/` and OpenSpec `stop-on-failure-not-policy`
 
 | Review | Findings delivered? | Code/docs follow-ups | Ready to archive? |
 |--------|---------------------|----------------------|-------------------|
-| `debt-ledger/` | yes (2026-07-20) | pay-list D2/D3/T1/T2/T3/D4/T7 + **DD4/rapidgzip-truncation** open; **D1/D5/D6 done**; **Q1–Q4 decided**; Q5 open | no |
+| `debt-ledger/` | yes (2026-07-20) | pay-list D2/T1/T2/T3/D4/T7 + **DD4/rapidgzip-truncation** open; **D1/D3/D5/D6 done**; **Q1–Q5 decided** | no |
 | `performance/` | yes (#134 + follow-ups) | P3–P5 done; listing L0–L3 + peers; residual band miss **accepted as aspirational** (debt-ledger Q2 (b)); wall enforcement **Q2 decided** (drift gate #171); **Q4 open** | no |
 
 Archived this pass: `archive/2026-07-19-api-coherence/`,
@@ -23,7 +23,6 @@ OpenSpec archived: `archive/2026-07-20-stop-on-failure-not-policy/`.
 | ID | Action |
 |----|--------|
 | **D2** | Write `SECURITY.md` / disclosure process. |
-| **D3** | Start `CHANGELOG.md` (Q5 form). |
 | **T1 / T2** | Solid-RAR mutation net; parametrize seek-interleaving over lzip/`.Z`. |
 | **T3** | Benchmark-gate RAR / encrypted / accelerator data cases (perf P6 remainder). |
 | **D4 / T7** | `open-issues.md` sweep; corpus-matrix audit. |
@@ -48,7 +47,7 @@ OpenSpec archived: `archive/2026-07-20-stop-on-failure-not-policy/`.
 | **Q2** | ZIP listing above band: L5 pre-release vs publish honest number | **decided** — (b) aspirational bands + measured table; L5 → `IDEAS.md` |
 | **Q3** | S2+S3: entry gate vs pay pre-release | **decided** — (b) pay now; OpenSpec `unify-pass-driver` |
 | **Q4** | rapidgzip-truncation rides past 0.2.0? | **decided** — PAY before 0.2.0; implement later |
-| **Q5** | CHANGELOG form | lean: committed `CHANGELOG.md` |
+| **Q5** | CHANGELOG form | **decided** — committed `CHANGELOG.md` + release checklist |
 
 ### `performance/QUESTIONS.md`
 
@@ -101,4 +100,5 @@ Full table also in `backlog.md` → "Parked from archived deep reviews".
 | cli-product P1–P3/P5–P14/D1 | #144 follow-ups + #163/#165 |
 | OpenSpec `stop-on-failure-not-policy` | #165 → archived 2026-07-20 |
 | Nightly wall-ratio drift gate | #171 |
-| D1 VISION/costs/philosophy peer bands (debt-ledger Q2 (b)) | this PR (refresh of #172) |
+| D1 VISION/costs/philosophy peer bands (debt-ledger Q2 (b)) | **#191** |
+| D3 CHANGELOG + release checklist (Q5) | this PR (refresh of #176) |

--- a/review/debt-ledger/QUESTIONS.md
+++ b/review/debt-ledger/QUESTIONS.md
@@ -69,9 +69,9 @@ characterization change is 1/11 tasks done. The ledger's earlier lean was KEEP
 refining later is non-breaking). Maintainer overrode: knowingly-heuristic guard
 on a supported path is unacceptable release debt even when opt-in.
 
-## Q5 — Does a `CHANGELOG` entry-zero get written now?
+## Q5 — Does a `CHANGELOG` entry-zero get written now? — **DECIDED + DONE**
 
-D3 says PAY. The only real question is form: a conventional
-`CHANGELOG.md` starting at 0.2.0 ("initial public release" + highlights), or
-generated release notes only. Recommendation: a committed `CHANGELOG.md` —
-the adoption capstone explicitly looks for one in-repo.
+**Decision:** committed Keep a Changelog `CHANGELOG.md` (not generated-only),
+plus `docs/internal/release-checklist.md` for the every-release loop. Pays
+debt-ledger **D3**.
+

--- a/review/debt-ledger/SUMMARY.md
+++ b/review/debt-ledger/SUMMARY.md
@@ -38,7 +38,7 @@ stable over time.
 | **D1** | VISION/philosophy/costs still publish **≤1.3× for open/list** — falsified by own measurements; maintainer's Q1 re-scoping (peer-ratio bands) never reached the docs | `VISION.md`; `review/performance/QUESTIONS.md` Q1 | **F3** | **DONE** (2026-07-20 / refreshed 2026-07-24) — aspirational peer bands + measured table in `docs/costs.md` (Q2 (b)); L5 → `IDEAS.md` |
 | **D2** | No `SECURITY.md` / disclosure process — gates the "safe" positioning per threat-model O5.4 + PLAN | `docs/internal/threat-model.md` O5 | **F3** | **PAY** (SECURITY.md); OSS-Fuzz may trail |
 | **DD1/DD3** | Perf **Q2** (wall enforcement) + ZIP listing above its own band (L5 or honest number) | `review/performance/` | **F3** | **DECIDED** — Q1 (a) drift (#171); Q2 (b) aspirational bands |
-| **D3** | No `CHANGELOG`; `0.2.0.dev0` sets the record at release | `pyproject.toml:7` | **F3** | **PAY** (cheap; form → Q5) |
+| **D3** | No `CHANGELOG`; `0.2.0.dev0` sets the record at release | `pyproject.toml` | **F3** | **DONE** — committed `CHANGELOG.md` + `docs/internal/release-checklist.md` (Q5) |
 | **DD6** | Salvage mode absent though it's the founding use case | PLAN / IDEAS / reserved `--salvage` | **F3**→ok | **KEEP** — sequencing decision already recorded; docs verified honest |
 | **T1** | Mutation-fuzz + conformance sweep cover only declarative `CORPUS`; **solid-RAR demux** (where RAR-review bugs lived) has no generative net | `tests/test_mutation_fuzz.py:118`; `rar_reader.py:578-649` | **F2** | **PAY** — mutate static fixtures / build solid RAR into corpus |
 | **T3** | Benchmark gate has no RAR/encrypted/accelerator data cases — D1's claim can't be honest for unmeasured paths | `tests/test_benchmark_gate.py` | **F2** | **PAY** (already tracked as perf P6 remainder) |
@@ -60,7 +60,7 @@ stable over time.
 
 1. ~~**D1** — re-word the perf claim~~ **done** (Q1/Q2 decided; VISION/costs/philosophy updated).
 2. **D2** — write `SECURITY.md`.
-3. **D3** — start `CHANGELOG.md`.
+3. ~~**D3** — start `CHANGELOG.md`~~ **done** (committed Keep a Changelog + release checklist).
 4. **T1 + T2** — widen the generative nets (solid-RAR mutation; lzip/`.Z`
    seek property test). Cheap, reuses machinery, and T1 doubles as the
    safety net for `unify-pass-driver` (S2+S3).

--- a/review/debt-ledger/drift-and-decisions.md
+++ b/review/debt-ledger/drift-and-decisions.md
@@ -29,13 +29,12 @@ security-positioned library launching without a disclosure path is a story
 adopters remember); OSS-Fuzz onboarding can trail the release. **PAY
 (SECURITY.md) before 0.2.0; OSS-Fuzz may follow.**
 
-## D3 — no CHANGELOG (PAY — cheap)
+## D3 — no CHANGELOG — **DONE**
 
-`pyproject.toml` is at `0.2.0.dev0`; there is no `CHANGELOG*` anywhere. The
-first public release sets the record and the precedent (the adoption capstone
-in `backlog.md` Topic 7 names "a trustworthy changelog" as a confidence
-signal). Retro-writing it later from ~170 PRs is strictly more expensive than
-starting it now. **PAY before 0.2.0.**
+Committed Keep a Changelog `CHANGELOG.md` (Unreleased / 0.2.0 scaffold) plus
+`docs/internal/release-checklist.md` (every-release loop: triage, perf vs prior
+tag, docs/security gates, three-config tests, bump/tag/publish). Linked from
+README, CONTRIBUTING, PLAN, MkDocs nav, and the cutover runbook. Pays Q5.
 
 ## D4 — `docs/internal/open-issues.md` has gone stale against its own resolutions (PAY — 15-minute sweep)
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Refresh of conflicting **#176** onto current `main` (post-#191). Pays debt-ledger **D3** / decides **Q5**.

### Added
- `CHANGELOG.md` (Keep a Changelog; Unreleased / 0.2.0 scaffold)
- `docs/internal/release-checklist.md` (every-release loop: triage, perf vs prior tag, docs/security, three-config tests, bump/tag/publish)

### Linked from
README, CONTRIBUTING, PLAN, MkDocs nav, internal index, cutover runbook.

### Ledger
Mark D3/Q5 **DONE**. CHANGELOG notes measured perf tables already published via #191.

### Supersedes
Replaces [**#176**](https://github.com/davitf/archivey-2/pull/176) (was CONFLICTING).

Docs-only; `mkdocs build --strict` green.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a4f19563-a02d-4243-abcc-5b17b8330f53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a4f19563-a02d-4243-abcc-5b17b8330f53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

