### PR TITLE
docs: reshape /code-review output for maintainer skim + implementor paste

### DIFF
--- a/.claude/skills/code-review-skill/SKILL.md
+++ b/.claude/skills/code-review-skill/SKILL.md
@@ -42,9 +42,10 @@ Transform code reviews from gatekeeping to knowledge sharing through constructiv
 > `/code-review-skill` **report findings**; they do **not** modify code unless you
 > explicitly ask. Emit the addendum **§0 output shape**: (1) maintainer briefing,
 > (2) copy-paste implementor handoff with findings ranked by **severity × confidence**,
-> (3) maintainer decisions. Output is markdown prose, not a host-specific findings tool.
-> This holds however the skill is invoked (Cursor command or `Skill`). Reviewing an
-> OpenSpec proposal rather than code? Use
+> (3) maintainer decisions. **Brevity is presentation-only** for blocks 1 and 3 — do not
+> shrink pass depth or block 2 specificity (see §0 brevity fence). Output is markdown
+> prose, not a host-specific findings tool. This holds however the skill is invoked
+> (Cursor command or `Skill`). Reviewing an OpenSpec proposal rather than code? Use
 > [addendum §9](reference/archivey-review-addendum.md) (values-first), not the code-first
 > order — same three-block output.
 

--- a/.claude/skills/code-review-skill/SKILL.md
+++ b/.claude/skills/code-review-skill/SKILL.md
@@ -38,14 +38,15 @@ Transform code reviews from gatekeeping to knowledge sharing through constructiv
 > wires `/code-review` to this skill + addendum (findings-first defaults + archivey
 > process). Invoking `/code-review-skill` also loads this skill directly.
 >
-> **Repo default — findings first, no edits:** in archivey, `/code-review` and
+> **Repo default — three-block report, no edits:** in archivey, `/code-review` and
 > `/code-review-skill` **report findings**; they do **not** modify code unless you
-> explicitly ask. Lead with findings ranked by **severity × confidence** (see
-> [addendum §0](reference/archivey-review-addendum.md)); output is markdown prose, not a
-> host-specific findings tool. This holds however the skill is invoked (Cursor command or
-> `Skill`). Reviewing an OpenSpec proposal rather than code? Use
+> explicitly ask. Emit the addendum **§0 output shape**: (1) maintainer briefing,
+> (2) copy-paste implementor handoff with findings ranked by **severity × confidence**,
+> (3) maintainer decisions. Output is markdown prose, not a host-specific findings tool.
+> This holds however the skill is invoked (Cursor command or `Skill`). Reviewing an
+> OpenSpec proposal rather than code? Use
 > [addendum §9](reference/archivey-review-addendum.md) (values-first), not the code-first
-> order.
+> order — same three-block output.
 
 ## When to Use This Skill
 
@@ -139,7 +140,8 @@ Transform code reviews from gatekeeping to knowledge sharing through constructiv
    designs yet)
 
 Then run Phases 2–3 as **pass 1 (code alone)**. Open the PR narrative, OpenSpec
-change, and contracts as **pass 2** per addendum §8 before writing the verdict.
+change, and contracts as **pass 2** per addendum §8 before writing the
+**three-block §0 report**.
 
 > For large diffs, pipe the diff through [`scripts/pr-analyzer.py`](scripts/pr-analyzer.py) (`git diff main...HEAD | python scripts/pr-analyzer.py`) to triage complexity and get a suggested review approach before reading.
 
@@ -164,6 +166,12 @@ For each file, check:
 - **Reuse** - Before accepting new code, search for existing utilities/helpers that could replace it. Check adjacent files and shared modules for similar patterns. See [Universal Quality Guide](reference/code-quality-universal.md) for anti-patterns like parameter sprawl, leaky abstractions, nested conditionals, stringly-typed code, TOCTOU, and no-op updates.
 
 ### Phase 4: Summary & Decision (2-3 minutes)
+
+> **Archivey override:** Do **not** emit a free-form “summary then findings” write-up.
+> Use the addendum’s **§0 three-block output**: (1) Maintainer briefing, (2) Implementor
+> handoff (copy-paste ready), (3) Maintainer decisions. Verdict lives in blocks 1 and 2.
+
+For non-archivey use of this skill:
 
 1. Summarize key concerns
 2. Highlight what you liked

--- a/.claude/skills/code-review-skill/SKILL.md
+++ b/.claude/skills/code-review-skill/SKILL.md
@@ -171,6 +171,7 @@ For each file, check:
 > **Archivey override:** Do **not** emit a free-form “summary then findings” write-up.
 > Use the addendum’s **§0 three-block output**: (1) Maintainer briefing, (2) Implementor
 > handoff (copy-paste ready), (3) Maintainer decisions. Verdict lives in blocks 1 and 2.
+> Honor the §0 **brevity fence** — short blocks 1/3 must not thin the review or block 2.
 
 For non-archivey use of this skill:
 

--- a/.claude/skills/code-review-skill/assets/pr-review-template.md
+++ b/.claude/skills/code-review-skill/assets/pr-review-template.md
@@ -1,83 +1,84 @@
 # PR Review Template
 
 Copy and use this template for code reviews in this repo.
+Matches [addendum §0 output shape](../reference/archivey-review-addendum.md).
 
 ---
 
-## Summary
+## 1. Maintainer briefing (read this first)
 
-[Brief overview of what was reviewed — 1-2 sentences]
+**What this change is**
 
-**PR Size:** [Small/Medium/Large] (~X lines)
-**Review Time:** [X minutes]
+[2–4 sentences: intent, areas touched, behaviour delta — readable without the diff]
 
-## Strengths
+**Snapshot**
 
-- [What was done well]
-- [Good patterns or approaches used]
-- [Improvements from previous code]
+- **PR size:** [Small/Medium/Large] (~X lines)
+- **Gates:** [ruff / pyrefly / ty / pytest — if known]
+- **Verdict:** [✅ Approve / 💬 Comment / 🔄 Request Changes]
 
-## Architecture & Performance
+**Main points**
 
-**Architecture Assessment**
-- [ ] Separation of concerns — responsibilities clearly divided?
-- [ ] Fits existing reader/backend patterns?
-- [ ] Dependency direction toward stable abstractions?
-- [ ] Public API / exception contract preserved or intentionally changed?
+- 🔴/🟡 [one-sentence gist]
+- …
 
-> See [Architecture Review Guide](../reference/architecture-review-guide.md).
+**What’s fine** (optional)
 
-**Performance Assessment**
-- [ ] Algorithm / member-loop complexity acceptable?
-- [ ] Memory — streaming vs full buffers; unbounded growth?
-- [ ] I/O — avoid silent re-decompression / redundant reads?
+- [Load-bearing thing that looked correct]
 
-> See [Performance Review Guide](../reference/performance-review-guide.md).
+---
 
-## Required Changes
+## 2. Implementor handoff (copy-paste ready)
 
-🔴 **[blocking]** [Issue description]
-> [Code location or example]
-> [Suggested fix or explanation]
+**Context:** [PR # / branch / scope — so this paste stands alone]
 
-## Important Suggestions
+### Required changes
 
-🟡 **[important]** [Issue description]
-> [Why this matters]
-> [Suggested approach]
+🔴 **[blocking]** `CONFIRMED|PLAUSIBLE` — [Title]
 
-## Minor Suggestions
+**Location:** `path/to/file.py:123`
 
-🟢 **[nit]** [Minor improvement suggestion]
+[What’s wrong and why it matters]
 
-💡 **[suggestion]** [Alternative approach to consider]
+**Suggested fix:** [concrete direction]
 
-## Learning Notes
+**Trigger:** [input/state → failure], or needs-repro
 
-📚 [Educational context]
+### Important suggestions
 
-## Security Considerations
+🟡 **[important]** `CONFIRMED|PLAUSIBLE` — [Title]
 
-- [ ] No hardcoded secrets
-- [ ] Extract path / symlink safety considered
-- [ ] Hostile size / bomb risks considered
-- [ ] Subprocess usage is safe (no shell interpolation)
-- [ ] Passwords / key material not leaked in logs/errors
-- [ ] Dependency / extra changes justified for zero-dep core
+**Location:** `path/to/file.py:123`
 
-> See [Security Review Guide](../reference/security-review-guide.md).
+[Why this matters]
 
-## Test Coverage
+**Consider:**
+- Option A: [description]
+- Option B: [description]
 
-- [ ] Unit / behavior tests added or updated
-- [ ] Edge, truncated, and error cases covered
-- [ ] Format fixtures / corpus used where appropriate
+### Minor / suggestions
 
-## Verdict
+🟢 **[nit]** [Suggestion — not blocking]
 
-**[ ] ✅ Approve** — Ready to merge
-**[ ] 💬 Comment** — Minor suggestions, can merge
-**[ ] 🔄 Request Changes** — Must address blocking issues
+💡 **[suggestion]** [Alternative approach]
+
+📚 **[learning]** [Educational note — no action needed]
+
+🎉 **[praise]** [Specific strength worth keeping]
+
+**Verdict:** [✅ Approve / 💬 Comment / 🔄 Request Changes]
+
+---
+
+## 3. Maintainer decisions (your attention)
+
+Numbered items that need a **human call** only. Each must be decidable without reading
+the briefing, handoff, or diff. If none: `None.`
+
+1. **[Decision]** — [yes/no or A vs B]
+   - **Why you:** [spec/VISION conflict, product trade-off, pause-and-ask, …]
+   - **Options:** A — [consequence]; B — [consequence]
+   - **Recommendation (optional):** […]
 
 ---
 
@@ -85,21 +86,25 @@ Copy and use this template for code reviews in this repo.
 
 ### Blocking Issue
 ```
-🔴 **[blocking]** [Title]
-
-[Description of the issue]
+🔴 **[blocking]** `CONFIRMED` — [Title]
 
 **Location:** `path/to/file.py:123`
+
+[Description of the issue]
 
 **Suggested fix:**
 \`\`\`python
 # suggested code
 \`\`\`
+
+**Trigger:** [input/state → failure]
 ```
 
 ### Important Suggestion
 ```
-🟡 **[important]** [Title]
+🟡 **[important]** `PLAUSIBLE` — [Title]
+
+**Location:** `path/to/file.py:123`
 
 [Why this is important]
 
@@ -127,4 +132,12 @@ Not blocking, but consider [improvement].
 📚 **[learning]** [Educational note]
 
 For context, [X] works this way because [Y]. No action needed — just sharing.
+```
+
+### Maintainer decision
+```
+1. **[Decision title]** — choose A or B
+   - **Why you:** [conflict / trade-off]
+   - **Options:** A — [consequence]; B — [consequence]
+   - **Recommendation (optional):** [A because …]
 ```

--- a/.claude/skills/code-review-skill/assets/pr-review-template.md
+++ b/.claude/skills/code-review-skill/assets/pr-review-template.md
@@ -3,6 +3,9 @@
 Copy and use this template for code reviews in this repo.
 Matches [addendum §0 output shape](../reference/archivey-review-addendum.md).
 
+Brevity fence: keep blocks 1 and 3 skim-friendly; put full evidence and fix direction in
+block 2. Do not drop real pause-and-ask items to leave section 3 empty.
+
 ---
 
 ## 1. Maintainer briefing (read this first)

--- a/.claude/skills/code-review-skill/assets/review-checklist.md
+++ b/.claude/skills/code-review-skill/assets/review-checklist.md
@@ -77,6 +77,15 @@ local *why* for non-obvious choices; bugs / safety / tests.
 - [ ] Contract fit: OpenSpec / VISION / threat model / addendum (§1, §3, §5)
 - [ ] Spec ↔ code ↔ docs: match, intentional revision, or pause-and-ask
 - [ ] Concerns that only dissolve after external prose → usually 🟡 doc debt in the code
+- [ ] Write the **§0 three-block report**: briefing → implementor handoff → decisions
+
+---
+
+## Output shape (addendum §0)
+
+1. **Maintainer briefing** — what the change is, snapshot + verdict, main 🔴/🟡 points
+2. **Implementor handoff** — paste-ready full findings (severity × confidence, `file:line`)
+3. **Maintainer decisions** — only human calls; each decidable without the diff; or `None.`
 
 ---
 

--- a/.claude/skills/code-review-skill/assets/review-checklist.md
+++ b/.claude/skills/code-review-skill/assets/review-checklist.md
@@ -87,6 +87,9 @@ local *why* for non-obvious choices; bugs / safety / tests.
 2. **Implementor handoff** — paste-ready full findings (severity × confidence, `file:line`)
 3. **Maintainer decisions** — only human calls; each decidable without the diff; or `None.`
 
+Brevity fence: short form is blocks 1/3 presentation only — do not shrink pass depth or
+block 2 specificity; keep real pause-and-ask items.
+
 ---
 
 ## Severity Labels

--- a/.claude/skills/code-review-skill/reference/archivey-review-addendum.md
+++ b/.claude/skills/code-review-skill/reference/archivey-review-addendum.md
@@ -40,6 +40,20 @@ often has **not** read the diff; design for that reader first, then the implemen
 
 Do **not** lead with a long findings dump. Put dense detail only in block 2.
 
+**Brevity fence (do not let skim-friendly layout shrink the review):** short form
+applies **only** to how blocks 1 and 3 are *presented*. It must **not** reduce:
+
+- review depth (still run full pass 1 + pass 2 / §8–§9; same tracing and checklists),
+- finding discipline (still over-report on existence; still severity × confidence),
+- **block 2** length or specificity (full locations, why, fix direction, triggers /
+  repro notes — never collapse a real finding into a briefing one-liner and stop),
+- real pause-and-ask items in block 3 (omit filler questions, not genuine decisions;
+  when unsure whether something needs a human call, **include it** and label
+  confidence).
+
+If block 1 is short because the analysis was thin, that is a failed review — not
+compliance with this shape.
+
 #### 1. Maintainer briefing (read this first)
 
 Audience: you, the maintainer, skimming without the code open.
@@ -66,6 +80,10 @@ If there are **zero** findings worth action, say so here and keep blocks 2–3 m
 Audience: the person who will fix or reply. This block must be **safe to paste** into a
 PR comment, chat, or issue with little or no editing.
 
+This is where review quality lives in the write-up. Prefer being thorough here over
+keeping the whole reply short. A long block 2 with traced findings is correct; a short
+block 2 that drops evidence to match the briefing is not.
+
 - Start with a one-line context header (PR / branch / scope) so the paste stands alone.
 - Then the **full findings**, ranked by severity then confidence (§0 axes below).
 - Each finding is self-contained: severity, confidence, location (`file:line`), what’s
@@ -90,7 +108,9 @@ blocks 1–2 or the diff**:
 - Your **recommendation** if you have one (optional; label it as such).
 
 Skip routine “please add a test for X” fixes — those belong in block 2. If nothing needs
-a decision, write `None.` Do not invent soft questions to fill the section.
+a decision, write `None.` Do not invent soft filler questions — but **do not drop** a
+real decision gap to keep this section empty; when unsure, include it (see brevity
+fence above).
 
 Same three blocks apply when reviewing an OpenSpec proposal (§9); “what this change is”
 summarizes the proposal’s intent, and block 2 is the handoff for whoever will revise the

--- a/.claude/skills/code-review-skill/reference/archivey-review-addendum.md
+++ b/.claude/skills/code-review-skill/reference/archivey-review-addendum.md
@@ -33,6 +33,69 @@ Output stays **markdown prose** (portable across Cursor / Claude Code / others).
 route findings through a host-specific findings tool — the two-axis + reclassification
 model below is richer than those schemas, and prose is the source of truth.
 
+### Output shape — three blocks (required)
+
+Write the review as **exactly three top-level sections**, in this order. The maintainer
+often has **not** read the diff; design for that reader first, then the implementor.
+
+Do **not** lead with a long findings dump. Put dense detail only in block 2.
+
+#### 1. Maintainer briefing (read this first)
+
+Audience: you, the maintainer, skimming without the code open.
+
+Keep this short and scannable (aim for roughly half a screen unless the change is huge):
+
+- **What this change is** — 2–4 sentences: intent, main files/areas touched, and the
+  behaviour delta in plain language. Assume no prior familiarity with the PR or the
+  OpenSpec change name.
+- **Snapshot** — size (approx. lines / “small|medium|large”), gates if known
+  (ruff / pyrefly / ty / pytest), and **Verdict**: ✅ Approve / 💬 Comment /
+  🔄 Request Changes.
+- **Main points** — a short ranked bullet list of the things that actually matter
+  (blockers and important items only; fold nits out). One line each: severity +
+  one-sentence gist. No `file:line` essays here.
+- **What’s fine** (optional, 1–3 bullets) — load-bearing things that looked correct, so
+  the briefing isn’t only negatives.
+
+If there are **zero** findings worth action, say so here and keep blocks 2–3 minimal
+(“none” / empty decision list).
+
+#### 2. Implementor handoff (copy-paste ready)
+
+Audience: the person who will fix or reply. This block must be **safe to paste** into a
+PR comment, chat, or issue with little or no editing.
+
+- Start with a one-line context header (PR / branch / scope) so the paste stands alone.
+- Then the **full findings**, ranked by severity then confidence (§0 axes below).
+- Each finding is self-contained: severity, confidence, location (`file:line`), what’s
+  wrong, why it matters, concrete fix direction, and a trigger / repro note when
+  possible (`CONFIRMED` + trigger ⇒ red–green candidate, §4).
+- Include 🟢 nits / 💡 suggestions here (not in the briefing), still ranked.
+- End with the same **Verdict** line so a pasted comment doesn’t depend on block 1.
+
+No “as above” / “see briefing” cross-references that break when pasted alone.
+
+#### 3. Maintainer decisions (your attention)
+
+Audience: you again — only items that need a **human call**, not implementor busywork.
+
+A concise numbered list. For each item give **enough context to decide without reading
+blocks 1–2 or the diff**:
+
+- The decision in one line (what to choose between, or yes/no).
+- **Why it needs you** — conflict with VISION/spec/docs, product trade-off, pause-and-ask
+  discrepancy, or an under-specified contract (§9 decision gaps).
+- **Options** (when useful) — A / B / … with a one-line consequence each.
+- Your **recommendation** if you have one (optional; label it as such).
+
+Skip routine “please add a test for X” fixes — those belong in block 2. If nothing needs
+a decision, write `None.` Do not invent soft questions to fill the section.
+
+Same three blocks apply when reviewing an OpenSpec proposal (§9); “what this change is”
+summarizes the proposal’s intent, and block 2 is the handoff for whoever will revise the
+proposal / implement later.
+
 ### Two axes: severity ≠ confidence
 
 Rate every finding on two independent axes so the maintainer can read
@@ -77,7 +140,7 @@ result, crash, or contract violation:
 - Can't build one → the finding still stands, tagged `PLAUSIBLE` / needs-repro. A missing
   repro lowers confidence, never existence.
 
-### Keep it scannable
+### Keep findings disciplined (inside block 2)
 
 Over-reporting fails only when it is *unlabeled*. Hold the noise down by discipline, not
 suppression:
@@ -86,6 +149,8 @@ suppression:
 - **Rank** by severity, then confidence within a tier.
 - Every finding carries: severity, confidence tag, location (`file:line`), why it
   matters, a fix direction, and (where possible) a trigger.
+- Briefing (block 1) stays thin; detail lives in the handoff (block 2); decisions
+  (block 3) stay only what needs you.
 
 ---
 
@@ -384,8 +449,9 @@ Now open the narrative and contracts:
    / invents undecided behavior / breaks format parity.”
 4. Gates relevant to the change (targeted pytest; three configs before push when
    behavior depends on extras/versions).
-5. Write feedback with skill severity labels; put maintainer decisions in questions,
-   not silent resolutions.
+5. Write feedback in the **three-block output shape (§0)** — briefing, implementor
+   handoff, maintainer decisions — with skill severity labels; put pause-and-ask items
+   in block 3, not silent resolutions.
 
 | Pass | Job | Pass if… |
 |------|-----|----------|
@@ -466,11 +532,13 @@ Go looking, don't wait for gaps to surface during implementation.
   or assumed? Flag the untested ones and the cheapest way to test them.
 
 These are findings too (§0): a decision gap that could send implementation down the wrong
-path is 🟡+ and belongs in **maintainer questions** (pause-and-ask), never a silent
-assumption baked into the review.
+path is 🟡+ and belongs in **block 3 (Maintainer decisions)** — pause-and-ask, never a
+silent assumption baked into the review. Detail for whoever revises the proposal goes in
+block 2.
 
 Rank the same way (§0/§7): a proposal that undercuts a load-bearing VISION claim (§1) is
-🔴; a decision gap or thin scenario is 🟡; wording nits are 🟢.
+🔴; a decision gap or thin scenario is 🟡; wording nits are 🟢. Emit the same
+three-block output shape (§0).
 
 ---
 

--- a/.cursor/commands/code-review.md
+++ b/.cursor/commands/code-review.md
@@ -20,9 +20,9 @@ This repo vendors a fuller review skill under `.claude/skills/code-review-skill/
 Combine the priorities above with that skill’s process:
 
 1. **Read process rules:** `.claude/skills/code-review-skill/reference/archivey-review-addendum.md`
-   — especially **§8 (code first, then context)**, plus VISION ranking, contracts,
-   and the domain checklist. Do **not** absorb OpenSpec / design / long PR rationale
-   before the cold code pass.
+   — especially **§0 (output shape + finding discipline)** and **§8 (code first, then
+   context)**, plus VISION ranking, contracts, and the domain checklist. Do **not**
+   absorb OpenSpec / design / long PR rationale before the cold code pass.
 2. **Pass 1 — code alone:** changed code (+ nearby context) for self-explanatory
    sense in the resulting tree, local docs for non-obvious choices, bugs/safety/tests.
    Use `.claude/skills/code-review-skill/SKILL.md` techniques and severity labels;
@@ -46,22 +46,40 @@ Combine the priorities above with that skill’s process:
 
 ## Output format
 
-Lead with findings (no long preamble). Follow **addendum §0 (finding discipline)**:
-over-report on existence, label honestly, verification *reclassifies* (a disproven bug
-often becomes a clarity/doc-debt finding) — it never silently culls. For each finding:
+Emit **exactly three sections**, in order — addendum **§0 (Output shape)**. The
+maintainer often has not read the diff; do not dump a long findings list first.
 
-- **Severity** (impact if real): 🔴 `[blocking]` / 🟡 `[important]` / 🟢 `[nit]` /
-  💡 `[suggestion]` / 📚 `[learning]` / 🎉 `[praise]`
-- **Confidence** (how well traced): `CONFIRMED` / `PLAUSIBLE` / `DISPROVEN→reclassified`
-- Rank archivey blockers using the addendum (VISION claims, exception contract,
-  path/bomb safety, silent solid re-decode, unjustified debt, etc.); order by severity,
-  then confidence
-- Location, what’s wrong, why it matters, and a concrete fix direction
-- A concrete trigger where possible (`CONFIRMED` + trigger = red–green regression-test
-  candidate); missing trigger lowers confidence, not existence
-- Call out missing tests when behavior changed
+### 1. Maintainer briefing (read this first)
 
-After findings, a short **Verdict**: Approve / Comment / Request Changes — plus any
-maintainer questions (pause-and-ask; do not silently resolve spec conflicts).
+Short and scannable (about half a screen unless the change is huge):
+
+- **What this change is** — 2–4 plain-language sentences (intent, areas touched,
+  behaviour delta); no assumed PR/OpenSpec familiarity
+- **Snapshot** — size, gates if known, **Verdict** (✅ Approve / 💬 Comment /
+  🔄 Request Changes)
+- **Main points** — ranked one-liners for 🔴/🟡 only (severity + gist; no essays)
+- **What’s fine** (optional, 1–3 bullets)
+
+### 2. Implementor handoff (copy-paste ready)
+
+Paste-safe block for the implementor. Self-contained (no “see above”):
+
+- One-line context header, then **full findings** ranked by severity × confidence
+  (`CONFIRMED` / `PLAUSIBLE` / `DISPROVEN→reclassified`)
+- Each finding: severity, confidence, `file:line`, what’s wrong, why it matters, fix
+  direction, trigger/repro when possible (`CONFIRMED` + trigger = red–green candidate)
+- Include 🟢/💡 here; end with the Verdict line again
+
+Follow **addendum §0 (finding discipline)**: over-report on existence, label honestly;
+verification *reclassifies* (a disproven bug often becomes clarity/doc-debt) — it never
+silently culls. Rank archivey blockers using the addendum (VISION claims, exception
+contract, path/bomb safety, silent solid re-decode, unjustified debt, etc.).
+
+### 3. Maintainer decisions (your attention)
+
+Numbered list of items that need a **human call** only. Each item must be decidable
+without reading blocks 1–2 or the diff: the decision, why it needs you, options +
+consequences when useful, optional recommendation. Routine fixes stay in block 2. If
+nothing needs a decision: `None.`
 
 Skip formatting/lint nits that `ruff` / type-checkers already own.

--- a/.cursor/commands/code-review.md
+++ b/.cursor/commands/code-review.md
@@ -49,6 +49,11 @@ Combine the priorities above with that skill’s process:
 Emit **exactly three sections**, in order — addendum **§0 (Output shape)**. The
 maintainer often has not read the diff; do not dump a long findings list first.
 
+**Brevity fence:** short form applies only to blocks 1 and 3 *presentation*. Do not
+shrink review depth (full §8/§9 passes), finding discipline, block 2 specificity, or
+real pause-and-ask items. A thin block 2 that matches a short briefing is a failed
+review, not compliance.
+
 ### 1. Maintainer briefing (read this first)
 
 Short and scannable (about half a screen unless the change is huge):
@@ -62,7 +67,8 @@ Short and scannable (about half a screen unless the change is huge):
 
 ### 2. Implementor handoff (copy-paste ready)
 
-Paste-safe block for the implementor. Self-contained (no “see above”):
+Paste-safe block for the implementor. Self-contained (no “see above”). Prefer
+thoroughness here over keeping the whole reply short:
 
 - One-line context header, then **full findings** ranked by severity × confidence
   (`CONFIRMED` / `PLAUSIBLE` / `DISPROVEN→reclassified`)
@@ -80,6 +86,7 @@ contract, path/bomb safety, silent solid re-decode, unjustified debt, etc.).
 Numbered list of items that need a **human call** only. Each item must be decidable
 without reading blocks 1–2 or the diff: the decision, why it needs you, options +
 consequences when useful, optional recommendation. Routine fixes stay in block 2. If
-nothing needs a decision: `None.`
+nothing needs a decision: `None.` Do not invent filler questions; when unsure whether
+something needs a human call, include it.
 
 Skip formatting/lint nits that `ruff` / type-checkers already own.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Makes `/code-review` (and the skill) emit a **three-block** report so the maintainer can skim without the diff open, then paste a self-contained handoff to the implementor, then decide only the questions that need a human call.

## Changes

- **`archivey-review-addendum.md` §0** — required output shape:
  1. **Maintainer briefing** — what the change is, snapshot + verdict, main 🔴/🟡 points (and optional “what’s fine”)
  2. **Implementor handoff** — copy-paste-ready full findings (no “see above”)
  3. **Maintainer decisions** — only human calls, each decidable without reading the rest (or `None.`)
- **Brevity fence** — short form applies only to blocks 1/3 *presentation*. Pass depth, finding discipline, block 2 specificity, and real pause-and-ask items must not shrink; a thin block 2 that merely matches a short briefing is a failed review.
- Wired the same shape (and fence) through `.cursor/commands/code-review.md`, `SKILL.md`, the PR review template, and the quick checklist.
- Finding discipline (severity × confidence, over-report + reclassify) is unchanged; dense detail lives in block 2.

## Test plan

- [ ] Run `/code-review` on a small PR and confirm the three sections appear in order
- [ ] Confirm block 2 stays detailed (locations, triggers, fix directions) even when block 1 is short
- [ ] Confirm block 2 pastes cleanly as a standalone PR comment
- [ ] Confirm block 3 stays empty (`None.`) when there are no pause-and-ask items, but still surfaces real decision gaps when present

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-78da2bd3-9b6f-4f10-938e-e3b3c900ba26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-78da2bd3-9b6f-4f10-938e-e3b3c900ba26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

