### PR TITLE
packaging: fix README links on PyPI, add project URLs and classifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,16 @@ This is the **v2** clean-slate implementation. The previous (v1) codebase is arc
 
 ## Documentation
 
-- **User guide** (MkDocs): [Philosophy](docs/philosophy.md) · [Usage](docs/usage.md) · [Migrating](docs/migrating.md) · [Costs & pitfalls](docs/costs.md) · [Formats](docs/formats.md) · [Safe extraction](docs/safe-extraction.md) · [Platforms & threading](docs/support-matrix.md) · [API](docs/api.md) · [Acknowledgements](docs/acknowledgements.md)
-- **[VISION.md](VISION.md)** — full maintainer vision and trade-off priorities
-- **[Decision log](docs/decisions/index.md)** — why key design choices were made
-- **[Threat model](docs/internal/threat-model.md)** — trust boundaries and open gaps
-- **[Security policy](SECURITY.md)** — private vulnerability reporting
-- **[PLAN.md](PLAN.md)** — phased roadmap · **[IDEAS.md](IDEAS.md)** — backlog
-- Authoritative contracts: `openspec/specs/`
-- **[CHANGELOG.md](CHANGELOG.md)** — notable changes · **[Release checklist](docs/internal/release-checklist.md)** — how to cut a version
-- **[CONTRIBUTING.md](CONTRIBUTING.md)** — coding / testing standards
+**<https://davitf.github.io/archivey/>**
+
+[Usage](https://davitf.github.io/archivey/usage/) ·
+[Migrating from zipfile/tarfile](https://davitf.github.io/archivey/migrating/) ·
+[Formats and extras](https://davitf.github.io/archivey/formats/) ·
+[Safe extraction](https://davitf.github.io/archivey/safe-extraction/) ·
+[API reference](https://davitf.github.io/archivey/api/)
+
+## Contributing and security
+
+- **[CONTRIBUTING.md](https://github.com/davitf/archivey/blob/main/CONTRIBUTING.md)** — coding / testing standards
+- **[VISION.md](https://github.com/davitf/archivey/blob/main/VISION.md)** — priorities and trade-offs; authoritative contracts live in `openspec/specs/`
+- **[SECURITY.md](https://github.com/davitf/archivey/blob/main/SECURITY.md)** — private vulnerability reporting

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,39 @@ requires-python = ">=3.11"
 authors = [
     { name = "Davi Figueiredo", email = "gh@davitf.com" }
 ]
+keywords = [
+    "archive", "zip", "tar", "rar", "7z", "iso",
+    "compression", "decompression", "extract", "streaming",
+]
+# Development Status is a judgement call, not a fact: 4 = "the API is settling but not
+# frozen", which is what a pre-1.0 first public release is. Bump to 5 at 1.0.
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Intended Audience :: System Administrators",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Topic :: System :: Archiving",
+    "Topic :: System :: Archiving :: Compression",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Typing :: Typed",
+]
+
+# Shown in the PyPI sidebar. Without these the project page links nowhere, which is
+# most of why relative README links were the only navigation.
+[project.urls]
+Homepage = "https://davitf.github.io/archivey/"
+Documentation = "https://davitf.github.io/archivey/"
+Source = "https://github.com/davitf/archivey"
+Changelog = "https://github.com/davitf/archivey/blob/main/CHANGELOG.md"
+Issues = "https://github.com/davitf/archivey/issues"
 
 [project.scripts]
 archivey = "archivey.cli.main:main"

--- a/review/README.md
+++ b/review/README.md
@@ -17,9 +17,13 @@ completed changes out of `changes/`.
 
 ## In flight
 
-**Nothing.** The round commissioned 2026-07-17 — the **non-security** pass toward the
-first public `0.2.0` — closed on 2026-07-28 when `debt-ledger/` and `performance/`
-were archived. Every finding is fixed, accepted, or recorded as an explicit deferral.
+| Dir | Review | Status |
+|-----|--------|--------|
+| `docs/` | Documentation full review — audience separation + information architecture | Brief 2026-07-29; analysis phase not started |
+
+The round commissioned 2026-07-17 — the **non-security** pass toward the first public
+`0.2.0` — closed on 2026-07-28 when `debt-ledger/` and `performance/` were archived.
+Every finding there is fixed, accepted, or recorded as an explicit deferral.
 
 `backlog.md` holds what is left: Topic 6 (decode-engine perf, + parked stream-layering
 Q4), Topic 7 (outside-in adoption capstone — the **capstone**, meaningful only once

--- a/review/STATUS.md
+++ b/review/STATUS.md
@@ -4,7 +4,7 @@
 
 | Review | State |
 |---|---|
-| [`docs/`](docs/brief.md) — documentation full review | Brief written 2026-07-29. Four-phase process (audit → decide → migrate → guardrail); phase 1 not started. |
+| [`docs/`](docs/brief.md) — documentation full review | Brief written 2026-07-29. Four-phase process (audit → decide → migrate → guardrail); phase 1 not started. Bias control: [`independent-brief.md`](docs/independent-brief.md) commissions a code-only outline to run **first**. |
 
 `debt-ledger/` and `performance/` were archived on 2026-07-28 after the last two ledger
 items (**T7** corpus-matrix audit, **T4** half-test) landed and **performance Q4** was

--- a/review/STATUS.md
+++ b/review/STATUS.md
@@ -1,9 +1,14 @@
-# In-flight review status (2026-07-28)
+# In-flight review status (2026-07-29)
 
-**No reviews are in flight.** `debt-ledger/` and `performance/` were archived on
-2026-07-28 after the last two ledger items (**T7** corpus-matrix audit, **T4**
-half-test) landed and **performance Q4** was decided. This file stays as the entry
-point for the next round.
+## In flight
+
+| Review | State |
+|---|---|
+| [`docs/`](docs/brief.md) — documentation full review | Brief written 2026-07-29. Four-phase process (audit → decide → migrate → guardrail); phase 1 not started. |
+
+`debt-ledger/` and `performance/` were archived on 2026-07-28 after the last two ledger
+items (**T7** corpus-matrix audit, **T4** half-test) landed and **performance Q4** was
+decided.
 
 ## What closed the round
 
@@ -15,19 +20,23 @@ point for the next round.
 Every other item on both reviews is fixed, accepted (bands aspirational, #191), or an
 explicit KEEP with a recorded justification — see each review's `SUMMARY.md`.
 
-## What is next (not review work)
+## What is next
 
 Ranked, from `backlog.md` and `PLAN.md`:
 
-1. **Release bundle** (`PLAN.md` item 6) — the actual critical path to `0.2.0`, and
-   the one thing no review ever tracked: packaging finalize (`version` is still
-   `0.2.0.dev0`), the **explicit free-threading support statement** (today it lives
-   only in `docs/internal/threat-model.md` C4 and `AGENTS.md`, nothing user-facing),
-   and the **migration guide** (`zipfile`/`tarfile`/`shutil.unpack_archive`/`patool`
-   → archivey) + doc sweep.
-2. **Topic 6** — decode-engine performance (`backlog.md`); unblocked since #137.
-3. **Topic 7** — outside-in adoption capstone. Run **last**: it judges the finished
-   library, and items 1–2 are exactly the gaps it would otherwise re-find.
+1. **Release bundle** (`PLAN.md` item 6) — the critical path to `0.2.0`. Landed since:
+   the free-threading support statement and migration guide (`docs/support-matrix.md`,
+   `docs/migrating.md`, #206) and the PyPI metadata (#207). **Remaining:** drop the
+   `0.2.0.dev0` suffix when cutting the tag, and the repo-cutover leftovers
+   (`docs/internal/release-repo-cutover.md`: discovery metadata, Pages settings).
+2. **Docs full review** (in flight above) — the doc sweep, scoped as an information
+   architecture problem rather than a content edit. Best done **before** more releases
+   ship more permanent URLs.
+3. **Topic 6** — decode-engine performance (`backlog.md`); unblocked since #137.
+4. **Topic 7** — outside-in adoption capstone. Run **last**: it judges the finished
+   library, and items 1–3 are exactly the gaps it would otherwise re-find. The docs
+   review deliberately hands persuasion/adoption findings to it rather than acting on
+   them.
 
 ## Carried forward from the archived reviews
 

--- a/review/STATUS.md
+++ b/review/STATUS.md
@@ -32,10 +32,14 @@ Ranked, from `backlog.md` and `PLAN.md`:
 2. **Docs full review** (in flight above) — the doc sweep, scoped as an information
    architecture problem rather than a content edit. Best done **before** more releases
    ship more permanent URLs.
-3. **Topic 6** — decode-engine performance (`backlog.md`); unblocked since #137.
-4. **Topic 7** — outside-in adoption capstone. Run **last**: it judges the finished
-   library, and items 1–3 are exactly the gaps it would otherwise re-find. The docs
-   review deliberately hands persuasion/adoption findings to it rather than acting on
+3. **Topic 8** — documentation *content* (accuracy vs the code, then gaps, then
+   quality). Separate from the IA review by design: that one decides where pages live,
+   this one whether they are right. Starts from the `observations.md` the IA audit
+   produces as a byproduct.
+4. **Topic 6** — decode-engine performance (`backlog.md`); unblocked since #137.
+5. **Topic 7** — outside-in adoption capstone. Run **last**: it judges the finished
+   library, and items 1–4 are exactly the gaps it would otherwise re-find. The docs
+   reviews deliberately hand persuasion/adoption findings to it rather than acting on
    them.
 
 ## Carried forward from the archived reviews

--- a/review/backlog.md
+++ b/review/backlog.md
@@ -35,8 +35,10 @@ review directories for these.
 | CLI **Q4** `--raw` / TTY-only quoting remainder | cli-product Q4 | debt-ledger DD8 (additive; recommended style already applied) |
 | `SlicingStream.readinto` (**Q4**) + optional `VerifyingStream` delete | stream-layering | Topic 6 adjacency above |
 
-No reviews are in flight as of 2026-07-28; [`STATUS.md`](STATUS.md) records what
-closed the round and what comes next (the release bundle, then Topics 6 and 7).
+The **docs full review** is in flight as of 2026-07-29 ([`docs/brief.md`](docs/brief.md)) —
+an information-architecture pass separating user / contributor / design-record / history,
+commissioned ahead of Topic 7 because it decides where docs *live*, not whether they
+persuade. [`STATUS.md`](STATUS.md) records the current ordering.
 
 When commissioned, each gets its own top-level directory with a `brief.md` and
 archives when addressed (see `README.md`).

--- a/review/backlog.md
+++ b/review/backlog.md
@@ -20,6 +20,11 @@ round (`debt-ledger`, `performance`). They differ in character and timing:
 - **Topic 7** (outside-in adoption / confidence) — a **capstone**, meaningful only
   *after everything else is fully addressed*; it judges the finished library, not a
   work in progress.
+- **Topic 8** (documentation *content*) — accuracy / gaps / quality of the prose, after
+  the in-flight docs IA review has settled where each page lives.
+
+**Topic numbers are IDs, not an order.** Current intended sequence: the docs IA review
+(in flight) → **Topic 8** → **Topic 6** → **Topic 7** last. See [`STATUS.md`](STATUS.md).
 
 ## Parked from archived deep reviews (2026-07)
 
@@ -153,6 +158,41 @@ fully addressed. Two framings, usable together:
 
 This is judgement + gap analysis, not a bug hunt — closer to a product/positioning audit
 grounded in the code and docs. It likely produces roadmap items, not fixes.
+
+## Topic 8 — Documentation *content* (after the IA pass)
+
+**Why separate from the docs IA review** (`docs/brief.md`, in flight): that one decides
+where prose *lives*; this one judges whether the prose is *right*. Keeping them apart is
+a reviewability argument, not a tidiness one — a `git mv`-only migration diff can be
+checked by inspection, a move-plus-rewrite diff cannot. It is also cheaper: polishing a
+page that is about to be merged or deleted is wasted work, and "is this page complete?"
+is unanswerable until the page's scope is settled.
+
+**Head start:** the IA audit reads every file anyway and records what it notices in
+`review/docs/observations.md` without acting on it. Start there rather than from zero.
+
+Three distinct passes hide under "content review". They have different value and are
+worth ranking rather than bundling:
+
+1. **Accuracy vs the code (highest value).** Does each page still describe what the code
+   does? The surface has churned hard — native 7z/RAR, the CLI, verify fusion, extraction
+   policies, diagnostics. Past debt-ledger passes found docstring/spec mismatches; the
+   user guide has never had a systematic pass. Mechanically checkable in places: every
+   code block in `docs/` should run, and several would make good doctests.
+2. **Gaps.** What does an adopting engineer look for and not find? Overlaps Topic 7 —
+   coordinate: Topic 7 judges whether the docs *persuade*, this asks whether they
+   *answer*. If Topic 7 has already run, take its gap list as input.
+3. **Quality: tone, length, examples, structure within a page.** Lowest value per hour
+   and the easiest to bikeshed. Do it last, and only where a page is load-bearing
+   (`index`, `usage`, `formats`, `safe-extraction`).
+
+**Sequencing.** After the IA migration lands, before Topic 7 ideally — so the capstone
+judges docs that are both correctly filed and correct. If time forces a choice, do (1)
+alone: an inaccurate doc is a bug, an unpolished one is not.
+
+**Guardrail to consider while doing it:** executable examples (doctest or a tested
+snippets file) turn accuracy from a recurring manual review into a CI failure. That is
+the difference between doing this pass once and doing it every release.
 
 ## Not a review — a feature gap to track separately
 

--- a/review/docs/brief.md
+++ b/review/docs/brief.md
@@ -1,0 +1,172 @@
+# Brief — documentation full review (audience separation + information architecture)
+
+Commissioned 2026-07-29 against `main` @ `403e7ff`. Prompted by the observation that
+the README had accumulated links for four different audiences, and that the published
+docs site carries far more maintainer material than user material.
+
+## The ask
+
+The repo's prose has grown organically to ~8,300 lines across four homes with no
+enforced rule for what goes where. Produce an **information architecture** that
+separates, cleanly and durably:
+
+1. **User documentation** — someone using the library.
+2. **Contributor documentation** — someone changing the code.
+3. **Design record** — the normative "what is true" and the "why" behind it.
+4. **History and evidence** — investigations, superseded prose, review and change logs.
+
+Deliverable: an audit assigning **every** prose file to an audience and a target home,
+a proposed structure, the decisions the maintainer must make, and a migration plan that
+does not break published links.
+
+This review is **analysis-first**: propose and get decisions before moving anything
+(see Process below).
+
+## Why now
+
+`0.2.0` is close, and two things are about to freeze:
+
+- **Published URLs.** The docs site is live, and `0.2.0.dev0` is on TestPyPI with a
+  README pointing at specific `davitf.github.io/archivey/<page>/` URLs. **PyPI release
+  metadata is immutable** — the README of a published release can never be edited. Every
+  URL shipped in a release must keep resolving, forever. Reorganise before more releases
+  ship more URLs, not after.
+- **First impressions.** The PyPI page and the docs site are the front door for the
+  adoption question Topic 7 (`backlog.md`) will judge. Structure is cheap to change now.
+
+## The starting inventory (measured at `403e7ff`)
+
+| Home | Files | Lines | Published on the site? |
+|---|---:|---:|---|
+| `docs/*.md` (user guide) | 11 | 1,482 | yes |
+| `docs/internal/` | 12 | 3,968 | yes (6 of them **not in nav**) |
+| `docs/grab-bag/` | 6 | 2,831 | yes, declared non-normative |
+| Root `*.md` | 13 | ~1,900 | no |
+| `docs/decisions/` | 15 | — | yes (1 not in nav) |
+| `openspec/specs/` | 24 | — | no |
+| `openspec/changes/archive/` | 60 dirs | — | no |
+| `review/archive/` | 10 dirs | — | no |
+
+The headline number: **the published site is roughly 82% non-user content** (6,799 of
+8,281 published lines sit under `internal/` + `grab-bag/`). A user searching the docs for
+"PPMd" lands in a 695-line upstream investigation report.
+
+## Known problems to fold in (do not re-derive)
+
+- **`docs/internal/` conflates three kinds of thing**: live normative registers
+  (`threat-model.md`, `open-issues.md`, `known-issues.md`), process runbooks
+  (`release-checklist.md`, `release-repo-cutover.md`), and finished investigations
+  (`ppmd-*` ×3 at 1,668 lines, `pyppmd-upstream-report.md`,
+  `rapidgzip-upstream-report.md`). These have different lifetimes and different readers.
+- **`docs/grab-bag/` is published but explicitly non-normative** (2,831 lines of
+  historical `SPEC`/`ARCHITECTURE`/`COMPARISON`/`ASYNC`). Its own index says "triage
+  later" — this is that triage.
+- **Six pages are built and reachable by URL but absent from the nav**
+  (`internal/ppmd-*` ×3, `internal/pyppmd-upstream-report`,
+  `internal/rapidgzip-upstream-report`, `decisions/0014-*`). Published-but-unlisted is
+  already-existing drift, and the `--strict` build does not fail on it.
+- **Four root tombstone stubs** (`ARCHITECTURE.md`, `ASYNC.md`, `COMPARISON.md`,
+  `SPEC.md`) are 5–7 line "moved to…" pointers. They are precedent for a redirect
+  pattern, and also clutter — decide which.
+- **The repo root mixes every audience**: `README` (user), `CONTRIBUTING`/`AGENTS`/
+  `CLAUDE` (contributor), `VISION`/`PLAN`/`IDEAS` (product direction),
+  `CHANGELOG`/`SECURITY` (release), plus the four tombstones.
+- **History lives in three parallel archives with three conventions**: `review/archive/`
+  (dated dirs, `README.md` lifecycle), `openspec/changes/archive/` (dated dirs, OpenSpec
+  lifecycle), `docs/grab-bag/` (undated, "historical"). A reader looking for "why did we
+  decide X" must know which to search.
+- **`AGENTS.md` (83 lines) and `CLAUDE.md` (117 lines) overlap**; `AGENTS.md` opens by
+  deferring to `CLAUDE.md`. Decide whether one is canonical.
+- **`known-issues.md` is user-relevant** (709 lines of real behaviour users hit) but
+  filed under `internal/`. This is the clearest example of the audience question.
+
+## The organising question
+
+Suggested decision rule for the reviewer to test and refine — two axes, four quadrants:
+
+| | **Current / normative** | **Historical / evidence** |
+|---|---|---|
+| **User** | published docs site | `CHANGELOG.md` |
+| **Maintainer** | contributor guide, `openspec/specs/`, live registers, ADRs | investigations, superseded prose, `review/` + `changes/` archives |
+
+Everything should land in exactly one quadrant, and **the published site should be the
+"User + current" quadrant only** — that is the hypothesis to test, not a conclusion.
+Contributor and design material stays in-repo (or in a clearly separated, unindexed
+section) rather than interleaved with the user guide.
+
+Note the deliberate tension to resolve rather than paper over: some material is genuinely
+dual-audience. `threat-model.md` is a normative design record *and* the honest
+security-posture statement an evaluating user wants. `known-issues.md` is maintainer
+triage *and* user-facing gotchas. The reviewer should propose a rule (split the doc?
+publish a user-facing summary that links the internal register?) rather than filing them
+arbitrarily.
+
+## Scope
+
+- Assign **every** prose file (root, `docs/**`, `review/**`, `openspec/**`, `.claude/**`)
+  to an audience and a target home. An explicit "delete" or "keep where it is" is a valid
+  assignment; silence is not.
+- Propose the target tree, the nav, and the rule that decides where a *new* doc goes.
+- Identify duplication and contradiction across homes (the same thing explained twice,
+  differently) — this is where drift hides.
+- Check the user guide for **gaps** as well as excess: what would an adopting engineer
+  look for and not find? (Coordinate with, do not pre-empt, Topic 7.)
+- Propose the migration mechanics, including the redirect strategy (below).
+- Propose the guardrail that keeps the structure from re-rotting.
+
+## Out of scope
+
+- Rewriting page *content* for quality/tone. Note it, do not do it — that is a separate
+  pass, and mixing a content rewrite into a file-move review makes both unreviewable.
+- Re-litigating decided ADRs or spec contracts.
+- Topic 7 (outside-in adoption) — that judges whether the docs *persuade*; this one
+  decides where they *live*. Findings that belong to Topic 7 should be handed to it.
+
+## Hard constraints
+
+- **Published URLs must not 404.** Any page reachable today at
+  `https://davitf.github.io/archivey/<path>/` that moves needs a redirect left behind
+  (`mkdocs-redirects` is the usual mechanism, and would be a new docs-group dependency —
+  evaluate it). URLs shipped in a *released* README (`0.2.0.dev0` onward) can never be
+  fixed at the source and must be treated as permanent.
+- **`mkdocs build --strict` must stay green**, and CI's docs job must keep passing.
+- The `review/` and `openspec/` lifecycles are working and deliberate — propose changes
+  to them only with a specific reason, not for symmetry.
+- `openspec/specs/` is authoritative. Where prose and spec disagree, **pause and ask**
+  (`CLAUDE.md`) rather than editing either to match.
+
+## Suggested process
+
+A docs reorg differs from other reviews: it produces a **migration**, not just findings.
+Recommended four phases, with a decision gate between the first two.
+
+1. **Audit (this review).** Inventory + audience assignment + proposed tree + gap list.
+   Deliverable per `review/README.md`: `SUMMARY.md`, theme files, `QUESTIONS.md`, and an
+   `inventory.md` table (file → audience → current home → proposed home → rationale).
+   **No files move in this phase.** The audit must be reviewable on its own.
+2. **Decide.** Maintainer answers `QUESTIONS.md`: the taxonomy, what the site publishes,
+   what is deleted vs archived, the dual-audience cases, `AGENTS`/`CLAUDE`. These are
+   product/ownership calls, not reviewer calls.
+3. **Execute** as one or more OpenSpec changes, kept **mechanical**: `git mv` + redirects
+   + nav + link fixes, no content edits, so the diff is verifiable by inspection. Split
+   by quadrant if it gets large — a reviewable series beats one 200-file commit.
+4. **Guardrail.** Make the structure self-enforcing, or it re-rots within two months:
+   a nav-completeness check (fail on published-but-unlisted, which would have caught the
+   six pages above), a link checker in CI (internal links *and* the absolute URLs the
+   README now ships), and a short "where does a new doc go?" rule in `CONTRIBUTING.md`
+   pointing at the decision table.
+
+Phase 4 is the part most likely to be skipped and the part that determines whether this
+review is worth doing twice.
+
+## Conventions
+
+Inherits `review/README.md`. Analysis-only in phase 1; cite paths and line counts as of
+`main` @ `403e7ff`. Where a proposal depends on a fact that was not verified (e.g.
+whether a page is linked from outside the repo), say so rather than assuming.
+
+Deliverable shape: `SUMMARY.md` (headline + proposed tree + top findings table),
+`inventory.md` (the full file-by-file assignment), theme files as useful,
+`QUESTIONS.md` (maintainer decisions), and a "what is actually fine" section — the
+`review/` and `openspec/` lifecycles, the ADR log, and the user guide's core pages are
+working and should not be churned for tidiness.

--- a/review/docs/brief.md
+++ b/review/docs/brief.md
@@ -160,6 +160,20 @@ Everything else — accuracy against the code, gaps, examples, tone, length — 
 - `openspec/specs/` is authoritative. Where prose and spec disagree, **pause and ask**
   (`CLAUDE.md`) rather than editing either to match.
 
+## Bias control: the independent code-derived outline
+
+Everything above anchors you. Before phase 1 publishes, a separate agent derives a
+documentation outline from **`src/` and `tests/` only** — no `docs/`, no `review/`, not
+even this brief — and argues adversarially that the current structure is wrong. See
+[`independent-brief.md`](independent-brief.md).
+
+Its output is an **input to be diffed, not a proposal to adopt**. Triage it three ways:
+we have it (weak signal); we lack it (the blind spot this is for); we deliberately don't
+(record *why* — that rationale currently exists only in the maintainer's head).
+
+Weight its **disagreements** heavily and its agreements lightly: isolating context removes
+anchoring but not shared model priors, so convergence proves less than it appears to.
+
 ## Suggested process
 
 A docs reorg differs from other reviews: it produces a **migration**, not just findings.

--- a/review/docs/brief.md
+++ b/review/docs/brief.md
@@ -117,10 +117,35 @@ arbitrarily.
 ## Out of scope
 
 - Rewriting page *content* for quality/tone. Note it, do not do it — that is a separate
-  pass, and mixing a content rewrite into a file-move review makes both unreviewable.
+  pass (Topic 8, below), and mixing a content rewrite into a file-move review makes both
+  unreviewable: a `git mv`-only diff can be verified by inspection, a move-plus-rewrite
+  diff cannot.
+  **But do capture what you notice.** The audit reads every file anyway, so record
+  content observations in an `observations.md` for the content pass to start from —
+  inaccuracies, duplication, pages that are really three pages, pages nobody should
+  read. Recording them is free; acting on them is out of scope.
 - Re-litigating decided ADRs or spec contracts.
 - Topic 7 (outside-in adoption) — that judges whether the docs *persuade*; this one
   decides where they *live*. Findings that belong to Topic 7 should be handed to it.
+
+## Sequencing: the content pass comes after, with two exceptions
+
+Content review is **Topic 8** in `backlog.md` and runs after this one. The reasons are
+practical, not aesthetic: polishing prose that is about to be merged or deleted is wasted
+work, and a reviewer cannot judge whether a page is *complete* until it is clear what that
+page is now responsible for.
+
+Two kinds of content decision are genuinely structural and must be made **here**, not
+deferred — deferring them would make the migration wrong rather than merely unpolished:
+
+- **Merge / split / delete.** "These two pages say the same thing differently" and "this
+  page is really three pages" are filing decisions. A page slated for deletion should not
+  be moved first.
+- **Dual-audience splits.** If `threat-model.md` or `known-issues.md` needs to become a
+  user-facing page plus an internal register, that is a content operation that determines
+  where each half lives.
+
+Everything else — accuracy against the code, gaps, examples, tone, length — waits.
 
 ## Hard constraints
 

--- a/review/docs/independent-brief.md
+++ b/review/docs/independent-brief.md
@@ -1,0 +1,127 @@
+# Brief — independent code-derived documentation outline (bias control)
+
+Commissioned 2026-07-29 against `main` @ `403e7ff`, as an **input to** the docs full
+review ([`brief.md`](brief.md)) rather than a review of its own.
+
+## Why this exists
+
+`brief.md` hands its reviewer an inventory, a four-quadrant taxonomy, and a list of named
+problems. That is efficient, and it is also **anchoring**: a reviewer given a structure
+will mostly confirm it. The failure mode that survives is the one an incumbent reviewer
+structurally cannot see — **what was never written down at all**.
+
+So: derive, from the code alone, the documentation set this library *should* have. The
+artifact we want is not your docs. It is the **diff** between what you propose and what
+exists — and most of the value is in what you include that we lack.
+
+## Deliberate exception to a repo convention
+
+`review/README.md` says a re-review that resurfaces settled ground wastes budget, and
+briefs normally front-load context to prevent that. **This brief deliberately does the
+opposite**, and the waste is the point: re-derivation from scratch is the only way to get
+an unanchored answer. Do not treat the convention as forgotten.
+
+## Inputs
+
+**Read these:**
+
+- `src/` — the implementation and its docstrings.
+- `tests/` — the richest input available. Tests encode intended behaviour, edge cases,
+  and error contracts far better than prose does.
+- `pyproject.toml` — the public surface, extras, entry points, supported Pythons.
+
+**Do NOT read these** — reading them defeats the entire purpose:
+
+- `docs/**` (including `internal/` and `grab-bag/`), `README.md`
+- `VISION.md`, `PLAN.md`, `IDEAS.md`, `CHANGELOG.md`, `SECURITY.md`
+- `review/**` — including `brief.md`, which sits next to this file
+- `CONTRIBUTING.md`, `AGENTS.md`, `CLAUDE.md`
+
+**`openspec/specs/`: excluded on this pass.** A real tension — the specs are normative and
+would make you more accurate, but they are *derived from intent*, so reading them
+re-anchors you on the same framing the existing docs came from. If the maintainer wants
+a spec-informed second opinion, that is a separate pass with a separate brief.
+
+If you find yourself needing a forbidden file to answer something, **that is a finding**:
+record what you could not determine from code, and move on.
+
+## Framing: argue, don't propose
+
+Neutral framing produces agreement. Work adversarially:
+
+- Assume the current documentation is **wrong until the code says otherwise**.
+- For every page you propose, state what breaks for a user if it does not exist.
+- Prefer the uncomfortable claim ("this API cannot be used safely without explaining X")
+  over the safe one ("a usage guide would be helpful").
+
+## Deliverables
+
+Write into `review/docs/independent/`. **Do not modify anything under `docs/`.**
+
+1. **`api-surface.md`** — the public surface as the code defines it: every exported
+   symbol, what it does, its error contract, and its preconditions. Cite `file:line`.
+   This doubles as a check on the real docs later.
+
+2. **`must-explain.md` — the highest-value deliverable.** Every behaviour a user *will*
+   hit that is **not inferable from the signature**: defaults that surprise, operations
+   that are O(n²) if used naively, errors that mean something non-obvious, states that
+   are illegal but type-check, resources that must be closed in an order. For each: the
+   concrete failure a user experiences if nobody tells them.
+
+3. **`rationale-gaps.md`** — behaviours where you can see **what** the code does but not
+   **why**, and where a reasonable user would ask why. This is the inverse of the usual
+   deliverable and it is deliberately valuable: it is precisely the list of things
+   documentation *must* carry, because the code cannot. Do not guess the rationale —
+   naming the gap is the whole output.
+
+4. **`proposed-outline.md`** — the doc set you would write: page list, one line of purpose
+   each, ordered by what a new user needs first. Include rough proportions (which pages
+   are long, which are a screen). If a topic deserves a third of the guide, say so.
+
+5. **Two sample pages, no more.** Pick the two you think matter most and write them
+   properly. This is a probe for depth and voice, not a writing assignment.
+
+**Do not write the full documentation set.** Generated prose has to be verified claim by
+claim against the code, and that verification costs more than the writing saved.
+Unverified generated docs are worse than missing ones: they are confidently wrong in ways
+a reader cannot detect. The outline is the product.
+
+## Rules of evidence
+
+- Every behavioural claim cites `file:line` or a test. If you inferred it, say "inferred".
+- Where the code is ambiguous, say so rather than picking the plausible reading — an
+  ambiguity you flag is more useful than a guess you don't.
+- Do not propose documenting something as a *defect* when it may be a deliberate
+  trade-off; you cannot see intent from here. Phrase those as questions.
+
+## Known limitation, recorded honestly
+
+**Independence here is partial.** Isolating context removes *anchoring*; it does not
+remove *model priors*. If this outline broadly matches the existing structure, that is
+weak evidence the structure is right — it may only show that two runs of similar models
+reach for similar shapes. Weight **disagreements** heavily and **agreements** lightly.
+
+Two things sharpen it, in order of effect:
+
+- run this on a **different model** from the one that wrote `brief.md`;
+- the adversarial framing above, which is why it is a requirement and not a suggestion.
+
+## How the output will be used
+
+Not adopted, and not merged into `docs/`. The docs review will diff it against the real
+structure and triage into three buckets:
+
+| Bucket | Meaning |
+|---|---|
+| **We have it** | agreement — weak signal, note and move on |
+| **We lack it** | the blind spot this exercise is for — triage seriously |
+| **We deliberately don't** | the agent could not see intent; record *why* so the reason is written down |
+
+That third bucket is a quiet win: every entry is a rationale that currently lives only in
+the maintainer's head, and it feeds `rationale-gaps.md` straight into Topic 8.
+
+## Timing
+
+Run **before** the docs audit (`brief.md` phase 1) publishes findings, so nothing leaks
+backwards. If that ordering slips, run it anyway — the input isolation matters more than
+the sequence, since the agent never reads `review/` regardless.


### PR DESCRIPTION
Fixes the broken links on the TestPyPI project page. Version deliberately left at `0.2.0.dev0`.

## The bug

It is the main README — `pyproject.toml` has `readme = "README.md"`, and **PyPI resolves relative links against the project page URL**, not the repo. So `](docs/philosophy.md)` rendered as `https://test.pypi.org/project/archivey/0.2.0.dev0/docs/philosophy.md`. GitHub resolves these correctly, which is why it went unnoticed.

All 18 links are now absolute:

- `docs/*.md` → the live MkDocs site (`https://davitf.github.io/archivey/<page>/`). Better than repo blob links, since readers land on rendered docs from both GitHub and PyPI.
- Root files (`VISION.md`, `SECURITY.md`, `CONTRIBUTING.md`) → `github.com/davitf/archivey/blob/main/…`

I derived the URL scheme from the built `site/` tree rather than assuming MkDocs' `use_directory_urls` behaviour, and verified every target resolves to a real page — plus that the packaged `METADATA` contains no relative link at all.

## Trimmed the link list

Most of what was there was maintainer-facing (PLAN, IDEAS, decision log, threat model, release checklist) — the wrong audience for a PyPI landing page. Kept the docs-site entry point, five user-facing pages, and contributing/security.

**This is a light trim, not the documentation sweep** — that stays deferred as you asked.

## The related gap: no packaging metadata at all

While checking what PyPI renders, I found `[project.urls]`, `classifiers`, and `keywords` were **entirely absent** — which is most of *why* the README was carrying all that navigation. The sidebar had no links whatsoever.

- **`[project.urls]`** — Homepage, Documentation, Source, Changelog, Issues.
- **16 classifiers** — Python 3.11–3.14, OS Independent, `Typing :: Typed` (verified `src/archivey/py.typed` ships), plus the archiving/compression topics that make the project findable.
- **`keywords`** for search.

One judgement call flagged in a comment rather than made silently: `Development Status :: 4 - Beta`. That's my read of a pre-1.0 first public release, not a fact — say the word if you'd rather ship `3 - Alpha`.

## Verification

- `uv build` + `twine check --strict` pass on both sdist and wheel.
- Inspected the packaged `METADATA` directly: all five `Project-URL` entries, 16 classifiers, and **zero** relative links in the rendered README body.
- Every docs URL checked against the built `site/` tree; every root-file link checked to exist.
- `mkdocs build --strict` clean; `ruff` clean; `[all]` suite 1992 passed / 58 skipped.

Worth noting I could not fetch `davitf.github.io` from this sandbox (network policy denies it), so the docs-site URLs are verified against the locally built site and your confirmation that the site is live — not by fetching them.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1G2pL3FRbyR6VzmqQWpdV)_