### PR TITLE
Regenerate uv.lock to drop the stale 7z-write extra

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -22,16 +22,12 @@ source = { editable = "." }
     { name = "pybcj" },
     { name = "pyppmd" },
 ]
-7z-write = [
-    { name = "py7zr" },
-]
 all = [
     { name = "backports-zstd", marker = "python_full_version < '3.14'" },
     { name = "brotli" },
     { name = "cryptography" },
     { name = "inflate64" },
     { name = "lz4" },
-    { name = "py7zr" },
     { name = "pybcj" },
     { name = "pycdlib" },
     { name = "pyppmd" },
@@ -59,7 +55,6 @@ recommended = [
     { name = "cryptography" },
     { name = "inflate64" },
     { name = "lz4" },
-    { name = "py7zr" },
     { name = "pybcj" },
     { name = "pycdlib" },
     { name = "pyppmd" },
@@ -72,7 +67,6 @@ recommended-lite = [
     { name = "cryptography" },
     { name = "inflate64" },
     { name = "lz4" },
-    { name = "py7zr" },
     { name = "pybcj" },
     { name = "pycdlib" },
     { name = "pyppmd" },
@@ -123,7 +117,7 @@ fuzz = [
 
 [package.metadata]
 requires-dist = [
-    { name = "archivey", extras = ["7z", "rar", "7z-write", "iso", "zstd", "lz4", "cli"], marker = "extra == 'recommended-lite'" },
+    { name = "archivey", extras = ["7z", "rar", "iso", "zstd", "lz4", "cli"], marker = "extra == 'recommended-lite'" },
     { name = "archivey", extras = ["recommended"], marker = "extra == 'all'" },
     { name = "archivey", extras = ["recommended-lite", "seekable"], marker = "extra == 'recommended'" },
     { name = "backports-zstd", marker = "python_full_version < '3.14' and extra == '7z'", specifier = ">=1.0.0" },
@@ -135,14 +129,13 @@ requires-dist = [
     { name = "inflate64", marker = "extra == '7z'", specifier = ">=1.0.0" },
     { name = "lz4", marker = "extra == '7z'", specifier = ">=4.4.5" },
     { name = "lz4", marker = "extra == 'lz4'", specifier = ">=4.4.5" },
-    { name = "py7zr", marker = "extra == '7z-write'", specifier = ">=1.0.0" },
     { name = "pybcj", marker = "extra == '7z'", specifier = ">=1.0.6" },
     { name = "pycdlib", marker = "extra == 'iso'", specifier = ">=1.16.0" },
     { name = "pyppmd", marker = "extra == '7z'", specifier = ">=1.3.1" },
     { name = "rapidgzip", marker = "extra == 'seekable'", specifier = ">=0.16.0" },
     { name = "tqdm", marker = "extra == 'cli'", specifier = ">=4.67.0" },
 ]
-provides-extras = ["7z", "rar", "crypto", "7z-write", "iso", "zstd", "lz4", "cli", "seekable", "recommended-lite", "recommended", "all"]
+provides-extras = ["7z", "rar", "crypto", "iso", "zstd", "lz4", "cli", "seekable", "recommended-lite", "recommended", "all"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary

Lock-hygiene only. `pyproject.toml` dropped the `7z-write` extra back in #154 (7z writing is not shipped; `py7zr` stays a **dev/test oracle only**, per `CLAUDE.md`), but `uv.lock` was never regenerated. It still carried:

- the `7z-write = [...]` optional-dependency group,
- `py7zr` inside the `all` / `recommended` / `recommended-lite` bundles (pulled in via that extra), and
- `7z-write` in `requires-dist` and `provides-extras`.

Running `uv lock` removes those stale entries (2 insertions, 9 deletions).

## Why it was latent

CI uses plain `uv sync` (not `uv sync --locked`), which resolves from `pyproject.toml` rather than trusting the lock's extra sections, so the drift never surfaced and **no install behavior changes** — `pip/uv install archivey[all]` already excluded `py7zr`. This just realigns the file.

## Not removed

`py7zr` remains in the `dev` group (it's the 7z **write oracle** for tests). Verified it's still present in `uv.lock` after the relock.

## Testing

- `uv lock` resolves cleanly (81 packages).
- Diff is confined to `uv.lock`; no `pyproject.toml` or source changes.

Spun out of the PR #196 review as an unrelated pre-existing cleanup, kept on its own branch off `main`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C5NRQwpG2QB1fTRgyfZr3c)_