### PR TITLE
docs+ci: support matrix, migration guide, real free-threading coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,10 +276,18 @@ jobs:
           uv run --python ${{ matrix.python-version }} --no-sync
           pytest tests/test_property_safety.py -q
 
-  # Free-threaded correctness for the declared MemberStreams.CONCURRENT seam (core backends).
-  # Optional extras are not claimed covered here — skips do not count as free-threaded support.
+  # Free-threaded correctness. Two stages: the zero-dep core, then the subset of extras
+  # that actually keep the GIL disabled. An extra whose C extension has not declared
+  # free-thread support makes CPython silently *re-enable* the GIL on import, which would
+  # turn this whole job into a GIL-ed run pretending to be a free-threaded one — so the
+  # extras stage asserts the GIL is still off before it runs anything.
+  # Deliberately excluded (measured 2026-07-29, CPython 3.13.7t):
+  #   pyppmd / inflate64 / brotli / rapidgzip -> import re-enables the GIL
+  #   cryptography ([crypto], and so [7z]/[rar]) -> cffi does not support free-threaded
+  #     3.13 at all ("Upgrade to free-threaded 3.14 or newer"), so it cannot be installed
+  # Revisit both lists on 3.14t. See docs/support-matrix.md.
   free-threaded-concurrency:
-    name: free-threaded-concurrency / py3.13t / concurrent_reader
+    name: free-threaded-concurrency / py3.13t / core + GIL-safe extras
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -295,12 +303,31 @@ jobs:
         run: uv sync --python 3.13t --no-dev
       - name: Assert zero-dependency core
         run: uv run --python 3.13t --no-sync python tests/check_zero_dep_core.py
-      - name: Run concurrent_reader tests
-        # Override addopts so we do not need pytest-cov in the core-only ephemeral env.
+      # The whole suite, not just the concurrent_reader subset: single-threaded
+      # free-threaded breakage (dict/list races in shared state, C-API assumptions) shows
+      # up here, and the marked subset is only ~46 of ~2000 tests.
+      # Override addopts so we do not need pytest-cov in the core-only ephemeral env.
+      - name: Run full suite (core-only)
         run: >
           uv run --python 3.13t --no-sync
           --with pytest --with pytest-timeout
-          pytest -m concurrent_reader -q --timeout=60 -o addopts=
+          pytest tests/ -q --timeout=120 -o addopts=
+
+      - name: Sync GIL-safe extras
+        run: uv sync --python 3.13t --no-dev --extra iso --extra zstd --extra lz4 --extra cli
+      - name: Assert the GIL is still disabled with those extras
+        # Fail loudly if a future release of one of these starts re-enabling the GIL:
+        # the job would otherwise keep passing while testing nothing free-threaded.
+        run: >
+          uv run --python 3.13t --no-sync python -W ignore -c
+          "import sys, pycdlib, lz4.frame, tqdm, backports.zstd;
+          assert not sys._is_gil_enabled(), 'an extra re-enabled the GIL';
+          print('GIL still disabled with iso/zstd/lz4/cli')"
+      - name: Run full suite + concurrent_reader (GIL-safe extras)
+        run: >
+          uv run --python 3.13t --no-sync
+          --with pytest --with pytest-timeout
+          pytest tests/ -q --timeout=120 -o addopts=
 
   # Blocking gate = **structural only** (seek baselines + solid decode-once).
   # Wall-time ratios are noisy on shared runners; they run separately, non-blocking,

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,22 +18,33 @@ name: Publish
 #       project `archivey`, owner `davitf`, repo `archivey`,
 #       workflow `publish.yml`, environment `pypi`.
 #   • TestPyPI (https://test.pypi.org/manage/account/publishing/):
-#       project `archivey`, owner `davitf`, repo `archivey-2`,
+#       project `archivey`, owner `davitf`, repo `archivey`,
 #       workflow `publish.yml`, environment `testpypi`.
 # Also create the GitHub environments `pypi` and `testpypi` (Settings → Environments)
 # and add protection rules (e.g. required reviewer) to the `pypi` one.
 #
-# ── Repo-rename note ────────────────────────────────────────────────────────────────
-# The `pypi` job is gated on `davitf/archivey`; the `testpypi` job on `davitf/archivey-2`.
-# While this repo is still named `archivey-2`, tag pushes go to TestPyPI. After the repo
-# is renamed to `archivey`, tag pushes go to real PyPI, and the `testpypi` job stops
-# matching (drop it, or repoint it, once the rename lands).
+# ── Choosing a target (post-rename) ─────────────────────────────────────────────────
+# The repo rename to `davitf/archivey` is done, so the old "archivey-2 means TestPyPI"
+# routing no longer applies. Now:
+#   • pushing a `v*` tag            -> real PyPI
+#   • Run workflow -> target=testpypi -> TestPyPI (dry run, no tag needed)
+#   • Run workflow -> target=pypi     -> real PyPI from the chosen ref
+# Do the TestPyPI dry run first: it exercises Trusted Publishing, the built metadata and
+# the upload path without burning a version number on real PyPI (a filename can never be
+# re-uploaded there, even after deletion).
 
 on:
   push:
     tags:
       - 'v*'
-  workflow_dispatch: {}
+  workflow_dispatch:
+    inputs:
+      target:
+        description: Index to publish to
+        required: true
+        default: testpypi
+        type: choice
+        options: [testpypi, pypi]
 
 permissions:
   contents: read
@@ -65,6 +76,10 @@ jobs:
             echo "::error::Tag '$GITHUB_REF_NAME' does not match packaged version '$pkg'. Bump [project].version in pyproject.toml (and drop any .devN suffix) before tagging." >&2
             exit 1
           fi
+      # Metadata problems (bad README rendering, malformed classifiers) are rejected by
+      # PyPI *after* upload, when the filename can no longer be reused. Catch them here.
+      - name: Check distribution metadata
+        run: uvx twine check --strict dist/*
       - name: Upload distributions
         uses: actions/upload-artifact@v4
         with:
@@ -74,8 +89,10 @@ jobs:
   pypi:
     name: Publish to PyPI
     needs: [build]
-    # Real PyPI only from the canonical repo, and only for an actual version tag.
-    if: github.repository == 'davitf/archivey' && startsWith(github.ref, 'refs/tags/')
+    # Real PyPI only from the canonical repo: a version tag, or an explicit manual run.
+    if: >-
+      github.repository == 'davitf/archivey'
+      && (startsWith(github.ref, 'refs/tags/') || inputs.target == 'pypi')
     runs-on: ubuntu-latest
     environment: pypi
     permissions:
@@ -92,8 +109,10 @@ jobs:
   testpypi:
     name: Publish to TestPyPI
     needs: [build]
-    # Dry-run target while this repo is still `archivey-2` (tag pushes and manual dispatch).
-    if: github.repository == 'davitf/archivey-2'
+    # Dry run: manual dispatch only, so a tag push can never land on TestPyPI by accident.
+    if: >-
+      github.repository == 'davitf/archivey'
+      && github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi'
     runs-on: ubuntu-latest
     environment: testpypi
     permissions:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is the **v2** clean-slate implementation. The previous (v1) codebase is arc
 
 ## Documentation
 
-- **User guide** (MkDocs): [Philosophy](docs/philosophy.md) · [Usage](docs/usage.md) · [Costs & pitfalls](docs/costs.md) · [Formats](docs/formats.md) · [Safe extraction](docs/safe-extraction.md) · [API](docs/api.md) · [Acknowledgements](docs/acknowledgements.md)
+- **User guide** (MkDocs): [Philosophy](docs/philosophy.md) · [Usage](docs/usage.md) · [Migrating](docs/migrating.md) · [Costs & pitfalls](docs/costs.md) · [Formats](docs/formats.md) · [Safe extraction](docs/safe-extraction.md) · [Platforms & threading](docs/support-matrix.md) · [API](docs/api.md) · [Acknowledgements](docs/acknowledgements.md)
 - **[VISION.md](VISION.md)** — full maintainer vision and trade-off priorities
 - **[Decision log](docs/decisions/index.md)** — why key design choices were made
 - **[Threat model](docs/internal/threat-model.md)** — trust boundaries and open gaps

--- a/docs/api.md
+++ b/docs/api.md
@@ -87,3 +87,4 @@ spec for lifecycle, retention, and policy.
 ::: archivey.ResourceLimitError
 ::: archivey.DiagnosticRaisedError
 ::: archivey.ArchiveyUsageError
+::: archivey.ConcurrentAccessError

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,12 +32,14 @@ with archivey.open_archive("photos.zip") as reader:
 
 1. **[Philosophy](philosophy.md)** — why Archivey exists and the defaults that follow
 2. **[Basic usage](usage.md)** — open, list, stream, extract
-3. **[Gotchas](gotchas.md)** — traps worth knowing after the basics (read this next)
-4. **[Access costs and pitfalls](costs.md)** — hidden decompression costs and how to avoid them
-5. **[Formats and extras](formats.md)** — per-format quirks, required libraries, limitations
-6. **[Safe extraction](safe-extraction.md)** — what “safe by default” means in practice
-7. **[API reference](api.md)** — generated from source
-8. **[Acknowledgements](acknowledgements.md)** — libraries, oracles, and design references
+3. **[Migrating](migrating.md)** — coming from `zipfile`, `tarfile`, `shutil`, `patool`
+4. **[Gotchas](gotchas.md)** — traps worth knowing after the basics (read this next)
+5. **[Access costs and pitfalls](costs.md)** — hidden decompression costs and how to avoid them
+6. **[Formats and extras](formats.md)** — per-format quirks, required libraries, limitations
+7. **[Safe extraction](safe-extraction.md)** — what “safe by default” means in practice
+8. **[Platforms and threading](support-matrix.md)** — supported Pythons/OSes and what free-threading claims
+9. **[API reference](api.md)** — generated from source
+10. **[Acknowledgements](acknowledgements.md)** — libraries, oracles, and design references
 
 ## For contributors
 

--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -1,0 +1,174 @@
+# Migrating from zipfile, tarfile, shutil, and patool
+
+Recipes for replacing the tool you're using now. Each section shows the old code, the
+Archivey equivalent, and — where it matters — what actually changes in behaviour.
+
+The recurring theme: the stdlib modules are per-format and extract permissively by
+default; Archivey is one interface for every format and **blocks unsafe members unless
+you opt out**. Most migrations are shorter code plus stricter defaults.
+
+## Cheat sheet
+
+| You're doing | Now | With Archivey |
+| --- | --- | --- |
+| Open an archive | `zipfile.ZipFile(p)` / `tarfile.open(p)` | `archivey.open_archive(p)` |
+| List names | `zf.namelist()` / `tf.getnames()` | `[m.name for m in reader]` |
+| Member metadata | `ZipInfo` / `TarInfo` | `ArchiveMember` (same shape for every format) |
+| Read one member | `zf.read(n)` / `tf.extractfile(n).read()` | `reader.read(n)` |
+| Extract everything | `zf.extractall(d)` / `tf.extractall(d, filter="data")` | `archivey.extract(p, d)` |
+| Unpack any format | `shutil.unpack_archive(p, d)` | `archivey.extract(p, d)` |
+| Decompress a `.gz` | `gzip.open(p)` | `archivey.open_stream(p)` |
+| Detect the format | guess from the extension | `archivey.detect_format(p)` |
+
+## From `zipfile`
+
+```python
+# Before
+import zipfile
+with zipfile.ZipFile("photos.zip") as zf:
+    for name in zf.namelist():
+        print(name, zf.getinfo(name).file_size)
+    data = zf.read("subdir/a.txt")
+    zf.extractall("out/")
+
+# After
+import archivey
+with archivey.open_archive("photos.zip") as reader:
+    for member in reader:
+        print(member.name, member.size)
+    data = reader.read("subdir/a.txt")
+    reader.extract_all("out/")
+```
+
+What changes:
+
+- **`extractall` was never safe.** `zipfile.extractall` sanitizes absolute paths and `..`
+  by mangling them, but happily writes symlinks that point outside the destination.
+  `extract_all` **blocks** traversal and symlink escapes by default and reports them as
+  `ExtractionStatus.BLOCKED`. See [Safe extraction](safe-extraction.md).
+- **Passwords are an open-time argument**, not per-call `pwd=`:
+  `open_archive("secret.zip", password="hunter2")`. Archivey also reads **WinZip AES**
+  members (with the `[crypto]` extra), which `zipfile` cannot decrypt at all.
+- **Duplicate names are visible.** `namelist()` returns duplicates with no way to tell
+  which one wins; Archivey marks the live entry with `member.is_current`. See
+  [duplicate names](usage.md#duplicate-names-and-is_current).
+- `reader.read(name)` needs no `getinfo` round-trip, and works the same on every format.
+
+## From `tarfile`
+
+```python
+# Before
+import tarfile
+with tarfile.open("backup.tar.gz") as tf:
+    for info in tf:
+        print(info.name, info.size)
+    with tf.extractfile("etc/config") as f:
+        data = f.read()
+    tf.extractall("out/", filter="data")
+
+# After
+import archivey
+with archivey.open_archive("backup.tar.gz") as reader:
+    for member in reader:
+        print(member.name, member.size)
+    data = reader.read("etc/config")
+    reader.extract_all("out/")
+```
+
+What changes:
+
+- **You no longer choose a filter.** `tarfile`'s `filter="data"` (the 3.14 default, and a
+  `DeprecationWarning` before that) is closest to Archivey's default
+  `ExtractionPolicy.STRICT`. Archivey's policies are
+  `STRICT` / `STANDARD` / `TRUSTED` and apply to *every* format, not just tar.
+- **`extractfile` can return `None`** for non-regular members, so stdlib code needs a
+  `None` check; `reader.read(name)` raises a typed error instead.
+- **Compressed tars are solid.** `tarfile` lets you call `extractfile` in any order and
+  silently re-decompresses from the start each time — that's the classic accidental
+  O(n²). Archivey makes the cost visible via `reader.cost` and steers you to
+  `stream_members()`. See [Access costs](costs.md).
+- **Truncated archives.** `tarfile` often stops silently at a short read. Archivey gives
+  you the recovered prefix *and* the error via `members_report()`.
+
+## From `shutil.unpack_archive`
+
+```python
+# Before
+import shutil
+shutil.unpack_archive("bundle.tar.xz", "out/")
+
+# After
+import archivey
+archivey.extract("bundle.tar.xz", "out/")
+```
+
+What changes:
+
+- **More formats.** `unpack_archive` handles zip/tar family only. Archivey adds RAR, 7z,
+  ISO, and single-file streams through the same call.
+- **Format comes from content, not the filename.** `unpack_archive` dispatches on the
+  extension and fails on a misnamed file; Archivey sniffs the bytes.
+- **Safe by default**, with the same policy knobs as `extract_all`.
+- You get an `ExtractionReport` back — what was written, skipped, or blocked — instead of
+  `None`.
+
+## From `patool` / shelling out to `7z` / `unrar`
+
+```python
+# Before
+subprocess.run(["7z", "x", "-o" + dest, "archive.7z"], check=True)
+
+# After
+import archivey
+archivey.extract("archive.7z", dest)
+```
+
+What changes:
+
+- **No external binary for 7z**, and no CLI output parsing. Archivey has a native 7z
+  reader (common codecs in the core; PPMd/Deflate64 via `[7z]`, AES via `[crypto]`).
+- **RAR still needs `unrar`** for member *data* — metadata and listing are native. That is
+  a licensing constraint, not an oversight ([decision 0002](decisions/0002-native-rar-metadata-unrar-data.md)).
+- **Errors are exceptions, not exit codes**, and hostile archives can't reach a shell:
+  the whole point is not handing untrusted filenames to a subprocess.
+- Wrong passwords raise `EncryptionError` rather than prompting on a tty and hanging.
+
+## From `py7zr` / `rarfile`
+
+Both remain useful as *writers* and as cross-check oracles; Archivey does not write 7z or
+RAR. For reading:
+
+```python
+# Before
+import py7zr
+with py7zr.SevenZipFile("a.7z") as z:
+    z.extractall("out/")
+
+# After
+import archivey
+archivey.extract("a.7z", "out/")
+```
+
+The reason to switch is memory safety and uniformity: Archivey parses 7z and RAR metadata
+in pure Python rather than delegating to a third-party parser, and the same reader
+interface covers every other format you handle. See
+[decision 0001](decisions/0001-native-7z-not-py7zr.md).
+
+## Things that will bite you
+
+Worth reading before you migrate a production path:
+
+1. **Extraction is strict.** Archives that "worked" with `extractall` may now report
+   `BLOCKED` members. That is the point — but check the
+   [`ExtractionReport`](safe-extraction.md) rather than assuming success.
+2. **One live member stream by default.** If you held several `extractfile()` handles
+   open, declare `MemberStreams.CONCURRENT`. See
+   [supported platforms and threading](support-matrix.md).
+3. **`read()` is all-or-raise.** A truncated member raises instead of returning a short
+   body; use a chunked loop if you want the recoverable prefix
+   ([usage](usage.md#read-a-member)).
+4. **Random access on a pipe fails loudly** instead of silently buffering the whole thing
+   into memory ([decision 0010](decisions/0010-no-silent-buffer-nonseekable.md)). Pass
+   `streaming=True` for a forward-only pass.
+5. **Salvage is not implemented yet.** Reading a badly damaged archive gives you the
+   recoverable prefix plus an honest error, not a best-effort resync past the damage.

--- a/docs/philosophy.md
+++ b/docs/philosophy.md
@@ -75,5 +75,5 @@ harness if you want numbers on your machine.
 
 - Not an everything-tool (no in-place modify, no async in v1)
 - Not a backup engine by itself
-- Not a compatibility shim for `zipfile` / `tarfile` / `py7zr` APIs — one clean API,
-  migration guides later
+- Not a compatibility shim for `zipfile` / `tarfile` / `py7zr` APIs — one clean API, with
+  a [migration guide](migrating.md) rather than a drop-in replacement

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -1,0 +1,140 @@
+# Supported platforms, Python versions, and threading
+
+What Archivey commits to, and — just as importantly — what it deliberately does not
+claim. Everything on this page is backed by a CI job; where a claim is narrower than you
+might expect, it is because the job that proves it is narrower.
+
+## Python and operating systems
+
+Archivey requires **Python 3.11+** and is pure Python (no compiled extensions of its
+own), so it runs anywhere CPython does. What CI *proves* on every pull request:
+
+| OS | Python | Install |
+| --- | --- | --- |
+| Linux | 3.11, 3.12, 3.13, 3.14 | all extras |
+| Linux | 3.11, 3.14 | zero-dependency core |
+| Linux | 3.11 | all extras, **minimum** dependency versions |
+| Linux | 3.13t (free-threaded) | core, and the GIL-safe extras — see below |
+| macOS | 3.11, 3.14 | all extras |
+| Windows | 3.11, 3.14 | all extras |
+
+The minimum-versions leg matters more than it looks: optional libraries change behaviour
+by their *version* as well as their presence, so the floor of each declared range is
+tested, not just the newest release.
+
+Other platforms (BSDs, other CPython builds) are expected to work and are not tested. A
+platform-specific bug report is welcome and treatable; it is just not something a green
+badge here is asserting today.
+
+### Non-CPython interpreters
+
+Not tested. Archivey's core is pure Python, but the optional accelerators and codec
+backends are C/C++ extensions, so PyPy or GraalPy would at best run the core plus
+whatever extras build there.
+
+## Free-threaded Python (3.13t and later)
+
+Free-threaded builds remove the GIL, which turns "we were accidentally safe" into real
+data races. Archivey does not rely on the GIL for correctness — the reader uses explicit
+locks — but the **claim is scoped to what CI actually exercises**, and that scope is
+narrow on purpose.
+
+### What is claimed
+
+On a reader opened with `MemberStreams.CONCURRENT`, after member materialization, it is
+safe for multiple threads to call `open()` and to work on **different** member streams
+concurrently:
+
+```python
+from archivey import MemberStreams, open_archive
+
+with open_archive("photos.zip", member_streams=MemberStreams.CONCURRENT) as reader:
+    members = reader.members()          # materialize once, on one thread
+    # Now: fan out. Each thread opens and reads its own member.
+```
+
+This is verified by a required CI job on **Linux, CPython 3.13t**, which runs the **whole
+test suite** (not just the concurrency tests) in two stages: the zero-dependency core,
+then the core plus the extras that keep the GIL disabled.
+
+### Which extras are free-threaded
+
+This is the part that catches people out. When a C extension has not declared
+free-thread support, importing it makes CPython **silently re-enable the GIL** — your
+program keeps working, but you are no longer running free-threaded. Measured on CPython
+3.13.7t:
+
+| Extra | Package | Free-threaded on 3.13t? |
+| --- | --- | --- |
+| `[iso]` | `pycdlib` | Yes — covered by CI |
+| `[zstd]` | `backports.zstd` | Yes — covered by CI |
+| `[lz4]` | `lz4` | Yes — covered by CI |
+| `[cli]` | `tqdm` | Yes — covered by CI |
+| `[seekable]` | `rapidgzip` | **No** — import re-enables the GIL |
+| `[7z]` | `pyppmd`, `inflate64`, `brotli` | **No** — import re-enables the GIL |
+| `[crypto]`, `[rar]`, `[7z]` | `cryptography` | **Cannot install** — its `cffi` dependency rejects free-threaded 3.13 outright ("upgrade to free-threaded 3.14 or newer") |
+
+So on a free-threaded build today you can use the core formats plus ISO, zstd and lz4 and
+stay genuinely GIL-free. Pull in the 7z codecs, RAR/ZIP encryption, or the seek
+accelerator and you are back to a GIL-ed interpreter (or, for `cryptography`, cannot
+install at all).
+
+None of this is Archivey's own code — it is the state of the wider wheel ecosystem on
+3.13t, and it should improve on 3.14t. The CI job asserts the GIL is *still* disabled
+after importing the four safe extras, so if one of them regresses the job fails rather
+than quietly testing a GIL-ed interpreter.
+
+### What is *not* claimed
+
+- **macOS and Windows free-threaded builds.** The job is Linux-only.
+- **The extras in the "No" rows above.** They are not tested under free-threading, and
+  since importing them re-enables the GIL, "free-threaded support" is not a meaningful
+  question for them yet.
+- **Everything except member streams.** Iteration, materialization, extraction,
+  `stream_members()`, and `close()` are **single-owner** operations. Driving any of them
+  from several threads is a usage error, not a race to be fixed.
+- **Parallel speedup.** Nothing here promises that fanning out is *faster*; it promises
+  it is correct. Decode work may still serialize on a backend lock.
+
+### The default is fail-fast, not racy
+
+If you do not declare `MemberStreams.CONCURRENT`, the reader allows **one live member
+stream**. A second overlapping `open()` raises
+[`ConcurrentAccessError`][archivey.ConcurrentAccessError] rather than quietly returning
+interleaved bytes:
+
+```python
+with open_archive("photos.zip") as reader:      # no CONCURRENT declared
+    s1 = reader.open("a.txt")
+    s2 = reader.open("b.txt")                   # raises ConcurrentAccessError
+```
+
+That is the deliberate design: accidental cross-thread sharing fails loudly on the first
+call instead of corrupting data on some later run. See
+[decision 0003](decisions/0003-member-streams-opt-in.md) for why capabilities are opt-in.
+
+Note that `ConcurrentAccessError` is an
+[`ArchiveyUsageError`][archivey.ArchiveyUsageError], which sits **outside** the
+`ArchiveyError` tree ([decision 0012](decisions/0012-usage-errors-outside-archiveyerror.md)).
+A broad `except ArchiveyError` around your archive handling will *not* swallow it — which
+is intended, because it reports a bug in the calling code, not a problem with the archive.
+
+### One live-stream caveat
+
+Closing a reader while member streams are still open defers backend teardown until the
+last stream closes, so escaped streams stay readable. This is by design, but it means a
+`close()` on one thread can block on I/O finishing elsewhere — don't treat reader close
+as instantaneous under concurrency.
+
+## Thread-safety summary
+
+| Operation | Safe from multiple threads? |
+| --- | --- |
+| `open()` + reading **different** member streams | Yes, with `MemberStreams.CONCURRENT`, after materialization |
+| Reading the **same** member stream object | No — one owner per stream |
+| `members()` / `__iter__` / `scan_members()` | No — single-owner; materialize once, then share the result |
+| `extract_all()` / `stream_members()` | No — single-owner passes |
+| `close()` | Safe to call twice; not safe to race against in-flight opens |
+| Separate `ArchiveReader` objects | Yes — independent readers share no mutable state |
+
+The simplest correct pattern is: **materialize on one thread, then fan out reads.**

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,10 +6,12 @@ nav:
   - Home: index.md
   - Philosophy: philosophy.md
   - Basic usage: usage.md
+  - Migrating from zipfile/tarfile: migrating.md
   - Gotchas: gotchas.md
   - Access costs and pitfalls: costs.md
   - Formats and extras: formats.md
   - Safe extraction: safe-extraction.md
+  - Platforms and threading: support-matrix.md
   - API reference: api.md
   - Acknowledgements: acknowledgements.md
   - Decisions:


### PR DESCRIPTION
Three of the four release-bundle items from `PLAN.md` item 6. **Packaging finalize is deliberately not here** — `version` stays `0.2.0.dev0` for a first trial publish, as requested.

## `docs/support-matrix.md` — platforms and threading

The explicit statement the release checklist (§4) asks for. Free-threading was previously documented only in `threat-model.md` C4 and `AGENTS.md`, so the support matrix was implicit in a CI flag.

## `docs/migrating.md` — migration guide

`zipfile` / `tarfile` / `shutil.unpack_archive` / `patool` / `py7zr` / `rarfile` recipes with a cheat-sheet table, plus a "things that will bite you" section (strict extraction, one live member stream, all-or-raise `read()`, no silent buffering on pipes, salvage not implemented). `philosophy.md` promised "migration guides later" and now links it.

## Free-threading: measured, and the claim changed

I checked instead of assuming, and the answer to "does the current job mean the core is safe?" is **no — it proves much less than that, and the core is in better shape than the job shows.**

- **The job ran 46 of ~2000 tests.** `-m concurrent_reader` only. The full core suite already passes under 3.13t (**1590 passed / 406 skipped**) — CI just never ran it. It now does, so single-threaded free-threaded breakage is caught too.

- **Extras split cleanly by whether they keep the GIL disabled:**

  | | Packages | 3.13t |
  |---|---|---|
  | `[iso]` `[zstd]` `[lz4]` `[cli]` | pycdlib, backports.zstd, lz4, tqdm | **GIL stays off** |
  | `[7z]` `[seekable]` | pyppmd, inflate64, brotli, rapidgzip | **import re-enables the GIL** |
  | `[crypto]` `[rar]` `[7z]` | cryptography | **cannot install** — cffi rejects free-threaded 3.13 outright |

  The job now installs the four safe extras and runs the suite again with them (**1678 passed / 318 skipped**), which brings the ISO concurrency tests into free-threaded coverage for the first time. 8/8 stress repeats of `concurrent_reader` clean.

- **The trap this creates.** A C extension that hasn't declared free-thread support makes CPython *silently* re-enable the GIL. Adding extras naively would leave the job green while testing a GIL-ed interpreter — the worst outcome, since it looks like coverage. The job now asserts the GIL is still disabled after importing those four. Verified the assert fires: importing `pyppmd` trips it.

None of the "No" rows are Archivey's code — it's the wheel ecosystem's state on 3.13t, and should improve on 3.14t. Both lists are in a comment on the job with a note to revisit.

## `publish.yml` — dry-run path was dead

The workflow already existed and is sound, but its `testpypi` job was still gated on `github.repository == 'davitf/archivey-2'`. **After the rename that job can never run**, so the only remaining path was tag → real PyPI with no dry run. Its own comment predicted this ("drop it, or repoint it, once the rename lands").

Repointed both gates at `davitf/archivey` and added a `workflow_dispatch` `target` choice, so TestPyPI is reachable without cutting a tag. Also added `twine check --strict` to the build job, since PyPI rejects bad metadata only *after* the version number is burned and a filename can never be reused.

## Verification

- Full free-threaded job dry-run green locally, both stages.
- `mkdocs build --strict` exit 0; all new cross-references and anchors resolve. Added `ConcurrentAccessError` to `api.md` (it was referenced but undocumented).
- `[all]` suite: 1992 passed / 58 skipped.
- `uv build` + `twine check --strict` pass on `0.2.0.dev0`; the tag-vs-version guard computes `0.2.0.dev0`, so `v0.2.0.dev0` would match.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1G2pL3FRbyR6VzmqQWpdV)_