### PR TITLE
ci: install p7zip on Linux; add a WinZip AES corpus variant

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,9 +200,9 @@ jobs:
       # (stdlib ``zipfile`` cannot write encryption). Without this the rows skip, and
       # before this step nothing installed it — so whether they ran depended on the
       # runner image and could vanish on an image bump with no test turning red.
-      # Linux only, deliberately: the rows exercise ZipCrypto/AES *reading* (pure
-      # Python) over flat files, so they engage none of the path/symlink surface the
-      # macOS and Windows legs exist for. See the T7 audit, residual 1, in
+      # Linux only, deliberately: the rows exercise ZipCrypto *reading* (pure Python)
+      # over flat files, so they engage none of the path/symlink surface the macOS and
+      # Windows legs exist for. See the T7 audit, residual 1, in
       # ``review/archive/2026-07-28-debt-ledger/corpus-matrix.md``.
       # ``p7zip-full`` is transitional on Ubuntu 24.04 (-> ``7zip``) but still provides
       # ``/usr/bin/7z``, which is the name the builder invokes.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,6 +196,27 @@ jobs:
           uv run --python ${{ matrix.python-version }} --no-sync python -c \
             "from archivey.internal.backends.rar_unrar import find_rarlab_unrar; print(find_rarlab_unrar())"
 
+      # The encrypted-ZIP corpus rows shell out to ``7z`` to build their fixtures
+      # (stdlib ``zipfile`` cannot write encryption). Without this the rows skip, and
+      # before this step nothing installed it — so whether they ran depended on the
+      # runner image and could vanish on an image bump with no test turning red.
+      # Linux only, deliberately: the rows exercise ZipCrypto/AES *reading* (pure
+      # Python) over flat files, so they engage none of the path/symlink surface the
+      # macOS and Windows legs exist for. See the T7 audit, residual 1, in
+      # ``review/archive/2026-07-28-debt-ledger/corpus-matrix.md``.
+      # ``p7zip-full`` is transitional on Ubuntu 24.04 (-> ``7zip``) but still provides
+      # ``/usr/bin/7z``, which is the name the builder invokes.
+      - name: Install p7zip (encrypted-ZIP corpus builder, Linux)
+        if: (matrix.install == 'all' || matrix.install == 'all-lowest') && runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y p7zip-full
+      - name: Verify 7z on PATH (Linux)
+        if: (matrix.install == 'all' || matrix.install == 'all-lowest') && runner.os == 'Linux'
+        run: |
+          command -v 7z
+          # Fail loudly if the package ever stops providing the ``7z`` name: a silent
+          # skip is exactly the unpinned-coverage failure this step exists to remove.
+          7z i | head -n 3
+
       - name: Assert synced venv Python matches matrix
         # Catch regressions where `.python-version` silently overrides the matrix again.
         run: >

--- a/review/STATUS.md
+++ b/review/STATUS.md
@@ -33,7 +33,7 @@ Ranked, from `backlog.md` and `PLAN.md`:
 
 | Item | Where it lives now |
 |------|--------------------|
-| Corpus rows unpinned in CI (ambient `7z` CLI) | `archive/2026-07-28-debt-ledger/corpus-matrix.md` residual 1 — a CI-workflow call |
+| ~~Corpus rows unpinned in CI (ambient `7z` CLI)~~ | **Closed 2026-07-29** — `p7zip-full` on the Linux CI legs; see `archive/2026-07-28-debt-ledger/corpus-matrix.md` residual 1 |
 | DD5–DD12, T5/T6, N1 (`pyppmd`), DD6 salvage | `archive/2026-07-28-debt-ledger/` — explicit KEEPs |
 | P8/P9, L4/L5 listing/accelerator follow-ups | `archive/2026-07-28-performance/` |
 | CLI `--json` / `--raw` | `IDEAS.md` (DD7/DD8) |

--- a/review/archive/2026-07-28-debt-ledger/SUMMARY.md
+++ b/review/archive/2026-07-28-debt-ledger/SUMMARY.md
@@ -20,10 +20,11 @@
 freezes at release any more; everything remaining is an explicit KEEP with a
 recorded justification, so the ledger closes.
 
-One audit finding is handed onward rather than fixed here: **11 of 71 corpus rows
-never run in CI**, and only 8 of them by decision — the 3 encrypted-ZIP rows need an
-ambient `7z` CLI no workflow installs, making that coverage unpinned. It is a CI
-workflow call, recorded as residual 1 in [`corpus-matrix.md`](corpus-matrix.md).
+One audit finding was handed onward rather than fixed in the T7 change: **11 of 71
+corpus rows never ran in CI**, and only 8 of them by decision — the 3 encrypted-ZIP rows
+needed an ambient `7z` CLI no workflow installed, making that coverage unpinned.
+**Closed 2026-07-29** by installing `p7zip-full` on the Linux legs (residual 1 in
+[`corpus-matrix.md`](corpus-matrix.md)); the 8 `rar`-writer rows stay skipped by design.
 
 **Freeze-rank legend** — F3: frozen at release. F2: compounds. F1: stable cost.
 

--- a/review/archive/2026-07-28-debt-ledger/corpus-matrix.md
+++ b/review/archive/2026-07-28-debt-ledger/corpus-matrix.md
@@ -78,7 +78,7 @@ committed fixtures in `tests/fixtures/rar/` (which is what this change extended)
 
 The `7z`-CLI half is not a decision anyone made. `encrypted`, `encrypted-mixed`, and
 `encrypted-multi` build their **ZIP** rows by shelling out to `7z` (stdlib `zipfile`
-cannot write encryption), and no workflow installs it — so whether ZipCrypto/AES ZIP
+cannot write encryption), and no workflow installs it — so whether encrypted-ZIP
 listing and per-member password behaviour is swept at all depends on whatever the
 runner image happens to ship, and differs across the Linux/macOS/Windows legs. The
 coverage is not absent, it is **unpinned**, which is worse: it can disappear on a
@@ -109,9 +109,20 @@ three rows pass as written, and sweep + mutation go from 304 passed / 55 skipped
   the same wrong assumption. Keep the CLI for the corpus; `zipcrypto.py` stays for the
   targeted cases that need a hand-built archive.
 
-Note that ZIP *AES* decryption itself is separately covered by `tests/test_zip_aes.py`
-and the structural bench gate (T3), both using in-process fixtures — so this gap is
-about the corpus sweep's cross-format assertions, not about AES support being untested.
+### Which cipher each encrypted-ZIP builder actually emits
+
+Worth stating explicitly, because the repo has three encrypted-ZIP builders and they are
+**complementary, not redundant** — they write different ciphers for different consumers:
+
+| Builder | Cipher emitted | Consumers | In sweep? | In mutation? |
+|---|---|---|---|---|
+| `_zip_build_encrypted` (7z CLI) | **ZipCrypto** (PKWARE; 7-Zip's ZIP default — verified STORED + encrypted flag, no `0x9901` field) | corpus `encrypted*` rows | yes | yes |
+| `tests/zipcrypto.py` | ZipCrypto, single-entry | `test_cli.py`, `test_zip_multipassword.py` (the 1-in-256 check-byte hazard) | no | no |
+| `tests/zip_aes_fixture.py` | **WinZip AES** (method 99, AE-1/AE-2) | `test_zip_aes.py`, `benchmarks/fixtures.py` (structural gate) | no | no |
+
+So AES support is well covered by targeted tests and the bench gate, but **no corpus row
+is AES** — WinZip AES members never go through the sweep's cross-format conformance
+assertions or through mutation fuzz. Recorded as residual 5.
 
 ## Finding 3 — ISO exercised only one of the reader's three name sources
 
@@ -154,6 +165,12 @@ than a shared shape. Recorded as a residual.
    expectations for the `8.3` mangled names.
 4. **RAR multi-volume joining** is in `test_volumes.py` only, never under mutation —
    mutating a volume *set* needs a multi-path harness the mutation net does not have.
+5. **No corpus row uses WinZip AES.** The 7z CLI writes ZipCrypto by default, so the
+   `encrypted*` rows are all ZipCrypto and AES reaches neither the sweep nor mutation
+   fuzz. Cheap to close now that `7z` is installed on CI: `7z a -tzip -mem=AES256`
+   emits method 99 and archivey reads it (verified), so an AES row fits the
+   builder-variant pattern (`zip-aes`, as `iso-joliet` is to `iso`) — it would need the
+   `[crypto]` extra as a builder/reader gate.
 
 ## Verification
 

--- a/review/archive/2026-07-28-debt-ledger/corpus-matrix.md
+++ b/review/archive/2026-07-28-debt-ledger/corpus-matrix.md
@@ -64,14 +64,14 @@ contract directly — `open_archive` without a password raises `EncryptionError`
 than yielding a plausible empty listing (`test_corpus_sweep.py`, `entry.encrypt_header`
 branch), which is O8's residual failure mode expressed as a corpus assertion.
 
-## Finding 2 — 11 of 71 rows never run in CI, and only 8 of them deliberately
+## Finding 2 — 11 of 71 rows never ran in CI, and only 8 of them deliberately
 
 This is the audit's real result, and it is not visible from the matrix alone.
 
 | Gate | Rows | Deliberate? |
 |---|---:|---|
 | `rar` **writer** binary | 8 | **Yes** — `ci.yml` installs `unrar` only and explicitly removes the writer on macOS ("keep writer off the PATH here"), because corpus RAR digest expectations are Linux-fixture-oriented |
-| `7z` **CLI** (encrypted-ZIP builder) | 3 | **No** — no workflow installs it |
+| `7z` **CLI** (encrypted-ZIP builder) | 3 | **Was not** — no workflow installed it. **Closed 2026-07-29**: `ci.yml` now installs `p7zip-full` on the Linux `all` / `all-lowest` legs |
 
 The RAR half is a recorded decision, and RAR keeps real CI coverage through the
 committed fixtures in `tests/fixtures/rar/` (which is what this change extended).
@@ -84,9 +84,30 @@ runner image happens to ship, and differs across the Linux/macOS/Windows legs. T
 coverage is not absent, it is **unpinned**, which is worse: it can disappear on a
 runner-image bump with no test turning red.
 
-Not fixed here — it is a CI-workflow change, and pinning it properly means deciding
-between installing `p7zip` on every leg or teaching the builder to write encrypted ZIPs
-in-process. Recorded as a residual below rather than silently carried.
+**Closed in the follow-up (2026-07-29).** `ci.yml` installs `p7zip-full` on the Linux
+`all` / `all-lowest` legs, plus a `command -v 7z` verify step so the coverage fails
+loudly instead of silently skipping if the package ever stops providing that name
+(`p7zip-full` is transitional on Ubuntu 24.04 → `7zip`, but still ships `/usr/bin/7z`,
+which is the name `_zip_build_encrypted` invokes). No test changes were needed: the
+three rows pass as written, and sweep + mutation go from 304 passed / 55 skipped to
+**319 / 40** with `7z` present.
+
+**Linux only, deliberately.** The other two candidates were rejected:
+
+- *macOS / Windows legs* — Homebrew's `p7zip` formula is deprecated in favour of
+  `sevenzip` (which ships `7zz`, not `7z`), and Windows needs its own path handling. The
+  cost is real and the signal is not: these rows exercise ZipCrypto/AES **reading**,
+  which is pure Python, over flat files with no symlinks or mode bits — none of the
+  path/symlink/junction surface those legs exist for. Linux pins the coverage; the
+  other legs would be near-duplicates.
+- *Teaching the builder to write encrypted ZIPs in-process* (generalising
+  `tests/zipcrypto.py`, which already writes single-entry ZipCrypto members, to
+  multi-member with mixed per-member passwords) — this would drop the binary dependency
+  everywhere including for local contributors, but it costs the **independent-oracle**
+  property: today 7z writes the fixtures and archivey reads them, so the rows cross-check
+  two implementations. Building them with our own writer risks writer and reader sharing
+  the same wrong assumption. Keep the CLI for the corpus; `zipcrypto.py` stays for the
+  targeted cases that need a hand-built archive.
 
 Note that ZIP *AES* decryption itself is separately covered by `tests/test_zip_aes.py`
 and the structural bench gate (T3), both using in-process fixtures — so this gap is
@@ -122,8 +143,9 @@ than a shared shape. Recorded as a residual.
 
 ## Residual gaps (recorded, not paid)
 
-1. **Encrypted-ZIP corpus rows are unpinned in CI** (Finding 2). Fix is a workflow
-   decision: install `p7zip` on every leg, or write encrypted ZIPs in-process.
+1. ~~**Encrypted-ZIP corpus rows are unpinned in CI**~~ — **closed 2026-07-29**;
+   `p7zip-full` on the Linux legs + a verify step (Finding 2). The 8 `rar`-writer rows
+   remain skipped by design, so 8 of 71 rows still do not run in CI.
 2. **`encrypted-multi` is ZIP-only.** For `7z` the builder rejects it outright
    (`_7z_build`: py7zr takes one archive password); for `rar` the builder *does*
    support per-member password groups since v7, but the row would only ever run where

--- a/review/archive/2026-07-28-debt-ledger/corpus-matrix.md
+++ b/review/archive/2026-07-28-debt-ledger/corpus-matrix.md
@@ -13,11 +13,12 @@ added here buys coverage in both nets at once — that leverage is why T7 is wor
 
 ## The matrix after this change
 
-**20 shapes / 71 rows.** Rows per format:
+**20 shapes / 74 rows.** Rows per format:
 
 | Format | Rows | Format | Rows |
 |---|---:|---|---:|
 | `zip` | 13 | `dir` | 4 |
+| `zip-aes` | 3 | | |
 | `tar` | 10 | `iso` | 3 |
 | `7z` | 8 | `tar.zst` | 2 |
 | `rar` | 8 | `iso-joliet` | 1 |
@@ -41,8 +42,8 @@ Shape → formats:
 | `duplicates` | `zip`, `tar` |
 | `large` | `zip`, `tar.gz`, `tar.zst`, `7z`, `rar` |
 | `adversarial` / `adversarial-tar` | `zip` / `tar`, `tar.gz` |
-| `encrypted` / `encrypted-mixed` | `zip`, `7z`, `rar` |
-| `encrypted-multi` | `zip` |
+| `encrypted` / `encrypted-mixed` | `zip`, **`zip-aes`**, `7z`, `rar` |
+| `encrypted-multi` | `zip`, **`zip-aes`** |
 | **`encrypted-header`** | **`7z`** |
 | `single-file` / `single-file-meta` | 8 codecs / `gz-meta` |
 
@@ -65,6 +66,9 @@ than yielding a plausible empty listing (`test_corpus_sweep.py`, `entry.encrypt_
 branch), which is O8's residual failure mode expressed as a corpus assertion.
 
 ## Finding 2 — 11 of 71 rows never ran in CI, and only 8 of them deliberately
+
+> Counts are as of the audit (71 rows). The `zip-aes` rows added when closing residual
+> 5 bring the corpus to 74; the CI-skipped set is unchanged at the 8 `rar`-writer rows.
 
 This is the audit's real result, and it is not visible from the matrix alone.
 
@@ -116,13 +120,18 @@ Worth stating explicitly, because the repo has three encrypted-ZIP builders and 
 
 | Builder | Cipher emitted | Consumers | In sweep? | In mutation? |
 |---|---|---|---|---|
-| `_zip_build_encrypted` (7z CLI) | **ZipCrypto** (PKWARE; 7-Zip's ZIP default — verified STORED + encrypted flag, no `0x9901` field) | corpus `encrypted*` rows | yes | yes |
+| `_zip_build_encrypted` (7z CLI), `zip` key | **ZipCrypto** (PKWARE; 7-Zip's ZIP default — verified STORED + encrypted flag, no `0x9901` field) | corpus `encrypted*` rows | yes | yes |
+| `_zip_build_encrypted` with `-mem=AES256`, `zip-aes` key | **WinZip AES** (AE-2 / AES-256, verified via the `0x9901` field) | corpus `encrypted*` rows | yes | yes |
 | `tests/zipcrypto.py` | ZipCrypto, single-entry | `test_cli.py`, `test_zip_multipassword.py` (the 1-in-256 check-byte hazard) | no | no |
 | `tests/zip_aes_fixture.py` | **WinZip AES** (method 99, AE-1/AE-2) | `test_zip_aes.py`, `benchmarks/fixtures.py` (structural gate) | no | no |
 
-So AES support is well covered by targeted tests and the bench gate, but **no corpus row
-is AES** — WinZip AES members never go through the sweep's cross-format conformance
-assertions or through mutation fuzz. Recorded as residual 5.
+AES support was well covered by targeted tests and the bench gate, but originally **no
+corpus row was AES** — WinZip AES members reached neither the sweep's cross-format
+conformance assertions nor mutation fuzz. **Closed 2026-07-29** with the `zip-aes`
+builder-variant key (`7z a -tzip -mem=AES256`), added to all three encrypted shapes so
+single-password, mixed plain/encrypted, and multi-password AES all sweep and mutate.
+Verified the rows really carry AE-2/AES-256 members rather than silently falling back
+to ZipCrypto.
 
 ## Finding 3 — ISO exercised only one of the reader's three name sources
 
@@ -156,7 +165,7 @@ than a shared shape. Recorded as a residual.
 
 1. ~~**Encrypted-ZIP corpus rows are unpinned in CI**~~ — **closed 2026-07-29**;
    `p7zip-full` on the Linux legs + a verify step (Finding 2). The 8 `rar`-writer rows
-   remain skipped by design, so 8 of 71 rows still do not run in CI.
+   remain skipped by design, so 8 of the now-74 rows still do not run in CI.
 2. **`encrypted-multi` is ZIP-only.** For `7z` the builder rejects it outright
    (`_7z_build`: py7zr takes one archive password); for `rar` the builder *does*
    support per-member password groups since v7, but the row would only ever run where
@@ -165,12 +174,9 @@ than a shared shape. Recorded as a residual.
    expectations for the `8.3` mangled names.
 4. **RAR multi-volume joining** is in `test_volumes.py` only, never under mutation —
    mutating a volume *set* needs a multi-path harness the mutation net does not have.
-5. **No corpus row uses WinZip AES.** The 7z CLI writes ZipCrypto by default, so the
-   `encrypted*` rows are all ZipCrypto and AES reaches neither the sweep nor mutation
-   fuzz. Cheap to close now that `7z` is installed on CI: `7z a -tzip -mem=AES256`
-   emits method 99 and archivey reads it (verified), so an AES row fits the
-   builder-variant pattern (`zip-aes`, as `iso-joliet` is to `iso`) — it would need the
-   `[crypto]` extra as a builder/reader gate.
+5. ~~**No corpus row uses WinZip AES.**~~ — **closed 2026-07-29** by the `zip-aes`
+   variant key on all three encrypted shapes, gated on the `[crypto]` extra via the new
+   `READER_PACKAGES` table so the rows skip (not fail) in the core-only leg.
 
 ## Verification
 

--- a/review/archive/2026-07-28-debt-ledger/tests.md
+++ b/review/archive/2026-07-28-debt-ledger/tests.md
@@ -45,7 +45,8 @@ extensions, the deliberate exclusions, and four recorded residuals. Closed: ISO 
 corpus-dead); header-encrypted 7z as a new shape in **both** sweep and mutation;
 encrypted-header + volume RAR fixtures into the static mutation intake.
 
-Audit finding worth carrying forward: **11 of 71 rows never run in CI**, and only the
-8 `rar`-writer rows are a deliberate decision — the 3 encrypted-ZIP rows depend on an
-ambient `7z` CLI that no workflow installs, so that coverage is *unpinned* rather than
-absent. Recorded as residual 1 in the audit doc; it is a CI-workflow call.
+Audit finding: **11 of 71 rows never ran in CI**, and only the 8 `rar`-writer rows were
+a deliberate decision — the 3 encrypted-ZIP rows depended on an ambient `7z` CLI that no
+workflow installed, so that coverage was *unpinned* rather than absent. **Closed
+2026-07-29**: `ci.yml` installs `p7zip-full` on the Linux legs (residual 1 in the audit
+doc). The `rar`-writer rows remain skipped by design.

--- a/tests/sample_archives.py
+++ b/tests/sample_archives.py
@@ -144,6 +144,9 @@ class CorpusEntry:
 # Corpus format key -> the ArchiveFormat the sweep gates availability on.
 FORMAT_KEYS: dict[str, ArchiveFormat] = {
     "zip": ArchiveFormat.ZIP,
+    # Builder variant: same ZIP reader, WinZip AES members instead of the 7z CLI's
+    # default ZipCrypto (see READER_PACKAGES — decryption needs the [crypto] extra).
+    "zip-aes": ArchiveFormat.ZIP,
     "tar": ArchiveFormat.TAR,
     "tar.gz": ArchiveFormat.TAR_GZ,
     "tar.bz2": ArchiveFormat.TAR_BZ2,
@@ -344,13 +347,24 @@ CORPUS: tuple[CorpusEntry, ...] = (
     CorpusEntry("adversarial", _ADVERSARIAL_COMMON, ("zip",)),
     CorpusEntry("adversarial-tar", _ADVERSARIAL_TAR, ("tar", "tar.gz")),
     # Encrypted ZIPs are built with the 7z CLI (stdlib zipfile cannot write encryption).
+    # ``zip`` is ZipCrypto (7-Zip's ZIP default); ``zip-aes`` is the same shape written
+    # with -mem=AES256, so WinZip AES members reach the sweep and mutation fuzz too
+    # (T7 residual 5 — previously AES was only in targeted tests + the bench gate).
     CorpusEntry(
-        "encrypted", _ENC_SINGLE, ("zip", "7z", "rar"), requires_binaries=("7z",)
+        "encrypted",
+        _ENC_SINGLE,
+        ("zip", "zip-aes", "7z", "rar"),
+        requires_binaries=("7z",),
     ),
     CorpusEntry(
-        "encrypted-mixed", _ENC_MIXED, ("zip", "7z", "rar"), requires_binaries=("7z",)
+        "encrypted-mixed",
+        _ENC_MIXED,
+        ("zip", "zip-aes", "7z", "rar"),
+        requires_binaries=("7z",),
     ),
-    CorpusEntry("encrypted-multi", _ENC_MULTI, ("zip",), requires_binaries=("7z",)),
+    CorpusEntry(
+        "encrypted-multi", _ENC_MULTI, ("zip", "zip-aes"), requires_binaries=("7z",)
+    ),
     # Header-encrypted 7z (``-mhe=on``): the member *names* are encrypted too, so the
     # native header parser must decrypt before it can list at all. Reaches the
     # kEncodedHeader path that threat-model O8 hardened; py7zr writes it in-process,
@@ -439,9 +453,9 @@ def _compress(data: bytes, key: str) -> bytes:
     raise ValueError(f"no compressor for {key!r}")
 
 
-def _zip_build(entry: CorpusEntry, path: Path) -> None:
+def _zip_build(entry: CorpusEntry, path: Path, *, aes: bool = False) -> None:
     if entry.passwords:
-        _zip_build_encrypted(entry, path)
+        _zip_build_encrypted(entry, path, aes=aes)
         return
     with zipfile.ZipFile(path, "w") as zf:
         if entry.archive_comment:
@@ -470,8 +484,12 @@ def _zip_build(entry: CorpusEntry, path: Path) -> None:
                 zf.writestr(zi, m.contents)
 
 
-def _zip_build_encrypted(entry: CorpusEntry, path: Path) -> None:
-    """Encrypted ZIP via the 7z CLI (one invocation per password group; plain last)."""
+def _zip_build_encrypted(entry: CorpusEntry, path: Path, *, aes: bool = False) -> None:
+    """Encrypted ZIP via the 7z CLI (one invocation per password group; plain last).
+
+    7-Zip's ZIP default is legacy **ZipCrypto**; ``aes=True`` adds ``-mem=AES256`` for
+    **WinZip AES** (method 99, AE-2) instead, which the reader decrypts via ``[crypto]``.
+    """
     with tempfile.TemporaryDirectory() as td:
         tmp = Path(td)
         groups: dict[str | None, list[Member]] = {}
@@ -485,6 +503,8 @@ def _zip_build_encrypted(entry: CorpusEntry, path: Path) -> None:
                 p.write_bytes(m.contents)
                 names.append(m.name)
             cmd = ["7z", "a", "-tzip", str(path), *names, "-y"]
+            if aes:
+                cmd.append("-mem=AES256")
             if password is not None:
                 cmd.append(f"-p{password}")
             subprocess.run(cmd, cwd=tmp, check=True, capture_output=True)
@@ -639,6 +659,8 @@ def build_archive(entry: CorpusEntry, key: str, path: Path) -> None:
     """Build ``entry`` as format ``key`` at ``path`` (a file, or a directory for dir)."""
     if key == "zip":
         _zip_build(entry, path)
+    elif key == "zip-aes":
+        _zip_build(entry, path, aes=True)
     elif key == "dir":
         _dir_build(entry, path)
     elif key == "iso":
@@ -678,6 +700,13 @@ BUILDER_BINARIES: dict[str, tuple[str, ...]] = {
     "rar": ("rar",),
 }
 
+# Optional packages the *reader* needs for a format key, beyond what the registry's
+# format availability reports. ZIP itself is core, but WinZip AES member decryption
+# needs the ``[crypto]`` extra — without it the rows must skip, not fail.
+READER_PACKAGES: dict[str, tuple[str, ...]] = {
+    "zip-aes": ("cryptography",),
+}
+
 
 # ---------------------------------------------------------------------------
 # Generation cache (content-keyed, atomic, parallel-safe)
@@ -696,6 +725,8 @@ def _filename(entry: CorpusEntry, key: str) -> str:
         return f"{entry.id}.gz"
     if key == "iso-joliet":
         return f"{entry.id}.iso"
+    if key == "zip-aes":
+        return f"{entry.id}.zip"
     return f"{entry.id}.{key}"
 
 

--- a/tests/test_corpus_sweep.py
+++ b/tests/test_corpus_sweep.py
@@ -38,6 +38,7 @@ from tests.sample_archives import (
     BUILDER_PACKAGES,
     CORPUS,
     FORMAT_KEYS,
+    READER_PACKAGES,
     CorpusEntry,
     Member,
     corpus_archive_path,
@@ -60,6 +61,16 @@ _MODE_FORMATS = {
 # listing check differs (see format-single-file-compressors).
 _SINGLE_FILE_KEYS = {"gz", "gz-meta", "bz2", "xz", "zst", "lz4", "lz", "zz", "br"}
 
+# Builder-variant keys write the same container a different way, so the reader contract
+# they must satisfy is the base format's. The per-format assertions below key off this,
+# not the raw key — otherwise a variant silently takes every "not that format" branch.
+_BASE_KEY = {"gz-meta": "gz", "iso-joliet": "iso", "zip-aes": "zip"}
+
+
+def _base(key: str) -> str:
+    return _BASE_KEY.get(key, key)
+
+
 _PARAMS = [
     pytest.param(entry, key, id=f"{entry.id}-{key}")
     for entry in CORPUS
@@ -73,6 +84,9 @@ def _skip_unless_runnable(entry: CorpusEntry, key: str) -> None:
         pytest.skip(
             f"format {key!r} not readable here: {availability.missing or 'no backend'}"
         )
+    for package in READER_PACKAGES.get(key, ()):
+        if importlib.util.find_spec(package) is None:
+            pytest.skip(f"reader needs package {package!r}")
     for package in BUILDER_PACKAGES.get(key, ()):
         if package == "_zstd_backend":
             if not _has_zstd_backend():
@@ -116,13 +130,13 @@ def _check_listing(ar, entry: CorpusEntry, key: str) -> None:
             assert act.type is exp.type, f"type of {name!r}"
             if exp.type is MemberType.FILE and not exp.password:
                 assert act.size == len(exp.contents), f"size of {name!r}"
-            if exp.link_target is not None and key != "iso":
+            if exp.link_target is not None and _base(key) != "iso":
                 assert act.link_target == exp.link_target, f"link_target of {name!r}"
-            if exp.mode is not None and key in _MODE_FORMATS:
+            if exp.mode is not None and _base(key) in _MODE_FORMATS:
                 assert act.mode == exp.mode, f"mode of {name!r}"
             if exp.uid is not None and key.startswith("tar"):
                 assert act.uid == exp.uid, f"uid of {name!r}"
-            if exp.comment is not None and key == "zip":
+            if exp.comment is not None and _base(key) == "zip":
                 assert act.comment == exp.comment, f"comment of {name!r}"
             _assert_stored_digest_parity(act, key)
 
@@ -134,7 +148,7 @@ def _check_listing(ar, entry: CorpusEntry, key: str) -> None:
                 f"unexpected non-directory member {name!r}"
             )
 
-    if entry.archive_comment is not None and key == "zip":
+    if entry.archive_comment is not None and _base(key) == "zip":
         assert ar.info.comment == entry.archive_comment
 
 
@@ -146,7 +160,7 @@ def _assert_stored_digest_parity(member, key: str) -> None:
         HashAlgorithm.BLAKE2SP,
         HashAlgorithm.ADLER32,
     }
-    if key == "zip":
+    if _base(key) == "zip":
         if member.type in (MemberType.FILE, MemberType.SYMLINK):
             # AE-2 (WinZip AES) stores CRC as 0 and relies on the HMAC — no crc32 digest.
             if member.extra.get("zip.aes_vendor_version") == 2:
@@ -160,7 +174,7 @@ def _assert_stored_digest_parity(member, key: str) -> None:
                 f"zip {member.name!r} unexpected crc32"
             )
         return
-    if key == "7z":
+    if _base(key) == "7z":
         if member.type is MemberType.FILE:
             assert HashAlgorithm.CRC32 in keys, f"7z {member.name!r} missing crc32"
         elif member.type is MemberType.DIRECTORY:
@@ -169,7 +183,7 @@ def _assert_stored_digest_parity(member, key: str) -> None:
             )
         # SYMLINK may carry a CRC of the stored link payload; do not require or forbid.
         return
-    if key == "rar":
+    if _base(key) == "rar":
         if member.type is MemberType.FILE:
             # RAR5 may store Blake2sp instead of (or in addition to) CRC32.
             assert digest_keys, f"rar FILE {member.name!r} missing stored digest"


### PR DESCRIPTION
Follow-up to #204: closes **residuals 1 and 5** of the T7 corpus-matrix audit. Three commits.

## 1. Install p7zip on the Linux legs (residual 1)

`encrypted`, `encrypted-mixed` and `encrypted-multi` build their ZIP rows by shelling out to `7z` (stdlib `zipfile` cannot write encryption), and no workflow installed it. Whether those rows ran depended on whatever the runner image happened to ship — the coverage wasn't absent, it was **unpinned**, and could vanish on an image bump with nothing turning red.

One apt step on the Linux `all` / `all-lowest` legs mirroring the existing `unrar` step, plus a `command -v 7z` verify step so a package that stops providing that name fails loudly instead of quietly returning to skipping. `p7zip-full` is transitional on Ubuntu 24.04 (→ `7zip`) but still ships `/usr/bin/7z`, the name `_zip_build_encrypted` invokes — so no builder change was needed.

**Linux only, deliberately.** Homebrew's `p7zip` formula is deprecated in favour of `sevenzip` (ships `7zz`, not `7z`) and Windows needs its own path handling — real work for near-duplicate signal, since these rows exercise ZipCrypto/AES *reading* (pure Python) over flat files and engage none of the path/symlink/junction surface those legs exist for.

## 2. Name the cipher each builder emits

Checking what `7z a -tzip -p` actually writes turned up a correction to the audit doc, which had said these rows sweep "ZipCrypto/AES". The three encrypted-ZIP builders are **complementary, not redundant** — they write different ciphers:

| Builder | Cipher | Consumers |
|---|---|---|
| `_zip_build_encrypted` (`zip` key) | **ZipCrypto** — 7-Zip's ZIP default; verified STORED + encrypted flag, no `0x9901` field | corpus `encrypted*` rows |
| `tests/zipcrypto.py` | ZipCrypto, single-entry | `test_cli.py`, `test_zip_multipassword.py` (the 1-in-256 check-byte hazard) |
| `tests/zip_aes_fixture.py` | **WinZip AES** (method 99, AE-1/AE-2) | `test_zip_aes.py`, `benchmarks/fixtures.py` |

## 3. Add a WinZip AES corpus variant (residual 5)

The consequence of #2: **no corpus row was AES**, so AES members reached neither the sweep's cross-format assertions nor mutation fuzz — corrupted AES members were never exercised anywhere.

New `zip-aes` builder-variant key (the pattern `iso-joliet` uses for `iso`): same shape, `7z a -tzip -mem=AES256`, applied to all three encrypted shapes so single-password, mixed plain/encrypted, and multi-password AES all sweep and mutate. Verified the rows really carry AE-2/AES-256 members via the `0x9901` extra field rather than silently falling back to ZipCrypto.

Decryption needs the `[crypto]` extra, which the registry's format availability can't express (ZIP is core; AES is a member-level feature), so there's a new `READER_PACKAGES` table beside `BUILDER_PACKAGES`. Confirmed in core-only the rows skip rather than fail: `reader needs package 'cryptography'`.

**Latent trap fixed along the way.** The sweep's per-format assertions compared the raw format key, so a builder-variant key silently took every "not that format" branch. `iso-joliet` (from #204) was skipping the `link_target` check and would have skipped the ZIP digest-parity branch — it passed only because `basic` has no links. A `zip-aes` row would have failed the bottom "no stored digests" assert outright. Variants now map to their base format via `_BASE_KEY` for those assertions.

## Testing

| Config | Result |
|---|---|
| `[all]` | 1992 passed / 58 skipped (was 1948 / 87 on main) |
| `[all-lowest]` | identical — the other leg that gets p7zip |
| `[core-only]` | 1590 / 403; `zip-aes` rows skip on `cryptography` |

Corpus 71 → 74 rows; sweep 60 → 66 passing rows; mutation +12 params. A 10× deeper mutation sweep (`ARCHIVEY_FUZZ_MUTATIONS=60`) over the AES rows is clean — no raw exceptions or hangs from the AES decryption path. `ruff`, `pyrefly` and `ty` clean.

The 8 `rar`-writer rows remain skipped by design, so 8 of 74 rows still don't run in CI — down from 11, and all 8 now deliberate.