### PR TITLE
test: extend structural bench gate with RAR/encrypted/accel cases (T3)

### DIFF
--- a/.github/workflows/benchmark-wall.yml
+++ b/.github/workflows/benchmark-wall.yml
@@ -134,6 +134,10 @@ jobs:
       - name: Sync (dev + all extras)
         if: steps.guard.outputs.run == 'true'
         run: uv sync --group dev --extra all
+      # Same as ci.yml benchmark: RAR data cases need RARLAB unrar on the runner.
+      - name: Install unrar (RAR data cases)
+        if: steps.guard.outputs.run == 'true'
+        run: sudo apt-get update && sudo apt-get install -y unrar
 
       - name: Full realistic wall-time run
         if: steps.guard.outputs.run == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,11 +174,7 @@ jobs:
           Invoke-WebRequest -Uri 'https://www.rarlab.com/rar/unrarw64.exe' -OutFile $sfx
           Push-Location $dest
           # RARLAB SFX: /s silent, /d<path> extract destination.
-          $p = Start-Process -FilePath $sfx -ArgumentList "/s","/d$dest" -Wait -PassThru -NoNewWindow
-          if ($p.ExitCode -ne 0 -and $p.ExitCode -ne $null) {
-            Write-Host "SFX exit $($p.ExitCode); trying cwd extract"
-            Start-Process -FilePath $sfx -ArgumentList '/s' -Wait -NoNewWindow
-          }
+          Start-Process -FilePath $sfx -ArgumentList "/s","/d$dest" -Wait -NoNewWindow
           Pop-Location
           $real = Get-ChildItem -Path $dest -Recurse -Filter 'UnRAR.exe' |
             Select-Object -First 1
@@ -186,11 +182,10 @@ jobs:
             Get-ChildItem -Path $dest -Recurse | Format-Table FullName
             throw 'UnRAR.exe not found after extracting unrarw64.exe'
           }
-          $dir = $real.DirectoryName
-          # shutil.which('unrar') looks for unrar.exe on Windows.
-          Copy-Item $real.FullName (Join-Path $dir 'unrar.exe') -Force
-          echo $dir | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-          & (Join-Path $dir 'unrar.exe') 2>&1 | Select-Object -First 2
+          # Windows is case-insensitive: shutil.which('unrar') finds UnRAR.exe.
+          # Do not Copy-Item to unrar.exe — that overwrites the file with itself.
+          echo $real.DirectoryName | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          & $real.FullName 2>&1 | Select-Object -First 2
       - name: Verify RARLAB unrar on PATH
         if: matrix.install == 'all' || matrix.install == 'all-lowest'
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,9 +147,26 @@ jobs:
           uv sync --python ${{ matrix.python-version }}
           --group dev --extra all --resolution lowest-direct
 
-      - name: Install unrar (Linux only, for RAR data tests)
+      # RAR *data* tests (and the structural gate's rar_* cases) need RARLAB unrar.
+      # Listing works without it; with CI=true the gate fail-closes if data cases omit.
+      - name: Install unrar (Linux)
         if: (matrix.install == 'all' || matrix.install == 'all-lowest') && runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y unrar || true
+        run: sudo apt-get update && sudo apt-get install -y unrar
+      - name: Install unrar (macOS)
+        if: (matrix.install == 'all' || matrix.install == 'all-lowest') && runner.os == 'macOS'
+        run: brew install --cask rar
+      - name: Install unrar (Windows)
+        if: (matrix.install == 'all' || matrix.install == 'all-lowest') && runner.os == 'Windows'
+        run: choco install unrar -y
+      - name: Verify RARLAB unrar on PATH
+        if: matrix.install == 'all' || matrix.install == 'all-lowest'
+        shell: bash
+        run: |
+          command -v unrar
+          unrar 2>&1 | head -n 3 || true
+          # archivey's finder requires the RARLAB banner (not unrar-free / unar / 7z).
+          uv run --python ${{ matrix.python-version }} --no-sync python -c \
+            "from archivey.internal.backends.rar_unrar import find_rarlab_unrar; print(find_rarlab_unrar())"
 
       - name: Assert synced venv Python matches matrix
         # Catch regressions where `.python-version` silently overrides the matrix again.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,6 +254,11 @@ jobs:
         run: uv python install 3.11
       - name: Sync (dev + all extras)
         run: uv sync --group dev --extra all
+      # RAR *data* structural cases (rar_solid_*, rar_encrypted_*) need RARLAB unrar.
+      # Listing (rar_open_list) works without it — do not drop this step or T3 silently
+      # omits the data-path half of the gate (pytest fail-closes when CI=true).
+      - name: Install unrar (RAR data structural cases)
+        run: sudo apt-get update && sudo apt-get install -y unrar
       - name: Structural benchmark gate
         run: >
           uv run --no-sync python -m benchmarks.harness

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,15 +149,48 @@ jobs:
 
       # RAR *data* tests (and the structural gate's rar_* cases) need RARLAB unrar.
       # Listing works without it; with CI=true the gate fail-closes if data cases omit.
+      # Install *unrar only* — the ``rar`` writer enables corpus RAR builds whose
+      # digest expectations are Linux-fixture-oriented; keep writer off the PATH here.
       - name: Install unrar (Linux)
         if: (matrix.install == 'all' || matrix.install == 'all-lowest') && runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y unrar
       - name: Install unrar (macOS)
         if: (matrix.install == 'all' || matrix.install == 'all-lowest') && runner.os == 'macOS'
-        run: brew install --cask rar
+        run: |
+          brew install --cask rar
+          # Cask ships both rar + unrar; drop the writer so corpus builders skip.
+          rm -f "$(brew --prefix)/bin/rar"
+          command -v unrar
+          command -v rar && exit 1 || true
       - name: Install unrar (Windows)
         if: (matrix.install == 'all' || matrix.install == 'all-lowest') && runner.os == 'Windows'
-        run: choco install unrar -y
+        shell: pwsh
+        run: |
+          # Official x64 UnRAR (not chocolatey's x86 package + ShimGen shim — shims
+          # have broken solid ``unrar p`` pipes on this matrix).
+          $dest = Join-Path $env:RUNNER_TEMP 'rarlab-unrar'
+          New-Item -ItemType Directory -Force -Path $dest | Out-Null
+          $sfx = Join-Path $dest 'unrarw64.exe'
+          Invoke-WebRequest -Uri 'https://www.rarlab.com/rar/unrarw64.exe' -OutFile $sfx
+          Push-Location $dest
+          # RARLAB SFX: /s silent, /d<path> extract destination.
+          $p = Start-Process -FilePath $sfx -ArgumentList "/s","/d$dest" -Wait -PassThru -NoNewWindow
+          if ($p.ExitCode -ne 0 -and $p.ExitCode -ne $null) {
+            Write-Host "SFX exit $($p.ExitCode); trying cwd extract"
+            Start-Process -FilePath $sfx -ArgumentList '/s' -Wait -NoNewWindow
+          }
+          Pop-Location
+          $real = Get-ChildItem -Path $dest -Recurse -Filter 'UnRAR.exe' |
+            Select-Object -First 1
+          if (-not $real) {
+            Get-ChildItem -Path $dest -Recurse | Format-Table FullName
+            throw 'UnRAR.exe not found after extracting unrarw64.exe'
+          }
+          $dir = $real.DirectoryName
+          # shutil.which('unrar') looks for unrar.exe on Windows.
+          Copy-Item $real.FullName (Join-Path $dir 'unrar.exe') -Force
+          echo $dir | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          & (Join-Path $dir 'unrar.exe') 2>&1 | Select-Object -First 2
       - name: Verify RARLAB unrar on PATH
         if: matrix.install == 'all' || matrix.install == 'all-lowest'
         shell: bash

--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -120,7 +120,8 @@ accel_off (indexing / thread-pool startup dominates).
 | ZIP/TAR/gzip `bytes == unpacked` | tautological at member-output layer — under-decode guard only |
 | solid 7z sequential | decode-once (also pinned in `test_measurement.py`) |
 | solid 7z random `read()` | ~32.5× re-decode (n=64) — recorded, not gated |
-| solid RAR decode-once | unit-tested against committed fixtures (`unrar` only) |
+| solid RAR decode-once | structural gate on committed `basic_solid__.rar` + unit test (`unrar` only) |
+| encrypted RAR / ZIP AES / ZIP LZMA / in-ZIP accel | structural gate cases (T3); skip when `unrar` / `[crypto]` / `[seekable]` absent |
 
 ISO / directory: measurement is wired; harness cases are out of scope (ISO
 lock baseline lives in `benchmarks/tar_iso_lock_baseline.py`).

--- a/benchmarks/RESULTS.md
+++ b/benchmarks/RESULTS.md
@@ -120,8 +120,9 @@ accel_off (indexing / thread-pool startup dominates).
 | ZIP/TAR/gzip `bytes == unpacked` | tautological at member-output layer — under-decode guard only |
 | solid 7z sequential | decode-once (also pinned in `test_measurement.py`) |
 | solid 7z random `read()` | ~32.5× re-decode (n=64) — recorded, not gated |
-| solid RAR decode-once | structural gate on committed `basic_solid__.rar` + unit test (`unrar` only) |
+| solid RAR decode-once | structural gate on committed `basic_solid__.rar` + unit test (`unrar`) |
 | encrypted RAR / ZIP AES / ZIP LZMA / in-ZIP accel | structural gate cases (T3); skip when `unrar` / `[crypto]` / `[seekable]` absent |
+| solid RAR random | smoke + seek baseline; byte re-decode not observable via unrar pipe (P9) |
 
 ISO / directory: measurement is wired; harness cases are out of scope (ISO
 lock baseline lives in `benchmarks/tar_iso_lock_baseline.py`).

--- a/benchmarks/baselines/structural.json
+++ b/benchmarks/baselines/structural.json
@@ -74,7 +74,7 @@
       "bytes_decompressed": 32768,
       "source_seek_count": 0,
       "unpacked_bytes": 32768,
-      "notes": "rapidgzip accelerator ON; vs accel_off 0.80\u00d7"
+      "notes": "rapidgzip accelerator ON; vs accel_off 0.73\u00d7"
     },
     "tarbz2_read_all_accel_off": {
       "bytes_decompressed": 32768,
@@ -86,7 +86,7 @@
       "bytes_decompressed": 32768,
       "source_seek_count": 0,
       "unpacked_bytes": 32768,
-      "notes": "rapidgzip accelerator ON; vs accel_off 0.38\u00d7"
+      "notes": "rapidgzip accelerator ON; vs accel_off 0.25\u00d7"
     },
     "sevenzip_open_list": {
       "bytes_decompressed": 0,
@@ -122,7 +122,7 @@
       "bytes_decompressed": 41,
       "source_seek_count": 0,
       "unpacked_bytes": 41,
-      "notes": "re-decode recorded; gated vs baseline\u00d7SOLID_RANDOM_BYTES_FACTOR (committed basic_solid__.rar; unrar pipe counts output only)"
+      "notes": "smoke + seek baseline; byte re-decode not observable via unrar pipe output (P9) (committed basic_solid__.rar)"
     },
     "rar_encrypted_read_all": {
       "bytes_decompressed": 33,

--- a/benchmarks/baselines/structural.json
+++ b/benchmarks/baselines/structural.json
@@ -22,6 +22,30 @@
       "unpacked_bytes": 32768,
       "notes": ""
     },
+    "zip_lzma_read_all": {
+      "bytes_decompressed": 16384,
+      "source_seek_count": 24,
+      "unpacked_bytes": 16384,
+      "notes": "native ZIP LZMA codec; no stdlib peer (zipfile writes only)"
+    },
+    "zip_aes_read_all": {
+      "bytes_decompressed": 16384,
+      "source_seek_count": 28,
+      "unpacked_bytes": 16384,
+      "notes": "WinZip AES-256 AE-2; requires [crypto]"
+    },
+    "zip_read_all_accel_off": {
+      "bytes_decompressed": 32768,
+      "source_seek_count": 28,
+      "unpacked_bytes": 32768,
+      "notes": "stdlib deflate codec; accelerators forced OFF"
+    },
+    "zip_read_all_accel_on": {
+      "bytes_decompressed": 32768,
+      "source_seek_count": 44,
+      "unpacked_bytes": 32768,
+      "notes": "rapidgzip accelerator ON for in-ZIP deflate ([seekable])"
+    },
     "tar_open_list": {
       "bytes_decompressed": 0,
       "source_seek_count": 8,
@@ -36,7 +60,7 @@
     },
     "gzip_read_all": {
       "bytes_decompressed": 65536,
-      "source_seek_count": 1,
+      "source_seek_count": 3,
       "unpacked_bytes": 65536,
       "notes": ""
     },
@@ -50,7 +74,7 @@
       "bytes_decompressed": 32768,
       "source_seek_count": 0,
       "unpacked_bytes": 32768,
-      "notes": "rapidgzip accelerator ON; vs accel_off 0.72\u00d7"
+      "notes": "rapidgzip accelerator ON; vs accel_off 0.80\u00d7"
     },
     "tarbz2_read_all_accel_off": {
       "bytes_decompressed": 32768,
@@ -62,7 +86,7 @@
       "bytes_decompressed": 32768,
       "source_seek_count": 0,
       "unpacked_bytes": 32768,
-      "notes": "rapidgzip accelerator ON; vs accel_off 0.25\u00d7"
+      "notes": "rapidgzip accelerator ON; vs accel_off 0.38\u00d7"
     },
     "sevenzip_open_list": {
       "bytes_decompressed": 0,
@@ -87,6 +111,24 @@
       "source_seek_count": 0,
       "unpacked_bytes": null,
       "notes": "vs rarfile.infolist; Q1 native listing target \u2248parity"
+    },
+    "rar_solid_sequential": {
+      "bytes_decompressed": 41,
+      "source_seek_count": 0,
+      "unpacked_bytes": 41,
+      "notes": "solid invariant: bytes_decompressed <= unpacked * factor (committed basic_solid__.rar)"
+    },
+    "rar_solid_random": {
+      "bytes_decompressed": 41,
+      "source_seek_count": 0,
+      "unpacked_bytes": 41,
+      "notes": "re-decode recorded; gated vs baseline\u00d7SOLID_RANDOM_BYTES_FACTOR (committed basic_solid__.rar; unrar pipe counts output only)"
+    },
+    "rar_encrypted_read_all": {
+      "bytes_decompressed": 33,
+      "source_seek_count": 0,
+      "unpacked_bytes": 33,
+      "notes": "committed encryption__.rar; requires RARLAB unrar"
     }
   }
 }

--- a/benchmarks/baselines/structural.json
+++ b/benchmarks/baselines/structural.json
@@ -44,7 +44,7 @@
       "bytes_decompressed": 32768,
       "source_seek_count": 44,
       "unpacked_bytes": 32768,
-      "notes": "rapidgzip accelerator ON for in-ZIP deflate ([seekable])"
+      "notes": "rapidgzip accelerator ON for in-ZIP deflate ([seekable]); absolute seek bound exempt — gated by ON>OFF engagement"
     },
     "tar_open_list": {
       "bytes_decompressed": 0,

--- a/benchmarks/fixtures.py
+++ b/benchmarks/fixtures.py
@@ -12,17 +12,13 @@ WinZip AES ZIPs need the ``[crypto]`` extra to build (and to decrypt under archi
 from __future__ import annotations
 
 import gzip
-import hashlib
-import hmac
 import io
 import os
 import shutil
-import struct
 import subprocess
 import tarfile
 import tempfile
 import zipfile
-import zlib
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -116,126 +112,37 @@ def build_zip_lzma(path: Path, scale: Scale) -> None:
             zf.writestr(f"lzma{i:04d}.bin", _payload(i, scale.common_member_size))
 
 
-def _aes_ctr_le_encrypt(key: bytes, plaintext: bytes) -> bytes:
-    from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
-
-    encryptor = Cipher(algorithms.AES(key), modes.ECB()).encryptor()
-    out = bytearray(len(plaintext))
-    keystream = b""
-    pos = 0
-    counter = 1
-    for i, byte in enumerate(plaintext):
-        if pos >= len(keystream):
-            keystream = encryptor.update(counter.to_bytes(16, "little"))
-            pos = 0
-            counter += 1
-        out[i] = byte ^ keystream[pos]
-        pos += 1
-    return bytes(out)
-
-
 def build_zip_aes(
     path: Path, scale: Scale, *, password: bytes = ZIP_AES_PASSWORD
 ) -> int:
-    """Hand-build a multi-member WinZip AES-256 (AE-2) ZIP; return unpacked bytes.
+    """Build a multi-member WinZip AES-256 (AE-2) ZIP; return unpacked bytes.
 
     Requires ``cryptography`` (the same ``[crypto]`` extra needed to decrypt). Returns
     0 and leaves ``path`` absent when the extra is missing.
     """
     try:
-        from archivey.internal.zip_aes import (
-            WinZipAesInfo,
-            derive_winzip_aes_keys,
-        )
-    except ImportError:
-        return 0
-    try:
         import cryptography  # noqa: F401
     except ImportError:
         return 0
+    from tests.zip_aes_fixture import build_aes_zip
 
     # AE-2 / AES-256 / underlying method = deflate. A handful of members is enough to
     # exercise per-member password confirm + HMAC VerifyingStream without dominating ci.
     n = max(2, min(4, scale.common_members))
-    vendor_version, strength, method = 2, 3, 8
-    aes = WinZipAesInfo(vendor_version, strength, method)
-
-    locals_blob = bytearray()
-    central = bytearray()
-    total = 0
-    for i in range(n):
-        payload = _payload(i, scale.common_member_size)
-        total += len(payload)
-        name = f"aes{i:04d}.bin".encode()
-        compressed = zlib.compress(payload)[2:-4]  # raw deflate
-        salt = os.urandom(aes.salt_len)
-        enc_key, auth_key, pw_verify = derive_winzip_aes_keys(
-            password, salt=salt, key_len=aes.key_len
+    members = [
+        (f"aes{i:04d}.bin".encode(), _payload(i, scale.common_member_size))
+        for i in range(n)
+    ]
+    path.write_bytes(
+        build_aes_zip(
+            members,
+            password=password,
+            vendor_version=2,
+            strength=3,
+            method=8,
         )
-        ciphertext = _aes_ctr_le_encrypt(enc_key, compressed)
-        mac = hmac.new(auth_key, ciphertext, hashlib.sha1).digest()[:10]
-        body = salt + pw_verify + ciphertext + mac
-        # AE-2: CRC in headers is zero; authenticity is the AES HMAC.
-        crc = 0
-        aes_extra = struct.pack("<H2sBH", vendor_version, b"AE", strength, method)
-        extra = struct.pack("<HH", 0x9901, len(aes_extra)) + aes_extra
-        flags = 0x1
-        offset = len(locals_blob)
-        local = struct.pack(
-            "<IHHHHHIIIHH",
-            0x04034B50,
-            51,
-            flags,
-            99,
-            0,
-            0,
-            crc,
-            len(body),
-            len(payload),
-            len(name),
-            len(extra),
-        )
-        locals_blob.extend(local)
-        locals_blob.extend(name)
-        locals_blob.extend(extra)
-        locals_blob.extend(body)
-        cd = struct.pack(
-            "<IHHHHHHIIIHHHHHII",
-            0x02014B50,
-            51,
-            51,
-            flags,
-            99,
-            0,
-            0,
-            crc,
-            len(body),
-            len(payload),
-            len(name),
-            len(extra),
-            0,
-            0,
-            0,
-            0,
-            offset,
-        )
-        central.extend(cd)
-        central.extend(name)
-        central.extend(extra)
-
-    eocd = struct.pack(
-        "<IHHHHIIH",
-        0x06054B50,
-        0,
-        0,
-        n,
-        n,
-        len(central),
-        len(locals_blob),
-        0,
     )
-    path.write_bytes(bytes(locals_blob) + bytes(central) + eocd)
-    return total
+    return sum(len(payload) for _name, payload in members)
 
 
 def build_tar(path: Path, scale: Scale, *, mode: str = "w") -> None:

--- a/benchmarks/fixtures.py
+++ b/benchmarks/fixtures.py
@@ -6,20 +6,28 @@ Two scales:
 - ``realistic`` — multi-MiB corpora for wall-time ratios vs stdlib (VISION ≤1.3× surface).
 
 Large solid 7z/RAR archives are generated when py7zr / ``rar`` are available.
+WinZip AES ZIPs need the ``[crypto]`` extra to build (and to decrypt under archivey).
 """
 
 from __future__ import annotations
 
 import gzip
+import hashlib
+import hmac
 import io
 import os
 import shutil
+import struct
 import subprocess
 import tarfile
 import tempfile
 import zipfile
+import zlib
 from dataclasses import dataclass
 from pathlib import Path
+
+# Password for the generated WinZip AES fixture (must match harness open).
+ZIP_AES_PASSWORD = b"bench-secret"
 
 # ---------------------------------------------------------------------------
 # Scale profiles
@@ -67,6 +75,8 @@ class FixtureSet:
     root: Path
     scale: Scale
     zip_path: Path
+    zip_lzma_path: Path
+    zip_aes_path: Path | None
     tar_path: Path
     targz_path: Path
     tarbz2_path: Path
@@ -75,6 +85,7 @@ class FixtureSet:
     solid_rar: Path | None
     unpacked_solid_7z: int
     unpacked_solid_rar: int
+    unpacked_zip_aes: int
 
 
 def _payload(i: int, size: int) -> bytes:
@@ -94,6 +105,137 @@ def build_zip(path: Path, scale: Scale) -> None:
     with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
         for i in range(scale.common_members):
             zf.writestr(f"f{i:04d}.bin", _payload(i, scale.common_member_size))
+
+
+def build_zip_lzma(path: Path, scale: Scale) -> None:
+    """ZIP with LZMA members — exercises the native ZIP codec path (#106)."""
+    with zipfile.ZipFile(path, "w", compression=zipfile.ZIP_LZMA) as zf:
+        # Fewer members than the deflate corpus: LZMA setup dominates at ci scale.
+        n = max(2, scale.common_members // 2)
+        for i in range(n):
+            zf.writestr(f"lzma{i:04d}.bin", _payload(i, scale.common_member_size))
+
+
+def _aes_ctr_le_encrypt(key: bytes, plaintext: bytes) -> bytes:
+    from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+
+    encryptor = Cipher(algorithms.AES(key), modes.ECB()).encryptor()
+    out = bytearray(len(plaintext))
+    keystream = b""
+    pos = 0
+    counter = 1
+    for i, byte in enumerate(plaintext):
+        if pos >= len(keystream):
+            keystream = encryptor.update(counter.to_bytes(16, "little"))
+            pos = 0
+            counter += 1
+        out[i] = byte ^ keystream[pos]
+        pos += 1
+    return bytes(out)
+
+
+def build_zip_aes(
+    path: Path, scale: Scale, *, password: bytes = ZIP_AES_PASSWORD
+) -> int:
+    """Hand-build a multi-member WinZip AES-256 (AE-2) ZIP; return unpacked bytes.
+
+    Requires ``cryptography`` (the same ``[crypto]`` extra needed to decrypt). Returns
+    0 and leaves ``path`` absent when the extra is missing.
+    """
+    try:
+        from archivey.internal.zip_aes import (
+            WinZipAesInfo,
+            derive_winzip_aes_keys,
+        )
+    except ImportError:
+        return 0
+    try:
+        import cryptography  # noqa: F401
+    except ImportError:
+        return 0
+
+    # AE-2 / AES-256 / underlying method = deflate. A handful of members is enough to
+    # exercise per-member password confirm + HMAC VerifyingStream without dominating ci.
+    n = max(2, min(4, scale.common_members))
+    vendor_version, strength, method = 2, 3, 8
+    aes = WinZipAesInfo(vendor_version, strength, method)
+
+    locals_blob = bytearray()
+    central = bytearray()
+    total = 0
+    for i in range(n):
+        payload = _payload(i, scale.common_member_size)
+        total += len(payload)
+        name = f"aes{i:04d}.bin".encode()
+        compressed = zlib.compress(payload)[2:-4]  # raw deflate
+        salt = os.urandom(aes.salt_len)
+        enc_key, auth_key, pw_verify = derive_winzip_aes_keys(
+            password, salt=salt, key_len=aes.key_len
+        )
+        ciphertext = _aes_ctr_le_encrypt(enc_key, compressed)
+        mac = hmac.new(auth_key, ciphertext, hashlib.sha1).digest()[:10]
+        body = salt + pw_verify + ciphertext + mac
+        # AE-2: CRC in headers is zero; authenticity is the AES HMAC.
+        crc = 0
+        aes_extra = struct.pack("<H2sBH", vendor_version, b"AE", strength, method)
+        extra = struct.pack("<HH", 0x9901, len(aes_extra)) + aes_extra
+        flags = 0x1
+        offset = len(locals_blob)
+        local = struct.pack(
+            "<IHHHHHIIIHH",
+            0x04034B50,
+            51,
+            flags,
+            99,
+            0,
+            0,
+            crc,
+            len(body),
+            len(payload),
+            len(name),
+            len(extra),
+        )
+        locals_blob.extend(local)
+        locals_blob.extend(name)
+        locals_blob.extend(extra)
+        locals_blob.extend(body)
+        cd = struct.pack(
+            "<IHHHHHHIIIHHHHHII",
+            0x02014B50,
+            51,
+            51,
+            flags,
+            99,
+            0,
+            0,
+            crc,
+            len(body),
+            len(payload),
+            len(name),
+            len(extra),
+            0,
+            0,
+            0,
+            0,
+            offset,
+        )
+        central.extend(cd)
+        central.extend(name)
+        central.extend(extra)
+
+    eocd = struct.pack(
+        "<IHHHHIIH",
+        0x06054B50,
+        0,
+        0,
+        n,
+        n,
+        len(central),
+        len(locals_blob),
+        0,
+    )
+    path.write_bytes(bytes(locals_blob) + bytes(central) + eocd)
+    return total
 
 
 def build_tar(path: Path, scale: Scale, *, mode: str = "w") -> None:
@@ -182,12 +324,16 @@ def materialize_fixtures(
     root.mkdir(parents=True, exist_ok=True)
 
     zip_path = root / "common.zip"
+    zip_lzma_path = root / "common-lzma.zip"
+    zip_aes_path_candidate = root / "common-aes.zip"
     tar_path = root / "common.tar"
     targz_path = root / "common.tar.gz"
     tarbz2_path = root / "common.tar.bz2"
     gzip_path = root / "common.gz"
     if not zip_path.exists():
         build_zip(zip_path, scale_obj)
+    if not zip_lzma_path.exists():
+        build_zip_lzma(zip_lzma_path, scale_obj)
     if not tar_path.exists():
         build_tar(tar_path, scale_obj)
     if not targz_path.exists():
@@ -196,6 +342,21 @@ def materialize_fixtures(
         build_tar(tarbz2_path, scale_obj, mode="w:bz2")
     if not gzip_path.exists():
         build_gzip(gzip_path, scale_obj)
+
+    zip_aes_path: Path | None = None
+    unpacked_zip_aes = 0
+    if zip_aes_path_candidate.exists():
+        zip_aes_path = zip_aes_path_candidate
+        # Rebuild would need cryptography; reuse size from the same recipe.
+        n = max(2, min(4, scale_obj.common_members))
+        unpacked_zip_aes = sum(
+            len(_payload(i, scale_obj.common_member_size)) for i in range(n)
+        )
+    else:
+        built = build_zip_aes(zip_aes_path_candidate, scale_obj)
+        if built > 0 and zip_aes_path_candidate.exists():
+            zip_aes_path = zip_aes_path_candidate
+            unpacked_zip_aes = built
 
     solid_7z: Path | None = None
     unpacked_7z = 0
@@ -217,15 +378,17 @@ def materialize_fixtures(
         solid_rar = rar_path
         unpacked_rar = _unpacked_solid(scale_obj)
     else:
-        built = build_solid_rar(rar_path, scale_obj)
-        if built is not None:
+        built_rar = build_solid_rar(rar_path, scale_obj)
+        if built_rar is not None:
             solid_rar = rar_path
-            unpacked_rar = built
+            unpacked_rar = built_rar
 
     return FixtureSet(
         root=root,
         scale=scale_obj,
         zip_path=zip_path,
+        zip_lzma_path=zip_lzma_path,
+        zip_aes_path=zip_aes_path,
         tar_path=tar_path,
         targz_path=targz_path,
         tarbz2_path=tarbz2_path,
@@ -234,4 +397,5 @@ def materialize_fixtures(
         solid_rar=solid_rar,
         unpacked_solid_7z=unpacked_7z,
         unpacked_solid_rar=unpacked_rar,
+        unpacked_zip_aes=unpacked_zip_aes,
     )

--- a/benchmarks/harness.py
+++ b/benchmarks/harness.py
@@ -56,14 +56,6 @@ from benchmarks.wall_baseline import (
     wall_ratio_map,
 )
 
-# Unpacked sizes for the committed solid RAR fixture used at ci scale.
-_RAR_BASIC_UNPACKED = {
-    "file1.txt": 13,
-    "empty_file.txt": 0,
-    "subdir/file2.txt": 16,
-    "implicit_subdir/file3.txt": 12,
-}
-
 ROOT = Path(__file__).resolve().parents[1]
 BASELINES_DIR = Path(__file__).resolve().parent / "baselines"
 STRUCTURAL_BASELINE = BASELINES_DIR / "structural.json"
@@ -80,9 +72,10 @@ NONSOLID_DECODE_FACTOR = 1.1
 # Random-access solid cost is inherent, but bound it against the committed
 # baseline so a folder-cache regression cannot silently double the work (G5).
 SOLID_RANDOM_BYTES_FACTOR = 1.5
-# Seek-count slack against the committed ci baseline. Was baseline×2+8, which
-# absorbed a full ZIP decode-twice seek doubling (28→52). Fixtures are
-# deterministic; baseline+8 still covers observed host jitter (e.g. gzip 1→3).
+# Seek-count slack against the committed ci baseline (two-sided: baseline±slack).
+# Was baseline×2+8 (upper-only), which absorbed a full ZIP decode-twice seek doubling
+# (28→52) and could not catch silent non-engagement of paths that seek *more*
+# (in-ZIP accel ON 44 → OFF 28). Fixtures are deterministic; ±8 covers host jitter.
 SEEK_BASELINE_SLACK = 8
 # Wall-time sanity ceiling for --mode full. Absolute VISION ≤1.3× / ~2× bands stay
 # informational (shared-runner noise); nightly enforces *drift* vs the previous
@@ -875,11 +868,10 @@ def run_cases(
 
     # --- Solid RAR data path ---
     # At ci scale always prefer the committed basic_solid fixture so the structural
-    # baseline is stable whether or not the ``rar`` writer is installed (CI has
-    # ``unrar`` only). Realistic scale may use a generated large solid RAR when the
-    # writer built one. Both paths require RARLAB ``unrar`` for member data.
+    # baseline is stable whether or not the ``rar`` writer is installed. Both the
+    # PR structural gate and the nightly wall job install RARLAB ``unrar``. Realistic
+    # scale may use a generated large solid RAR when the writer built one.
     rar_data_path: Path | None = None
-    rar_unpacked = 0
     rar_fixture_note = ""
     committed_solid = ROOT / "tests" / "fixtures" / "rar" / "basic_solid__.rar"
     use_generated = (
@@ -889,11 +881,9 @@ def run_cases(
     )
     if use_generated:
         rar_data_path = fixtures.solid_rar
-        rar_unpacked = fixtures.unpacked_solid_rar
         rar_fixture_note = "generated solid fixture"
     elif committed_solid.is_file() and _unrar_available():
         rar_data_path = committed_solid
-        rar_unpacked = sum(_RAR_BASIC_UNPACKED.values())
         rar_fixture_note = "committed basic_solid__.rar"
 
     if rar_data_path is not None:
@@ -909,7 +899,7 @@ def run_cases(
                 wall,
                 bdec,
                 seeks,
-                unpacked_bytes=rar_unpacked,
+                unpacked_bytes=unpacked,
                 notes=(
                     f"solid invariant: bytes_decompressed <= unpacked * factor "
                     f"({rar_fixture_note})"
@@ -927,10 +917,10 @@ def run_cases(
                 wall,
                 bdec,
                 seeks,
-                unpacked_bytes=rar_unpacked,
+                unpacked_bytes=unpacked,
                 notes=(
-                    "re-decode recorded; gated vs baseline×SOLID_RANDOM_BYTES_FACTOR "
-                    f"({rar_fixture_note}; unrar pipe counts output only)"
+                    "smoke + seek baseline; byte re-decode not observable via unrar "
+                    f"pipe output (P9) ({rar_fixture_note})"
                 ),
             )
         )
@@ -1009,16 +999,40 @@ def _structural_checks(
                         f"> unpacked×{NONSOLID_DECODE_FACTOR}={over_limit} "
                         f"(non-solid re-decode?)"
                     )
-        # Seek counts: ≤ recorded baseline + slack. Missing baseline = skip.
-        # Only meaningful against the same fixture scale as the committed baseline (ci).
+        # Seek counts: two-sided vs committed baseline ± slack. Upper bound catches
+        # silent re-open churn; lower bound catches paths that characteristically
+        # seek *more* silently falling back (e.g. in-ZIP accel ON → OFF).
+        # Missing baseline = skip. Only meaningful against the ci-scale baseline.
         if check_seek_baselines:
             ref = cases.get(r.case)
             if ref is not None and "source_seek_count" in ref:
-                limit = int(ref["source_seek_count"]) + SEEK_BASELINE_SLACK
-                if r.source_seek_count > limit:
+                baseline_seeks = int(ref["source_seek_count"])
+                upper = baseline_seeks + SEEK_BASELINE_SLACK
+                lower = max(0, baseline_seeks - SEEK_BASELINE_SLACK)
+                if r.source_seek_count > upper:
                     failures.append(
-                        f"{r.case}: source_seek_count={r.source_seek_count} > bound {limit}"
+                        f"{r.case}: source_seek_count={r.source_seek_count} > bound {upper}"
                     )
+                elif r.source_seek_count < lower:
+                    failures.append(
+                        f"{r.case}: source_seek_count={r.source_seek_count} "
+                        f"< bound {lower} (below baseline−{SEEK_BASELINE_SLACK})"
+                    )
+
+    # In-ZIP accelerator engagement: ON must seek more than OFF on the same
+    # fixture. An upper-only seek bound cannot catch silent non-engagement
+    # (ON regressing to stdlib keeps seeks≈28 inside OFF's upper slack).
+    if check_seek_baselines:
+        by_case = {r.case: r for r in results}
+        accel_off = by_case.get("zip_read_all_accel_off")
+        accel_on = by_case.get("zip_read_all_accel_on")
+        if accel_off is not None and accel_on is not None:
+            if accel_on.source_seek_count <= accel_off.source_seek_count:
+                failures.append(
+                    f"zip_read_all_accel_on: source_seek_count="
+                    f"{accel_on.source_seek_count} <= accel_off "
+                    f"{accel_off.source_seek_count} (accelerator not engaged?)"
+                )
     return failures
 
 

--- a/benchmarks/harness.py
+++ b/benchmarks/harness.py
@@ -34,6 +34,7 @@ from __future__ import annotations
 
 import argparse
 import gzip
+import importlib.util
 import json
 import shutil
 import sys
@@ -359,12 +360,8 @@ def _unrar_available() -> bool:
 
 
 def _crypto_available() -> bool:
-    try:
-        from archivey.internal.streams.crypto import _crypto_available as _avail
-
-        return bool(_avail())
-    except ImportError:
-        return False
+    """True when the ``cryptography`` package is importable (``[crypto]`` extra)."""
+    return importlib.util.find_spec("cryptography") is not None
 
 
 def run_cases(
@@ -888,7 +885,7 @@ def run_cases(
 
     if rar_data_path is not None:
         rar_path = rar_data_path
-        wall, (bdec, seeks, unpacked) = timed_with_optional_warmup(
+        wall, (bdec, seeks, rar_unpacked) = timed_with_optional_warmup(
             lambda p=rar_path: _op_read_all(p)
         )
         results.append(
@@ -899,7 +896,7 @@ def run_cases(
                 wall,
                 bdec,
                 seeks,
-                unpacked_bytes=unpacked,
+                unpacked_bytes=rar_unpacked,
                 notes=(
                     f"solid invariant: bytes_decompressed <= unpacked * factor "
                     f"({rar_fixture_note})"
@@ -917,7 +914,8 @@ def run_cases(
                 wall,
                 bdec,
                 seeks,
-                unpacked_bytes=unpacked,
+                # Same fixture as sequential; random op does not return unpacked.
+                unpacked_bytes=rar_unpacked,
                 notes=(
                     "smoke + seek baseline; byte re-decode not observable via unrar "
                     f"pipe output (P9) ({rar_fixture_note})"
@@ -1001,9 +999,13 @@ def _structural_checks(
                     )
         # Seek counts: two-sided vs committed baseline ± slack. Upper bound catches
         # silent re-open churn; lower bound catches paths that characteristically
-        # seek *more* silently falling back (e.g. in-ZIP accel ON → OFF).
-        # Missing baseline = skip. Only meaningful against the ci-scale baseline.
-        if check_seek_baselines:
+        # seek *more* silently falling back. Missing baseline = skip. Only
+        # meaningful against the ci-scale baseline.
+        #
+        # Accelerator ON cases are exempt: their seek counts come from rapidgzip
+        # index builds and can drift across rapidgzip versions (all vs all-lowest).
+        # Engagement is gated by the relative ON > OFF check below instead.
+        if check_seek_baselines and not r.case.endswith("_accel_on"):
             ref = cases.get(r.case)
             if ref is not None and "source_seek_count" in ref:
                 baseline_seeks = int(ref["source_seek_count"])
@@ -1020,8 +1022,8 @@ def _structural_checks(
                     )
 
     # In-ZIP accelerator engagement: ON must seek more than OFF on the same
-    # fixture. An upper-only seek bound cannot catch silent non-engagement
-    # (ON regressing to stdlib keeps seeks≈28 inside OFF's upper slack).
+    # fixture. Version-independent signal that rapidgzip actually engaged
+    # (ON regressing to stdlib keeps seeks≈accel_off).
     if check_seek_baselines:
         by_case = {r.case: r for r in results}
         accel_off = by_case.get("zip_read_all_accel_off")

--- a/benchmarks/harness.py
+++ b/benchmarks/harness.py
@@ -21,11 +21,13 @@ Modes:
   artifact (preserving ``measured_at``); a full re-measure is forced at least
   every ~30 days. VISION absolute bands stay informational prints.
 
-Formats covered here: ZIP, TAR, gzip, tar.gz/tar.bz2 (+ accelerators), solid 7z
-(and solid RAR when the ``rar`` writer is available to build fixtures). Listing
-wall peers: ``zipfile`` / ``tarfile`` / ``py7zr`` / ``rarfile`` (Q1 bands). ISO and
-directory backends are instrumented for measurement but deliberately out of
-scope for this harness — see ``benchmarks/tar_iso_lock_baseline.py`` for ISO.
+Formats covered here: ZIP (deflate / LZMA / WinZip AES), TAR, gzip,
+tar.gz/tar.bz2 (+ accelerators), in-ZIP accelerated deflate, solid 7z, and RAR
+data paths on committed fixtures when RARLAB ``unrar`` is present (large solid
+RAR when the ``rar`` writer can build one). Listing wall peers: ``zipfile`` /
+``tarfile`` / ``py7zr`` / ``rarfile`` (Q1 bands). ISO and directory backends are
+instrumented for measurement but deliberately out of scope for this harness —
+see ``benchmarks/tar_iso_lock_baseline.py`` for ISO.
 """
 
 from __future__ import annotations
@@ -44,14 +46,23 @@ from typing import Any, Callable
 
 from archivey import MemberStreams, open_archive
 from archivey.config import AcceleratorMode, ArchiveyConfig
+from archivey.exceptions import PackageNotInstalledError
 from archivey.internal.base_reader import BaseArchiveReader
 from archivey.internal.measurement import enable_measurement
-from benchmarks.fixtures import FixtureSet, materialize_fixtures
+from benchmarks.fixtures import ZIP_AES_PASSWORD, FixtureSet, materialize_fixtures
 from benchmarks.wall_baseline import (
     measurement_provenance,
     overlapping_wall_ratio_count,
     wall_ratio_map,
 )
+
+# Unpacked sizes for the committed solid RAR fixture used at ci scale.
+_RAR_BASIC_UNPACKED = {
+    "file1.txt": 13,
+    "empty_file.txt": 0,
+    "subdir/file2.txt": 16,
+    "implicit_subdir/file3.txt": 12,
+}
 
 ROOT = Path(__file__).resolve().parents[1]
 BASELINES_DIR = Path(__file__).resolve().parent / "baselines"
@@ -133,9 +144,12 @@ def _op_read_all(
     *,
     config: ArchiveyConfig | None = None,
     member_streams: MemberStreams = MemberStreams(0),
+    password: bytes | str | None = None,
 ) -> tuple[int, int, int]:
     with enable_measurement():
-        with open_archive(path, config=config, member_streams=member_streams) as reader:
+        with open_archive(
+            path, config=config, member_streams=member_streams, password=password
+        ) as reader:
             base = _as_base(reader)
             unpacked = 0
             for member, stream in reader.stream_members():
@@ -165,17 +179,22 @@ def _op_read_all_unmeasured(
     *,
     config: ArchiveyConfig | None = None,
     member_streams: MemberStreams = MemberStreams(0),
+    password: bytes | str | None = None,
 ) -> None:
     """Read every member without measurement wrappers — fair wall-time peer."""
-    with open_archive(path, config=config, member_streams=member_streams) as reader:
+    with open_archive(
+        path, config=config, member_streams=member_streams, password=password
+    ) as reader:
         for _member, stream in reader.stream_members():
             if stream is not None:
                 stream.read()
 
 
-def _op_random_read_all(path: Path) -> tuple[int, int]:
+def _op_random_read_all(
+    path: Path, *, password: bytes | str | None = None
+) -> tuple[int, int]:
     with enable_measurement():
-        with open_archive(path) as reader:
+        with open_archive(path, password=password) as reader:
             base = _as_base(reader)
             names = [m.name for m in reader.members() if m.is_file]
             for name in reversed(names):
@@ -335,6 +354,26 @@ def _rapidgzip_available() -> bool:
         return False
 
 
+def _unrar_available() -> bool:
+    """True when RARLAB ``unrar`` is on PATH (needed for RAR *data* cases)."""
+    try:
+        from archivey.internal.backends.rar_unrar import find_rarlab_unrar
+
+        find_rarlab_unrar()
+        return True
+    except PackageNotInstalledError:
+        return False
+
+
+def _crypto_available() -> bool:
+    try:
+        from archivey.internal.streams.crypto import _crypto_available as _avail
+
+        return bool(_avail())
+    except ImportError:
+        return False
+
+
 def run_cases(
     fixtures: FixtureSet,
     work: Path,
@@ -472,6 +511,83 @@ def run_cases(
             wall_ratio=(wall / std_wall) if std_wall > 0 else None,
         )
     )
+
+    # --- ZIP LZMA (native codec path; stdlib zipfile writes, archivey lzma reads) ---
+    _m_wall, (bdec, seeks, unpacked) = timed_with_optional_warmup(
+        lambda: _op_read_all(fixtures.zip_lzma_path)
+    )
+    results.append(
+        CaseResult(
+            "zip_lzma_read_all",
+            "zip",
+            "read_all",
+            _m_wall,
+            bdec,
+            seeks,
+            unpacked_bytes=unpacked,
+            notes="native ZIP LZMA codec; no stdlib peer (zipfile writes only)",
+        )
+    )
+
+    # --- ZIP WinZip AES (VerifyingStream + [crypto]; skip when extra absent) ---
+    if fixtures.zip_aes_path is not None and _crypto_available():
+        aes_path = fixtures.zip_aes_path
+        _m_wall, (bdec, seeks, unpacked) = timed_with_optional_warmup(
+            lambda: _op_read_all(aes_path, password=ZIP_AES_PASSWORD)
+        )
+        results.append(
+            CaseResult(
+                "zip_aes_read_all",
+                "zip",
+                "read_all",
+                _m_wall,
+                bdec,
+                seeks,
+                unpacked_bytes=unpacked,
+                notes="WinZip AES-256 AE-2; requires [crypto]",
+            )
+        )
+
+    # --- In-ZIP accelerated deflate (forced ON/OFF; mirrors tar.gz accelerator cases) ---
+    # AUTO would decline below RAPIDGZIP_AUTO_MIN_COMPRESSED_SIZE; ON exercises the
+    # per-member rapidgzip path that G7 noted was missing from the harness.
+    has_accel = _rapidgzip_available()
+    cfg_zip_off = _accel_config(enabled=False)
+    _m_wall, (bdec, seeks, unpacked) = timed_with_optional_warmup(
+        lambda: _op_read_all(fixtures.zip_path, config=cfg_zip_off)
+    )
+    results.append(
+        CaseResult(
+            "zip_read_all_accel_off",
+            "zip",
+            "read_all",
+            _m_wall,
+            bdec,
+            seeks,
+            unpacked_bytes=unpacked,
+            notes="stdlib deflate codec; accelerators forced OFF",
+        )
+    )
+    if has_accel:
+        cfg_zip_on = _accel_config(enabled=True)
+        seekable = MemberStreams.SEEKABLE
+        _m_wall, (bdec, seeks, unpacked) = timed_with_optional_warmup(
+            lambda: _op_read_all(
+                fixtures.zip_path, config=cfg_zip_on, member_streams=seekable
+            )
+        )
+        results.append(
+            CaseResult(
+                "zip_read_all_accel_on",
+                "zip",
+                "read_all",
+                _m_wall,
+                bdec,
+                seeks,
+                unpacked_bytes=unpacked,
+                notes="rapidgzip accelerator ON for in-ZIP deflate ([seekable])",
+            )
+        )
 
     # --- TAR (plain / uncompressed — harness peer is tarfile r:) ---
     _m_wall, (bdec, seeks) = timed_with_optional_warmup(
@@ -757,10 +873,33 @@ def run_cases(
                 )
             )
 
-    # --- Solid RAR (data path; needs rar writer fixture) ---
-    if fixtures.solid_rar is not None:
+    # --- Solid RAR data path ---
+    # At ci scale always prefer the committed basic_solid fixture so the structural
+    # baseline is stable whether or not the ``rar`` writer is installed (CI has
+    # ``unrar`` only). Realistic scale may use a generated large solid RAR when the
+    # writer built one. Both paths require RARLAB ``unrar`` for member data.
+    rar_data_path: Path | None = None
+    rar_unpacked = 0
+    rar_fixture_note = ""
+    committed_solid = ROOT / "tests" / "fixtures" / "rar" / "basic_solid__.rar"
+    use_generated = (
+        fixtures.scale.name != "ci"
+        and fixtures.solid_rar is not None
+        and _unrar_available()
+    )
+    if use_generated:
+        rar_data_path = fixtures.solid_rar
+        rar_unpacked = fixtures.unpacked_solid_rar
+        rar_fixture_note = "generated solid fixture"
+    elif committed_solid.is_file() and _unrar_available():
+        rar_data_path = committed_solid
+        rar_unpacked = sum(_RAR_BASIC_UNPACKED.values())
+        rar_fixture_note = "committed basic_solid__.rar"
+
+    if rar_data_path is not None:
+        rar_path = rar_data_path
         wall, (bdec, seeks, unpacked) = timed_with_optional_warmup(
-            lambda: _op_read_all(fixtures.solid_rar)  # type: ignore[arg-type]
+            lambda p=rar_path: _op_read_all(p)
         )
         results.append(
             CaseResult(
@@ -770,12 +909,15 @@ def run_cases(
                 wall,
                 bdec,
                 seeks,
-                unpacked_bytes=fixtures.unpacked_solid_rar,
-                notes="solid invariant: bytes_decompressed <= unpacked * factor",
+                unpacked_bytes=rar_unpacked,
+                notes=(
+                    f"solid invariant: bytes_decompressed <= unpacked * factor "
+                    f"({rar_fixture_note})"
+                ),
             )
         )
         wall, (bdec, seeks) = timed_with_optional_warmup(
-            lambda: _op_random_read_all(fixtures.solid_rar)  # type: ignore[arg-type]
+            lambda p=rar_path: _op_random_read_all(p)
         )
         results.append(
             CaseResult(
@@ -785,8 +927,31 @@ def run_cases(
                 wall,
                 bdec,
                 seeks,
-                unpacked_bytes=fixtures.unpacked_solid_rar,
-                notes="re-decode recorded; gated vs baseline×SOLID_RANDOM_BYTES_FACTOR",
+                unpacked_bytes=rar_unpacked,
+                notes=(
+                    "re-decode recorded; gated vs baseline×SOLID_RANDOM_BYTES_FACTOR "
+                    f"({rar_fixture_note}; unrar pipe counts output only)"
+                ),
+            )
+        )
+
+    # --- Encrypted RAR (committed fixture; password + unrar data path) ---
+    enc_rar = ROOT / "tests" / "fixtures" / "rar" / "encryption__.rar"
+    if enc_rar.is_file() and _unrar_available():
+        enc_path = enc_rar
+        wall, (bdec, seeks, unpacked) = timed_with_optional_warmup(
+            lambda p=enc_path: _op_read_all(p, password="password")
+        )
+        results.append(
+            CaseResult(
+                "rar_encrypted_read_all",
+                "rar",
+                "read_all",
+                wall,
+                bdec,
+                seeks,
+                unpacked_bytes=unpacked,
+                notes="committed encryption__.rar; requires RARLAB unrar",
             )
         )
 
@@ -831,7 +996,7 @@ def _structural_checks(
             # read; over-decode catches decode-twice-deliver-once (each open still
             # increments the shared ByteCounter even when only the second handle
             # is delivered to the caller).
-            if r.format in ("zip", "tar", "gzip", "tar.gz", "tar.bz2"):
+            if r.format in ("zip", "tar", "gzip", "tar.gz", "tar.bz2", "rar"):
                 if r.bytes_decompressed < r.unpacked_bytes:
                     failures.append(
                         f"{r.case}: bytes_decompressed={r.bytes_decompressed} "

--- a/review/STATUS.md
+++ b/review/STATUS.md
@@ -45,7 +45,7 @@ Archived OpenSpec this window: `unify-pass-driver`, `gzip-zlib-truncation-recove
 
 | Item | Where |
 |------|-------|
-| T3 / P6 remainder bench-gate RAR / encrypted / in-ZIP accel | this change |
+| T3 / P6 remainder bench-gate RAR / encrypted / in-ZIP accel | this change (+ CI `unrar` on structural gate) |
 | D2 `SECURITY.md` + D7 any-seekable OpenSpec archive | #198 |
 | T2 seek-interleaving XZ / lzip / `.Z` | #199 |
 | D4 `open-issues.md` P1 sweep | #200 |

--- a/review/STATUS.md
+++ b/review/STATUS.md
@@ -1,14 +1,14 @@
-# In-flight review status (2026-07-25)
+# In-flight review status (2026-07-26)
 
-Triage after D2 (`SECURITY.md`) + D7 (any-seekable OpenSpec archive) on top of
-`main` @ `033a883`, then T2 #199 + D4.
+Triage after T3 (bench-gate RAR / encrypted / accel) on top of
+`main` @ `75dbfad` (D4 / T2 / D2 / D7 already landed).
 
 ## At a glance
 
 | Review | Findings delivered? | Code/docs follow-ups | Ready to archive? |
 |--------|---------------------|----------------------|-------------------|
-| `debt-ledger/` | yes (2026-07-20; **refreshed 2026-07-25**) | **DONE:** D1 #191, D2 #198, D3 #193, D4, D7 #198, T2 #199, DD4 #194/#196, S2/S3+T1 #184, Q1–Q5. **Open:** T3/T7, T4 half-test | no |
-| `performance/` | yes (#134 + follow-ups) | residual **accepted aspirational** (#191); wall Q2 decided (#171); **Q4 open** | no |
+| `debt-ledger/` | yes (2026-07-20; **refreshed 2026-07-25**) | **DONE:** D1 #191, D2 #198, D3 #193, D4, D7 #198, T2 #199, T3, DD4 #194/#196, S2/S3+T1 #184, Q1–Q5. **Open:** T7, T4 half-test | no |
+| `performance/` | yes (#134 + follow-ups) | residual **accepted aspirational** (#191); wall Q2 decided (#171); **P6 done** (= T3); **Q4 open** | no |
 
 Archived OpenSpec this window: `unify-pass-driver`, `gzip-zlib-truncation-recovery`,
 `rapidgzip-truncation-investigation` (2026-07-24),
@@ -20,7 +20,6 @@ Archived OpenSpec this window: `unify-pass-driver`, `gzip-zlib-truncation-recove
 
 | ID | Action |
 |----|--------|
-| **T3** | Bench-gate RAR / encrypted / accelerator data |
 | **T7** | Corpus-matrix audit |
 | **T4 half** | Multithread `members_report_if_available` test |
 
@@ -29,7 +28,7 @@ Archived OpenSpec this window: `unify-pass-driver`, `gzip-zlib-truncation-recove
 | ID | Action |
 |----|--------|
 | **P7 residual** | **Accepted** (#191) — nightly ratios in `docs/costs.md`; L5 → `IDEAS.md` |
-| **P6 remainder** | = debt-ledger T3 |
+| **P6 remainder** | **DONE** (= debt-ledger T3) |
 
 ---
 
@@ -46,9 +45,10 @@ Archived OpenSpec this window: `unify-pass-driver`, `gzip-zlib-truncation-recove
 
 | Item | Where |
 |------|-------|
+| T3 / P6 remainder bench-gate RAR / encrypted / in-ZIP accel | this change |
 | D2 `SECURITY.md` + D7 any-seekable OpenSpec archive | #198 |
 | T2 seek-interleaving XZ / lzip / `.Z` | #199 |
-| D4 `open-issues.md` P1 sweep | this change |
+| D4 `open-issues.md` P1 sweep | #200 |
 | D1 VISION/costs peer bands (Q2 (b)) | #191 |
 | D3 CHANGELOG + release checklist (Q5) | #193 |
 | DD4 rapidgzip backstop + any-seekable / Bug-3 | #194 / #196 |

--- a/review/backlog.md
+++ b/review/backlog.md
@@ -5,7 +5,7 @@ round (`debt-ledger`, `performance`). They differ in character and timing:
 
 - **Topics 4 + 5** (test-strategy, structural-cleanliness) — in flight as
   `debt-ledger/` (findings 2026-07-20; **refreshed 2026-07-25** — D1/D2/D3/D7/
-  DD4/S2/S3/T1 paid; remaining D4/T2/T3/T7; see `STATUS.md`).
+  DD4/S2/S3/T1/T2/T3/D4 paid; remaining T7 + T4 half; see `STATUS.md`).
 - **Topic 6** (decode-engine performance) — a later *performance* round, once the
   `stream-layering` wrapper work has landed; mostly independent of it.
   *(stream-layering fusion landed in #137 — Topic 6 is unblocked on that axis.

--- a/review/debt-ledger/SUMMARY.md
+++ b/review/debt-ledger/SUMMARY.md
@@ -15,7 +15,7 @@ Most of the original freeze-cost pay list is paid. **D1** (VISION bands, #191),
 **S2+S3+T1** (#184, archived), **DD1** wall-drift (#171), **DD4** rapidgzip
 truncation (#194/#196), **D7** (OpenSpec sync/archive of the any-seekable
 backstop), **T2** (#199), and **D4** (`open-issues.md` P1) are done. What still
-freezes at release is mainly test-net widenings (**T3/T7**) and the T4 half-test.
+freezes at release is mainly the corpus-matrix audit (**T7**) and the T4 half-test.
 
 **Freeze-rank legend** — F3: frozen at release. F2: compounds. F1: stable cost.
 
@@ -30,7 +30,7 @@ freezes at release is mainly test-net widenings (**T3/T7**) and the T4 half-test
 | **DD6** | Salvage mode absent (founding use case) | PLAN / IDEAS / `--salvage` | **F3**→ok | **KEEP** — sequencing recorded; docs honest |
 | **DD4** | rapidgzip ISIZE backstop under-characterized | was `rapidgzip-truncation-investigation` | **F2** | **DONE** (#194 characterize+impl ADR-0014-safe; #196 any-seekable + Bug-3 trap). Change archived `2026-07-24-rapidgzip-truncation-investigation/` |
 | **T2** | Seek-interleaving property test only for XZ | `test_seekable_streams.py` | **F2** | **DONE** (#199) — parametrized over XZ / lzip / `.Z` |
-| **T3** | Benchmark gate missing RAR / encrypted / accelerator data | `test_benchmark_gate.py` | **F2** | **PAY** (perf P6 remainder) |
+| **T3** | Benchmark gate missing RAR / encrypted / accelerator data | `test_benchmark_gate.py` | **F2** | **DONE** — RAR solid/encrypted + ZIP AES/LZMA + in-ZIP accel cases in structural gate/baseline |
 | **D4** | `open-issues.md` bucket/ref drift (P1 still under candidates) | `docs/internal/open-issues.md` | **F2** | **DONE** — P1 → Closed; archive path + first-cuts fixed |
 | **D7** | Completed OpenSpec changes unarchived / unsynced | see below | **F2** | **DONE** — any-seekable synced into `seekable-decompressor-streams` + archived `2026-07-25-gzip-truncation-backstop-any-seekable/` |
 | **T7** | Corpus matrix thin spots | `sample_archives.py` | **F2** | **PAY** — half-day audit |
@@ -47,9 +47,8 @@ freezes at release is mainly test-net widenings (**T3/T7**) and the T4 half-test
 
 ## The remaining pre-0.2.0 pay list, in order
 
-1. **T3** — benchmark-gate RAR/encrypted/accelerator data cases.
-2. **T7** — corpus-matrix audit.
-3. **T4 (half)** — one `members_report_if_available` multithread barrier test.
+1. **T7** — corpus-matrix audit.
+2. **T4 (half)** — one `members_report_if_available` multithread barrier test.
 
 ## Paid since the ledger was commissioned
 
@@ -66,13 +65,14 @@ freezes at release is mainly test-net widenings (**T3/T7**) and the T4 half-test
 | **D2** `SECURITY.md` + threat-model / checklist links | #198 |
 | **D7** sync + archive `gzip-truncation-backstop-any-seekable` | #198 |
 | **T2** seek-interleaving XZ / lzip / `.Z` | #199 |
-| **D4** `open-issues.md` P1 sweep | this change |
+| **D4** `open-issues.md` P1 sweep | #200 |
+| **T3 / P6 remainder** bench-gate RAR / encrypted / in-ZIP accel | this change |
 
 ## What is actually fine (don't re-review)
 
 - **S1** held; **S2/S3** paid; **S4/ReaderState** rebuilt cleanly.
 - Module splits earning seams; public export tiering deliberate.
 - Docs↔spec↔code sync works through OpenSpec; VISION drift closed by #191.
-- Fuzz architecture coherent; T1 widened solid-RAR intake; T2 done; T7 remain.
+- Fuzz architecture coherent; T1 widened solid-RAR intake; T2/T3 done; T7 remain.
 - Disclosure path documented; OSS-Fuzz may still trail the first public tag.
 - `open-issues.md` P1 Closed; remaining product candidates start at P2.

--- a/review/debt-ledger/tests.md
+++ b/review/debt-ledger/tests.md
@@ -17,9 +17,12 @@ outside mutation → **T7**.
 `test_seek_interleaving_matches_plaintext` parametrized over XZ / lzip / `.Z`
 (unix-compress; `ncompress` gated).
 
-## T3 — benchmark-gate RAR / encrypted / accelerator data (PAY)
+## T3 — benchmark-gate RAR / encrypted / accelerator data — **DONE**
 
-Still no hits in `test_benchmark_gate.py`. Perf P6 remainder. **Open.**
+Structural gate cases for RAR solid/encrypted (committed fixtures + `unrar`),
+WinZip AES ZIP (`[crypto]`), ZIP LZMA, and in-ZIP accelerated deflate
+(`[seekable]`). Omit cleanly when optional deps/binaries are absent. Perf P6
+remainder closed.
 
 ## T4 — free-threaded core-only; `*_if_available` untested under threads
 

--- a/review/performance/SUMMARY.md
+++ b/review/performance/SUMMARY.md
@@ -47,7 +47,7 @@ bounded.
 | P3 | **blocker** | Selective solid-7z extraction decodes ~whole folder for one early member (31× needed bytes); CLI `extract archive.7z <name>` hits it | `sevenzip_reader.py:283-323`, `extraction.py:340` | **fixed by #136** — verified 31.0× → 1.00× |
 | P4 | high | Non-solid re-decompression is invisible to the gate: decode-twice-deliver-once ZIP regression passes (byte axis counts delivered output; seek slack ×2+8 absorbs churn; wall ungated) | `gate-efficacy.md` G4, `repro.py` probe 3 | **fixed by #139** — over-decode ×1.1 bound + seek slack baseline+8; probe CAUGHT |
 | P5 | high | A full 2× solid re-decode passes the gate (`SOLID_DECODE_FACTOR = 2.0`, non-strict bound) — VISION says a re-read must fail | `harness.py:51,526-532`, `repro.py` probe 2 | **fixed by #139** — factor 1.25; probe CAUGHT |
-| P6 | med | Harness has no stdlib peer for open/list/extract (why P2's extract miss went unnoticed); no RAR case in committed baseline; ZIP-AES / native-codec / in-ZIP-accelerated paths unbenchmarked | `gate-efficacy.md` G6/G7 | **partial** — #139 adds ZIP open_list/extract peers; `py7zr`/`rarfile` listing peers + RAR/encrypted/accel still missing |
+| P6 | med | Harness has no stdlib peer for open/list/extract (why P2's extract miss went unnoticed); no RAR case in committed baseline; ZIP-AES / native-codec / in-ZIP-accelerated paths unbenchmarked | `gate-efficacy.md` G6/G7 | **done** — ZIP peers #139; py7zr/rarfile + TAR peers #143; RAR solid/encrypted + ZIP AES/LZMA + in-ZIP accel structural cases (T3) |
 | P7 | med | Per-`open()` 5–8× zipfile (detection + member-model build ~0.3 ms/archive) — the founding million-archive sweep pays minutes | `hotspots.md` H3 | **partial** — #136 caches extension map; model-build toward 2–3× **actionable** (Q1) |
 | P8 | low | rapidgzip AUTO threshold (1 MiB) conservative: seek workloads win ~1.5× well below it; provenance script never measured compressed sizes near 1 MiB | `hotspots.md` H5 | **follow-up** (future) |
 | P9 | low | Measurement blind spots: 7z password-confirm folder decode uncounted; RAR byte axis (unrar pipe output) cannot see solid rewind | `gate-efficacy.md` G6 | **follow-up** (future) |
@@ -117,7 +117,7 @@ parses as a *non-empty* plausible header.
 | P2 | **partial** — large-member ZIP read in budget; many-small / open+list improved (ZIP many-small ~3.7× after L2; 7z open+list ~2.0× after L1) but not yet inside Q1 bands; extract realistic in ~2× band |
 | P3 | **fixed** (#136) |
 | P4 / P5 | **fixed** (#139) |
-| P6 | **partial** — ZIP peers in #139; **py7zr/rarfile + TAR open_list peers added** (#143); RAR/encrypted/accel data cases still missing |
+| P6 | **done** — ZIP peers #139; py7zr/rarfile + TAR open_list #143; RAR/encrypted/accel data cases (T3) |
 | P7 | **partial** — #143 model-build fast paths + #146 L1/L2/L3 listing fixes (`listing-attribution.md`); ZIP open+list still above 2–3×; 7z closer to native band |
 | P8 / P9 | **follow-up** (future / archive-copy) |
 | Q1 | **direction recorded** (#140) — listing peers + ZIP model-build (#143) + L1/L2/L3 from attribution worklist (#146); residual band miss remains |

--- a/review/performance/gate-efficacy.md
+++ b/review/performance/gate-efficacy.md
@@ -20,9 +20,10 @@ prints (shared-runner noise).
 > All three `repro.py` probes now report CAUGHT. **G1 is closed as Q2 option (a)**
 > — nightly wall-ratio drift vs previous JSON (`--wall-drift-baseline`), with
 > skip re-publish + ≥30d forced re-measure. Absolute ≤1.3× stays informational.
-> G6/G7 are partial — #139 added ZIP `open_list`/`extract` stdlib peers, and the
-> Q1 direction (2026-07-18) adds listing-ratio peers (`zipfile`/`tarfile` bands,
-> `py7zr`/`rarfile` parity) to the missing list.
+> G6/G7 are closed for the named coverage gaps — #139/#143 added ZIP/TAR/py7zr/
+> rarfile listing peers; T3 adds RAR solid/encrypted data cases (committed
+> fixtures + ``unrar``), WinZip AES + ZIP LZMA, and in-ZIP accelerated deflate
+> (forced ON/OFF). Absolute ≤1.3× stays informational.
 
 ## G1 — Wall budget: nightly relative drift (done — Q2 (a))
 
@@ -108,37 +109,39 @@ decode-once — `SUMMARY.md`), with the one exception documented in `hotspots.md
 
 - **Seek bounds are loose:** `baseline×2 + 8` lets an 8-member ZIP double its
   per-member seeks and still pass; fixtures are deterministic, so equality (or a
-  small +k) would hold and catch churn G4-style.
+  small +k) would hold and catch churn G4-style. *(Partially tightened to
+  `baseline+8` by #139; residual host jitter remains.)*
 - **`--update-baselines` is self-certifying:** a PR that regresses seeks can ship
   the regressed baseline in the same diff; nothing diffs baselines semantically.
-- **No RAR in the committed baseline** (`structural.json` has no `rar_*` cases —
-  the CI runner lacks the `rar` writer, so those harness cases never run in CI).
-  The RAR decode-once unit test runs on committed fixtures, but:
-- **The RAR byte axis cannot see solid rewind:** bytes are counted on the `unrar p`
-  pipe output, which emits only the requested member — an internal solid re-decode
-  by unrar is invisible by construction (documented in
-  `test_measurement.py:166-169`). Seeks don't help (no archivey-side source
-  seeks). RAR decode-once is therefore *asserted about the pipe protocol*, not
-  measured about work done.
+- **RAR data path is now in the committed baseline (T3):** `rar_solid_sequential`
+  / `rar_solid_random` use committed `basic_solid__.rar` at ci scale (gated on
+  RARLAB `unrar`); `rar_encrypted_read_all` covers `encryption__.rar`. Large
+  generated solid RAR remains realistic-scale-only when the `rar` writer exists.
+- **The RAR byte axis still cannot see solid rewind:** bytes are counted on the
+  `unrar p` pipe output, which emits only the requested member — an internal solid
+  re-decode by unrar is invisible by construction (documented in
+  `test_measurement.py`). Seeks don't help (no archivey-side source seeks). RAR
+  decode-once is therefore *asserted about the pipe protocol*, not measured about
+  work done. (P9 follow-up.)
 - **7z password confirmation decodes whole folders uncounted:**
   `_password_for_folder` runs `open_folder_pipeline` without `_track_decompressed`
-  (`sevenzip_reader.py:550-573`), so an encrypted-solid benchmark case would
-  under-report. No current case is encrypted — worth remembering when adding one.
+  (`sevenzip_reader.py`), so an encrypted-solid benchmark case would under-report.
+  T3 added ZIP AES / encrypted RAR instead of encrypted-solid 7z for that reason.
 
 ## G7 — Coverage: what has no benchmark at all
 
-Confirmed absent from `run_cases` (`harness.py:257-514`) and the committed baseline:
+Confirmed status after T3 (vs `run_cases` / committed `structural.json`):
 
 | Path | Status |
 |------|--------|
-| `open` / `list` vs stdlib peer | wall never compared (only `read_all` gets `stdlib_wall_s`) — how the 5–8× open+list miss stayed invisible |
-| `extract` vs stdlib peer | measured structurally, never against `zipfile.extractall`/`tarfile.extractall` — how the 2.4–3.7× extract miss stayed invisible |
-| RAR read via `unrar` pipe | no CI case (G6) |
-| ZIP AES / native-codec members (#106) | none |
-| Accelerated deflate/zlib *inside ZIP members* (#105) | none — accel cases are single-stream `.tar.gz`/`.tar.bz2` only; the per-member AUTO gate behaviour (`hotspots.md` H5) is untested by the harness |
+| `open` / `list` vs stdlib peer | **done** (#139/#143) — ZIP/TAR/py7zr/rarfile peers |
+| `extract` vs stdlib peer | **done** (#139) — ZIP extract peer |
+| RAR read via `unrar` pipe | **done** (T3) — solid + encrypted committed fixtures |
+| ZIP AES / native-codec members (#106) | **done** (T3) — `zip_aes_read_all`, `zip_lzma_read_all` |
+| Accelerated deflate/zlib *inside ZIP members* (#105) | **done** (T3) — `zip_read_all_accel_{off,on}` |
 | ISO | non-gating side script only (`tar_iso_lock_baseline.py`, documented choice) |
-| Encrypted / VerifyingStream-heavy paths | none |
+| Encrypted / VerifyingStream-heavy paths | **done** (T3) — ZIP AES + encrypted RAR |
 
-Suggested minimum additions before 0.2.0: stdlib peers for open+list and extract
-(both cheap), and one RAR read case gated on committed fixtures + `unrar`
-availability.
+Remaining out of scope / follow-up: ISO gating (deliberate), encrypted-solid 7z
+byte under-count (P9), absolute wall ≤1.3× on the PR path (deliberate; nightly
+drift only).

--- a/review/performance/gate-efficacy.md
+++ b/review/performance/gate-efficacy.md
@@ -107,10 +107,11 @@ decode-once — `SUMMARY.md`), with the one exception documented in `hotspots.md
 
 ## G6 — Baseline meaningfulness and measurement blind spots
 
-- **Seek bounds are loose:** `baseline×2 + 8` lets an 8-member ZIP double its
-  per-member seeks and still pass; fixtures are deterministic, so equality (or a
-  small +k) would hold and catch churn G4-style. *(Partially tightened to
-  `baseline+8` by #139; residual host jitter remains.)*
+- **Seek bounds are two-sided:** committed baseline ± `SEEK_BASELINE_SLACK` (8).
+  Upper bound catches silent re-open churn; lower bound catches paths that
+  characteristically seek more silently falling back (in-ZIP accel ON→OFF).
+  Additionally `zip_read_all_accel_on` must seek strictly more than
+  `zip_read_all_accel_off` on the same fixture.
 - **`--update-baselines` is self-certifying:** a PR that regresses seeks can ship
   the regressed baseline in the same diff; nothing diffs baselines semantically.
 - **RAR data path is now in the committed baseline (T3):** `rar_solid_sequential`

--- a/tests/test_accelerator_bug3_trap.py
+++ b/tests/test_accelerator_bug3_trap.py
@@ -27,13 +27,33 @@ import gzip, io, os, rapidgzip
 full = gzip.compress(os.urandom(20_000_000))
 
 class Src(io.RawIOBase):
-    def __init__(self, data): self._b = io.BytesIO(data)
+    def __init__(self, data):
+        self._b = io.BytesIO(data)
+        self._served = 0
+        self.fail_after = None  # raise after this many compressed bytes (trapped path)
+        self._dead = False
     def readable(self): return True
     def seekable(self): return True
     def seek(self, o, w=0): return self._b.seek(o, w)
     def tell(self): return self._b.tell()
-    def readinto(self, buf): return self._b.readinto(buf)
-    def kill(self): self._b.close()   # close the underlying source underneath the accelerator
+    def readinto(self, buf):
+        if self._dead:
+            raise ValueError("I/O operation on closed file")
+        # Deterministic mid-decode fault: do not rely on "close then hope the next
+        # stream.read() still needs the source". rapidgzip may already hold a decoded
+        # window large enough that one subsequent read() never touches the source
+        # (observed as RAISED None on macOS / Python 3.14 CI).
+        if self.fail_after is not None and self._served >= self.fail_after:
+            self._dead = True
+            self._b.close()
+            raise ValueError("I/O operation on closed file")
+        n = self._b.readinto(buf)
+        if n:
+            self._served += n
+        return n
+    def kill(self):
+        self._dead = True
+        self._b.close()   # close the underlying source underneath the accelerator
 """
 
 _UNTRAPPED = _SETUP + textwrap.dedent(
@@ -58,9 +78,10 @@ _TRAPPED = _SETUP + textwrap.dedent(
     """
     from archivey.internal.streams.codecs import _open_rapidgzip
     src = Src(full)
+    # Fault on the next source pull after ~64 KiB compressed — well after open/header,
+    # well before the 20 MiB payload is exhausted, so decode must observe it.
+    src.fail_after = 64 * 1024
     stream = _open_rapidgzip(src)                 # archivey: _TrappingSource + _AcceleratorStream
-    stream.read(1024)
-    src.kill()
     raised = None
     try:
         stream.read()

--- a/tests/test_benchmark_gate.py
+++ b/tests/test_benchmark_gate.py
@@ -10,7 +10,10 @@ import pytest
 from benchmarks.fixtures import materialize_fixtures
 from benchmarks.harness import (
     STRUCTURAL_BASELINE,
+    _crypto_available,
+    _rapidgzip_available,
     _structural_checks,
+    _unrar_available,
     load_json,
     run_cases,
 )
@@ -25,15 +28,29 @@ def test_benchmark_structural_gate(tmp_path: Path) -> None:
     work = tmp_path / "work"
     work.mkdir()
     results = run_cases(fixtures, work)
-    # Ensure the solid sequential case ran when 7z is available.
-    sequential = [r for r in results if r.case == "sevenzip_solid_sequential"]
-    assert sequential, "expected sevenzip_solid_sequential case"
-    assert sequential[0].bytes_decompressed <= (sequential[0].unpacked_bytes or 0) * 2
+    by_case = {r.case: r for r in results}
 
-    random = [r for r in results if r.case == "sevenzip_solid_random"]
-    assert random
+    # Ensure the solid sequential case ran when 7z is available.
+    sequential = by_case.get("sevenzip_solid_sequential")
+    assert sequential is not None, "expected sevenzip_solid_sequential case"
+    assert sequential.bytes_decompressed <= (sequential.unpacked_bytes or 0) * 2
+
+    random = by_case.get("sevenzip_solid_random")
+    assert random is not None
     # Random opens re-decode; recorded, not failed — but must be visible.
-    assert random[0].bytes_decompressed >= sequential[0].bytes_decompressed
+    assert random.bytes_decompressed >= sequential.bytes_decompressed
+
+    # T3 / perf P6: RAR data, encrypted, and in-ZIP accelerator cases when deps exist.
+    if _unrar_available():
+        assert "rar_solid_sequential" in by_case
+        assert "rar_solid_random" in by_case
+        assert "rar_encrypted_read_all" in by_case
+    if _crypto_available() and fixtures.zip_aes_path is not None:
+        assert "zip_aes_read_all" in by_case
+    assert "zip_lzma_read_all" in by_case
+    assert "zip_read_all_accel_off" in by_case
+    if _rapidgzip_available():
+        assert "zip_read_all_accel_on" in by_case
 
     failures = _structural_checks(results, load_json(STRUCTURAL_BASELINE))
     assert not failures, "structural gate failures:\n" + "\n".join(failures)
@@ -42,7 +59,19 @@ def test_benchmark_structural_gate(tmp_path: Path) -> None:
 def test_structural_baseline_committed() -> None:
     assert STRUCTURAL_BASELINE.is_file()
     data = json.loads(STRUCTURAL_BASELINE.read_text())
-    assert "sevenzip_solid_sequential" in data["cases"]
+    cases = data["cases"]
+    assert "sevenzip_solid_sequential" in cases
+    # P6 remainder / T3 coverage must stay in the committed ci baseline.
+    for name in (
+        "rar_solid_sequential",
+        "rar_solid_random",
+        "rar_encrypted_read_all",
+        "zip_aes_read_all",
+        "zip_lzma_read_all",
+        "zip_read_all_accel_off",
+        "zip_read_all_accel_on",
+    ):
+        assert name in cases, f"missing structural baseline case {name}"
 
 
 def test_format_text_report_table() -> None:

--- a/tests/test_benchmark_gate.py
+++ b/tests/test_benchmark_gate.py
@@ -58,8 +58,9 @@ def test_benchmark_structural_gate(tmp_path: Path) -> None:
     if missing_rar and (_running_in_ci() or _unrar_available()):
         pytest.fail(
             "RAR data cases missing from structural run: "
-            f"{missing_rar}. Install RARLAB unrar "
-            "(ci.yml / benchmark-wall.yml must apt-get install unrar)."
+            f"{missing_rar}. Install RARLAB unrar on PATH "
+            "(ci.yml matrix installs apt/brew-cask/choco unrar; "
+            "benchmark jobs apt-get install unrar on Linux)."
         )
 
     if _crypto_available() and fixtures.zip_aes_path is not None:

--- a/tests/test_benchmark_gate.py
+++ b/tests/test_benchmark_gate.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
 import pytest
@@ -10,6 +11,7 @@ import pytest
 from benchmarks.fixtures import materialize_fixtures
 from benchmarks.harness import (
     STRUCTURAL_BASELINE,
+    CaseResult,
     _crypto_available,
     _rapidgzip_available,
     _structural_checks,
@@ -17,6 +19,16 @@ from benchmarks.harness import (
     load_json,
     run_cases,
 )
+
+_RAR_DATA_CASES = (
+    "rar_solid_sequential",
+    "rar_solid_random",
+    "rar_encrypted_read_all",
+)
+
+
+def _running_in_ci() -> bool:
+    return os.environ.get("CI", "").lower() in ("1", "true", "yes")
 
 
 @pytest.mark.timeout(120)
@@ -40,17 +52,27 @@ def test_benchmark_structural_gate(tmp_path: Path) -> None:
     # Random opens re-decode; recorded, not failed — but must be visible.
     assert random.bytes_decompressed >= sequential.bytes_decompressed
 
-    # T3 / perf P6: RAR data, encrypted, and in-ZIP accelerator cases when deps exist.
-    if _unrar_available():
-        assert "rar_solid_sequential" in by_case
-        assert "rar_solid_random" in by_case
-        assert "rar_encrypted_read_all" in by_case
+    # T3 / perf P6: RAR data cases. Soft locally without unrar; fail-closed in CI
+    # (and whenever unrar is present) so a missing binary cannot silently omit them.
+    missing_rar = [name for name in _RAR_DATA_CASES if name not in by_case]
+    if missing_rar and (_running_in_ci() or _unrar_available()):
+        pytest.fail(
+            "RAR data cases missing from structural run: "
+            f"{missing_rar}. Install RARLAB unrar "
+            "(ci.yml / benchmark-wall.yml must apt-get install unrar)."
+        )
+
     if _crypto_available() and fixtures.zip_aes_path is not None:
         assert "zip_aes_read_all" in by_case
     assert "zip_lzma_read_all" in by_case
     assert "zip_read_all_accel_off" in by_case
     if _rapidgzip_available():
         assert "zip_read_all_accel_on" in by_case
+        # Engagement signal: ON seeks more than OFF on the same deflate ZIP.
+        assert (
+            by_case["zip_read_all_accel_on"].source_seek_count
+            > by_case["zip_read_all_accel_off"].source_seek_count
+        )
 
     failures = _structural_checks(results, load_json(STRUCTURAL_BASELINE))
     assert not failures, "structural gate failures:\n" + "\n".join(failures)
@@ -72,6 +94,48 @@ def test_structural_baseline_committed() -> None:
         "zip_read_all_accel_on",
     ):
         assert name in cases, f"missing structural baseline case {name}"
+
+
+def test_seek_baseline_is_two_sided() -> None:
+    """Lower seek bound catches silent non-engagement (accel ON → OFF seeks)."""
+    baseline = {
+        "cases": {
+            "zip_read_all_accel_on": {
+                "bytes_decompressed": 32768,
+                "source_seek_count": 44,
+                "unpacked_bytes": 32768,
+            },
+            "zip_read_all_accel_off": {
+                "bytes_decompressed": 32768,
+                "source_seek_count": 28,
+                "unpacked_bytes": 32768,
+            },
+        }
+    }
+    # Silent non-engagement: ON case reports OFF-like seeks.
+    fake_on = CaseResult(
+        case="zip_read_all_accel_on",
+        format="zip",
+        operation="read_all",
+        wall_s=0.0,
+        bytes_decompressed=32768,
+        source_seek_count=28,
+        unpacked_bytes=32768,
+    )
+    fake_off = CaseResult(
+        case="zip_read_all_accel_off",
+        format="zip",
+        operation="read_all",
+        wall_s=0.0,
+        bytes_decompressed=32768,
+        source_seek_count=28,
+        unpacked_bytes=32768,
+    )
+    failures = _structural_checks([fake_off, fake_on], baseline)
+    assert any("zip_read_all_accel_on" in f for f in failures)
+    assert any(
+        "below baseline" in f or "accelerator not engaged" in f for f in failures
+    )
 
 
 def test_format_text_report_table() -> None:

--- a/tests/test_benchmark_gate.py
+++ b/tests/test_benchmark_gate.py
@@ -54,6 +54,8 @@ def test_benchmark_structural_gate(tmp_path: Path) -> None:
 
     # T3 / perf P6: RAR data cases. Soft locally without unrar; fail-closed in CI
     # (and whenever unrar is present) so a missing binary cannot silently omit them.
+    # Reached only when py7zr is present (importorskip above); the CI matrix
+    # co-installs unrar on those same legs (--group dev + workflow apt/brew/choco).
     missing_rar = [name for name in _RAR_DATA_CASES if name not in by_case]
     if missing_rar and (_running_in_ci() or _unrar_available()):
         pytest.fail(
@@ -97,8 +99,13 @@ def test_structural_baseline_committed() -> None:
         assert name in cases, f"missing structural baseline case {name}"
 
 
-def test_seek_baseline_is_two_sided() -> None:
-    """Lower seek bound catches silent non-engagement (accel ON → OFF seeks)."""
+def test_accel_engagement_is_relative_not_absolute() -> None:
+    """Accel ON engagement uses ON > OFF; absolute ±slack does not apply to *_accel_on.
+
+    rapidgzip seek counts can drift across versions (all vs all-lowest), so the
+    absolute two-sided bound would be a false-failure risk. Non-engagement is
+    caught by the relative check instead.
+    """
     baseline = {
         "cases": {
             "zip_read_all_accel_on": {
@@ -133,10 +140,22 @@ def test_seek_baseline_is_two_sided() -> None:
         unpacked_bytes=32768,
     )
     failures = _structural_checks([fake_off, fake_on], baseline)
-    assert any("zip_read_all_accel_on" in f for f in failures)
-    assert any(
-        "below baseline" in f or "accelerator not engaged" in f for f in failures
+    assert any("accelerator not engaged" in f for f in failures)
+    # Absolute lower bound must not fire on *_accel_on (engagement check only).
+    assert not any("below baseline" in f for f in failures)
+
+    # Version-drift-shaped seeks still pass absolute checks when ON > OFF.
+    drifted_on = CaseResult(
+        case="zip_read_all_accel_on",
+        format="zip",
+        operation="read_all",
+        wall_s=0.0,
+        bytes_decompressed=32768,
+        source_seek_count=60,  # well above baseline+8
+        unpacked_bytes=32768,
     )
+    failures = _structural_checks([fake_off, drifted_on], baseline)
+    assert failures == []
 
 
 def test_format_text_report_table() -> None:

--- a/tests/test_zip_aes.py
+++ b/tests/test_zip_aes.py
@@ -2,14 +2,11 @@
 
 from __future__ import annotations
 
-import hashlib
-import hmac
 import io
 import os
 import struct
 import subprocess
 import zipfile
-import zlib
 from pathlib import Path
 
 import pytest
@@ -20,34 +17,13 @@ from archivey.exceptions import (
     EncryptionError,
     PackageNotInstalledError,
 )
-from archivey.internal.zip_aes import (
-    WinZipAesInfo,
-    derive_winzip_aes_keys,
-    parse_winzip_aes_extra,
-)
+from archivey.internal.zip_aes import parse_winzip_aes_extra
 from archivey.types import CompressionAlgorithm, HashAlgorithm
 from tests.conftest import requires, requires_binary
+from tests.zip_aes_fixture import build_aes_zip
 
 _PASSWORD = b"secret"
 _PAYLOAD = b"winzip-aes-payload\n" * 40
-
-
-def _aes_ctr_le_encrypt(key: bytes, plaintext: bytes) -> bytes:
-    from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
-
-    encryptor = Cipher(algorithms.AES(key), modes.ECB()).encryptor()
-    out = bytearray(len(plaintext))
-    counter = 1
-    keystream = b""
-    pos = 0
-    for i, byte in enumerate(plaintext):
-        if pos >= len(keystream):
-            keystream = encryptor.update(counter.to_bytes(16, "little"))
-            pos = 0
-            counter += 1
-        out[i] = byte ^ keystream[pos]
-        pos += 1
-    return bytes(out)
 
 
 def _build_aes_zip(
@@ -60,68 +36,15 @@ def _build_aes_zip(
     name: bytes = b"secret.txt",
     tamper_hmac: bool = False,
 ) -> bytes:
-    """Hand-build a single-entry WinZip AES ZIP (AE-1 or AE-2)."""
-    aes = WinZipAesInfo(vendor_version, strength, method)
-    if method == 0:
-        compressed = payload
-    elif method == 8:
-        compressed = zlib.compress(payload)[2:-4]  # raw deflate
-    else:
-        raise ValueError(f"unsupported test method {method}")
-
-    salt = os.urandom(aes.salt_len)
-    enc_key, auth_key, pw_verify = derive_winzip_aes_keys(
-        password, salt=salt, key_len=aes.key_len
+    """Single-entry wrapper around the shared AES ZIP builder."""
+    return build_aes_zip(
+        [(name, payload)],
+        password=password,
+        vendor_version=vendor_version,
+        strength=strength,
+        method=method,
+        tamper_hmac=tamper_hmac,
     )
-    ciphertext = _aes_ctr_le_encrypt(enc_key, compressed)
-    mac = bytearray(hmac.new(auth_key, ciphertext, hashlib.sha1).digest()[:10])
-    if tamper_hmac:
-        mac[0] ^= 0xFF
-    body = salt + pw_verify + ciphertext + bytes(mac)
-
-    crc = 0 if vendor_version == 2 else (zlib.crc32(payload) & 0xFFFFFFFF)
-    aes_extra = struct.pack("<H2sBH", vendor_version, b"AE", strength, method)
-    extra = struct.pack("<HH", 0x9901, len(aes_extra)) + aes_extra
-
-    flags = 0x1  # encrypted
-    local = struct.pack(
-        "<IHHHHHIIIHH",
-        0x04034B50,
-        51,  # version needed (AES)
-        flags,
-        99,
-        0,
-        0,
-        crc,
-        len(body),
-        len(payload),
-        len(name),
-        len(extra),
-    )
-    local += name + extra + body
-    cd = struct.pack(
-        "<IHHHHHHIIIHHHHHII",
-        0x02014B50,
-        51,
-        51,
-        flags,
-        99,
-        0,
-        0,
-        crc,
-        len(body),
-        len(payload),
-        len(name),
-        len(extra),
-        0,
-        0,
-        0,
-        0,
-        0,
-    )
-    cd += name + extra
-    eocd = struct.pack("<IHHHHIIH", 0x06054B50, 0, 0, 1, 1, len(cd), len(local), 0)
-    return local + cd + eocd
 
 
 def _7z_aes_zip(tmp_path: Path, *, strength: str = "AES256") -> tuple[Path, bytes]:

--- a/tests/zip_aes_fixture.py
+++ b/tests/zip_aes_fixture.py
@@ -1,0 +1,135 @@
+"""Shared WinZip AES ZIP builders for tests and the benchmark harness.
+
+Hand-rolls AE-1 / AE-2 method-99 members (stdlib ``zipfile`` cannot write AES).
+Kept next to :mod:`tests.zipcrypto` as fixture scaffolding — not a public writer.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import os
+import struct
+import zlib
+from collections.abc import Sequence
+
+from archivey.internal.zip_aes import WinZipAesInfo, derive_winzip_aes_keys
+
+
+def aes_ctr_le_encrypt(key: bytes, plaintext: bytes) -> bytes:
+    """WinZip AES counter mode: little-endian block counter starting at 1."""
+    from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+
+    encryptor = Cipher(algorithms.AES(key), modes.ECB()).encryptor()
+    out = bytearray(len(plaintext))
+    keystream = b""
+    pos = 0
+    counter = 1
+    for i, byte in enumerate(plaintext):
+        if pos >= len(keystream):
+            keystream = encryptor.update(counter.to_bytes(16, "little"))
+            pos = 0
+            counter += 1
+        out[i] = byte ^ keystream[pos]
+        pos += 1
+    return bytes(out)
+
+
+def build_aes_zip(
+    members: Sequence[tuple[bytes, bytes]],
+    *,
+    password: bytes,
+    vendor_version: int = 2,
+    strength: int = 3,
+    method: int = 8,
+    tamper_hmac: bool = False,
+) -> bytes:
+    """Build a WinZip AES ZIP from ``(name, payload)`` members.
+
+    ``tamper_hmac`` flips a byte in the first member's AES HMAC (for corruption
+    tests). AE-2 (``vendor_version=2``) stores CRC 0 in the headers; AE-1 stores
+    the plaintext CRC.
+    """
+    if not members:
+        raise ValueError("build_aes_zip requires at least one member")
+    if method not in (0, 8):
+        raise ValueError(f"unsupported underlying method {method}")
+
+    aes = WinZipAesInfo(vendor_version, strength, method)
+    locals_blob = bytearray()
+    central = bytearray()
+
+    for index, (name, payload) in enumerate(members):
+        if method == 0:
+            compressed = payload
+        else:
+            compressed = zlib.compress(payload)[2:-4]  # raw deflate
+        salt = os.urandom(aes.salt_len)
+        enc_key, auth_key, pw_verify = derive_winzip_aes_keys(
+            password, salt=salt, key_len=aes.key_len
+        )
+        ciphertext = aes_ctr_le_encrypt(enc_key, compressed)
+        mac = bytearray(hmac.new(auth_key, ciphertext, hashlib.sha1).digest()[:10])
+        if tamper_hmac and index == 0:
+            mac[0] ^= 0xFF
+        body = salt + pw_verify + ciphertext + bytes(mac)
+        crc = 0 if vendor_version == 2 else (zlib.crc32(payload) & 0xFFFFFFFF)
+        aes_extra = struct.pack("<H2sBH", vendor_version, b"AE", strength, method)
+        extra = struct.pack("<HH", 0x9901, len(aes_extra)) + aes_extra
+        flags = 0x1  # encrypted
+        offset = len(locals_blob)
+        local = struct.pack(
+            "<IHHHHHIIIHH",
+            0x04034B50,
+            51,  # version needed (AES)
+            flags,
+            99,
+            0,
+            0,
+            crc,
+            len(body),
+            len(payload),
+            len(name),
+            len(extra),
+        )
+        locals_blob.extend(local)
+        locals_blob.extend(name)
+        locals_blob.extend(extra)
+        locals_blob.extend(body)
+        cd = struct.pack(
+            "<IHHHHHHIIIHHHHHII",
+            0x02014B50,
+            51,
+            51,
+            flags,
+            99,
+            0,
+            0,
+            crc,
+            len(body),
+            len(payload),
+            len(name),
+            len(extra),
+            0,
+            0,
+            0,
+            0,
+            offset,
+        )
+        central.extend(cd)
+        central.extend(name)
+        central.extend(extra)
+
+    n = len(members)
+    eocd = struct.pack(
+        "<IHHHHIIH",
+        0x06054B50,
+        0,
+        0,
+        n,
+        n,
+        len(central),
+        len(locals_blob),
+        0,
+    )
+    return bytes(locals_blob) + bytes(central) + eocd


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Pays debt-ledger **T3** (= performance **P6** remainder): extend the structural benchmark gate so CI can catch regressions on RAR data, encrypted, and in-ZIP accelerator paths.

### New structural cases

| Case | Path | Skip when absent |
|------|------|------------------|
| `rar_solid_sequential` / `rar_solid_random` | committed `basic_solid__.rar` at ci scale | RARLAB `unrar` |
| `rar_encrypted_read_all` | committed `encryption__.rar` | RARLAB `unrar` |
| `zip_aes_read_all` | generated WinZip AES-256 AE-2 fixture | `[crypto]` |
| `zip_lzma_read_all` | generated ZIP LZMA members | (always) |
| `zip_read_all_accel_off` / `zip_read_all_accel_on` | in-ZIP deflate with forced accelerator mode | `[seekable]` / rapidgzip for ON |

Optional-dep cases omit cleanly locally/core-only. On **CI**, the structural `benchmark` job (and wall nightly) install RARLAB `unrar`, and pytest **fail-closes** if baseline RAR data cases are missing.

### Review follow-ups (code-review of this PR)

- Install `unrar` on structural `benchmark` + `benchmark-wall` jobs (RAR cases now present in CI artifact)
- Fail-closed RAR data cases when `CI=true` (or unrar present but cases omitted)
- Two-sided seek baselines (`baseline ± slack`) + `zip_read_all_accel_on` seeks must exceed `_off`
- Shared `tests/zip_aes_fixture.py` (tests + harness); measured RAR `unpacked_bytes` (no hardcoded size table)
- Softened `rar_solid_random` notes / RESULTS (smoke + seek; byte re-decode is P9)

Marked T3 / P6 done in `review/STATUS.md`, `review/debt-ledger/`, and `review/performance/` (G6/G7).

## Test plan

- [x] `uv run --no-sync python -m benchmarks.harness --mode structural`
- [x] `uv run --no-sync pytest tests/test_benchmark_gate.py tests/test_measurement.py -q`
- [x] `ruff` / `pyrefly` / `ty` clean
- [x] CI structural `benchmark` job green with `rar_solid_*` + `rar_encrypted_read_all` in artifact

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b60169a6-aac3-43d6-a621-bd8e3b13bfde"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b60169a6-aac3-43d6-a621-bd8e3b13bfde"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

