### PR TITLE
review: triage independent docs pass; propose extras consolidation + capability booleans

### DIFF
--- a/openspec/changes/consolidate-optional-extras/design.md
+++ b/openspec/changes/consolidate-optional-extras/design.md
@@ -1,0 +1,61 @@
+## Why 4, and why these 4
+
+The question the maintainer posed was "do we need one extra per format?" The measured
+answer is that we never had one: `[7z]` is a codec bundle, `[rar]` is an alias of
+`[crypto]`, `[zstd]`/`[lz4]` are subsets of `[7z]`. So this is not a redesign — it is
+making the names match what the groups already are.
+
+The selection rule: **an extra should answer a question a user asks about themselves**,
+not name an internal dependency group. Users ask "will it just work?" (`recommended`),
+"do I need fast seeking?" (`seekable`), "am I on free-threaded Python?"
+(`free-threaded`), "give me everything" (`all`). Nobody asks "do I want pybcj?".
+
+## Why `cryptography` stays in `recommended` rather than becoming the split point
+
+The maintainer asked whether `cryptography` is simple enough to fold into the default
+bundle. It is **already there** transitively (`recommended` → `7z` → `cryptography`), so
+folding it in changes nothing; the question is whether to pull it *out*.
+
+Keep it in, because:
+
+- It is required for the encryption features that make the release's compatibility story
+  (WinZip AES ZIP, header-encrypted RAR, 7z AES). A "recommended" install that cannot open
+  an AES ZIP is not recommendable.
+- It ships wheels for every platform the project tests.
+
+But record the cost honestly, because it is the reason `free-threaded` must exist as a
+separate extra: `cryptography` depends on `cffi`, and **cffi refuses to build on
+free-threaded CPython 3.13**. So `recommended` cannot be installed there today. That is a
+property of the wheel ecosystem, not of archivey, and it is expected to resolve on 3.14t.
+
+## Why `free-threaded` is a separate extra, and the risk
+
+It is the only honest way to give free-threaded users an install line that works. The set
+is measured, not guessed (each package verified to leave `sys._is_gil_enabled()` false
+after import), and CI already installs exactly this set on 3.13t and asserts the GIL stays
+disabled — so the extra cannot silently rot.
+
+**The risk, recorded rather than hidden:** an extra named for a *runtime property* is a
+moving target. When `cryptography`/`pyppmd`/`rapidgzip` gain free-threaded support, the
+set grows and eventually `free-threaded` collapses into `recommended`. It could also be
+misread as "this makes archivey free-threaded" (it does not; it avoids dependencies that
+switch the GIL back on). Mitigations: the spec states both facts, and the extra is
+documented as "the subset that currently keeps the GIL disabled — expected to widen".
+
+The alternative — document the pip line in prose instead of shipping an extra — was
+rejected because a prose install line rots silently, while an extra is exercised by CI on
+every run.
+
+## Alternatives considered
+
+**Capability extras with format aliases** (`codecs`, `crypto`, … plus `7z` = alias).
+Non-breaking and more granular. Rejected on the maintainer's "err on the side of fewer"
+instruction: it *adds* names, and every added extra is permanent. It also keeps the
+format names that caused the confusion, merely making them correct by construction.
+
+**Keep the table, fix only the hint strings.** Cheapest, and it does fix the reported
+symptom. Rejected because `[rar]`-cannot-deliver-`unrar` and the free-threaded
+uninstallability remain, and because the window to remove extras closes at `0.2.0`.
+
+**Drop `[all]`.** It currently resolves to exactly `[recommended]` + `[seekable]`. Kept:
+it is the conventional name people try first, and it costs one line.

--- a/openspec/changes/consolidate-optional-extras/design.md
+++ b/openspec/changes/consolidate-optional-extras/design.md
@@ -35,9 +35,11 @@ is measured, not guessed (each package verified to leave `sys._is_gil_enabled()`
 after import), and CI already installs exactly this set on 3.13t and asserts the GIL stays
 disabled — so the extra cannot silently rot.
 
-**The risk, recorded rather than hidden:** an extra named for a *runtime property* is a
-moving target. When `cryptography`/`pyppmd`/`rapidgzip` gain free-threaded support, the
-set grows and eventually `free-threaded` collapses into `recommended`. It could also be
+**The risk, now confirmed with data rather than predicted:** an extra named for a
+*runtime property* is a moving target. Measured on 3.14t, `cryptography` **joins** the
+GIL-safe set while `pyppmd`, `inflate64`, `brotli` and `rapidgzip` still re-enable the
+GIL. So the set is already version-dependent, which is why the extra uses environment
+markers, and it will keep widening until it eventually collapses into `recommended`. It could also be
 misread as "this makes archivey free-threaded" (it does not; it avoids dependencies that
 switch the GIL back on). Mitigations: the spec states both facts, and the extra is
 documented as "the subset that currently keeps the GIL disabled — expected to widen".
@@ -45,6 +47,37 @@ documented as "the subset that currently keeps the GIL disabled — expected to 
 The alternative — document the pip line in prose instead of shipping an extra — was
 rejected because a prose install line rots silently, while an extra is exercised by CI on
 every run.
+
+## Should the crypto library change? (asked 2026-07-29 — no)
+
+`internal/streams/crypto.py` is a one-method `CryptoBackend` ABC
+(`aes_cbc_decrypt_stage`), and `zip_aes.py` adds AES-ECB for the CTR keystream. Every
+other primitive — PBKDF2, SHA-1/256, HMAC — is stdlib `hashlib`. So **AES block
+operations are the only third-party crypto need**, and swapping backends is genuinely
+cheap, exactly as the encapsulation intended.
+
+Measured, since the question was whether a free-thread-safe alternative exists:
+
+| Library | 3.13t | 3.14t |
+| --- | --- | --- |
+| `cryptography` | **cannot install** (cffi rejects FT 3.13) | installs, AES-CBC works, **GIL stays disabled** |
+| `pycryptodome` 3.23 | installs, AES-CBC + AES-ECB work, **GIL stays disabled** | not tested |
+
+So yes, a free-thread-safe alternative exists today. **Do not switch anyway**, and do not
+add a second backend:
+
+- The gap is **one pre-release runtime**, and it is already closed upstream on 3.14t —
+  which is the first free-threaded build with real support behind it. Trading a widely
+  audited, ecosystem-default security library for a workaround to a transient packaging
+  hole in an experimental interpreter is a bad exchange.
+- A second crypto backend is not free even when the plug point is: it doubles the
+  security surface to audit, adds divergence risk in padding and error paths (precisely
+  where crypto bugs live), and turns "which backend am I on?" into a support question
+  that affects observable behaviour.
+
+Keep the abstraction, though: it is what makes this a paragraph rather than a project, and
+it means the decision is cheap to revisit if `cryptography` ever becomes a problem for a
+reason that is not self-resolving.
 
 ## Alternatives considered
 

--- a/openspec/changes/consolidate-optional-extras/proposal.md
+++ b/openspec/changes/consolidate-optional-extras/proposal.md
@@ -20,6 +20,11 @@ cffi rejects free-threaded 3.13 ("upgrade to free-threaded 3.14 or newer"). The
 recommended install is therefore uninstallable on a runtime the project tests in CI, and
 nothing in the extras table says so.
 
+Verified on **3.14t**, `cryptography` installs, decrypts and leaves the GIL disabled — so
+this is a 3.13t-only packaging gap, already fixed upstream, not a property of the library.
+That is why `[free-threaded]` carries `cryptography` behind a `python_version >= '3.14'`
+marker rather than omitting it outright.
+
 `0.2.0` is the first public release, so the extras table has no users yet. Removing or
 renaming an extra is breaking **after** the tag and free **before** it. This is the only
 window.
@@ -32,7 +37,7 @@ Collapse 11 extras to **4**, chosen so each answers a question a user actually a
 | --- | --- | --- |
 | `[recommended]` | `pyppmd`, `inflate64`, `brotli`, `lz4`, `pybcj`, `backports.zstd` (<3.14), `cryptography`, `pycdlib`, `tqdm` | "give me everything that works everywhere" |
 | `[seekable]` | `rapidgzip` | "I want gz/bz2 random access and speed" — kept separate because it is a heavy native build, re-enables the GIL on free-threaded builds, and carries the accelerator process-abort known issue |
-| `[free-threaded]` | `pycdlib`, `lz4`, `tqdm`, `backports.zstd` (<3.14) | "I am on a free-threaded build" — the measured subset that keeps the GIL **disabled** |
+| `[free-threaded]` | `pycdlib`, `lz4`, `tqdm`, `backports.zstd` (<3.14), `cryptography` (>=3.14) | "I am on a free-threaded build" — the measured subset that keeps the GIL **disabled**. Version-conditional: `cryptography` is unusable on 3.13t and fine on 3.14t |
 | `[all]` | `[recommended]` + `[seekable]` | "everything" |
 
 **Removed:** `[7z]`, `[rar]`, `[crypto]`, `[iso]`, `[zstd]`, `[lz4]`, `[cli]`,

--- a/openspec/changes/consolidate-optional-extras/proposal.md
+++ b/openspec/changes/consolidate-optional-extras/proposal.md
@@ -1,0 +1,62 @@
+## Why
+
+The extras are **named by format but scoped by capability**, and the mismatch is
+user-visible. `[7z]` pulls seven packages, six of which are member codecs shared with ZIP
+and TAR — so a ZIP member using Deflate64 or PPMd raises
+`PackageNotInstalledError: pip install archivey[7z]`. That hint is *correct* and reads
+like the library misidentified the file. The name is what lies, not the message.
+
+Two more consequences of the same mismatch:
+
+- `[rar]` and `[crypto]` are **byte-identical** (both `cryptography` only), and `[rar]` is
+  doubly misleading: RAR member *data* needs the RARLAB `unrar` **binary**, which no pip
+  extra can supply. The packaging metadata promises something it cannot deliver.
+- `[zstd]` and `[lz4]` are strict subsets of `[7z]`, so the same codec is reachable under
+  two names with different implied meanings.
+
+Separately, and measured: **`pip install archivey[recommended]` fails outright on
+free-threaded CPython 3.13** — `[recommended]` → `[7z]` → `cryptography` → `cffi`, and
+cffi rejects free-threaded 3.13 ("upgrade to free-threaded 3.14 or newer"). The
+recommended install is therefore uninstallable on a runtime the project tests in CI, and
+nothing in the extras table says so.
+
+`0.2.0` is the first public release, so the extras table has no users yet. Removing or
+renaming an extra is breaking **after** the tag and free **before** it. This is the only
+window.
+
+## What Changes
+
+Collapse 11 extras to **4**, chosen so each answers a question a user actually asks.
+
+| Extra | Pulls | Answers |
+| --- | --- | --- |
+| `[recommended]` | `pyppmd`, `inflate64`, `brotli`, `lz4`, `pybcj`, `backports.zstd` (<3.14), `cryptography`, `pycdlib`, `tqdm` | "give me everything that works everywhere" |
+| `[seekable]` | `rapidgzip` | "I want gz/bz2 random access and speed" — kept separate because it is a heavy native build, re-enables the GIL on free-threaded builds, and carries the accelerator process-abort known issue |
+| `[free-threaded]` | `pycdlib`, `lz4`, `tqdm`, `backports.zstd` (<3.14) | "I am on a free-threaded build" — the measured subset that keeps the GIL **disabled** |
+| `[all]` | `[recommended]` + `[seekable]` | "everything" |
+
+**Removed:** `[7z]`, `[rar]`, `[crypto]`, `[iso]`, `[zstd]`, `[lz4]`, `[cli]`,
+`[recommended-lite]`. `[recommended-lite]` disappears by construction: with `[seekable]`
+no longer inside `[recommended]`, the lite variant *is* `[recommended]`.
+
+- Every `MissingComponent` install hint changes from `pip install archivey[7z]` to
+  `pip install archivey[recommended]` (or `[seekable]` for rapidgzip) — true regardless
+  of which container the member came from, which is the actual fix.
+- The `[rar]` extra's stale TODO goes away with the extra. Record in the spec that
+  BLAKE2sp is implemented natively on stdlib (`internal/hashing/blake2sp.py`, zero-dep),
+  which is what that TODO was waiting for.
+- `docs/formats.md`'s per-format extra column and `docs/support-matrix.md` are updated to
+  the new names.
+
+## Impact
+
+- **Breaking** for anyone pinning `archivey[7z]` etc. Nothing is published on real PyPI
+  (only `0.2.0.dev0` on TestPyPI), so the real blast radius is this repo and its CI.
+- CI legs using `--extra all` are unaffected; the free-threaded job's explicit extra list
+  becomes `--extra free-threaded`, which makes the job self-describing.
+- **Trade-off accepted deliberately:** a user who wants only ISO now installs
+  `[recommended]` and gets the codecs and `cryptography` too. This is a real regression in
+  install minimalism, chosen because "err on the side of fewer extras" is the stated
+  preference and because an extra, once published, can never be removed. It also
+  contradicts the current spec sentence requiring each extra to avoid pulling unrelated
+  dependencies — that requirement is modified here rather than quietly broken.

--- a/openspec/changes/consolidate-optional-extras/specs/packaging-and-extras/spec.md
+++ b/openspec/changes/consolidate-optional-extras/specs/packaging-and-extras/spec.md
@@ -12,7 +12,7 @@ codecs, encryption, ISO, seeking accelerators, and the CLI.
 | *(none)* | stdlib only + native parsers | ZIP, TAR + stdlib compressed TAR variants including `.tar.Z`, GZ, BZ2, XZ, Z (unix-compress), directory, 7z read for common codecs (including LZMA2+BCJ), RAR metadata/listing; RAR data still needs RARLAB `unrar` |
 | `[recommended]` | `pyppmd`, `inflate64`, `brotli`, `lz4`, `pybcj`, `backports.zstd` on Python <3.14, `cryptography`, `pycdlib`, `tqdm` | Every format and codec that installs everywhere: PPMd, Deflate64, Zstd, Brotli, LZ4, LZMA1+BCJ, AES/crypto (7z, RAR headers, WinZip AES ZIP), ISO, CLI progress |
 | `[seekable]` | `rapidgzip` | Faster gzip/bzip2 decompression and random access via rapidgzip / bundled `IndexedBzip2File` |
-| `[free-threaded]` | `pycdlib`, `lz4`, `tqdm`, `backports.zstd` on Python <3.14 | The subset that keeps the GIL **disabled** on free-threaded builds |
+| `[free-threaded]` | `pycdlib`, `lz4`, `tqdm`, `backports.zstd` on Python <3.14, `cryptography` on Python >=3.14 | The subset that keeps the GIL **disabled** on free-threaded builds |
 | `[all]` | `[recommended]` + `[seekable]` | Everything |
 
 The system SHALL make `[recommended]` the sensible all-useful install and `[seekable]`
@@ -35,6 +35,13 @@ be removed; fewer names is the durable choice.)
 `PackageNotInstalledError` install hints MUST name the extra that provides the missing
 package (`[recommended]`, or `[seekable]` for rapidgzip) and MUST NOT name a format,
 since member codecs are shared across containers.
+
+AES block operations are the only third-party crypto dependency (`CryptoBackend` in
+`internal/streams/crypto.py`; PBKDF2/SHA/HMAC are stdlib). The system SHALL ship exactly
+one crypto backend, `cryptography`. Alternate AES providers MUST NOT be added merely to
+work around a runtime where `cryptography` cannot yet install, since that doubles the
+security surface for a transient gap; the backend abstraction is retained so the choice
+stays cheap to revisit.
 
 The system SHALL treat `[free-threaded]` as a **measured, moving** set: membership is
 determined by whether importing the package leaves the GIL disabled on a free-threaded
@@ -72,7 +79,8 @@ NOT list `uncompresspy` in any user-facing extra or the `dev` group.
 | `pip install archivey[recommended]` | Every format/codec/crypto/ISO/CLI capability that installs everywhere; no rapidgzip |
 | `pip install archivey[seekable]` after `[recommended]` | Adds gz/bz2 random access and speed |
 | `pip install archivey[recommended]` on free-threaded 3.13 | **Fails** — `cryptography` -> `cffi` does not support free-threaded 3.13; documented, not worked around |
-| `pip install archivey[free-threaded]` on free-threaded 3.13 | Resolves; importing every included package leaves the GIL disabled |
+| `pip install archivey[free-threaded]` on free-threaded 3.13 | Resolves without `cryptography`; importing every included package leaves the GIL disabled |
+| `pip install archivey[free-threaded]` on free-threaded 3.14 | Resolves **with** `cryptography` (cffi supports 3.14t); GIL still disabled |
 | `pip install archivey[all]` | `[recommended]` + `[seekable]` |
 | ZIP member needs Deflate64 with no extras | `PackageNotInstalledError` naming `archivey[recommended]`, never a format-named extra |
 | `pip install archivey[7z]` | Fails: the extra no longer exists |

--- a/openspec/changes/consolidate-optional-extras/specs/packaging-and-extras/spec.md
+++ b/openspec/changes/consolidate-optional-extras/specs/packaging-and-extras/spec.md
@@ -1,0 +1,78 @@
+## MODIFIED Requirements
+
+### Requirement: Optional extras enable specific capabilities
+
+The system SHALL expose exactly **four** user-facing extras, each answering a question a
+user asks about their own environment rather than naming an internal dependency group.
+7z and RAR reading are native for the common case, so extras cover less-common member
+codecs, encryption, ISO, seeking accelerators, and the CLI.
+
+| Extra | Pulls in | Enables |
+| --- | --- | --- |
+| *(none)* | stdlib only + native parsers | ZIP, TAR + stdlib compressed TAR variants including `.tar.Z`, GZ, BZ2, XZ, Z (unix-compress), directory, 7z read for common codecs (including LZMA2+BCJ), RAR metadata/listing; RAR data still needs RARLAB `unrar` |
+| `[recommended]` | `pyppmd`, `inflate64`, `brotli`, `lz4`, `pybcj`, `backports.zstd` on Python <3.14, `cryptography`, `pycdlib`, `tqdm` | Every format and codec that installs everywhere: PPMd, Deflate64, Zstd, Brotli, LZ4, LZMA1+BCJ, AES/crypto (7z, RAR headers, WinZip AES ZIP), ISO, CLI progress |
+| `[seekable]` | `rapidgzip` | Faster gzip/bzip2 decompression and random access via rapidgzip / bundled `IndexedBzip2File` |
+| `[free-threaded]` | `pycdlib`, `lz4`, `tqdm`, `backports.zstd` on Python <3.14 | The subset that keeps the GIL **disabled** on free-threaded builds |
+| `[all]` | `[recommended]` + `[seekable]` | Everything |
+
+The system SHALL make `[recommended]` the sensible all-useful install and `[seekable]`
+an opt-in on top of it. `[seekable]` MUST remain separate rather than folded into
+`[recommended]`: it is a heavy native build that can fail to compile, importing it
+re-enables the GIL on free-threaded builds, and it carries the accelerator
+close-before-finalize hazard recorded in `known-issues.md`.
+
+The system SHALL NOT ship an extra per format. Removed names (`[7z]`, `[rar]`,
+`[crypto]`, `[iso]`, `[zstd]`, `[lz4]`, `[cli]`, `[recommended-lite]`) MUST NOT be
+reintroduced as aliases: format-named extras whose contents are capability-scoped are what
+made install hints name the wrong thing.
+
+Installing an extra MAY pull dependencies unrelated to the capability the caller wanted —
+`[recommended]` is deliberately a single broad bundle. This supersedes the previous
+requirement that each extra avoid unrelated dependencies, and is an accepted trade for a
+table small enough that no user has to reason about it. (Extras, once published, can never
+be removed; fewer names is the durable choice.)
+
+`PackageNotInstalledError` install hints MUST name the extra that provides the missing
+package (`[recommended]`, or `[seekable]` for rapidgzip) and MUST NOT name a format,
+since member codecs are shared across containers.
+
+The system SHALL treat `[free-threaded]` as a **measured, moving** set: membership is
+determined by whether importing the package leaves the GIL disabled on a free-threaded
+build, it is expected to widen as the ecosystem adds support, and it MAY eventually
+collapse into `[recommended]`. It MUST NOT be read as a claim that archivey is only
+free-thread-safe with it. CI MUST install exactly this set on a free-threaded interpreter
+and assert the GIL is still disabled, so the set cannot rot silently.
+
+The system SHALL keep `[all]` as the conventional superset; it MUST resolve to
+`[recommended]` + `[seekable]`.
+
+Missing optional libraries MUST degrade by one rule: raise `PackageNotInstalledError` or
+`UnsupportedFeatureError` only when bytes cannot be produced, and skip any integrity check
+that cannot be computed with an integrity diagnostic/warning instead of failing the read.
+
+RAR5 BLAKE2sp verification is implemented **natively on stdlib `hashlib`**
+(`internal/hashing/blake2sp.py`) and requires no third-party package; no extra pulls a
+Blake2sp backend.
+
+The system SHALL keep `py7zr` and `rarfile` as **dev-only** test oracles. 7z writing is
+not shipped in the current release (no `[7z-write]` extra); when writing lands in a later
+phase it MAY reintroduce a dedicated write extra. BCJ2-filtered 7z members MUST remain
+unsupported by every extra. No user-facing extra SHALL pull an alternate RAR decompressor
+library or tool wrapper, and no extra can supply the RARLAB `unrar` binary.
+
+Development tools, oracle libraries, and fixture generators such as `ncompress` SHALL live
+in the PEP 735 `dev` dependency group, not in user-facing runtime extras. The system SHALL
+NOT list `uncompresspy` in any user-facing extra or the `dev` group.
+
+#### Scenario: extras matrix
+
+| Case | Expected |
+| --- | --- |
+| `pip install archivey` | No third-party runtime packages; core formats work |
+| `pip install archivey[recommended]` | Every format/codec/crypto/ISO/CLI capability that installs everywhere; no rapidgzip |
+| `pip install archivey[seekable]` after `[recommended]` | Adds gz/bz2 random access and speed |
+| `pip install archivey[recommended]` on free-threaded 3.13 | **Fails** — `cryptography` -> `cffi` does not support free-threaded 3.13; documented, not worked around |
+| `pip install archivey[free-threaded]` on free-threaded 3.13 | Resolves; importing every included package leaves the GIL disabled |
+| `pip install archivey[all]` | `[recommended]` + `[seekable]` |
+| ZIP member needs Deflate64 with no extras | `PackageNotInstalledError` naming `archivey[recommended]`, never a format-named extra |
+| `pip install archivey[7z]` | Fails: the extra no longer exists |

--- a/openspec/changes/consolidate-optional-extras/tasks.md
+++ b/openspec/changes/consolidate-optional-extras/tasks.md
@@ -1,0 +1,41 @@
+## 1. Packaging
+
+- [ ] 1.1 Rewrite `[project.optional-dependencies]` to the four extras
+      (`recommended`, `seekable`, `free-threaded`, `all`); delete `7z`, `rar`, `crypto`,
+      `iso`, `zstd`, `lz4`, `cli`, `recommended-lite`.
+- [ ] 1.2 Drop the stale `[rar]` TODO; BLAKE2sp is native
+      (`internal/hashing/blake2sp.py`), so nothing is pending.
+- [ ] 1.3 Verify `uv build` + `twine check --strict` still pass and the built METADATA
+      lists exactly the four extras.
+
+## 2. Install hints
+
+- [ ] 2.1 Update every `MissingComponent` hint: `archivey[7z]` -> `archivey[recommended]`
+      (`streams/codecs.py:1455`, `:1523`, `:1579` and any others found by grep).
+- [ ] 2.2 rapidgzip hints -> `archivey[seekable]`.
+- [ ] 2.3 Grep the whole tree (`src/`, `tests/`, `docs/`, `benchmarks/`, `scripts/`,
+      `.github/`) for the removed extra names; none may survive outside archived
+      history.
+
+## 3. CI
+
+- [ ] 3.1 Free-threaded job: replace the explicit
+      `--extra iso --extra zstd --extra lz4 --extra cli` list with
+      `--extra free-threaded`; keep the GIL assertion.
+- [ ] 3.2 Confirm `--extra all` legs are unchanged and green.
+
+## 4. Docs
+
+- [ ] 4.1 `docs/formats.md` quick matrix: replace the per-format extra column with the
+      new names, and state plainly that RAR *data* needs the `unrar` binary, which no
+      extra provides.
+- [ ] 4.2 `docs/support-matrix.md`: point the free-threaded section at
+      `[free-threaded]`, keeping the measured GIL table.
+- [ ] 4.3 `docs/usage.md` install block; README install line if affected.
+
+## 5. Verification
+
+- [ ] 5.1 `pip install archivey[free-threaded]` resolves on 3.13t and the GIL stays
+      disabled (already asserted by CI; confirm locally too).
+- [ ] 5.2 Three-config suite green (`[all]`, `[all-lowest]`, core-only).
+- [ ] 5.3 `mkdocs build --strict` clean.

--- a/openspec/changes/consolidate-optional-extras/tasks.md
+++ b/openspec/changes/consolidate-optional-extras/tasks.md
@@ -1,6 +1,7 @@
 ## 1. Packaging
 
-- [ ] 1.1 Rewrite `[project.optional-dependencies]` to the four extras
+- [ ] 1.1 Rewrite `[project.optional-dependencies]` to the four extras, with
+      `cryptography; python_version >= "3.14"` inside `[free-threaded]`
       (`recommended`, `seekable`, `free-threaded`, `all`); delete `7z`, `rar`, `crypto`,
       `iso`, `zstd`, `lz4`, `cli`, `recommended-lite`.
 - [ ] 1.2 Drop the stale `[rar]` TODO; BLAKE2sp is native
@@ -35,7 +36,8 @@
 
 ## 5. Verification
 
-- [ ] 5.1 `pip install archivey[free-threaded]` resolves on 3.13t and the GIL stays
+- [ ] 5.1 `pip install archivey[free-threaded]` resolves on 3.13t **and** 3.14t (with
+      `cryptography` only on the latter) and the GIL stays
       disabled (already asserted by CI; confirm locally too).
 - [ ] 5.2 Three-config suite green (`[all]`, `[all-lowest]`, core-only).
 - [ ] 5.3 `mkdocs build --strict` clean.

--- a/openspec/changes/member-stream-capability-booleans/design.md
+++ b/openspec/changes/member-stream-capability-booleans/design.md
@@ -1,0 +1,42 @@
+## Two booleans vs. keeping the flags
+
+**Chosen: two booleans.**
+
+- Consistent with ADR 0004's recorded preference in the analogous case, so this is the
+  codebase's existing taste rather than a new direction.
+- Closes the vocabulary split: `seekable` means the same thing in `open_archive` and
+  `open_stream`.
+- Self-documenting where it matters. `seekable_members: bool = False` in the signature
+  tells the whole story — no import, no enum lookup, visible in autocomplete. That is the
+  point: this change came out of a "make the code say it so the docs need not" pass.
+- There are exactly two capabilities, and ADR 0003 frames them as two specific traps
+  (seek cost, overlapping opens) rather than an open-ended set.
+
+**The counter-argument, recorded because it is real:** flags are more extensible (a third
+capability is a new flag, not a new parameter) and composable (a caller can compute a
+capability set and pass it). If a third capability were expected, the cheaper fix would be
+to keep the enum and rename the parameter — `require=MemberStreams.SEEKABLE` reads well
+and fixes the flag-ness complaint alone. This change bets that a third is not coming; if
+that bet is wrong, adding `parallel_members=` later is still additive and non-breaking.
+
+## Naming
+
+`seekable_members` / `concurrent_members` over `seekable` / `concurrent` because
+`open_archive`'s subject is the archive, not a stream: unqualified `seekable=True` there
+would read as "the *source* is seekable", which is a different (and already inferred)
+property. The `_members` suffix keeps the subject unambiguous while keeping the shared
+`seekable` root that makes the two entry points rhyme.
+
+## Why remove rather than deprecate
+
+Deprecation exists to protect callers. There are none — `0.2.0` is the first public
+release and only `0.2.0.dev0` reached TestPyPI. Accepting both spellings would leave the
+library shipping the exact ambiguity this change removes, and every doc page would have to
+explain which to prefer.
+
+## Non-goals
+
+- No behavioural change. Same defaults, same `ConcurrentAccessError`, same
+  `io.UnsupportedOperation` on undeclared seek, same `streaming` + concurrency rejection.
+  Keeping behaviour fixed is what makes the large mechanical diff reviewable.
+- `MemberStreams` is not removed, and `CostReceipt` is untouched.

--- a/openspec/changes/member-stream-capability-booleans/proposal.md
+++ b/openspec/changes/member-stream-capability-booleans/proposal.md
@@ -1,0 +1,57 @@
+## Why
+
+One concept is spelled two ways at the two entry points:
+
+```python
+open_archive(p, member_streams=MemberStreams.SEEKABLE | MemberStreams.CONCURRENT)
+open_stream(p, seekable=True)
+```
+
+Every user learns it twice. Worse, `member_streams=` does not read like a flag set — it
+reads like it takes *streams*, or a count, or a mode — and you must import
+`MemberStreams` before you can pass anything at all, so the option is invisible in
+autocomplete until you have already found the enum.
+
+Two ADRs are directly on point and both point **toward** this change rather than against
+it:
+
+- **ADR 0004** rejected an `Intent` enum in favour of `streaming: bool`, reasoning "two
+  real modes, not three labels for two behaviors". The recorded taste is: prefer a bool
+  when the mode count is small.
+- **ADR 0003** describes the member-stream defaults and then says, of
+  `open_stream(..., seekable=False)`, "**same rule**" — the ADR already treats these as
+  one concept.
+
+Neither ADR defends `member_streams` as a *name* or the flag/bool split between entry
+points. That split is accretion, not a decision. It has now been independently flagged
+twice (the archived api-coherence review, then the code-derived documentation pass).
+
+`0.2.0` is the first public release, so there are no external callers. This is breaking
+after the tag and free before it.
+
+## What Changes
+
+- `open_archive` takes two keyword-only booleans instead of a flag enum:
+
+  ```python
+  open_archive(p, seekable_members=True, concurrent_members=True)
+  open_stream(p, seekable=True)
+  ```
+
+- `member_streams=` is **removed**, not deprecated. Nothing external depends on it, and
+  carrying both spellings would double exactly the surface this change exists to halve.
+- `MemberStreams` **stays exported**. It remains meaningful as the declared-capability
+  value on `CostReceipt` and in diagnostics, and removing a public name buys nothing.
+  Internal plumbing may keep using the flags; only the public entry point changes.
+- The existing rejection of `streaming=True` combined with concurrency keeps its
+  behaviour, now phrased against `concurrent_members=True`.
+
+## Impact
+
+- **Breaking**: one public signature (`core.py:101`). ~52 internal references, ~38 in
+  tests, 8 in docs — mechanical, with the tests carrying most of the work.
+- Behaviour is unchanged: same defaults (both `False`), same errors, same capability
+  semantics. This is a spelling change, deliberately kept free of behavioural drift so
+  the diff stays reviewable.
+- ADR 0003 needs a short amendment noting the new spelling; ADR 0004's reasoning is
+  reinforced rather than altered.

--- a/openspec/changes/member-stream-capability-booleans/specs/access-mode-and-cost/spec.md
+++ b/openspec/changes/member-stream-capability-booleans/specs/access-mode-and-cost/spec.md
@@ -1,0 +1,36 @@
+## MODIFIED Requirements
+
+### Requirement: Member stream capabilities are declared with booleans
+
+The system SHALL let callers declare member-stream capabilities at `open_archive` with
+two keyword-only booleans, `seekable_members` and `concurrent_members`, both defaulting
+to `False`. The system SHALL NOT expose a flag-enum parameter for this purpose.
+
+`open_stream` SHALL keep its `seekable: bool` parameter, and the two entry points SHALL
+use the same `seekable` vocabulary for the same concept. Concurrency has no meaning for a
+single standalone stream, so `open_stream` MUST NOT gain a concurrency parameter.
+
+Defaults and behaviour are unchanged by the spelling: with neither declared, member
+streams report `seekable() is False`, `seek()` raises `io.UnsupportedOperation`, and at
+most one member stream may be live — a second overlapping `open()` raises
+`ConcurrentAccessError`. Declaring `concurrent_members=True` together with
+`streaming=True` MUST be rejected at open with `ArchiveyUsageError`.
+
+The `MemberStreams` flag type SHALL remain publicly exported and SHALL remain the value
+reported for declared capabilities on `CostReceipt` and in diagnostics. It is no longer
+an input to `open_archive`.
+
+Declaring `concurrent_members=True` MUST NOT change solid open-order cost; that remains
+the caller's algorithm via `AccessCost` / `stream_members()`.
+
+#### Scenario: declaring capabilities
+
+| Case | Expected |
+| --- | --- |
+| `open_archive(p)` | Forward-only streams; one live at a time; `seek()` raises `io.UnsupportedOperation` |
+| `open_archive(p, seekable_members=True)` | Member streams seekable; still one live at a time |
+| `open_archive(p, concurrent_members=True)` | Overlapping opens allowed after materialization; streams not seekable |
+| `open_archive(p, seekable_members=True, concurrent_members=True)` | Both capabilities |
+| `open_archive(p, streaming=True, concurrent_members=True)` | `ArchiveyUsageError` at open |
+| `open_archive(p, member_streams=...)` | `TypeError` — the parameter no longer exists |
+| `reader.cost` after declaring | Declared capabilities reported as a `MemberStreams` value |

--- a/openspec/changes/member-stream-capability-booleans/tasks.md
+++ b/openspec/changes/member-stream-capability-booleans/tasks.md
@@ -1,0 +1,36 @@
+## 1. Public surface
+
+- [ ] 1.1 `open_archive`: replace `member_streams: MemberStreams` with keyword-only
+      `seekable_members: bool = False` and `concurrent_members: bool = False`
+      (`core.py:101`).
+- [ ] 1.2 Map to the internal `MemberStreams` value at the boundary; leave internal
+      plumbing on flags so the diff stays shallow.
+- [ ] 1.3 Re-express the `streaming` + concurrency rejection against
+      `concurrent_members` (`core.py:168`), keeping the error type and message shape.
+- [ ] 1.4 Update the docstring: state the two traps each flag opts into, and that
+      `open_stream` uses the same `seekable` vocabulary.
+
+## 2. Call sites
+
+- [ ] 2.1 Update internal callers (~52 refs), including `extract`/`extract_all` paths.
+- [ ] 2.2 Update tests (~38 refs). Behaviour assertions must not change — only the call
+      spelling. A test whose *expectations* change is a red flag for scope creep.
+- [ ] 2.3 Confirm `MemberStreams` is still exported and still used by `CostReceipt` /
+      diagnostics; `test_public_api.py` must stay green.
+
+## 3. Docs and decision record
+
+- [ ] 3.1 `docs/usage.md`, `docs/costs.md`, `docs/support-matrix.md` (8 refs) — the
+      support-matrix concurrency example is the load-bearing one.
+- [ ] 3.2 Amend ADR 0003 with the new spelling; note ADR 0004's reasoning applies.
+- [ ] 3.3 Check `docs/migrating.md`'s "one live member stream by default" note still
+      reads correctly.
+
+## 4. Verification
+
+- [ ] 4.1 Three-config suite green (`[all]`, `[all-lowest]`, core-only).
+- [ ] 4.2 Free-threaded `concurrent_reader` job green — it exercises the concurrency
+      capability directly.
+- [ ] 4.3 `pyrefly` + `ty` clean; `mkdocs build --strict` clean.
+- [ ] 4.4 Grep for `member_streams=` across the tree: no survivors outside archived
+      history.

--- a/review/STATUS.md
+++ b/review/STATUS.md
@@ -4,7 +4,7 @@
 
 | Review | State |
 |---|---|
-| [`docs/`](docs/brief.md) — documentation full review | Brief written 2026-07-29. Four-phase process (audit → decide → migrate → guardrail); phase 1 not started. Bias control: [`independent-brief.md`](docs/independent-brief.md) commissions a code-only outline to run **first**. |
+| [`docs/`](docs/brief.md) — documentation full review | Brief written 2026-07-29. Four-phase process (audit → decide → migrate → guardrail); phase 1 not started. Bias control pass **delivered** (#208, `docs/independent/`): headline is a proportional disagreement — safe extraction is 6.3% of our guide vs ~25% proposed. Code-shaped findings filtered into [`code-self-documentation.md`](docs/code-self-documentation.md). |
 
 `debt-ledger/` and `performance/` were archived on 2026-07-28 after the last two ledger
 items (**T7** corpus-matrix audit, **T4** half-test) landed and **performance Q4** was

--- a/review/docs/api-surface-suggestions.md
+++ b/review/docs/api-surface-suggestions.md
@@ -1,0 +1,163 @@
+# Two public-surface suggestions (A1 extras, C1 capability vocabulary)
+
+From [`code-self-documentation.md`](code-self-documentation.md) A1 and C1, expanded at the
+maintainer's request. Both are **public surface**, so both are free to change now and
+expensive after `0.2.0`. Verified against `main` @ `49f221f`.
+
+**The timing argument applies to both, and it is the strongest one available:** `0.2.0`
+is the *first* public release. There are no external users to break. Neither change will
+ever be this cheap again.
+
+---
+
+## A1 — the extras are named by format but scoped by capability
+
+### The finding is bigger than the error message
+
+The question was "should we rename the `7z` extra?" The measured answer: **the scheme is
+already not one-extra-per-format**, and the mismatch between the names and the contents
+is what produces the confusing message.
+
+| Extra | Actually pulls |
+|---|---|
+| `7z` | pyppmd, inflate64, backports.zstd, brotli, lz4, cryptography, pybcj |
+| `rar` | cryptography |
+| `crypto` | cryptography |
+| `iso` | pycdlib |
+| `zstd` | backports.zstd |
+| `lz4` | lz4 |
+| `seekable` | rapidgzip |
+| `cli` | tqdm |
+
+Three things fall out:
+
+1. **`7z` is a codec bundle, not a format extra.** Six of its seven packages are member
+   codecs shared with ZIP and TAR. A ZIP user needing Deflate64 is correctly told to
+   install it — the name is what lies, not the hint.
+2. **`rar` and `crypto` are byte-identical.** And `rar` is doubly misleading: RAR *member
+   data* needs the RARLAB `unrar` **binary**, which no extra can ever provide. A user who
+   runs `pip install archivey[rar]` and expects to read RAR payloads has been told the
+   wrong thing by the package metadata itself.
+3. **`zstd` and `lz4` are strict subsets of `7z`**, so the same codec is reachable under
+   two names with different implied meanings.
+
+### Recommendation: capability extras as the truth, format names as aliases
+
+Do **not** rename or remove anything. Adding extras is non-breaking; renaming or removing
+them breaks `pip install` lines in the wild and in other people's lockfiles. So:
+
+```toml
+# The real groups — what the code actually needs.
+codecs  = ["pyppmd", "inflate64", "backports.zstd; python_version < '3.14'",
+           "brotli", "lz4", "pybcj"]
+crypto  = ["cryptography"]
+iso     = ["pycdlib"]
+seekable = ["rapidgzip"]
+cli     = ["tqdm"]
+
+# Format names stay, as aliases, because users think in formats.
+"7z" = ["archivey[codecs,crypto]"]
+rar  = ["archivey[crypto]"]        # + document that data needs the unrar binary
+zstd = ["backports.zstd; python_version < '3.14'"]   # granular, keep
+lz4  = ["lz4"]                                        # granular, keep
+```
+
+Then the codec hints at `streams/codecs.py:1455,1523,1579` say `pip install
+archivey[codecs]`, which is **true regardless of which container the member came from** —
+that is the actual fix for A1, and it stops being a docs problem permanently.
+
+Keeping the format aliases matters for discoverability: `archivey[7z]` is what someone
+will guess, and PyPI's page lists extras, so they're a real part of the first-run
+experience. The aliases become correct-by-construction instead of coincidentally correct.
+
+### Also worth fixing while you're in there
+
+`rar`'s docstring/comment should state the `unrar` binary requirement, since the extra
+cannot express it. That is the single most misleading thing in the current extras table,
+and it costs one comment.
+
+**Cost:** one `pyproject.toml` edit plus three message strings. No behaviour change, no
+breakage, no test changes beyond any that assert hint text.
+
+---
+
+## C1 — `member_streams` and the flag-vs-bool split
+
+### What the ADRs already decided
+
+Worth reading before touching this, because two ADRs are directly on point and they point
+in the *same* direction rather than against the change:
+
+- **ADR 0004** rejected an `Intent` enum in favour of `streaming: bool`, reasoning "two
+  real modes, not three labels for two behaviors". The recorded taste is: **when the mode
+  count is small, prefer a bool.**
+- **ADR 0003** describes the member-stream defaults and then says, of `open_stream(...,
+  seekable=False)`, "**same rule**". So the ADR already treats these as one concept —
+  which means aligning the spelling is *implementing* ADR 0003's framing, not
+  re-litigating it.
+
+Neither ADR defends `member_streams` as a *name*, or the flags-vs-bool split between the
+two entry points. That is accretion, not a decision.
+
+### The two problems, which are really one
+
+```python
+open_archive(p, member_streams=MemberStreams.SEEKABLE | MemberStreams.CONCURRENT)
+open_stream(p, seekable=True)
+```
+
+- **Not evidently a flag set.** `member_streams=` reads like it takes *streams*, or a
+  count, or a mode. Nothing in the name says "OR these together". You must import
+  `MemberStreams` to pass anything at all — friction on the common path, and invisible in
+  autocomplete until you've already found the enum.
+- **Two vocabularies for one concept**, which every user pays for twice.
+
+### Recommendation: two booleans on `open_archive`
+
+```python
+open_archive(p, seekable_members=True, concurrent_members=True)
+open_stream(p, seekable=True)
+```
+
+Why this one:
+
+- It is what ADR 0004 already chose in the analogous case, so it is consistent with the
+  codebase's recorded taste rather than a new direction.
+- It closes the vocabulary split: `seekable` means the same thing in both entry points.
+- **It is self-documenting in the IDE** — `seekable_members: bool = False` in the
+  signature tells the whole story, no import, no enum lookup. Given the theme of this
+  whole exercise (make the code say it so the docs needn't), that is the point.
+- There are exactly two capabilities, and ADR 0003 frames them as two specific traps
+  rather than an open-ended set.
+
+**The honest counter-argument**, which you should weigh rather than take my word on: flags
+are more extensible (a third capability is a new flag, not a new parameter) and
+composable (you can compute a capability set and pass it). If you expect a third
+capability, keep the enum and just **rename the parameter** — `require=` reads well
+(`require=MemberStreams.SEEKABLE`) and fixes the flag-ness complaint at a fraction of the
+cost. I do not think a third is coming, but you know the roadmap.
+
+Either way I would **keep `MemberStreams` exported**: it is meaningful in `CostReceipt`
+and diagnostics, and removing a public name buys nothing.
+
+**Cost:** one public signature (`core.py:101`), ~52 internal references, ~38 in tests,
+8 in docs. Mechanical, and the tests are the real work. Nothing external to break, since
+nothing has shipped.
+
+---
+
+## Suggested handling
+
+| Item | Type | When |
+|---|---|---|
+| A1 extras + hints | Additive, non-breaking | Any time; safe to land alone |
+| A1 `rar`/`unrar` comment | Comment only | With the above |
+| C1 vocabulary | **Breaking after `0.2.0`** | Decide before the tag, or accept it forever |
+
+C1 is the one with a deadline. If the answer is "keep it as-is", that is a legitimate
+outcome — but it should become an ADR, because this is the second time it has been
+independently flagged (api-coherence, then the code-derived pass), and an unrecorded
+decision will be re-derived a third time.
+
+Both want an OpenSpec change before implementation, per `CONTRIBUTING.md`. Happy to draft
+either once you pick a direction.

--- a/review/docs/api-surface-suggestions.md
+++ b/review/docs/api-surface-suggestions.md
@@ -159,5 +159,19 @@ outcome — but it should become an ADR, because this is the second time it has 
 independently flagged (api-coherence, then the code-derived pass), and an unrecorded
 decision will be re-derived a third time.
 
-Both want an OpenSpec change before implementation, per `CONTRIBUTING.md`. Happy to draft
-either once you pick a direction.
+## Decided 2026-07-29 — both drafted as OpenSpec changes
+
+- **A1** -> `openspec/changes/consolidate-optional-extras/`. Direction chosen: **fewer**,
+  not aliases — 11 extras collapse to 4 (`recommended`, `seekable`, `free-threaded`,
+  `all`). The alias option in this file was *rejected* on the "an extra can never be
+  removed" argument: it adds permanent names and keeps the format names that caused the
+  confusion.
+- **C1** -> `openspec/changes/member-stream-capability-booleans/`. Two booleans, as
+  recommended.
+
+One measured fact reframed A1's `cryptography` question after this file was written:
+**`pip install archivey[recommended]` already fails on free-threaded 3.13**
+(`recommended` -> `7z` -> `cryptography` -> `cffi`, which rejects FT 3.13). So
+`cryptography` is not "simple" in the way that matters, it is *already* in the
+recommended bundle, and that is precisely why a separate `[free-threaded]` extra earns
+its place.

--- a/review/docs/brief.md
+++ b/review/docs/brief.md
@@ -160,6 +160,46 @@ Everything else — accuracy against the code, gaps, examples, tone, length — 
 - `openspec/specs/` is authoritative. Where prose and spec disagree, **pause and ask**
   (`CLAUDE.md`) rather than editing either to match.
 
+## Bias control: the independent code-derived outline — **delivered**
+
+> **Result (2026-07-29, #208).** The pass ran and its output is in
+> [`independent/`](independent/). It produced the strongest signal the exercise could
+> have produced: a **quantified proportional disagreement**, arrived at without ever
+> seeing our docs.
+>
+> | Topic | Our guide | Its proposal |
+> |---|---:|---:|
+> | Safe extraction | **6.3%** (93 lines) | **~25%** |
+> | Access modes / streaming / cost | **10.4%** (154 lines) | **~20%** |
+> | Per-format notes | 12.1% | ~12% (agreement — ignore) |
+> | `usage.md` (our largest page, 18.2%) | — | argues *against* a generic page |
+>
+> Its closing line — "if the real guide buries safe extraction and access modes behind a
+> generic 'Usage' page, that is the failure mode this outline is arguing against" —
+> describes our actual structure, which it could not see. Treat that as the finding, not
+> as flattery: the guide under-weights the two pages that carry the safety and cost
+> claims `VISION.md` is built on.
+>
+> **This is a phase-1 finding, not a Topic 8 one.** "Safe extraction should be ~4× its
+> current size and `usage.md` should be split" is a page-shape decision, which the
+> Sequencing section below already reserves to this review.
+>
+> Also delivered: `must-explain.md` (29 cited behaviours not inferable from signatures),
+> `rationale-gaps.md` (32 places where the code shows *what* but not *why*), plus the
+> API surface and two sample pages. Two caveats when using them:
+>
+> - **It could not see intent, and it over-reports because of it.** Verified example:
+>   it flagged the ISO `pycdlib` monkeypatch as "surprising if documented nowhere", but
+>   `iso_reader.py:20-30` documents it thoroughly — what is missing is only the
+>   *user-facing* surfacing. Check each item against the code before acting.
+> - **Agreements are weak evidence** (shared model priors), as this brief predicted.
+>   The `formats` match at ~12% proves little. The disagreements above are the payload.
+>
+> Code-shaped findings are filtered into
+> [`code-self-documentation.md`](code-self-documentation.md) rather than actioned from
+> the raw output — see that file for why pointing an agent at these artifacts to "fix
+> the code" would re-litigate settled design.
+
 ## Bias control: the independent code-derived outline
 
 Everything above anchors you. Before phase 1 publishes, a separate agent derives a

--- a/review/docs/code-self-documentation.md
+++ b/review/docs/code-self-documentation.md
@@ -1,0 +1,99 @@
+# Code changes that would reduce the documentation burden
+
+Filtered out of the independent code-derived pass
+([`independent/`](independent/)). Those artifacts answer "what must the docs say";
+this one asks the inverse: **what could the code say itself, so the docs don't have to?**
+
+Every item below was re-verified against `main` @ `49f221f` before being listed — the
+independent agent could not see intent, so its raw output is an input, not a worklist.
+Items it raised that turned out to be already-handled are recorded at the bottom so they
+are not re-raised.
+
+## Why this is a separate artifact
+
+Do **not** point an agent at the independent brief and ask it to fix the code. That pass
+was explicitly denied `VISION.md`, the ADRs, the specs and the threat model, so it cannot
+distinguish a defect from a deliberate trade — and it says so. A large share of its
+"why?" items have recorded answers (usage errors outside the tree → ADR 0012; opt-in
+`MemberStreams` → ADR 0003; no implicit pipe buffering → ADR 0010). An agent told to
+"fix" from that list would re-litigate settled design against a public API that is about
+to freeze.
+
+The filter applied here: **would a competent user still need this explained after the
+change?** If yes, it is a docs task. Only if no does it belong below.
+
+---
+
+## A. Error messages that name the wrong thing (mechanical, no design change)
+
+**A1 — ZIP codec install hints point at the `[7z]` extra.**
+`streams/codecs.py:1455` (brotli), `:1523` (pyppmd), `:1579` (inflate64) all emit
+`pip install archivey[7z]`. A user hitting a Deflate64 or PPMd member **in a ZIP** is told
+to install the "7z" extra. It is technically correct — that extra does provide the codec —
+and reads like the library misidentified their file.
+
+Options: name the capability rather than the format (`archivey[7z]` provides "extended
+member codecs"), or add a codec-oriented alias extra. Either removes a documentation
+line permanently. Rationale-gap 4 asks whether `[7z]` is the intended umbrella — that is
+the decision to make first.
+
+---
+
+## B. Stale statements in shipped files (fix now — they actively mislead)
+
+**B1 — the `[rar]` extra's TODO is out of date.** `pyproject.toml:69-74` says the bundle
+should also pull a Blake2sp backend, that "no standalone package decided yet", and to
+"resolve when format-rar lands". Verified: format-rar landed, and BLAKE2sp is implemented
+natively on stdlib in `src/archivey/internal/hashing/blake2sp.py` (no third-party
+package, `hashlib`-based). The TODO describes a problem that was solved a different way.
+
+This is the clearest case in the set: a comment in shipped packaging metadata that tells a
+reader the opposite of what is true. Replace it with one line recording that BLAKE2sp is
+native and zero-dep.
+
+---
+
+## C. API vocabulary split (needs a decision, and the window closes at `0.2.0`)
+
+**C1 — two vocabularies for one concept.** `open_archive` takes
+`member_streams=MemberStreams.SEEKABLE` (a flag enum); `open_stream` takes
+`seekable=True` (a bool, `core.py:282`). The docstring explains why concurrency is
+meaningless for a single stream — which justifies *dropping CONCURRENT*, not *changing
+the spelling of SEEKABLE*.
+
+Every user who learns one API pays to learn the other, and no doc sentence makes that
+free. Worth deciding deliberately rather than by accretion, and **pre-`0.2.0` is the only
+time it is free** — after the tag it is a breaking change. Note this is a public-surface
+question that overlaps the archived api-coherence review; check its findings before
+reopening.
+
+---
+
+## D. Raised by the independent pass, verified as already handled — do not re-raise
+
+- **ISO monkeypatches `pycdlib.pycdlib.collections` process-wide**
+  (`must-explain.md` 29, `rationale-gaps.md` 6). The agent flagged it as "surprising if
+  documented nowhere". It is in fact documented thoroughly *in the code*:
+  `backends/iso_reader.py:20-30` module docstring states the process-global side effect,
+  the trade, and points at `known-issues.md`; `:115-131` explains why the guard is
+  installed once and permanently. **No code change.** The real gap is that none of this
+  reaches a *user-facing* page — a docs task, and a good example of the pass mistaking
+  "absent from published docs" for "absent from the code".
+- **Usage errors outside the `ArchiveyError` tree** — ADR 0012, deliberate.
+- **`MemberStreams` opt-in defaults** — ADR 0003, deliberate.
+- **No implicit buffering of a pipe** — ADR 0010, deliberate.
+- **`OnError` not aborting on the first `BLOCKED` member** — a recorded deferral with a
+  comment at `extraction_types.py:79-80` naming it a future opt-in.
+
+---
+
+## Suggested handling
+
+- **A1 + B1**: one small change, no decisions needed beyond A1's wording. Both are
+  message/comment edits with no behavioural effect.
+- **C1**: a maintainer decision, and time-boxed by the release. If the answer is "keep
+  both", record it as an ADR so the next reviewer does not re-derive it — which is
+  exactly what happened here.
+- **D**: no action; listed so the next pass does not spend budget on it.
+
+None of this blocks the docs IA review. A1/B1 can land independently at any time.

--- a/review/docs/code-self-documentation.md
+++ b/review/docs/code-self-documentation.md
@@ -87,6 +87,15 @@ reopening.
 
 ---
 
+## Expanded elsewhere
+
+A1 and C1 turned out to be bigger than message edits — both are public-surface shape
+questions with a `0.2.0` deadline. Options, recommendations and costs are in
+[`api-surface-suggestions.md`](api-surface-suggestions.md). Headline: the extras are
+already **not** one-per-format (`7z` is a codec bundle; `rar` is byte-identical to
+`crypto` and cannot express its real `unrar` binary requirement), and both ADR 0003 and
+ADR 0004 point *toward* aligning the capability vocabulary rather than against it.
+
 ## Suggested handling
 
 - **A1 + B1**: one small change, no decisions needed beyond A1's wording. Both are


### PR DESCRIPTION
Follow-up to #207 (merged). Four commits, all analysis and proposals — **no source code touched**.

## 1. Triage of the independent docs pass (#208)

The bias-control experiment worked. Its headline is a **quantified proportional disagreement**, reached without ever seeing our docs:

| Topic | Our guide | Its proposal |
|---|---:|---:|
| Safe extraction | **6.3%** (93 lines) | **~25%** |
| Access modes / streaming / cost | **10.4%** (154 lines) | **~20%** |
| Per-format notes | 12.1% | ~12% (agreement — weak signal) |

Its closing line argues against burying safety and access modes behind a generic "Usage" page — which is our exact structure, `usage.md` being our largest page at 18.2%. Recorded in the docs brief as a **phase-1** finding, since page shape is a filing decision that brief already reserves to the IA review.

Two caveats recorded with it: the pass **over-reports** because it cannot see intent (verified example — it flagged the ISO `pycdlib` monkeypatch as "documented nowhere" when `iso_reader.py:20-30` documents it thoroughly; the real gap is only that none of it reaches a user-facing page), and **agreements are weak evidence** given shared model priors.

## 2. Code-shaped findings, filtered

`review/docs/code-self-documentation.md`. Deliberately **not** actioned from the raw output: that pass was denied VISION, the ADRs, the specs and the threat model, so an agent told to "fix the code" from it would re-litigate settled design (ADR 0012, 0003, 0010 all appear in its "why?" list). Items verified as already-handled are listed so the next pass doesn't re-raise them.

## 3. Two OpenSpec changes (both validate strict)

**`consolidate-optional-extras`** — 11 extras → 4 (`recommended`, `seekable`, `free-threaded`, `all`).

The finding was bigger than the reported symptom: the extras are **named by format but scoped by capability**. `7z` pulls seven packages, six of them codecs shared with ZIP/TAR — so the hint is correct and the *name* lies. `rar` and `crypto` are byte-identical, and `rar` can never deliver the RARLAB `unrar` binary it implies. Per your "err on fewer" instruction I rejected my own earlier alias proposal — aliases add permanent names and keep the confusing ones.

Recorded rather than glossed: this contradicts an existing spec requirement that each extra avoid unrelated dependencies (written as an explicit `MODIFIED` requirement), and ISO-only users now pull codecs + cryptography.

**`member-stream-capability-booleans`** — `open_archive(p, seekable_members=True, concurrent_members=True)`; `member_streams` removed, `MemberStreams` still exported for `CostReceipt`. Both relevant ADRs support this: 0004 chose a bool over an enum in the analogous case, and 0003 already calls `open_stream(seekable=)` "the same rule". The counter-argument (flags are more extensible; `require=` is the cheaper fix if a third capability is coming) is preserved in `design.md`.

## 4. Crypto backend: measured, then decided against switching

| Library | 3.13t | 3.14t |
|---|---|---|
| `cryptography` | **cannot install** (cffi rejects FT 3.13) | installs, AES-CBC works, **GIL stays disabled** |
| `pycryptodome` 3.23 | installs, AES-CBC + AES-ECB work, **GIL stays disabled** | not tested |

A free-thread-safe alternative exists — but the gap is one pre-release runtime and it's already closed upstream on 3.14t. Swapping a widely-audited security library, or carrying two backends (double the audit surface, divergence risk in padding/error paths), isn't worth a transient packaging hole. The abstraction stays, so revisiting is cheap.

This sharpened the extras change: `[free-threaded]` now carries `cryptography; python_version >= "3.14"`, and the "moving target" risk is confirmed with data — on 3.14t `cryptography` joins the GIL-safe set while `pyppmd`/`inflate64`/`brotli`/`rapidgzip` still re-enable the GIL.

## Verification

`openspec validate --all`: **27 passed, 0 failed**. `mkdocs build --strict` clean; `ruff` clean. No source changes, so the test suite is unaffected — last full run on this branch was 1992 passed / 58 skipped.

Unresolved and not chased: `pybcj` installs but fails to import on 3.14.0rc2. It's in the codec group, which isn't GIL-safe regardless, so it doesn't affect the extras composition — but worth a look before 3.14 final.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1G2pL3FRbyR6VzmqQWpdV)_