### PR TITLE
Fix Cursor Cloud install for apt clock skew

### DIFF
--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -6,8 +6,22 @@ set -euo pipefail
 # Official uv installer lands here; keep it first for non-login shells.
 export PATH="${HOME}/.local/bin:${PATH}"
 
-sudo apt-get update
-sudo apt-get install -y unrar
+# Cloud VMs sometimes boot with a skewed clock; apt then rejects Release files as
+# "not valid yet". Prefer correcting the clock from an HTTP Date header; if that
+# fails, still allow a generous future skew so package installs can proceed.
+if date_hdr="$(
+  curl -fsSI --max-time 10 https://archive.ubuntu.com/ubuntu/ \
+    | awk -F': ' 'tolower($1) == "date" { print $2; exit }'
+)"; then
+  sudo date -s "${date_hdr}" >/dev/null 2>&1 || true
+fi
+
+# unrar: RAR member-data tests (multiverse). p7zip-full: encrypted ZIP fixture builds.
+sudo apt-get \
+  -o Acquire::Max-FutureTime=604800 \
+  -o Acquire::Check-Valid-Until=false \
+  update
+sudo apt-get install -y unrar p7zip-full
 
 npm install -g --prefix "${HOME}/.local" @fission-ai/openspec
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,15 +54,17 @@ Non-obvious gotchas:
 
 - The startup update script is committed at `.cursor/install.sh` (wired via
   `.cursor/environment.json`). It bootstraps `uv` if missing (JIT Cloud images may
-  not ship it), installs `unrar`, the `openspec` CLI, runs
+  not ship it), installs `unrar` + `p7zip-full`, the `openspec` CLI, runs
   `uv sync --group dev --extra all`, and `./scripts/install-git-hooks.sh`, so the
-  format-on-commit hook is present without a manual step.
+  format-on-commit hook is present without a manual step. It also best-effort
+  corrects a skewed VM clock (and relaxes apt Release-date checks) so
+  `apt-get update` does not fail with "Release file … is not valid yet".
 - **`unrar`** (system binary, from the `multiverse` apt component) backs RAR *data*
   tests; without it they skip cleanly rather than fail.
 - **`7z`** (system binary, from `p7zip-full`) is required by tests that build encrypted
   ZIP fixtures by shelling out to it (`tests/test_password.py`, the encrypted corpus
-  entries in `tests/test_corpus_sweep.py`); they skip cleanly when it is absent, but
-  install `p7zip-full` to run them.
+  entries in `tests/test_corpus_sweep.py`); they skip cleanly when it is absent.
+  The Cloud install script installs `p7zip-full` automatically.
 - **`openspec` CLI** lives at `~/.local/bin` (on `PATH`). `CLAUDE.md`'s
   `npm install -g @fission-ai/openspec` fails with `EACCES` here because the global npm
   prefix is not user-writable — the update script instead installs it into a writable,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Cloud agent update script (`.cursor/install.sh`) was aborting on boot because `apt-get update` failed when the VM clock was behind real time:

```text
E: Release file for …/InRelease is not valid yet (invalid for another 1d …)
```

With `set -e`, that stopped the rest of setup (`uv sync`, git hooks, etc.). Setup status in this environment was exit code `100`.

## Fix

- Best-effort clock sync from an HTTP `Date` header before apt
- Relax apt Release-date checks (`Acquire::Max-FutureTime=604800` + `Check-Valid-Until=false`) as a fallback
- Also install `p7zip-full` (needed for encrypted ZIP fixture tests; previously only a manual step)
- Document the behavior in `AGENTS.md`

## Verification

On this environment:

- With the clock deliberately set ~2 days behind, `apt-get` with the new options succeeds (exit 0)
- Full `./.cursor/install.sh` succeeds (installs `p7zip-full` / `7z`, syncs deps, installs the pre-commit hook)
- Second run is idempotent (exit 0; packages already present)
- `7z` and `unrar` are on `PATH`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e8a83f0a-d1d8-4c1f-b91e-722ec8858b0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e8a83f0a-d1d8-4c1f-b91e-722ec8858b0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

