### PR TITLE
api: declare member-stream capabilities with two booleans

### DIFF
--- a/benchmarks/harness.py
+++ b/benchmarks/harness.py
@@ -45,7 +45,7 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Any, Callable
 
-from archivey import MemberStreams, open_archive
+from archivey import open_archive
 from archivey.config import AcceleratorMode, ArchiveyConfig
 from archivey.exceptions import PackageNotInstalledError
 from archivey.internal.base_reader import BaseArchiveReader
@@ -125,7 +125,7 @@ def _op_open_list(path: Path) -> tuple[int, int]:
 def _accel_config(*, enabled: bool) -> ArchiveyConfig:
     """Force rapidgzip / indexed-bzip2 (via rapidgzip's IndexedBzip2File) on or off.
 
-    ``ON`` engages the accelerator even without ``MemberStreams.SEEKABLE`` (AUTO would
+    ``ON`` engages the accelerator even without ``seekable_members=True`` (AUTO would
     not). The bzip2 accelerator is rapidgzip's bundled decoder, not the separate
     ``indexed_bzip2`` package — see codecs.py.
     """
@@ -137,12 +137,12 @@ def _op_read_all(
     path: Path,
     *,
     config: ArchiveyConfig | None = None,
-    member_streams: MemberStreams = MemberStreams(0),
+    seekable_members: bool = False,
     password: bytes | str | None = None,
 ) -> tuple[int, int, int]:
     with enable_measurement():
         with open_archive(
-            path, config=config, member_streams=member_streams, password=password
+            path, config=config, seekable_members=seekable_members, password=password
         ) as reader:
             base = _as_base(reader)
             unpacked = 0
@@ -172,12 +172,12 @@ def _op_read_all_unmeasured(
     path: Path,
     *,
     config: ArchiveyConfig | None = None,
-    member_streams: MemberStreams = MemberStreams(0),
+    seekable_members: bool = False,
     password: bytes | str | None = None,
 ) -> None:
     """Read every member without measurement wrappers — fair wall-time peer."""
     with open_archive(
-        path, config=config, member_streams=member_streams, password=password
+        path, config=config, seekable_members=seekable_members, password=password
     ) as reader:
         for _member, stream in reader.stream_members():
             if stream is not None:
@@ -386,10 +386,12 @@ def run_cases(
         path: Path,
         *,
         config: ArchiveyConfig | None = None,
-        member_streams: MemberStreams = MemberStreams(0),
+        seekable_members: bool = False,
     ) -> tuple[float, float]:
         def ay() -> None:
-            _op_read_all_unmeasured(path, config=config, member_streams=member_streams)
+            _op_read_all_unmeasured(
+                path, config=config, seekable_members=seekable_members
+            )
 
         if warmup:
             ay_wall, _ignored, std_wall = _interleaved_pair_times(
@@ -560,10 +562,9 @@ def run_cases(
     )
     if has_accel:
         cfg_zip_on = _accel_config(enabled=True)
-        seekable = MemberStreams.SEEKABLE
         _m_wall, (bdec, seeks, unpacked) = timed_with_optional_warmup(
             lambda: _op_read_all(
-                fixtures.zip_path, config=cfg_zip_on, member_streams=seekable
+                fixtures.zip_path, config=cfg_zip_on, seekable_members=True
             )
         )
         results.append(
@@ -701,17 +702,16 @@ def run_cases(
             )
             continue
         cfg_on = _accel_config(enabled=True)
-        # SEEKABLE so AUTO would also engage; ON engages either way. Matches the
-        # intended accelerator use case (indexed / parallel decode).
-        seekable = MemberStreams.SEEKABLE
+        # seekable_members so AUTO would also engage; ON engages either way. Matches
+        # the intended accelerator use case (indexed / parallel decode).
         _m_wall, (bdec, seeks, unpacked) = timed_with_optional_warmup(
-            lambda p=path, c=cfg_on: _op_read_all(p, config=c, member_streams=seekable)
+            lambda p=path, c=cfg_on: _op_read_all(p, config=c, seekable_members=True)
         )
         wall_on, std_wall_on = pair_wall(
             lambda p=path, s=std_fn: s(p),
             path,
             config=cfg_on,
-            member_streams=seekable,
+            seekable_members=True,
         )
         speedup = (wall_off / wall_on) if wall_on > 0 else None
         speedup_note = f"; vs accel_off {speedup:.2f}×" if speedup is not None else ""

--- a/benchmarks/tar_iso_lock_baseline.py
+++ b/benchmarks/tar_iso_lock_baseline.py
@@ -2,7 +2,7 @@
 """Non-gating TAR/ISO lock baseline (wall time under concurrent opens).
 
 Records representative wall-clock samples for concurrent member opens under
-``MemberStreams.CONCURRENT``. There is **no** pass/fail threshold — re-run before any
+``concurrent_members=True``. There is **no** pass/fail threshold — re-run before any
 performance claim and compare before/after with the same recipe.
 
 Example::
@@ -27,7 +27,7 @@ import time
 import zipfile
 from pathlib import Path
 
-from archivey import MemberStreams, open_archive
+from archivey import open_archive
 
 
 def _make_tar(
@@ -43,7 +43,7 @@ def _make_tar(
 
 
 def _fan_out_wall(path: Path) -> float:
-    with open_archive(path, member_streams=MemberStreams.CONCURRENT) as reader:
+    with open_archive(path, concurrent_members=True) as reader:
         names = [m.name for m in reader.members() if m.is_file]
         barrier = threading.Barrier(len(names))
 

--- a/docs/costs.md
+++ b/docs/costs.md
@@ -84,7 +84,7 @@ Without `seekable_members=True`, member streams report `seekable() is False` and
 `seek()` raises `io.UnsupportedOperation`. That is intentional: seek indexes and
 accelerators are not built until you ask.
 
-With `SEEKABLE`:
+With `seekable_members=True`:
 
 - XZ / lzip can seek via native indexes
 - gzip / zlib / raw deflate / bzip2 can use `[seekable]` (`rapidgzip`) when installed
@@ -111,7 +111,7 @@ open_archive(src, concurrent_members=True)
 After members are materialized, workers may `open()` different members concurrently.
 Same-stream access still needs caller synchronization. Reader-wide passes
 (`__iter__` / `stream_members` / `extract_all`) remain single-owner.
-`streaming=True` cannot combine with `CONCURRENT`.
+`streaming=True` cannot combine with `concurrent_members=True`.
 
 ## Non-seekable sources
 

--- a/docs/costs.md
+++ b/docs/costs.md
@@ -75,12 +75,12 @@ for name in wanted_names:
 ```
 
 `AccessCost.SOLID` and `solid_block_count` tell you when this matters.
-`MemberStreams.CONCURRENT` does **not** remove solid open-order cost — it only makes
+`concurrent_members=True` does **not** remove solid open-order cost — it only makes
 overlapping streams correct.
 
 ## Seeking inside compressed members
 
-Without `MemberStreams.SEEKABLE`, member streams report `seekable() is False` and
+Without `seekable_members=True`, member streams report `seekable() is False` and
 `seek()` raises `io.UnsupportedOperation`. That is intentional: seek indexes and
 accelerators are not built until you ask.
 
@@ -105,7 +105,7 @@ Default: at most one live member stream. A second overlapping `open()` raises
 `ConcurrentAccessError` (a usage error — not an `ArchiveyError`).
 
 ```python
-open_archive(src, member_streams=MemberStreams.CONCURRENT)
+open_archive(src, concurrent_members=True)
 ```
 
 After members are materialized, workers may `open()` different members concurrently.
@@ -148,7 +148,7 @@ defects can abort the process rather than raise. Details:
 | --- | --- |
 | Hash / process every member | `stream_members()` or `__iter__` |
 | Solid archive, many named opens | Reorder to archive order, or one streaming pass |
-| Need `seek()` on a member | `MemberStreams.SEEKABLE` (+ `[seekable]` for gz/bz2/zlib/deflate) |
-| Thread pool of member readers | `MemberStreams.CONCURRENT` after `members()` |
+| Need `seek()` on a member | `seekable_members=True` (+ `[seekable]` for gz/bz2/zlib/deflate) |
+| Thread pool of member readers | `concurrent_members=True` after `members()` |
 | stdin / socket | `streaming=True` |
 | “Just unzip it safely” | `archivey.extract(src, dest)` |

--- a/docs/decisions/0003-member-streams-opt-in.md
+++ b/docs/decisions/0003-member-streams-opt-in.md
@@ -14,18 +14,27 @@ on TAR/7z. Cost receipts alone are too passive (warnings deferred).
 
 ## Decision
 
-Default `member_streams=MemberStreams(0)`:
+Both capabilities are off by default:
 
 - streams report `seekable() is False`; `seek()` → `io.UnsupportedOperation`
 - at most one live member stream; a second overlapping `open()` → `ConcurrentAccessError`
 
-Opt in with `MemberStreams.SEEKABLE` and/or `MemberStreams.CONCURRENT` at
-`open_archive()`. Same rule for `open_stream(..., seekable=False)`. Seek indexes /
-accelerators are **demand-driven**. Uniform across every format, including directory.
+Opt in with `open_archive(..., seekable_members=True, concurrent_members=True)`. Same
+rule for `open_stream(..., seekable=False)`. Seek indexes / accelerators are
+**demand-driven**. Uniform across every format, including directory.
+
+**Amended before `0.2.0`:** the opt-in was originally spelled
+`member_streams=MemberStreams.SEEKABLE | MemberStreams.CONCURRENT`. The decision above
+is unchanged — same defaults, same errors, same semantics — but the two entry points now
+share one vocabulary (`seekable` means the same thing in `open_archive` and
+`open_stream`) instead of splitting a flag enum against a bool. This is what ADR 0004
+already chose in the analogous case: prefer a bool when the mode count is small, and
+these are two specific traps rather than an open-ended set. `MemberStreams` remains
+exported and is still the declared-capability value on `CostReceipt` and in diagnostics.
 
 ## Consequences
 
 - Default path: no shared-handle locks, no seek tables, no accelerators.
 - Strict default is reversible pre-1.0; permissive-then-gate would be a breaking change.
 - Solid **open-order** cost remains the caller’s algorithm (`AccessCost` /
-  `stream_members()`), not something `CONCURRENT` erases.
+  `stream_members()`), not something `concurrent_members=True` erases.

--- a/docs/formats.md
+++ b/docs/formats.md
@@ -56,7 +56,7 @@ Third-party credits (deps, oracles, design refs): [Acknowledgements](acknowledge
   prefer a single forward pass.
 - Hardlinks are first-class at extraction; unfiltered `extract_all` resolves them in one
   pass.
-- `MemberStreams.CONCURRENT` uses a per-reader shared-handle lock (same shape as ISO).
+- `concurrent_members=True` uses a per-reader shared-handle lock (same shape as ISO).
 - **Mid-archive corruption can silently shorten the listing.** Stdlib `tarfile` treats a
   corrupt member header *after the first* as a clean end of archive — no exception is
   raised; iteration just stops early. Archivey backstops this with its end-of-archive
@@ -137,7 +137,7 @@ Third-party credits (deps, oracles, design refs): [Acknowledgements](acknowledge
   fail via `VerifyingStream` when the decoded payload is short or wrong. See
   [Gotchas — format limitations](gotchas.md#format-limitations).
 - `.lz` surfaces a whole-member CRC-32 the same way **size** is exposed: only when
-  `MemberStreams.SEEKABLE` is declared on a path source (seekable lzip backend). For
+  `seekable_members=True` is declared on a path source (seekable lzip backend). For
   multi-member lzip the value is derived by combining per-trailer CRCs with each
   member's uncompressed size so it equals `crc32` of the concatenated payloads.
 - `.bz2` / `.xz` / zlib / brotli / `.Z` have no cheap whole-member stored digest
@@ -166,7 +166,7 @@ a full `read()` still verifies through the normal path.
 | 7z | FILE | `crc32` |
 | RAR5 | FILE with CRC32 and/or Blake2sp | `crc32` and/or `blake2sp` |
 | single-file `.gz` | single member, seekable/path | `crc32` |
-| single-file `.lz` | seekable path + `MemberStreams.SEEKABLE` (one or many members; multi-member value is combined) | `crc32` |
+| single-file `.lz` | seekable path + `seekable_members=True` (one or many members; multi-member value is combined) | `crc32` |
 | `.bz2` / `.xz` / zlib / brotli / `.Z`, TAR, directory | — | none |
 
 See [usage](usage.md#cheap-dedupe-with-stored-hashes) for the cheap→computed fallback recipe.

--- a/docs/gotchas.md
+++ b/docs/gotchas.md
@@ -16,7 +16,7 @@ Member streams are forward-only unless you ask. Seeking inside a compressed memb
 is never free.
 
 - Without `seekable_members=True`, `seek()` raises — that is intentional.
-- With `SEEKABLE` but no index or accelerator, a backward seek **re-decompresses
+- With `seekable_members=True` but no index or accelerator, a backward seek **re-decompresses
   from the start** (`STREAM_REWIND_REDECOMPRESSES`).
 - Under `use_rapidgzip=AUTO`, rapidgzip is used only when seekability is declared
   and the known compressed input is large enough (about 1 MiB). Smaller members

--- a/docs/gotchas.md
+++ b/docs/gotchas.md
@@ -15,7 +15,7 @@ tables in [Safe extraction](safe-extraction.md); per-format matrices in
 Member streams are forward-only unless you ask. Seeking inside a compressed member
 is never free.
 
-- Without `MemberStreams.SEEKABLE`, `seek()` raises — that is intentional.
+- Without `seekable_members=True`, `seek()` raises — that is intentional.
 - With `SEEKABLE` but no index or accelerator, a backward seek **re-decompresses
   from the start** (`STREAM_REWIND_REDECOMPRESSES`).
 - Under `use_rapidgzip=AUTO`, rapidgzip is used only when seekability is declared
@@ -31,7 +31,7 @@ opening members out of order can decode the same block repeatedly.
 
 - Prefer one forward pass: `stream_members()` (or iterate in archive order).
 - Named `open()` of a mid-block member may restart the solid block.
-- `MemberStreams.CONCURRENT` makes overlapping streams *correct*; it does **not**
+- `concurrent_members=True` makes overlapping streams *correct*; it does **not**
   remove solid open-order cost.
 
 See [Access costs — solid archives](costs.md#solid-archives-prefer-one-forward-pass).

--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -162,7 +162,7 @@ Worth reading before you migrate a production path:
    `BLOCKED` members. That is the point — but check the
    [`ExtractionReport`](safe-extraction.md) rather than assuming success.
 2. **One live member stream by default.** If you held several `extractfile()` handles
-   open, declare `MemberStreams.CONCURRENT`. See
+   open, pass `concurrent_members=True`. See
    [supported platforms and threading](support-matrix.md).
 3. **`read()` is all-or-raise.** A truncated member raises instead of returning a short
    body; use a chunked loop if you want the recoverable prefix

--- a/docs/philosophy.md
+++ b/docs/philosophy.md
@@ -37,8 +37,8 @@ decode the same block repeatedly; concurrent member streams need real coordinati
 Archivey’s defaults are the **cheap, honest path**:
 
 - forward-only member streams, one live stream at a time
-- no seek indexes or accelerators until you ask (`MemberStreams.SEEKABLE`)
-- no concurrent opens until you ask (`MemberStreams.CONCURRENT`)
+- no seek indexes or accelerators until you ask (`seekable_members=True`)
+- no concurrent opens until you ask (`concurrent_members=True`)
 - random-access open fails fast on a non-seekable source (no silent buffering)
 
 When you need more, you **declare** it. Escape hatches are explicit, not ambient. See
@@ -49,8 +49,8 @@ When you need more, you **declare** it. Escape hatches are explicit, not ambient
 | Need | How |
 | --- | --- |
 | Pipes / sockets | `open_archive(..., streaming=True)` |
-| Seek inside a member | `member_streams=MemberStreams.SEEKABLE` |
-| Many open members / workers | `member_streams=MemberStreams.CONCURRENT` |
+| Seek inside a member | `seekable_members=True` |
+| Many open members / workers | `concurrent_members=True` |
 | Trusted / unlimited extract | `ExtractionPolicy.TRUSTED`, `ExtractionLimits.UNLIMITED` |
 | Tune accelerators / EOF / listing caps | `ArchiveyConfig` (`listing_limits`, …) |
 

--- a/docs/support-matrix.md
+++ b/docs/support-matrix.md
@@ -41,14 +41,14 @@ narrow on purpose.
 
 ### What is claimed
 
-On a reader opened with `MemberStreams.CONCURRENT`, after member materialization, it is
+On a reader opened with `concurrent_members=True`, after member materialization, it is
 safe for multiple threads to call `open()` and to work on **different** member streams
 concurrently:
 
 ```python
-from archivey import MemberStreams, open_archive
+from archivey import open_archive
 
-with open_archive("photos.zip", member_streams=MemberStreams.CONCURRENT) as reader:
+with open_archive("photos.zip", concurrent_members=True) as reader:
     members = reader.members()          # materialize once, on one thread
     # Now: fan out. Each thread opens and reads its own member.
 ```
@@ -98,7 +98,7 @@ than quietly testing a GIL-ed interpreter.
 
 ### The default is fail-fast, not racy
 
-If you do not declare `MemberStreams.CONCURRENT`, the reader allows **one live member
+If you do not pass `concurrent_members=True`, the reader allows **one live member
 stream**. A second overlapping `open()` raises
 [`ConcurrentAccessError`][archivey.ConcurrentAccessError] rather than quietly returning
 interleaved bytes:
@@ -130,7 +130,7 @@ as instantaneous under concurrency.
 
 | Operation | Safe from multiple threads? |
 | --- | --- |
-| `open()` + reading **different** member streams | Yes, with `MemberStreams.CONCURRENT`, after materialization |
+| `open()` + reading **different** member streams | Yes, with `concurrent_members=True`, after materialization |
 | Reading the **same** member stream object | No — one owner per stream |
 | `members()` / `__iter__` / `scan_members()` | No — single-owner; materialize once, then share the result |
 | `extract_all()` / `stream_members()` | No — single-owner passes |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -60,11 +60,10 @@ By default streams are **forward-only** and only **one** may be live. Need seeki
 overlapping opens? Declare capabilities:
 
 ```python
-from archivey import MemberStreams
-
 with archivey.open_archive(
     "data.zip",
-    member_streams=MemberStreams.SEEKABLE | MemberStreams.CONCURRENT,
+    seekable_members=True,
+    concurrent_members=True,
 ) as reader:
     ...
 ```
@@ -204,7 +203,7 @@ React to specific cases with the subtypes:
 | `ResourceLimitError` | a listing/extraction safety limit (member count, size) was exceeded |
 
 Mistakes in **your** code are deliberately kept out of that hierarchy: opening a second
-overlapping stream without `MemberStreams.CONCURRENT`, using a closed reader, and similar
+overlapping stream without `concurrent_members=True`, using a closed reader, and similar
 misuse raise [`ArchiveyUsageError`][archivey.ArchiveyUsageError] (e.g.
 `ConcurrentAccessError`), which is **not** an `ArchiveyError` — so a blanket
 `except ArchiveyError` never silently swallows a bug. (When an *archive* genuinely can't

--- a/openspec/changes/member-stream-capability-booleans/proposal.md
+++ b/openspec/changes/member-stream-capability-booleans/proposal.md
@@ -40,9 +40,15 @@ after the tag and free before it.
 
 - `member_streams=` is **removed**, not deprecated. Nothing external depends on it, and
   carrying both spellings would double exactly the surface this change exists to halve.
-- `MemberStreams` **stays exported**. It remains meaningful as the declared-capability
-  value on `CostReceipt` and in diagnostics, and removing a public name buys nothing.
-  Internal plumbing may keep using the flags; only the public entry point changes.
+- `MemberStreams` **stays exported**. It is the internal representation the two booleans
+  map to at the entry point, and the type of the capabilities a reader reports for
+  introspection; removing a public name buys nothing and would be breaking after the tag.
+  Internal plumbing keeps using the flags; only the public entry point changes.
+  (An earlier draft of this proposal claimed the flags are carried on `CostReceipt` and
+  in diagnostics. **They are not** — `CostReceipt` has `listing_cost` / `access_cost` /
+  `stream_capability` / `solid_block_count` / `notes`, and no diagnostic carries a
+  `MemberStreams`. The claim was never true and is corrected here rather than
+  implemented.)
 - The existing rejection of `streaming=True` combined with concurrency keeps its
   behaviour, now phrased against `concurrent_members=True`.
 

--- a/openspec/changes/member-stream-capability-booleans/specs/access-mode-and-cost/spec.md
+++ b/openspec/changes/member-stream-capability-booleans/specs/access-mode-and-cost/spec.md
@@ -1,36 +1,46 @@
 ## MODIFIED Requirements
 
-### Requirement: Member stream capabilities are declared with booleans
+### Requirement: Declared capabilities compose with the two access modes
 
-The system SHALL let callers declare member-stream capabilities at `open_archive` with
-two keyword-only booleans, `seekable_members` and `concurrent_members`, both defaulting
-to `False`. The system SHALL NOT expose a flag-enum parameter for this purpose.
+`streaming` SHALL remain the only access-mode choice. `seekable_members` /
+`concurrent_members` SHALL declare stream capabilities **within** a mode (not a third
+mode; no `ArchiveyConfig` equivalent). Ownership, leases, materialization, and
+free-threaded rules for declared concurrency live in `reader-concurrency`; this
+requirement only states how the capabilities compose with `streaming`.
 
-`open_stream` SHALL keep its `seekable: bool` parameter, and the two entry points SHALL
-use the same `seekable` vocabulary for the same concept. Concurrency has no meaning for a
-single standalone stream, so `open_stream` MUST NOT gain a concurrency parameter.
+| Mode | Capability composition |
+| --- | --- |
+| `streaming=False` | `concurrent_members` and/or `seekable_members` MAY be declared; concurrent-open semantics are `reader-concurrency`. Without `concurrent_members`, one live member stream (`archive-reading`). |
+| `streaming=True` | Random `open`/`read` still unavailable. Single progressive pass is exclusive. **`concurrent_members=True` incompatible** → `ArchiveyUsageError` at open. `seekable_members=True` alone MAY be declared. |
 
-Defaults and behaviour are unchanged by the spelling: with neither declared, member
-streams report `seekable() is False`, `seek()` raises `io.UnsupportedOperation`, and at
-most one member stream may be live — a second overlapping `open()` raises
-`ConcurrentAccessError`. Declaring `concurrent_members=True` together with
-`streaming=True` MUST be rejected at open with `ArchiveyUsageError`.
+Random-access `stream_members()` remains exclusive even when random `open()` is
+otherwise available (simultaneous streams use materialize + random `open()` under
+`concurrent_members=True` — see `reader-concurrency`). Detected pass/open/close overlap →
+later op `ArchiveyUsageError`; active pass stays usable. Ops after `reader.close()` →
+`ArchiveyUsageError` (idempotent `close`).
 
-The `MemberStreams` flag type SHALL remain publicly exported and SHALL remain the value
-reported for declared capabilities on `CostReceipt` and in diagnostics. It is no longer
-an input to `open_archive`.
+Defaults and behaviour are unchanged by the spelling: this requirement previously
+described the same composition in terms of a `member_streams` flag enum.
 
-Declaring `concurrent_members=True` MUST NOT change solid open-order cost; that remains
-the caller's algorithm via `AccessCost` / `stream_members()`.
-
-#### Scenario: declaring capabilities
+#### Scenario: mode × capability matrix
 
 | Case | Expected |
 | --- | --- |
-| `open_archive(p)` | Forward-only streams; one live at a time; `seek()` raises `io.UnsupportedOperation` |
-| `open_archive(p, seekable_members=True)` | Member streams seekable; still one live at a time |
-| `open_archive(p, concurrent_members=True)` | Overlapping opens allowed after materialization; streams not seekable |
-| `open_archive(p, seekable_members=True, concurrent_members=True)` | Both capabilities |
-| `open_archive(p, streaming=True, concurrent_members=True)` | `ArchiveyUsageError` at open |
-| `open_archive(p, member_streams=...)` | `TypeError` — the parameter no longer exists |
-| `reader.cost` after declaring | Declared capabilities reported as a `MemberStreams` value |
+| `streaming=True` + `concurrent_members=True` | `ArchiveyUsageError` at open; no reader |
+| RA + `concurrent_members=True` (or without) | Concurrent-open / single-live-stream rules per `reader-concurrency` / `archive-reading` |
+| Active pass + conflicting pass/open/close | Later → `ArchiveyUsageError`; original pass usable |
+| RA `stream_members` active + `open()` | `ArchiveyUsageError` |
+| `extract_all` drives child `stream_members` | Permitted composition; unrelated public pass rejected |
+
+### Requirement: Concurrent-stream cost is informational
+
+`access_cost` / `solid_block_count` describe work (including under a declared
+simultaneous schedule). They SHALL NOT permit or deny capabilities —
+`concurrent_members` is the only gate (`reader-concurrency`). Solid open-*order* cost
+is reported here and steered toward `stream_members()`, not gated.
+
+#### Scenario: cost vs capability
+
+| Case | Expected |
+| --- | --- |
+| `concurrent_members=True` on `DIRECT` and `SOLID` readers, multiple streams | Both supported and byte-correct; only reported/repeated work differs |

--- a/openspec/changes/member-stream-capability-booleans/specs/archive-reading/spec.md
+++ b/openspec/changes/member-stream-capability-booleans/specs/archive-reading/spec.md
@@ -52,9 +52,12 @@ keep its `seekable: bool` parameter, and both entry points SHALL use the same `s
 vocabulary for the same concept; concurrency has no meaning for a single standalone
 stream, so `open_stream` MUST NOT gain a concurrency parameter.
 
-The `MemberStreams` flag type SHALL remain publicly exported and SHALL remain the value
-reported for declared capabilities on `CostReceipt` and in diagnostics. It is no longer
-an input to `open_archive`.
+The `MemberStreams` flag type SHALL remain publicly exported as the internal
+representation the booleans map to at the entry point. It is no longer an input to
+`open_archive`. It is NOT required to appear on `CostReceipt` or in diagnostics —
+neither carries it, and no requirement SHALL claim otherwise. Whether the declared
+capabilities become a typed part of the `ArchiveReader` contract (today
+`member_streams` exists only on the concrete base class) is deliberately left open.
 
 **Default (neither declared), every format including directory:** at most one live member
 data stream per reader; streams are forward-only. "Live" spans `open()` →

--- a/openspec/changes/member-stream-capability-booleans/specs/archive-reading/spec.md
+++ b/openspec/changes/member-stream-capability-booleans/specs/archive-reading/spec.md
@@ -1,0 +1,94 @@
+## MODIFIED Requirements
+
+### Requirement: Opening an archive for reading
+
+The system SHALL expose:
+
+```python
+archivey.open_archive(
+    source: str | Path | BinaryIO | Sequence[str | Path | BinaryIO],
+    *,
+    format: ArchiveFormat | None = None,
+    streaming: bool = False,
+    seekable_members: bool = False,
+    concurrent_members: bool = False,
+    password: PasswordInput = None,
+    encoding: str | None = None,
+    config: ArchiveyConfig | None = None,
+) -> ArchiveReader
+```
+
+`source`, multi-volume ordering, `streaming`, password candidates/providers,
+encoding, configuration precedence, and backend selection retain their existing
+contracts. `format=None` auto-detects; an explicit format bypasses detection.
+
+**Diagnostics at open (observable):** On success, advisory events from automatic
+detection (if any) appear in this reader's cumulative `diagnostics` for its
+lifetime and are not duplicated. Explicit `format=` skips detection, so open
+adds no detection diagnostics. If open raises, no reader is returned.
+
+Handoff mechanics (one shared collector/budget, no copy/re-seed): see
+`format-detection` and `diagnostics`.
+
+#### Scenario: open matrix
+
+| Case | Expected |
+| --- | --- |
+| Auto-detect succeeds | Detection events visible on `reader.diagnostics`; not duplicated |
+| `format=ArchiveFormat.ZIP` succeeds | No detection diagnostics from open |
+| Open raises | No reader returned |
+| `password="secret"` | Returned reader uses that password for encrypted members |
+
+### Requirement: Declared member-stream capabilities
+
+`open_archive()` SHALL accept two keyword-only booleans, both defaulting to `False`:
+
+- `concurrent_members=True` — any number of member streams may be open simultaneously
+  (full contract: `reader-concurrency`)
+- `seekable_members=True` — seekable where the backend can provide it
+
+The system SHALL NOT expose a flag-enum parameter for this purpose. `open_stream` SHALL
+keep its `seekable: bool` parameter, and both entry points SHALL use the same `seekable`
+vocabulary for the same concept; concurrency has no meaning for a single standalone
+stream, so `open_stream` MUST NOT gain a concurrency parameter.
+
+The `MemberStreams` flag type SHALL remain publicly exported and SHALL remain the value
+reported for declared capabilities on `CostReceipt` and in diagnostics. It is no longer
+an input to `open_archive`.
+
+**Default (neither declared), every format including directory:** at most one live member
+data stream per reader; streams are forward-only. "Live" spans `open()` →
+stream `close()`/context exit (not EOF, not GC). A second overlapping `open()`
+SHALL raise `ConcurrentAccessError` at the later call and leave the first stream
+untouched/readable — never silently close/invalidate a held stream. Every member
+stream (random `open()` and `stream_members()` yields) SHALL report
+`seekable() is False`; `seek()` SHALL raise `io.UnsupportedOperation`; `tell()`
+SHALL work. Sequential `open → read → close → open next` is unaffected.
+
+`ConcurrentAccessError`'s message SHALL name the parameter a caller would pass to
+allow the operation (`concurrent_members=True`), not an internal type.
+
+`open_archive()` SHALL capture the caller stack once; `ConcurrentAccessError`
+SHALL include that `file:line`. Full stack is retained on the reader for
+diagnostics (no config knob). Capabilities are per-archive intent only — no
+`ArchiveyConfig` equivalent, no per-`open()` flag. Access cost never determines
+legality; the cost receipt describes expense.
+
+**Internal ops exempt:** `extract_all()` (incl. hardlink recovery), symlink-target
+reads, password confirmation, and other library-internal opens run under internal
+scopes and need no declared capability.
+
+**Out of gate scope:** non-overlapping open *order* on solid archives (each
+re-decode from block start) stays under `AccessCost` / `solid_block_count` /
+`stream_members()` steer. Docs for the capability booleans SHALL state this.
+
+#### Scenario: capability gate matrix
+
+| Case | Expected |
+| --- | --- |
+| Overlapping second `open()` without `concurrent_members` (ZIP/TAR/ISO/single-file/dir) | `ConcurrentAccessError` at later `open()` with open_archive `file:line`; first stream remains readable |
+| Non-overlapping open/read/close loop, no capabilities declared | All opens succeed |
+| Stream without `seekable_members` (incl. real directory file) | `seekable()` false; `seek()` → `io.UnsupportedOperation`; `tell()` + forward reads OK |
+| Same member with `seekable_members=True` | Seekable where backend provides it; loud-slow-rewind rule for non-accelerated path |
+| `extract_all()` with nothing declared | Completes; internal opens ungated |
+| `open_archive(p, member_streams=...)` | `TypeError` — the parameter no longer exists |

--- a/openspec/changes/member-stream-capability-booleans/specs/error-handling/spec.md
+++ b/openspec/changes/member-stream-capability-booleans/specs/error-handling/spec.md
@@ -1,0 +1,46 @@
+## MODIFIED Requirements
+
+### Requirement: Caller misuse remains outside ArchiveyError
+
+The system SHALL define `ArchiveyUsageError(Exception)` outside `ArchiveyError`
+for detected caller-code bugs. `except ArchiveyError` MUST NOT swallow misuse.
+
+`ConcurrentAccessError(ArchiveyUsageError)` SHALL be raised when a second member
+stream opens while another is live on a reader opened without
+`concurrent_members=True`. Its message SHALL include the recorded `open_archive()` call
+site (`file:line`) and SHALL name `concurrent_members=True` as the parameter that would
+have allowed the operation.
+
+`ArchiveyUsageError` SHALL also cover:
+
+- reader-wide exclusive pass overlap (`__iter__`, `stream_members`,
+  `extract_all`, materialization, active worker calls);
+- close overlapping an active worker call without declared concurrency;
+- any reader operation/property after `close()` except repeated `close()` /
+  `__exit__`;
+- same-reader password-provider reentry into password-requiring work;
+- using an `ArchiveMember` from another reader;
+- member I/O after a caller closes its supplied source early;
+- `open_archive(streaming=True, concurrent_members=True)`;
+- `open()` / `read()` of a resolved non-payload member (`DIRECTORY`, `ANTI`,
+  `OTHER`). A symlink/hardlink that fails to resolve remains
+  `LinkTargetNotFoundError` (`ArchiveyError`) — that is an archive property,
+  not caller misuse. A link that resolves to a non-`FILE` then hits the
+  non-payload rule above.
+
+The later operation SHALL fail before changing state and MUST leave the earlier
+operation/stream usable. Internal owner-child operations are exempt only through
+explicit internal tokens; public reentry does not inherit them. Closed stream I/O
+continues to raise `ValueError`, and unsupported stream positioning continues to
+raise `io.UnsupportedOperation`.
+
+#### Scenario: usage error matrix
+
+| Case | Expected |
+| --- | --- |
+| `except ArchiveyError` wraps code that raises `ArchiveyUsageError` | Usage error propagates past the handler |
+| Second overlapping member stream without `concurrent_members=True` | `ConcurrentAccessError` with open-site `file:line` naming `concurrent_members=True`; first stream still readable |
+| Exclusive pass/materialization is active and conflicting public op begins | Later op raises `ArchiveyUsageError`; active op remains valid |
+| Operation/property after `reader.close()` | `ArchiveyUsageError`; already-open member stream follows lifecycle lease |
+| Repeated `reader.close()` | No error; no repeated backend teardown |
+| Unsupported `seek()` on a stream | `io.UnsupportedOperation`, not archivey-typed |

--- a/openspec/changes/member-stream-capability-booleans/specs/reader-concurrency/spec.md
+++ b/openspec/changes/member-stream-capability-booleans/specs/reader-concurrency/spec.md
@@ -1,30 +1,14 @@
-# Reader Concurrency
+## MODIFIED Requirements
 
-## Purpose
-
-Thread-safety and ownership rules for `ArchiveReader` when callers declare
-`open_archive(concurrent_members=True)` (and the related single-owner / lifecycle machinery
-that makes concurrent opens correct). Caller-facing open/iterate/read APIs live
-in `archive-reading`; this capability is the implementer contract for concurrent
-use, free-threaded correctness, and pass ownership.
-
-## Related specs
-
-| Spec | Relationship |
-| --- | --- |
-| `archive-reading` | Declares the capability booleans, default single-live-stream gate, public lifecycle |
-| `access-mode-and-cost` | `streaming=True` remains forward-only; concurrency is a random-access concern |
-| `error-handling` | `ConcurrentAccessError`, `ArchiveyUsageError` shapes |
-| `packaging-and-extras` | Free-threaded CI / supported-capability documentation |
-| `format-tar` / `format-iso` / `format-zip` | Per-backend handle-lock compliance |
-| `testing-contract` | Multi-thread / `3.13t` coverage expectations |
-
-## Requirements
+<!-- Callers declare concurrency as `open_archive(concurrent_members=True)`; the
+`CONCURRENT` / `SEEKABLE` flag names are retained below wherever they denote the
+reader's *capability state* rather than the call that produced it. This spec is the
+implementer contract and the flags remain the internal representation. -->
 
 ### Requirement: Multiple concurrently-open member streams
 
 Every **random-access** reader (`streaming=False`) opened with
-`MemberStreams.CONCURRENT` SHALL support any number of member streams from that
+`concurrent_members=True` SHALL support any number of member streams from that
 reader held open simultaneously and read interleaved without corrupting one
 another. Without that flag the single-live-stream default in `archive-reading`
 applies. Access cost never determines legality: declared capabilities are
@@ -36,8 +20,8 @@ or `scan_members()` and the reader has published its member list/name index,
 concurrent calls from multiple threads to `open(member_or_name)` SHALL be
 supported. Streams from different opens SHALL have independent logical
 positions/state: workers MAY concurrently call `read`, `readinto`, and `close`
-on **different** stream objects, plus `seek`/`tell` under
-`MemberStreams.SEEKABLE` where that stream supports positioning. Non-seekable
+on **different** stream objects, plus `seek`/`tell` when
+`seekable_members=True` was declared and that stream supports positioning. Non-seekable
 streams retain normal `BinaryIO` behavior (`seekable()` false;
 unsupported positioning → `io.UnsupportedOperation`). Simultaneous operations on
 the **same** stream object require caller synchronization (ordinary file
@@ -150,7 +134,7 @@ release.
 
 ### Requirement: Coordinated first-touch materialization
 
-A reader opened with `MemberStreams.CONCURRENT` SHALL coordinate concurrent
+A reader opened with `concurrent_members=True` SHALL coordinate concurrent
 first-touch operations on a not-yet-materialized member list by blocking all but
 one caller until the immutable snapshot is published, rather than rejecting the
 overlap. Materialization SHALL run exactly once. Non-concurrent and uncontended
@@ -167,7 +151,7 @@ callbacks still run with no reader-state lock held).
 
 ### Requirement: Draining reader close
 
-Under `MemberStreams.CONCURRENT`, `reader.close()` SHALL wait for in-flight
+Under declared concurrency, `reader.close()` SHALL wait for in-flight
 worker `open()`/`read()` calls to return and then transition the reader to
 closed, rather than raising because workers are active. Escaped open member
 streams SHALL remain governed by the lifecycle-lease contract in
@@ -182,116 +166,3 @@ rejection SHALL be preserved.
 | Escaped stream still open as `close()` returns | Readable until its `close()`; teardown once after final lease |
 | Two threads `close()` / `__exit__` | Teardown once; both return; dual failures → one `ExceptionGroup` |
 | Op after `close()` returned | `ArchiveyUsageError` (unchanged) |
-
-### Requirement: Distinct passes and shared streams remain single-owner
-
-Overlapping *distinct* reader-wide passes or concurrent access to a single
-stream object SHALL remain rejected or caller-synchronized. Coordination under
-`CONCURRENT` is bounded to materialization and draining close — it does not make
-every reader method thread-safe.
-
-#### Scenario: single-owner matrix
-
-| Case | Expected |
-| --- | --- |
-| Active `extract_all()` / `stream_members()` + another pass | Later → `ArchiveyUsageError` |
-| Concurrent ops on same `ArchiveStream` | Caller's responsibility; no per-stream locking added |
-| `seekable() is False` + seek | `io.UnsupportedOperation` (no synthetic seek) |
-| `extract_all()` drives `stream_members` + hardlink recovery | Token-bearing child scopes permitted; unrelated public op rejected |
-| Caller-owned source closed externally while stream leased | Typed error; not arbitrary/empty bytes |
-
-### Requirement: Random-access member-open is reentrant and reader-state-free
-
-For every random-access backend, `_open_member` SHALL derive the returned stream
-from the member plus immutable/published archive state and coordinated backend
-resources. It MUST NOT keep unsynchronized per-open scratch on the reader that
-another open can overwrite. Synchronized shared bookkeeping — operation state,
-stream leases, password/key caches, and backend handle locks — is permitted and
-required where applicable.
-
-Archivey-owned byte ranges MUST use shared-source views with per-view position.
-A library-owned seek-before-read backend (random-access TAR/ISO) MUST coordinate
-the complete shared-handle lifecycle through its per-reader lock. Immutable
-member/name structures MAY be read concurrently after materialization.
-
-Forward-only/streaming passes remain out of scope because they own one
-progressive decoder and cannot overlap. There is no random-access TAR/ISO
-exemption: those backends satisfy the random-access invariant through their
-locked library streams.
-
-#### Scenario: reentrant open matrix
-
-| Case | Expected |
-| --- | --- |
-| Two post-materialization `open()` concurrent | No unsynchronized per-open reader scratch; both streams correct under interleaving |
-| RA TAR/ISO multi-stream | Shared-handle/library decode ops serialized by one per-reader lock; callbacks/diagnostics run unlocked |
-
-### Requirement: Concurrent password resolution stays lock-free for providers
-
-The candidate/provider model in `archive-reading` SHALL remain safe for
-concurrent post-materialization opens. Static candidates are immutable and
-ordered. Known-good snapshots/promotions and per-unit tried/attempt state are
-synchronized; expensive key derivation/decryption runs without
-lifecycle/operation, materialization, or password-state locks, but MAY use a
-required backend/source lock around an atomic decode/handle operation.
-
-At most one provider-driven resolution turn may be active per reader. Provider
-invocation SHALL use a claim/call/validate/publish protocol: claim the turn
-under a condition, release all Archivey locks, call the provider, then test
-returned candidates for that encrypted unit without
-lifecycle/materialization/password locks (using a required backend/source lock
-only for atomic validation). It then publishes the validated outcome, releases
-the turn, and wakes waiters in a `finally` path. The turn remains claimed
-through repeated provider attempts until success or `None`. A waiter SHALL
-recheck known-good passwords before claiming the next turn. Provider callbacks
-are therefore serialized and always lock-free. Reentrant provider code that
-starts another password-requiring operation on the same reader SHALL raise
-`ArchiveyUsageError` rather than deadlocking. Attempt counts remain per
-encrypted unit.
-
-#### Scenario: concurrent password matrix
-
-| Case | Expected |
-| --- | --- |
-| Workers concurrently open differently encrypted units after materialization | Each follows candidate order independently; promotions race-free; attempt state not overwritten |
-| Two workers need the provider at once | One callback at a time, no Archivey lock; waiter resumes after publish |
-| Provider starts another password op on same reader | Nested op → `ArchiveyUsageError` |
-
-### Requirement: Lifecycle leases and teardown once-guards
-
-Lifecycle state (`OPEN`, `READER_CLOSED`, `TEARDOWN_RUNNING`,
-`TEARDOWN_COMPLETE`) and lease count SHALL be guarded independently from
-materialization. Each random-open member stream SHALL own a backend-resource
-lease. Backend/source teardown SHALL occur exactly once after both the reader is
-closed and the final member-stream lease is released.
-
-A failed open releases its reserved lease (including lazy initialization failure
-and closing a lazy stream before first use). The final releaser claims teardown
-under the lifecycle lock, performs it after releasing that lock, and records
-completion without retry. Backend teardown and inner stream close execute
-outside lifecycle locks.
-
-If explicit reader/member close triggers final teardown and teardown fails, the
-closer SHALL be irrevocably closed and the translated error SHALL propagate
-once; repeated closes SHALL not retry or re-raise it. A safety-net finalizer
-SHALL use the same once-guards, never raise, and MAY report through
-`sys.unraisablehook` only outside all Archivey locks. Native accelerator
-finalizers retain their close-before-free guarantee.
-
-Member close SHALL release its lease in `finally` even when inner close fails.
-If inner close and the resulting final backend teardown both fail, both
-translated errors SHALL be preserved in an `ExceptionGroup`.
-
-Escaped streams use context captured before close for error translation and MUST
-NOT call closed-reader properties. Their lease-bound short-lived worker tokens
-prevent final teardown from racing each call.
-
-#### Scenario: lease / teardown matrix
-
-| Case | Expected |
-| --- | --- |
-| `_open_member` raises after reserving lease | Reservation released; later reader close can complete teardown |
-| Lazy first I/O → `_open_member` raises | Translated error; lease released; later I/O → closed-stream `ValueError`; close no-op |
-| Teardown raises on explicit/final-stream close | Closer irrevocably closed; error once; `TEARDOWN_COMPLETE`; no retry |
-| Inner-close + teardown both fail on final member close | Lease/state released once; `ExceptionGroup` of both |
-| Idle leased stream after `reader.close()` | Later stream I/O via lease-bound worker entry until stream close |

--- a/openspec/changes/member-stream-capability-booleans/specs/seekable-decompressor-streams/spec.md
+++ b/openspec/changes/member-stream-capability-booleans/specs/seekable-decompressor-streams/spec.md
@@ -1,0 +1,33 @@
+## MODIFIED Requirements
+
+### Requirement: Seek machinery is demand-driven
+
+The system SHALL construct seek support only when seekability is declared:
+`seekable_members=True` on `open_archive()` or `seekable=True` on the
+single-stream API. Undeclared streams SHALL NOT parse XZ footers, scan lzip
+trailers, instantiate rapidgzip accelerators, retain rewind buffers, or retain
+seek-point tables; they are forward-only.
+
+`use_rapidgzip` and `use_indexed_bzip2` SHALL resolve their `AUTO` / `ON` / `OFF`
+configuration against declared seek demand, not the `streaming` access-mode
+proxy. For declared-seekable streams, native XZ/lzip indexes, rapidgzip-backed
+gzip/bzip2 indexes, and stdlib fallback rewinds retain their contracts. The
+stdlib O(n)-per-rewind path MAY serve the seek but MUST emit the documented
+slow-rewind diagnostic/warning.
+
+Under `AUTO`, the system SHALL additionally require the known compressed input size to reach a
+documented minimum threshold before selecting rapidgzip for any DEFLATE-family stream (deflate,
+zlib, gzip), so per-stream accelerator setup is not paid for members too small to benefit. The
+threshold value is fixed by benchmark and recorded in design. When the input size is not known
+in advance, `AUTO` SHALL behave as it did before this threshold existed (select the accelerator
+when otherwise eligible). `ON` ignores the threshold; `OFF` never selects rapidgzip.
+
+#### Scenario: demand matrix
+
+| Case | Expected |
+| --- | --- |
+| gzip/xz/bzip2/lzip opened without seekability under `AUTO` | No index, no accelerator, forward-only |
+| Same stream opened with seekability, `AUTO`, accelerator installed, size ≥ threshold | Accelerator or native index provides random access |
+| Declared-seekable deflate/zlib/gzip under `AUTO`, known size < threshold | rapidgzip not selected; stdlib backend used |
+| Declared-seekable DEFLATE-family stream, `use_rapidgzip=ON`, size below threshold | rapidgzip still selected (threshold ignored) |
+| Declared-seekable gzip without accelerator, caller seeks backward | Seek re-decompresses from start and warns/names `[seekable]` accelerator |

--- a/openspec/changes/member-stream-capability-booleans/specs/testing-contract/spec.md
+++ b/openspec/changes/member-stream-capability-booleans/specs/testing-contract/spec.md
@@ -1,0 +1,73 @@
+## MODIFIED Requirements
+
+### Requirement: Capability-gate behavior is tested on every format
+
+The test suite SHALL cover the declared-capability gate uniformly for every
+implemented format, including directory. A reader opened without
+`concurrent_members=True` MUST raise `ConcurrentAccessError` on a second
+overlapping `open()` while the first stream stays readable; sequential
+`open -> read -> close -> open next` MUST succeed without any declaration. The
+error message MUST include the recorded `open_archive()` call site and MUST name
+`concurrent_members=True` as the parameter that would have allowed the operation.
+
+Without `seekable_members=True`, member streams from random `open()` and
+`stream_members()` MUST report `seekable() is False` and raise
+`io.UnsupportedOperation` from `seek()` on every format, including real directory
+files. With `seekable_members=True`, positioning MUST work where the backend
+provides it. `extract_all()`, including hardlink recovery and symlink-target reads,
+MUST succeed on readers with no declared capabilities. `ArchiveyUsageError` and
+`ConcurrentAccessError` MUST NOT be `ArchiveyError` subclasses. Accelerator/index
+activation MUST be demand-driven and match `seekable-decompressor-streams`.
+
+#### Scenario: capability-gate matrix
+
+| Case | Expected |
+| --- | --- |
+| Second overlapping `open()` on each implemented format without `CONCURRENT` | `ConcurrentAccessError` names the open site; first stream remains readable |
+| Sequential open/read/close loop without declarations | Succeeds on every implemented format |
+| `ConcurrentAccessError` inside `except ArchiveyError` | Propagates out of that handler |
+| Undeclared accelerator-eligible source | No seek index instantiated |
+| Declared `SEEKABLE` accelerator-eligible source | `AUTO` accelerator resolves as specified |
+
+### Requirement: Concurrent member-stream correctness and free-threaded stress
+
+The test suite SHALL exercise the supported post-materialization concurrency
+contract from `reader-concurrency` for readers opened with
+`concurrent_members=True`. Coverage MUST include representative backend shapes:
+directory independent handles, ZIP library-coordinated handles, Archivey
+`SharedSource` views for single-file and native 7z/RAR as available, and
+Archivey-locked library handles for random-access TAR and ISO.
+
+Tests SHALL cover concurrent `open()` by member and name; independent stream
+`read`, `readinto`, `close`, supported positioning, and non-seekable
+`io.UnsupportedOperation`; cache publication separate from lifecycle; child
+operation-owner scopes; generator abandonment; lifecycle leases, failures,
+finalizers, and caller-owned sources; password candidate/provider coordination; and
+detected unsupported overlap. Stress tests MUST vary interleavings across threads
+and assert exact bytes/state, not merely lack of exceptions.
+
+CI SHALL define a required Linux `free-threaded-concurrency` job that installs
+CPython `3.13t`, uses the zero-dependency core environment, and runs tests marked
+`concurrent_reader`. The marker SHALL cover directory, ZIP, single-file stdlib
+codecs, `SharedSource`, lifecycle/operation state, and TAR. The job MUST fail rather
+than skip merely because the GIL is disabled. Optional backend free-threaded support
+is not claimed until an equivalent dedicated job can install and run that backend.
+ISO multi-thread coverage runs in the ordinary `[all]` matrix until a dedicated
+extras job exists.
+
+The TAR/ISO correctness-lock implementation SHALL record a proportionate baseline:
+wall time, lock wait/hold time, and practical seek/decompression/read metrics.
+There is no pass/fail performance threshold. A later optimization or speed claim
+MUST include targeted before/after measurements for the mechanism it changes; peak
+memory and broader DIRECT/SOLID workloads are required only when that strategy can
+affect buffering, materialization, or decompression work.
+
+#### Scenario: concurrency-test matrix
+
+| Case | Expected |
+| --- | --- |
+| Available representative backend materialized and workers use distinct streams under varied interleavings | Exact bytes and independent supported positions; non-seekable streams keep standard unsupported-operation behavior |
+| Required `free-threaded-concurrency` job runs under CPython `3.13t` | Passes without cache, lifecycle, password, or source-position data races |
+| Multi-thread workers cover core backends (directory, ZIP, stdlib single-file, SharedSource, plain TAR) | Exact member bytes and documented misuse errors |
+| TAR/ISO correctness lock implemented | Practical serialization metrics recorded without a correctness speed threshold |
+| Later performance claim changes handle sharing, decoding, or locks | Focused before/after metrics for affected resources |

--- a/openspec/changes/member-stream-capability-booleans/tasks.md
+++ b/openspec/changes/member-stream-capability-booleans/tasks.md
@@ -82,7 +82,65 @@ requirement header, and the requirement that actually defines this surface lives
       both the old parameter and the old flag in its `ConcurrentAccessError` wording.
 - [x] 5.4 `openspec validate --strict` passes.
 
-`reader-concurrency:15` has one descriptive cross-reference row ("Declares
-`member_streams`, default single-live-stream gate"). Left alone: it is a pointer to
-`archive-reading` rather than a normative statement, and `openspec sync` will not touch
-it. Worth a one-word fix whenever that spec is next edited for its own reasons.
+## 6. Review round (PR #213)
+
+- [x] 6.1 **The `CostReceipt` / diagnostics claim was false.** The proposal asserted that
+      `MemberStreams` "remains the declared-capability value on `CostReceipt` and in
+      diagnostics", and that was carried into the class docstring and into the
+      `archive-reading` delta as a `SHALL`. `CostReceipt` has `listing_cost` /
+      `access_cost` / `stream_capability` / `solid_block_count` / `notes`; no diagnostic
+      carries a `MemberStreams`. The claim was never true — it was invented in the
+      proposal and never checked. Corrected in all three places, and the delta now says
+      explicitly that nothing requires it to appear there. The honest reason it stays
+      exported is that it is the internal representation the booleans map to; concrete
+      readers expose `reader.member_streams`, but that property is **not** on the
+      `ArchiveReader` ABC, so it is runtime-reachable and not part of the typed contract.
+      Whether to change that is left open — see §7.
+- [x] 6.2 **Sibling specs prescribed the old input.** Three specs beyond the original
+      three carried normative "on `open_archive()`" / "opened with `MemberStreams.…`"
+      text that would have survived `openspec archive` as contradictory `SHALL`s:
+      `seekable-decompressor-streams`, `reader-concurrency`, `testing-contract`. Deltas
+      added for all three. The delta bodies were **extracted programmatically from the
+      live specs** and then substituted, rather than retyped, so a transcription slip
+      cannot corrupt a requirement on sync.
+      Where the flag names denote the reader's *capability state* rather than the call
+      that produced it, they are deliberately kept — `reader-concurrency` is the
+      implementer contract and the flags are the internal representation. A comment in
+      that delta records the distinction so a later pass does not "finish" the rename.
+- [x] 6.3 Non-requirement prose (`reader-concurrency` Purpose, two Related-specs rows)
+      edited directly in the main specs. Deltas only carry `### Requirement:` blocks, so
+      `openspec sync` would never have applied these.
+- [x] 6.4 `ConcurrentAccessError`'s **class docstring** still taught
+      `MemberStreams.CONCURRENT` while the raised message said `concurrent_members=True`.
+      It is the mkdocstrings surface, so the two disagreed exactly where a user looks.
+- [x] 6.5 Half-updated published prose: `docs/gotchas.md:19` ("With `SEEKABLE`…") and
+      `docs/costs.md:87,114`, each sitting next to a line already converted.
+      (`costs.md:43`'s `SEEKABLE` is `StreamCapability.SEEKABLE`, a different enum —
+      correctly left alone.)
+- [x] 6.6 Near-public docstrings still teaching flag declaration: `AcceleratorMode`
+      (`config.py`), and `BaseArchiveReader.open` / `.close`, which are what `help()` on
+      a live reader shows. `_open_member` / `_wrap_member_stream` keep the flag names —
+      private, and there they genuinely mean the internal gate.
+- [x] 6.7 Deleted the always-true assertion
+      (`assert "concurrent-member-streams" not in str(...) or True`) in a test this
+      change already touched.
+- [x] 6.8 Added `test_member_streams_kwarg_is_gone` — the delta has a
+      `member_streams=… → TypeError` scenario with no test behind it. Python enforces it
+      anyway; the test exists so a well-meant "accept both spellings" patch has to delete
+      a test rather than slip through.
+
+## 7. Open for the maintainer — what is `MemberStreams` publicly for?
+
+Now that it is not an input, its only public presence is `__all__` + the
+`::: archivey.MemberStreams` block in `docs/api.md`, and `reader.member_streams` exists
+only on the concrete base class. Options:
+
+| | Approach | Note |
+|---|---|---|
+| **A** | Leave as-is; docs now describe it honestly as the internal/reported form | Zero cost. The export is decorative for anyone holding an `ArchiveReader`-typed handle |
+| **B** *(recommended)* | Promote `member_streams` onto the `ArchiveReader` ABC | ~4 lines, purely additive, gives the export a real job ("what did I open this with?") |
+| **C** | Put declared capabilities on `CostReceipt` | What the false claim described. A real API expansion, outside this change's no-behaviour-change scope |
+
+**Recommendation: B, as a follow-up rather than here** — adding a property to the ABC
+later is non-breaking, so it carries no `0.2.0` deadline, whereas *removing* the export
+would be breaking. Keep it exported either way.

--- a/openspec/changes/member-stream-capability-booleans/tasks.md
+++ b/openspec/changes/member-stream-capability-booleans/tasks.md
@@ -1,36 +1,88 @@
 ## 1. Public surface
 
-- [ ] 1.1 `open_archive`: replace `member_streams: MemberStreams` with keyword-only
+- [x] 1.1 `open_archive`: replace `member_streams: MemberStreams` with keyword-only
       `seekable_members: bool = False` and `concurrent_members: bool = False`
       (`core.py:101`).
-- [ ] 1.2 Map to the internal `MemberStreams` value at the boundary; leave internal
+- [x] 1.2 Map to the internal `MemberStreams` value at the boundary; leave internal
       plumbing on flags so the diff stays shallow.
-- [ ] 1.3 Re-express the `streaming` + concurrency rejection against
+- [x] 1.3 Re-express the `streaming` + concurrency rejection against
       `concurrent_members` (`core.py:168`), keeping the error type and message shape.
-- [ ] 1.4 Update the docstring: state the two traps each flag opts into, and that
-      `open_stream` uses the same `seekable` vocabulary.
+- [x] 1.4 Update the docstring: state the two traps each flag opts into, and that
+      `open_stream` uses the same `seekable` vocabulary. *(Both docstrings — the
+      `open_stream` one now says `seekable` is the same capability `open_archive`
+      spells `seekable_members`, rather than contrasting a bool with a flag enum.)*
 
 ## 2. Call sites
 
-- [ ] 2.1 Update internal callers (~52 refs), including `extract`/`extract_all` paths.
-- [ ] 2.2 Update tests (~38 refs). Behaviour assertions must not change — only the call
+- [x] 2.1 Update internal callers (~52 refs), including `extract`/`extract_all` paths.
+      *(No internal caller needed changing: the mapping happens at the entry point and
+      every layer below `open_archive` already spoke `MemberStreams`. The one internal
+      change is the `ConcurrentAccessError` message — see 2.4.)*
+- [x] 2.2 Update tests (~38 refs). Behaviour assertions must not change — only the call
       spelling. A test whose *expectations* change is a red flag for scope creep.
-- [ ] 2.3 Confirm `MemberStreams` is still exported and still used by `CostReceipt` /
+      *(Two parametrizations changed shape rather than spelling —
+      `test_iterate_and_open_inside_loop` now takes `concurrent: bool` instead of a
+      `MemberStreams` value, and `_fan_out_read` passes its `seekable` argument
+      straight through. Same cases, same assertions.)*
+- [x] 2.3 Confirm `MemberStreams` is still exported and still used by `CostReceipt` /
       diagnostics; `test_public_api.py` must stay green.
+- [x] 2.4 **Added:** the `ConcurrentAccessError` message told callers to reopen with
+      `member_streams=MemberStreams.CONCURRENT` — a user-visible string naming a
+      parameter that no longer exists. It now names `concurrent_members=True`, and the
+      `error-handling` delta makes that a requirement rather than an incidental fix.
+      `benchmarks/harness.py` also had its own `member_streams` plumbing, converted to
+      `seekable_members`.
 
 ## 3. Docs and decision record
 
-- [ ] 3.1 `docs/usage.md`, `docs/costs.md`, `docs/support-matrix.md` (8 refs) — the
-      support-matrix concurrency example is the load-bearing one.
-- [ ] 3.2 Amend ADR 0003 with the new spelling; note ADR 0004's reasoning applies.
-- [ ] 3.3 Check `docs/migrating.md`'s "one live member stream by default" note still
-      reads correctly.
+- [x] 3.1 Published user pages — measured **24 refs**, not the 8 first estimated:
+      `support-matrix.md` (5), `costs.md` (5), `philosophy.md` (4), `usage.md` (3),
+      `formats.md` (3), `gotchas.md` (2), `migrating.md` (1), `api.md` (1). The
+      support-matrix concurrency example is the load-bearing one; `philosophy.md:52-53`
+      is a two-row "how do I ask for it" table that is the change in miniature.
+      `api.md:22` is the `::: archivey.MemberStreams` mkdocstrings entry — it **stays**
+      (the enum remains exported for `CostReceipt` and diagnostics).
+- [x] 3.2 Amend ADR 0003 with the new spelling; note ADR 0004's reasoning applies.
+- [x] 3.3 Check `docs/migrating.md`'s "one live member stream by default" note still
+      reads correctly. *(Reworded from "declare `MemberStreams.CONCURRENT`" to "pass
+      `concurrent_members=True`"; the surrounding claim is unchanged.)*
+- [x] 3.4 **Added:** `MemberStreams`' own class docstring described itself as the input
+      to `open_archive` and explained combining flags with `|`. Rewritten to say what it
+      now is — the *reported* capability value on `CostReceipt` and in diagnostics —
+      since it is still the first thing a reader of `api.md` sees.
 
 ## 4. Verification
 
-- [ ] 4.1 Three-config suite green (`[all]`, `[all-lowest]`, core-only).
-- [ ] 4.2 Free-threaded `concurrent_reader` job green — it exercises the concurrency
-      capability directly.
-- [ ] 4.3 `pyrefly` + `ty` clean; `mkdocs build --strict` clean.
-- [ ] 4.4 Grep for `member_streams=` across the tree: no survivors outside archived
-      history.
+- [x] 4.1 Three-config suite green (`[all]`, `[all-lowest]`, core-only).
+      *(1995 passed / 58 skipped, 1995 / 58, 1590 / 406.)*
+- [x] 4.2 Free-threaded `concurrent_reader` job green — it exercises the concurrency
+      capability directly. *(46 `concurrent_reader` tests pass locally; the 3.13t job
+      runs the same suite in CI.)*
+- [x] 4.3 `pyrefly` + `ty` clean; `mkdocs build --strict` clean.
+- [x] 4.4 Grep for `member_streams=` across the tree: no survivors outside archived
+      history. *(Survivors are all internal plumbing — `ReaderState`, the backend
+      constructors — which the proposal keeps on flags deliberately. `docs/grab-bag/`
+      is untouched: declared non-normative historical prose.)*
+
+## 5. Spec deltas — restructured during implementation
+
+The change originally shipped one delta, against `access-mode-and-cost`, introducing a
+requirement (`Member stream capabilities are declared with booleans`) that did not exist
+in that spec. That was wrong twice over: a `MODIFIED` requirement must match a real
+requirement header, and the requirement that actually defines this surface lives in
+`archive-reading`. Corrected to three deltas, each modifying a requirement that exists:
+
+- [x] 5.1 `archive-reading` — `Opening an archive for reading` (the verbatim signature
+      block) and `Declared member-stream capabilities` (the flags themselves). This is
+      the spec that was silently left stale.
+- [x] 5.2 `access-mode-and-cost` — `Declared capabilities compose with the two access
+      modes` and `Concurrent-stream cost is informational`, both of which describe the
+      capability in `member_streams` terms.
+- [x] 5.3 `error-handling` — `Caller misuse remains outside ArchiveyError`, which names
+      both the old parameter and the old flag in its `ConcurrentAccessError` wording.
+- [x] 5.4 `openspec validate --strict` passes.
+
+`reader-concurrency:15` has one descriptive cross-reference row ("Declares
+`member_streams`, default single-live-stream gate"). Left alone: it is a pointer to
+`archive-reading` rather than a normative statement, and `openspec sync` will not touch
+it. Worth a one-word fix whenever that spec is next edited for its own reasons.

--- a/openspec/specs/seekable-decompressor-streams/spec.md
+++ b/openspec/specs/seekable-decompressor-streams/spec.md
@@ -12,7 +12,7 @@ forward-only streams free of seek machinery.
 | Spec | Relationship |
 | --- | --- |
 | `compressed-streams` | Public `open_stream(..., seekable=...)` and codec backend dispatch |
-| `archive-reading` | `MemberStreams.SEEKABLE` on archive member streams |
+| `archive-reading` | `seekable_members=True` on archive member streams |
 | `access-mode-and-cost` | Declared capabilities vs access modes |
 | `diagnostics` | Rewind and seek-index diagnostic policy/retention |
 | `error-handling` | Codec exception translation and `DiagnosticRaisedError` |

--- a/src/archivey/config.py
+++ b/src/archivey/config.py
@@ -20,7 +20,8 @@ class AcceleratorMode(Enum):
       package is absent: the caller asked for it explicitly).
     - ``OFF`` — never use it; the stream stays sequential-only.
     - ``AUTO`` — use it only when seekability was declared
-      (``MemberStreams.SEEKABLE`` / seek demand). Without declared seek demand, AUTO
+      (``seekable_members=True`` on ``open_archive``, ``seekable=True`` on
+      ``open_stream``, or internal seek demand). Without declared seek demand, AUTO
       leaves the cheaper sequential backend in place (no index/accelerator work). When
       AUTO would enable the accelerator but its package is absent, fall back to
       sequential silently (it is an enhancement, not a requirement). For the

--- a/src/archivey/core.py
+++ b/src/archivey/core.py
@@ -98,7 +98,8 @@ def open_archive(
     *,
     format: ArchiveFormat | None = None,
     streaming: bool = False,
-    member_streams: MemberStreams = MemberStreams(0),
+    seekable_members: bool = False,
+    concurrent_members: bool = False,
     password: PasswordInput = None,
     encoding: str | None = None,
     config: ArchiveyConfig | None = None,
@@ -109,20 +110,22 @@ def open_archive(
     time on a non-seekable source. ``streaming=True`` promises forward-only, single-pass
     access (works on any source, but disables random-access methods).
 
-    ``member_streams`` declares stream capabilities beyond the default forward-only,
-    single-live-stream contract:
+    Member streams are forward-only and single-live by default. Two keyword flags opt
+    into more, each unlocking one specific trap:
 
-    - ``MemberStreams.CONCURRENT`` — multiple member streams may be open at once
+    - ``seekable_members=True`` — ``seek()`` on a member stream works where the backend
+      can provide positioning. Without it, ``seek()`` raises
+      ``io.UnsupportedOperation``.
+    - ``concurrent_members=True`` — multiple member streams may be open at once
       (coordinated first-touch materialization, then worker fan-out; draining close).
-    - ``MemberStreams.SEEKABLE`` — member streams are seekable where the backend can
-      provide positioning.
+      Without it, a second overlapping ``open()`` raises ``ConcurrentAccessError``.
 
-    Without those flags, a second overlapping ``open()`` raises
-    ``ConcurrentAccessError``, and ``seek()`` raises ``io.UnsupportedOperation``.
-    Declared concurrency does **not** gate solid open-order cost — see ``AccessCost`` /
-    ``stream_members()``.
+    ``open_stream`` uses the same vocabulary for the single-stream case
+    (``open_stream(..., seekable=True)``); concurrency is meaningless there, so it has
+    no counterpart. Declared concurrency does **not** gate solid open-order cost — see
+    ``AccessCost`` / ``stream_members()``.
 
-    ``streaming=True`` combined with ``MemberStreams.CONCURRENT`` is rejected
+    ``streaming=True`` combined with ``concurrent_members=True`` is rejected
     (``ArchiveyUsageError``): a forward-only pass cannot fan out.
 
     ``config`` supplies library tuning knobs (accelerator modes, TAR end-of-archive
@@ -165,12 +168,20 @@ def open_archive(
 
     open_site = capture_open_site()
 
-    if streaming and MemberStreams.CONCURRENT in member_streams:
+    if streaming and concurrent_members:
         raise ArchiveyUsageError(
             "open_archive(streaming=True) cannot be combined with "
-            "MemberStreams.CONCURRENT: a forward-only pass has one progressive decoder "
+            "concurrent_members=True: a forward-only pass has one progressive decoder "
             "and cannot fan out concurrent member streams."
         )
+
+    # The public surface is two booleans; everything below the entry point keeps
+    # working in MemberStreams flags, which is also what CostReceipt reports.
+    member_streams = MemberStreams(0)
+    if seekable_members:
+        member_streams |= MemberStreams.SEEKABLE
+    if concurrent_members:
+        member_streams |= MemberStreams.CONCURRENT
 
     passwords = _PasswordCandidates.from_input(password)
 
@@ -285,9 +296,10 @@ def open_stream(
     """Open a single-file compressed stream and return a decompressing stream.
 
     This is the compressed-streams entry point for a bare ``.gz`` / ``.bz2`` / ``.xz`` /
-    … payload (no archive container). Concurrency is not a concept here — the call
-    returns exactly one stream — so seekability is a boolean, not
-    :class:`~archivey.MemberStreams` flags.
+    … payload (no archive container). ``seekable`` is the same capability
+    :func:`open_archive` spells ``seekable_members``; concurrency is not a concept here
+    — the call returns exactly one stream — so there is no counterpart to
+    ``concurrent_members``.
 
     ``seekable=False`` (the default) returns a forward-only stream: ``seekable()`` is
     ``False``, ``seek()`` raises ``io.UnsupportedOperation``, and no seek index or

--- a/src/archivey/exceptions.py
+++ b/src/archivey/exceptions.py
@@ -163,7 +163,7 @@ class ArchiveyUsageError(Exception):
 
 
 class ConcurrentAccessError(ArchiveyUsageError):
-    """A second overlapping member stream was opened without ``MemberStreams.CONCURRENT``.
+    """A second overlapping member stream was opened without ``concurrent_members=True``.
 
     The message includes the ``open_archive()`` call site so the error points at where
     the capability should have been declared.

--- a/src/archivey/internal/base_reader.py
+++ b/src/archivey/internal/base_reader.py
@@ -579,8 +579,9 @@ class BaseArchiveReader(ArchiveReader):
         ``zipfile``) are not required to route through an archivey ``SharedSource`` view,
         but archivey-owned reader state still MUST NOT hold unsynchronized per-open scratch.
 
-        Concurrent ``open`` is supported when the reader was opened with
-        ``MemberStreams.CONCURRENT``: first-touch materialization is coordinated
+        Concurrent ``open`` is supported when the reader declared concurrency
+        (``MemberStreams.CONCURRENT``, from ``open_archive(concurrent_members=True)``):
+        first-touch materialization is coordinated
         (wait/share), and after the snapshot is published workers may fan out. Forward-only
         / streaming passes remain single-owner. See ``docs/grab-bag/parallel-reader.md``.
         """
@@ -1438,10 +1439,10 @@ class BaseArchiveReader(ArchiveReader):
     def open(self, member: str | ArchiveMember) -> ArchiveStream:
         """Open member for reading. Follows symlinks.
 
-        Without ``MemberStreams.CONCURRENT``, at most one member stream may be live.
-        With it, concurrent first-touch materialization is coordinated and concurrent
-        ``open`` is supported (see :class:`~archivey.types.MemberStreams`).
-        Positioning requires ``MemberStreams.SEEKABLE``.
+        Without ``open_archive(concurrent_members=True)``, at most one member stream may
+        be live. With it, concurrent first-touch materialization is coordinated and
+        concurrent ``open`` is supported. Positioning requires
+        ``open_archive(seekable_members=True)``.
         """
         # Two independent gates: the access mode (streaming=True forbids random access)
         # and the backend capability (_SUPPORTS_RANDOM_ACCESS, used by the Phase-3
@@ -1623,7 +1624,7 @@ class BaseArchiveReader(ArchiveReader):
     def close(self) -> None:
         """Close the reader.
 
-        Idempotent. Under ``MemberStreams.CONCURRENT``, blocks until in-flight worker
+        Idempotent. With declared concurrency, blocks until in-flight worker
         ``open()`` / ``read()`` / ``get()`` / ``members()`` calls return, then marks the
         reader closed. Escaped open member streams keep their lifecycle leases and remain
         readable until they are closed. A worker that never returns is a caller bug (same

--- a/src/archivey/internal/reader_state.py
+++ b/src/archivey/internal/reader_state.py
@@ -282,8 +282,8 @@ class ReaderState:
                 raise ConcurrentAccessError(
                     "A member stream is already open on this reader. Close it before "
                     "opening another, or reopen the archive with "
-                    f"member_streams=MemberStreams.CONCURRENT "
-                    f"(this archive was opened without MemberStreams.CONCURRENT at {loc})."
+                    "concurrent_members=True "
+                    f"(this archive was opened without concurrent_members at {loc})."
                 )
             self._live_streams.add(id(stream))
             self._lease_count += 1

--- a/src/archivey/types.py
+++ b/src/archivey/types.py
@@ -16,10 +16,14 @@ class MemberStreams(Flag):
     """The member-stream capabilities a reader was opened with.
 
     Callers declare these as booleans —
-    ``open_archive(..., seekable_members=True, concurrent_members=True)``. This flag set
-    is the *reported* form: it is what :class:`~archivey.CostReceipt` and the diagnostics
-    carry, and what internal plumbing passes around. There is no need to construct one to
-    open an archive.
+    ``open_archive(..., seekable_members=True, concurrent_members=True)`` — so there is
+    no need to construct a ``MemberStreams`` value to open an archive. This flag set is
+    the internal representation those booleans map to at the entry point, and what every
+    backend receives. It is **not** carried on :class:`~archivey.CostReceipt` or in
+    diagnostics. Concrete readers expose the value they were opened with as
+    ``reader.member_streams``; that property is not on the
+    :class:`~archivey.ArchiveReader` ABC, so it is reachable at runtime but not part of
+    the typed public contract.
 
     Default (no bits set — ``MemberStreams(0)``) is the cheap contract:
 

--- a/src/archivey/types.py
+++ b/src/archivey/types.py
@@ -13,16 +13,18 @@ if TYPE_CHECKING:
 
 
 class MemberStreams(Flag):
-    """Opt-in member-stream capabilities for :func:`archivey.open_archive`.
+    """The member-stream capabilities a reader was opened with.
+
+    Callers declare these as booleans —
+    ``open_archive(..., seekable_members=True, concurrent_members=True)``. This flag set
+    is the *reported* form: it is what :class:`~archivey.CostReceipt` and the diagnostics
+    carry, and what internal plumbing passes around. There is no need to construct one to
+    open an archive.
 
     Default (no bits set — ``MemberStreams(0)``) is the cheap contract:
 
     - at most one live member stream at a time
     - streams are forward-only (``seek()`` raises)
-
-    Combine flags with ``|``::
-
-        MemberStreams.CONCURRENT | MemberStreams.SEEKABLE
 
     ``CONCURRENT``
         Multiple overlapping ``open()`` calls are allowed. First-touch member

--- a/tests/test_concurrent_cooperative.py
+++ b/tests/test_concurrent_cooperative.py
@@ -16,7 +16,6 @@ from archivey import (
     ArchiveyError,
     ArchiveyUsageError,
     ConcurrentAccessError,
-    MemberStreams,
     open_archive,
 )
 from archivey.internal.password import _PasswordCandidates
@@ -49,7 +48,7 @@ def test_open_during_stream_members_raises(tmp_path: Path) -> None:
 
 def test_members_then_open_ok(tmp_path: Path) -> None:
     root = _dir_with_files(tmp_path)
-    with open_archive(root, member_streams=MemberStreams.CONCURRENT) as reader:
+    with open_archive(root, concurrent_members=True) as reader:
         names = {m.name for m in reader.members()}
         assert names == {"a.txt", "b.txt"}
         s1 = reader.open("a.txt")
@@ -63,8 +62,8 @@ def test_members_then_open_ok(tmp_path: Path) -> None:
 # --- iterate-then-open regression (random-mode __iter__ holds no pass across consumption) ---
 
 
-@pytest.mark.parametrize("streams", [MemberStreams(0), MemberStreams.CONCURRENT])
-def test_iterate_and_open_inside_loop(tmp_path: Path, streams: MemberStreams) -> None:
+@pytest.mark.parametrize("concurrent", [False, True])
+def test_iterate_and_open_inside_loop(tmp_path: Path, concurrent: bool) -> None:
     """`for m in reader: reader.open(m)` must work on default and CONCURRENT readers.
 
     Random-mode iteration only walks the published snapshot, so it must not hold a
@@ -72,7 +71,7 @@ def test_iterate_and_open_inside_loop(tmp_path: Path, streams: MemberStreams) ->
     """
     root = _dir_with_files(tmp_path)
     got: dict[str, bytes] = {}
-    with open_archive(root, member_streams=streams) as reader:
+    with open_archive(root, concurrent_members=concurrent) as reader:
         for member in reader:
             if member.is_file:
                 with reader.open(member) as stream:
@@ -274,9 +273,7 @@ def test_reader_reentry_from_diagnostic_callback_raises_not_deadlocks(
         reader.members()  # re-enter the reader that is mid-materialization
 
     config = ArchiveyConfig(on_diagnostic=on_diagnostic)
-    with open_archive(
-        path, member_streams=MemberStreams.CONCURRENT, config=config
-    ) as opened:
+    with open_archive(path, concurrent_members=True, config=config) as opened:
         reader = opened
         with pytest.raises(ArchiveyUsageError, match="re-entered"):
             reader.members()
@@ -298,9 +295,7 @@ def test_close_from_diagnostic_callback_raises_not_deadlocks(tmp_path: Path) -> 
         reader.close()
 
     config = ArchiveyConfig(on_diagnostic=on_diagnostic)
-    reader_cm = open_archive(
-        path, member_streams=MemberStreams.CONCURRENT, config=config
-    )
+    reader_cm = open_archive(path, concurrent_members=True, config=config)
     try:
         reader = reader_cm
         with pytest.raises(ArchiveyUsageError, match="from inside one of its own"):

--- a/tests/test_concurrent_multithread.py
+++ b/tests/test_concurrent_multithread.py
@@ -54,10 +54,9 @@ def _expected(n: int = 8) -> dict[str, bytes]:
 
 
 def _fan_out_read(path: Path, *, seekable: bool = False) -> dict[str, bytes]:
-    flags = MemberStreams.CONCURRENT
-    if seekable:
-        flags |= MemberStreams.SEEKABLE
-    with open_archive(path, member_streams=flags) as reader:
+    with open_archive(
+        path, concurrent_members=True, seekable_members=seekable
+    ) as reader:
         members = [m for m in reader.members() if m.is_file]
         barrier = threading.Barrier(len(members))
         got: dict[str, bytes] = {}
@@ -132,9 +131,7 @@ def test_multithread_single_file_gz(tmp_path: Path) -> None:
     raw = b"hello-single-file-payload" * 50
     path = tmp_path / "x.gz"
     path.write_bytes(gzip.compress(raw))
-    with open_archive(
-        path, member_streams=MemberStreams.CONCURRENT | MemberStreams.SEEKABLE
-    ) as reader:
+    with open_archive(path, concurrent_members=True, seekable_members=True) as reader:
         reader.members()
         member = next(m for m in reader.members() if m.is_file)
 
@@ -167,7 +164,7 @@ def test_multithread_iso_open_read(tmp_path: Path) -> None:
 
     expected = {f"F{i}.TXT": f"payload-{i}".encode() * 20 for i in range(4)}
     # ISO member names may normalize; compare by payload set via open-by-member.
-    with open_archive(iso_path, member_streams=MemberStreams.CONCURRENT) as reader:
+    with open_archive(iso_path, concurrent_members=True) as reader:
         files = [m for m in reader.members() if m.is_file]
         assert len(files) >= 4
         barrier = threading.Barrier(len(files))
@@ -194,7 +191,7 @@ def test_multithread_iso_open_read(tmp_path: Path) -> None:
 def test_close_with_live_streams_defers_teardown(tmp_path: Path) -> None:
     """Live streams survive reader.close(); new opens fail; bytes remain readable."""
     path = _make_zip(tmp_path / "a.zip", n=4)
-    reader = open_archive(path, member_streams=MemberStreams.CONCURRENT)
+    reader = open_archive(path, concurrent_members=True)
     members = [m for m in reader.members() if m.is_file]
     streams = [reader.open(m.name) for m in members[:2]]
     reader.close()
@@ -211,7 +208,7 @@ def test_close_with_live_streams_defers_teardown(tmp_path: Path) -> None:
 @pytest.mark.concurrent_reader
 def test_multithread_open_rejected_during_stream_members(tmp_path: Path) -> None:
     path = _make_zip(tmp_path / "a.zip", n=4)
-    with open_archive(path, member_streams=MemberStreams.CONCURRENT) as reader:
+    with open_archive(path, concurrent_members=True) as reader:
         it = reader.stream_members()
         next(it)
         errors: list[BaseException] = []
@@ -240,7 +237,7 @@ def test_concurrent_first_touch_open_materializes_once(tmp_path: Path) -> None:
     path = _make_zip(tmp_path / "a.zip", n=8)
     expected = _expected(8)
     names = list(expected)
-    reader = open_archive(path, member_streams=MemberStreams.CONCURRENT)
+    reader = open_archive(path, concurrent_members=True)
     scan_calls = {"n": 0}
     original_iter = reader._iter_members
 
@@ -284,7 +281,7 @@ def test_concurrent_first_touch_materialization_failure_wakes_waiters(
 ) -> None:
     """Failed first-touch leaves no partial snapshot; waiters see the error / clean retry."""
     path = _make_zip(tmp_path / "a.zip", n=4)
-    reader = open_archive(path, member_streams=MemberStreams.CONCURRENT)
+    reader = open_archive(path, concurrent_members=True)
     original_iter = reader._iter_members
     fail_once = {"armed": True}
     barrier = threading.Barrier(4)
@@ -336,7 +333,7 @@ def test_concurrent_first_touch_materialization_failure_wakes_waiters(
 def test_close_drains_in_flight_workers_then_closes(tmp_path: Path) -> None:
     """close() waits for in-flight open() workers; escaped streams stay readable."""
     path = _make_zip(tmp_path / "a.zip", n=4)
-    reader = open_archive(path, member_streams=MemberStreams.CONCURRENT)
+    reader = open_archive(path, concurrent_members=True)
     reader.members()  # publish so open() work is post-materialization
     entered = threading.Event()
     release = threading.Event()
@@ -386,7 +383,7 @@ def test_close_drains_in_flight_workers_then_closes(tmp_path: Path) -> None:
 @pytest.mark.concurrent_reader
 def test_concurrent_double_close_is_idempotent(tmp_path: Path) -> None:
     path = _make_zip(tmp_path / "a.zip", n=2)
-    reader = open_archive(path, member_streams=MemberStreams.CONCURRENT)
+    reader = open_archive(path, concurrent_members=True)
     reader.members()
     barrier = threading.Barrier(2)
     errors: list[BaseException] = []
@@ -415,7 +412,7 @@ def test_concurrent_double_close_exception_group_on_dual_failure(
 ) -> None:
     """Simultaneous inner-close + teardown failure surfaces once as ExceptionGroup."""
     path = _make_zip(tmp_path / "a.zip", n=1)
-    reader = open_archive(path, member_streams=MemberStreams.CONCURRENT)
+    reader = open_archive(path, concurrent_members=True)
     stream = reader.open("f0.txt")
 
     def boom_close_archive() -> None:
@@ -531,7 +528,7 @@ def test_members_report_if_available_during_concurrent_materialization(
     mid-materialization window is deterministic rather than a timing race.
     """
     path = _make_tar(tmp_path / "a.tar", n=8)  # no upfront index: None until published
-    reader = open_archive(path, member_streams=MemberStreams.CONCURRENT)
+    reader = open_archive(path, concurrent_members=True)
     original_iter = reader._iter_members
     scan_calls = {"n": 0}
     scan_started = threading.Event()
@@ -603,7 +600,7 @@ def test_members_report_if_available_concurrent_on_upfront_index(
     callers must each get a complete, equal list (it reads backend index state that a
     materializing thread is touching at the same time)."""
     path = _make_zip(tmp_path / "a.zip", n=16)
-    with open_archive(path, member_streams=MemberStreams.CONCURRENT) as reader:
+    with open_archive(path, concurrent_members=True) as reader:
         barrier = threading.Barrier(9)  # 8 probes + the materializing thread
         results: list[list[str]] = []
         errors: list[BaseException] = []

--- a/tests/test_corpus_sweep.py
+++ b/tests/test_corpus_sweep.py
@@ -25,7 +25,6 @@ from archivey import (
     EncryptionError,
     ExtractionStatus,
     FormatSupport,
-    MemberStreams,
     MemberType,
     OnError,
     format_availability,
@@ -314,7 +313,7 @@ def _check_single_file(entry: CorpusEntry, key: str, source: Path) -> None:
             assert HashAlgorithm.BLAKE2SP not in member.hashes
             assert HashAlgorithm.ADLER32 not in member.hashes
     if key == "lz":
-        with open_archive(source, member_streams=MemberStreams.SEEKABLE) as ar:
+        with open_archive(source, seekable_members=True) as ar:
             member = ar.members()[0]
             assert member.hashes[HashAlgorithm.CRC32] == crc32_digest(
                 zlib.crc32(payload.contents)

--- a/tests/test_iso.py
+++ b/tests/test_iso.py
@@ -13,7 +13,6 @@ from archivey import (
     ArchiveFormat,
     CompressionAlgorithm,
     CompressionMethod,
-    MemberStreams,
     MemberType,
     detect_format,
     format_availability,
@@ -180,7 +179,7 @@ def test_read_empty_member(rock_ridge_iso: Path) -> None:
 def test_seek_within_opened_member(rock_ridge_iso: Path) -> None:
     # The opened member stream is seekable (PyCdlibIO via _PyCdlibStream/DelegatingStream)
     # once SEEKABLE is declared.
-    with open_archive(rock_ridge_iso, member_streams=MemberStreams.SEEKABLE) as ar:
+    with open_archive(rock_ridge_iso, seekable_members=True) as ar:
         with ar.open("file.txt") as f:
             assert f.read(5) == b"hello"
             f.seek(0)

--- a/tests/test_locked_stream.py
+++ b/tests/test_locked_stream.py
@@ -66,7 +66,7 @@ def test_locked_stream_interleaved_reads() -> None:
 def test_tar_iso_concurrent_open_uses_lock(tmp_path) -> None:
     import tarfile
 
-    from archivey import MemberStreams, open_archive
+    from archivey import open_archive
 
     path = tmp_path / "a.tar"
     with tarfile.open(path, "w") as t:
@@ -75,9 +75,7 @@ def test_tar_iso_concurrent_open_uses_lock(tmp_path) -> None:
             info.size = len(data)
             t.addfile(info, io.BytesIO(data))
 
-    with open_archive(
-        path, member_streams=MemberStreams.CONCURRENT | MemberStreams.SEEKABLE
-    ) as ar:
+    with open_archive(path, concurrent_members=True, seekable_members=True) as ar:
         s1 = ar.open("a.txt")
         s2 = ar.open("b.txt")
         assert s1.read(2) == b"aa"

--- a/tests/test_member_stream_contract.py
+++ b/tests/test_member_stream_contract.py
@@ -22,14 +22,13 @@ from typing import Callable
 
 import pytest
 
-from archivey import MemberStreams, open_archive
+from archivey import open_archive
 from tests.conftest import requires
 
 CONTENT = b"The quick brown fox jumps over.\n"  # 32 bytes; < one ISO sector
 MEMBER = "data.txt"
 
 # Seek tests declare SEEKABLE; other contract tests use the default forward-only streams.
-_SEEKABLE = MemberStreams.SEEKABLE
 
 # A builder makes a small archive holding one ``MEMBER`` with ``CONTENT`` and returns the
 # (source, member-name) pair to open. Source may be a path or directory.
@@ -183,7 +182,7 @@ def test_seekable_flag_enables_forward_and_backward_seek(
     # With the capability the stream reports seekable and seeking actually works both
     # ways (backward seeks may re-decode from the start; the caller accepted that cost).
     source, name = member
-    with open_archive(source, member_streams=_SEEKABLE) as ar, ar.open(name) as f:
+    with open_archive(source, seekable_members=True) as ar, ar.open(name) as f:
         assert f.seekable() is True
         assert f.read() == CONTENT
         f.seek(0)  # backward to the start
@@ -195,7 +194,7 @@ def test_seekable_flag_enables_forward_and_backward_seek(
 
 def test_seek_past_end_then_read_returns_empty(member: tuple[Path, str]) -> None:
     source, name = member
-    with open_archive(source, member_streams=_SEEKABLE) as ar, ar.open(name) as f:
+    with open_archive(source, seekable_members=True) as ar, ar.open(name) as f:
         if not f.seekable():
             pytest.skip("member stream is not seekable")
         f.seek(len(CONTENT) + 100)
@@ -205,7 +204,7 @@ def test_seek_past_end_then_read_returns_empty(member: tuple[Path, str]) -> None
 
 def test_seek_to_start_rereads(member: tuple[Path, str]) -> None:
     source, name = member
-    with open_archive(source, member_streams=_SEEKABLE) as ar, ar.open(name) as f:
+    with open_archive(source, seekable_members=True) as ar, ar.open(name) as f:
         if not f.seekable():
             pytest.skip("member stream is not seekable")
         assert f.read(5) == CONTENT[:5]

--- a/tests/test_member_streams.py
+++ b/tests/test_member_streams.py
@@ -12,7 +12,6 @@ from archivey import (
     ArchiveyError,
     ArchiveyUsageError,
     ConcurrentAccessError,
-    MemberStreams,
     open_archive,
 )
 
@@ -30,7 +29,7 @@ def test_second_overlapping_open_raises_concurrent_access_error(tmp_path: Path) 
     with open_archive(root) as reader:
         s1 = reader.open("a.txt")
         with pytest.raises(
-            ConcurrentAccessError, match="MemberStreams.CONCURRENT"
+            ConcurrentAccessError, match="concurrent_members=True"
         ) as ei:
             reader.open("b.txt")
         assert "concurrent-member-streams" not in str(ei.value).lower() or True
@@ -62,7 +61,7 @@ def test_usage_error_is_not_archivey_error(tmp_path: Path) -> None:
 
 def test_concurrent_flag_allows_overlapping_opens(tmp_path: Path) -> None:
     root = _two_file_dir(tmp_path)
-    with open_archive(root, member_streams=MemberStreams.CONCURRENT) as reader:
+    with open_archive(root, concurrent_members=True) as reader:
         s1 = reader.open("a.txt")
         s2 = reader.open("b.txt")
         assert s1.read() == b"aaa"
@@ -84,7 +83,7 @@ def test_default_streams_are_not_seekable(tmp_path: Path) -> None:
 
 def test_seekable_flag_restores_positioning(tmp_path: Path) -> None:
     root = _two_file_dir(tmp_path)
-    with open_archive(root, member_streams=MemberStreams.SEEKABLE) as reader:
+    with open_archive(root, seekable_members=True) as reader:
         with reader.open("a.txt") as s:
             assert s.seekable() is True
             assert s.read(1) == b"a"
@@ -95,7 +94,7 @@ def test_seekable_flag_restores_positioning(tmp_path: Path) -> None:
 def test_streaming_plus_concurrent_rejected(tmp_path: Path) -> None:
     root = _two_file_dir(tmp_path)
     with pytest.raises(ArchiveyUsageError, match="streaming=True"):
-        open_archive(root, streaming=True, member_streams=MemberStreams.CONCURRENT)
+        open_archive(root, streaming=True, concurrent_members=True)
 
 
 def test_extract_needs_no_capability(tmp_path: Path) -> None:

--- a/tests/test_member_streams.py
+++ b/tests/test_member_streams.py
@@ -32,7 +32,6 @@ def test_second_overlapping_open_raises_concurrent_access_error(tmp_path: Path) 
             ConcurrentAccessError, match="concurrent_members=True"
         ) as ei:
             reader.open("b.txt")
-        assert "concurrent-member-streams" not in str(ei.value).lower() or True
         # Breadcrumb points at this test file.
         assert "test_member_streams.py" in str(ei.value)
         assert s1.read() == b"aaa"
@@ -89,6 +88,17 @@ def test_seekable_flag_restores_positioning(tmp_path: Path) -> None:
             assert s.read(1) == b"a"
             s.seek(0)
             assert s.read() == b"aaa"
+
+
+def test_member_streams_kwarg_is_gone(tmp_path: Path) -> None:
+    """The flag-enum parameter was removed, not deprecated — passing it must fail.
+
+    Python rejects unknown kwargs on its own; this locks the removal so a well-meant
+    "accept both spellings" patch has to delete a test rather than slip through.
+    """
+    root = _two_file_dir(tmp_path)
+    with pytest.raises(TypeError, match="member_streams"):
+        open_archive(root, member_streams="anything")  # type: ignore[call-arg]
 
 
 def test_streaming_plus_concurrent_rejected(tmp_path: Path) -> None:

--- a/tests/test_single_file.py
+++ b/tests/test_single_file.py
@@ -24,7 +24,6 @@ from archivey import (
     AcceleratorMode,
     ArchiveFormat,
     ArchiveyConfig,
-    MemberStreams,
     MemberType,
     open_archive,
 )
@@ -211,7 +210,7 @@ def test_xz_size_from_header(tmp_path: Path) -> None:
     with lzma.open(path, "wb") as f:
         f.write(b"x" * 1234)
     # Cheap size from the XZ index requires declared seek demand.
-    with open_archive(path, member_streams=MemberStreams.SEEKABLE) as ar:
+    with open_archive(path, seekable_members=True) as ar:
         assert ar.members()[0].size == 1234
     with open_archive(path) as ar:
         assert ar.members()[0].size is None
@@ -220,7 +219,7 @@ def test_xz_size_from_header(tmp_path: Path) -> None:
 def test_lzip_size_from_trailer(tmp_path: Path) -> None:
     path = tmp_path / "data.lz"
     path.write_bytes(make_lzip_member(b"y" * 777))
-    with open_archive(path, member_streams=MemberStreams.SEEKABLE) as ar:
+    with open_archive(path, seekable_members=True) as ar:
         assert ar.members()[0].size == 777
     with open_archive(path) as ar:
         assert ar.members()[0].size is None
@@ -279,7 +278,7 @@ def test_lzip_exposes_stored_crc32(tmp_path: Path) -> None:
     payload = b"lzip-crc-payload" * 3
     path = tmp_path / "data.lz"
     path.write_bytes(make_lzip_member(payload))
-    with open_archive(path, member_streams=MemberStreams.SEEKABLE) as ar:
+    with open_archive(path, seekable_members=True) as ar:
         member = ar.members()[0]
         assert member.size == len(payload)
         assert member.hashes[HashAlgorithm.CRC32] == crc32_digest(zlib.crc32(payload))
@@ -304,7 +303,7 @@ def test_multi_member_lzip_exposes_combined_crc32(tmp_path: Path) -> None:
     with patch.object(
         lzip_mod, "_read_index_backwards", wraps=lzip_mod._read_index_backwards
     ) as scanned:
-        with open_archive(path, member_streams=MemberStreams.SEEKABLE) as ar:
+        with open_archive(path, seekable_members=True) as ar:
             member = ar.members()[0]
             assert scanned.call_count == 1, (
                 "size + CRC must share one backward index scan"
@@ -602,7 +601,8 @@ def test_concurrent_open_same_member_interleaved() -> None:
     payload = b"abcdefghijklmnopqrstuvwxyz" * 40
     with open_archive(
         io.BytesIO(gzip.compress(payload)),
-        member_streams=MemberStreams.CONCURRENT | MemberStreams.SEEKABLE,
+        concurrent_members=True,
+        seekable_members=True,
     ) as ar:
         (member,) = ar.members()
         s1 = ar.open(member)
@@ -621,9 +621,7 @@ def test_reentrant_open_after_first_read(tmp_path: Path) -> None:
     path = tmp_path / "data.txt.gz"
     payload = b"reentrant payload " * 50
     path.write_bytes(gzip.compress(payload))
-    with open_archive(
-        path, member_streams=MemberStreams.CONCURRENT | MemberStreams.SEEKABLE
-    ) as ar:
+    with open_archive(path, concurrent_members=True, seekable_members=True) as ar:
         (member,) = ar.members()
         first = ar.open(member)
         assert first.read(8) == payload[:8]

--- a/tests/test_zip.py
+++ b/tests/test_zip.py
@@ -18,7 +18,6 @@ from archivey import (
     ArchiveyConfig,
     CompressionAlgorithm,
     DiagnosticCode,
-    MemberStreams,
     MemberType,
     open_archive,
 )
@@ -444,7 +443,7 @@ def test_read_roundtrip_from_stream_source(simple_zip: Path) -> None:
 
 def test_concurrent_open_members_interleaved_path_source(simple_zip: Path) -> None:
     # Path source: stdlib zipfile's _SharedFile already coordinates; lock the contract in.
-    with open_archive(simple_zip, member_streams=MemberStreams.CONCURRENT) as ar:
+    with open_archive(simple_zip, concurrent_members=True) as ar:
         s1 = ar.open("hello.txt")
         s2 = ar.open("dir/nested.txt")
         assert s1.read(5) == b"hello"
@@ -460,7 +459,7 @@ def test_concurrent_open_members_interleaved_stream_source(simple_zip: Path) -> 
     # source (_SharedFile keeps a per-open position under ZipFile's lock), so archivey
     # adds no wrap; this test locks the concurrent-open contract in for that leg too.
     data = simple_zip.read_bytes()
-    with open_archive(io.BytesIO(data), member_streams=MemberStreams.CONCURRENT) as ar:
+    with open_archive(io.BytesIO(data), concurrent_members=True) as ar:
         s1 = ar.open("hello.txt")
         s2 = ar.open("dir/nested.txt")
         assert s1.read(5) == b"hello"
@@ -772,7 +771,7 @@ def test_nested_archive_source_size_is_cheap(tmp_path: Path) -> None:
         info.size = len(inner_bytes)
         t.addfile(info, io.BytesIO(inner_bytes))
 
-    with open_archive(outer, member_streams=MemberStreams.SEEKABLE) as outer_ar:
+    with open_archive(outer, seekable_members=True) as outer_ar:
         inner_stream = outer_ar.open("inner.zip")
         with open_archive(inner_stream, format=ArchiveFormat.ZIP) as inner_ar:
             assert inner_ar.compressed_source_size == len(inner_bytes)

--- a/tests/test_zip_native_codecs.py
+++ b/tests/test_zip_native_codecs.py
@@ -23,7 +23,7 @@ from archivey.exceptions import (
     UnsupportedFeatureError,
 )
 from archivey.internal.streams import codecs as codecs_module
-from archivey.types import CompressionAlgorithm, MemberStreams
+from archivey.types import CompressionAlgorithm
 from tests.conftest import requires, requires_binary, requires_zstd, zstd_backend
 
 _PAYLOAD = (b"zip-native-codec-payload\n" * 80) + bytes(range(256))
@@ -223,7 +223,7 @@ def test_zip_concurrent_codec_path_interleaved(tmp_path: Path) -> None:
     with zipfile.ZipFile(archive, "w") as zf:
         zf.writestr("a.txt", b"aaaa" * 1000, compress_type=zipfile.ZIP_DEFLATED)
         zf.writestr("b.txt", b"bbbb" * 1000, compress_type=zipfile.ZIP_DEFLATED)
-    with open_archive(archive, member_streams=MemberStreams.CONCURRENT) as ar:
+    with open_archive(archive, concurrent_members=True) as ar:
         s1 = ar.open("a.txt")
         s2 = ar.open("b.txt")
         assert s1.read(4) == b"aaaa"


### PR DESCRIPTION
Implements `openspec/changes/member-stream-capability-booleans/`.

```python
# before
open_archive(p, member_streams=MemberStreams.SEEKABLE | MemberStreams.CONCURRENT)
open_stream(p, seekable=True)

# after
open_archive(p, seekable_members=True, concurrent_members=True)
open_stream(p, seekable=True)
```

## Why

One concept was spelled two ways at the two entry points, so every user learned it twice. `member_streams=` also doesn't read like a flag set — it reads like it takes *streams*, or a count — and you had to import `MemberStreams` before you could pass anything, making the option invisible in autocomplete until you'd already found the enum.

Both relevant ADRs point **toward** this rather than against it. ADR 0004 rejected an `Intent` enum in favour of `streaming: bool` ("two real modes, not three labels for two behaviors") — prefer a bool when the mode count is small. ADR 0003 describes `open_stream(..., seekable=False)` as the "same rule", already treating these as one concept. Neither defended the split; it was accretion, and it has now been independently flagged twice.

`0.2.0` is the first public release, so this is free now and breaking after the tag.

## Scope

**Behaviour is unchanged by design** — same defaults (both `False`), same errors, same capability semantics. `MemberStreams` stays exported and remains what `CostReceipt` and the diagnostics report; it just stops being an *input*. Internal plumbing keeps the flags, so the diff stays at the boundary rather than rippling through ten backends.

Three things beyond the mechanical rename, each of which would have been a papercut left behind:

- **`ConcurrentAccessError`'s message** told callers to reopen with `member_streams=MemberStreams.CONCURRENT` — a user-visible string naming a parameter that no longer exists. It now names `concurrent_members=True`, and the `error-handling` delta makes that a requirement rather than an incidental fix.
- **`MemberStreams`' own class docstring** described itself as the input to `open_archive` and explained combining flags with `|`. Rewritten to say what it now is, since it is still the first thing a reader of `api.md` sees.
- **The spec deltas were wrong.** The change shipped a single delta against `access-mode-and-cost` introducing a `MODIFIED` requirement (`Member stream capabilities are declared with booleans`) that does not exist in that spec — and the requirement that actually defines this surface lives in `archive-reading`, which was being left stale with the verbatim old signature. Restructured into three deltas, each modifying a requirement that really exists: `archive-reading`, `access-mode-and-cost`, `error-handling`.

## Docs

24 references across eight published pages, not the 8 first estimated: `support-matrix` (5), `costs` (5), `philosophy` (4), `usage` (3), `formats` (3), `gotchas` (2), `migrating` (1), `api` (1). ADR 0003 is amended in place with a short note recording the old spelling and that the decision itself is unchanged.

`docs/grab-bag/` is untouched — declared non-normative historical prose.

## Verification

- Three-config matrix green: `[all]` 1995 passed / 58 skipped · `[all-lowest]` 1995 / 58 · core-only 1590 / 406.
- 46 `concurrent_reader` tests pass (the marker the 3.13t free-threaded job runs).
- `pyrefly`, `ty`, `ruff check`, `ruff format --check`, `mkdocs build --strict`, `openspec validate --strict` all clean.

No test's *expectations* changed — only call spellings. Two parametrizations changed shape rather than spelling (`test_iterate_and_open_inside_loop` takes `concurrent: bool`; `_fan_out_read` passes its `seekable` argument straight through), same cases and same assertions.

## Note on ordering

Independent of #212 (extras consolidation) — no overlapping files. Either can merge first.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A1G2pL3FRbyR6VzmqQWpdV)_