### PR TITLE
Speed up native 7z member listing vs py7zr

### DIFF
--- a/benchmarks/baselines/structural.json
+++ b/benchmarks/baselines/structural.json
@@ -94,6 +94,18 @@
       "unpacked_bytes": null,
       "notes": "vs py7zr.list; Q1 native listing target \u2248parity"
     },
+    "sevenzip_many_open_list": {
+      "bytes_decompressed": 0,
+      "source_seek_count": 3,
+      "unpacked_bytes": null,
+      "notes": "vs py7zr.list; 1000 tiny COPY members (solid); listing-cost regression guard"
+    },
+    "sevenzip_nonsolid_open_list": {
+      "bytes_decompressed": 0,
+      "source_seek_count": 3,
+      "unpacked_bytes": null,
+      "notes": "vs py7zr.list; 256 store members (-ms=off); negative control (no per-folder amortize)"
+    },
     "sevenzip_solid_sequential": {
       "bytes_decompressed": 2097152,
       "source_seek_count": 4,

--- a/benchmarks/fixtures.py
+++ b/benchmarks/fixtures.py
@@ -38,6 +38,9 @@ class Scale:
     gzip_size: int
     solid_members: int
     solid_member_size: int
+    # Tiny-payload listing corpora (header/member-build cost, not codec cost).
+    list_members: int
+    nonsolid_list_members: int
 
 
 SCALES: dict[str, Scale] = {
@@ -49,6 +52,8 @@ SCALES: dict[str, Scale] = {
         gzip_size=64 * 1024,
         solid_members=32,
         solid_member_size=64 * 1024,
+        list_members=1_000,
+        nonsolid_list_members=256,
     ),
     # ~16 MiB ZIP/TAR, 32 MiB gzip, ~16 MiB solid — wall-time vs stdlib.
     "realistic": Scale(
@@ -58,6 +63,8 @@ SCALES: dict[str, Scale] = {
         gzip_size=32 * 1024 * 1024,
         solid_members=64,
         solid_member_size=256 * 1024,
+        list_members=10_000,
+        nonsolid_list_members=1_000,
     ),
 }
 
@@ -78,6 +85,8 @@ class FixtureSet:
     tarbz2_path: Path
     gzip_path: Path
     solid_7z: Path | None
+    many_7z: Path | None
+    nonsolid_7z: Path | None
     solid_rar: Path | None
     unpacked_solid_7z: int
     unpacked_solid_rar: int
@@ -181,6 +190,48 @@ def build_solid_7z(path: Path, scale: Scale) -> int:
     return total
 
 
+_LIST_MEMBER_SIZE = 16
+
+
+def build_many_member_7z(path: Path, scale: Scale) -> None:
+    """Solid COPY 7z with many tiny members — listing cost dominates.
+
+    py7zr always packs FILTER_COPY members into one solid folder, which is exactly
+    the shape where per-folder listing caches amortize.
+    """
+    import py7zr
+
+    with py7zr.SevenZipFile(path, "w", filters=[{"id": py7zr.FILTER_COPY}]) as archive:
+        for i in range(scale.list_members):
+            archive.writestr(f"f{i:05d}.txt", f"payload-{i}\n"[:_LIST_MEMBER_SIZE])
+
+
+def build_nonsolid_7z(path: Path, scale: Scale) -> bool:
+    """Non-solid 7z (one folder per file) via ``7z -ms=off``; False if unavailable.
+
+    py7zr cannot emit this shape. Used as a listing negative control: the
+    per-folder cache misses every member, so wall time should not improve vs
+    a naive loop — and must not regress from extra per-miss work.
+    """
+    if shutil.which("7z") is None:
+        return False
+    src = path.parent / f"{path.stem}-src"
+    if src.exists():
+        shutil.rmtree(src)
+    src.mkdir(parents=True)
+    for i in range(scale.nonsolid_list_members):
+        (src / f"f{i:05d}.txt").write_text(f"payload-{i}\n"[:_LIST_MEMBER_SIZE])
+    # -mx=0 store; -ms=off forces one folder per file.
+    cmd = ["7z", "a", "-t7z", "-ms=off", "-mx=0", str(path), str(src / "*")]
+    try:
+        subprocess.run(cmd, check=True, capture_output=True)
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        if path.exists():
+            path.unlink()
+        return False
+    return path.exists()
+
+
 def build_solid_rar(path: Path, scale: Scale) -> int | None:
     """Build a solid RAR via the ``rar`` binary; return unpacked bytes or None if unavailable."""
     if shutil.which("rar") is None:
@@ -266,6 +317,8 @@ def materialize_fixtures(
             unpacked_zip_aes = built
 
     solid_7z: Path | None = None
+    many_7z: Path | None = None
+    nonsolid_7z: Path | None = None
     unpacked_7z = 0
     try:
         import py7zr  # noqa: F401
@@ -277,6 +330,12 @@ def materialize_fixtures(
             unpacked_7z = build_solid_7z(solid_7z, scale_obj)
         else:
             unpacked_7z = _unpacked_solid(scale_obj)
+        many_7z = root / "many-list.7z"
+        if not many_7z.exists():
+            build_many_member_7z(many_7z, scale_obj)
+        nonsolid_path = root / "nonsolid-list.7z"
+        if nonsolid_path.exists() or build_nonsolid_7z(nonsolid_path, scale_obj):
+            nonsolid_7z = nonsolid_path
 
     solid_rar: Path | None = None
     unpacked_rar = 0
@@ -301,6 +360,8 @@ def materialize_fixtures(
         tarbz2_path=tarbz2_path,
         gzip_path=gzip_path,
         solid_7z=solid_7z,
+        many_7z=many_7z,
+        nonsolid_7z=nonsolid_7z,
         solid_rar=solid_rar,
         unpacked_solid_7z=unpacked_7z,
         unpacked_solid_rar=unpacked_rar,

--- a/benchmarks/harness.py
+++ b/benchmarks/harness.py
@@ -811,6 +811,85 @@ def run_cases(
             )
         )
 
+    def _append_7z_open_list(
+        case: str,
+        path: Path,
+        *,
+        notes: str,
+    ) -> None:
+        _m_wall, (bdec, seeks) = timed_with_optional_warmup(
+            lambda p=path: _op_open_list(p)
+        )
+
+        def _ay() -> None:
+            with open_archive(path) as reader:
+                _ = reader.info
+                list(reader.members())
+
+        if _py7zr_available():
+            if warmup:
+                wall, _ignored, std_wall = _interleaved_pair_times(
+                    _ay,
+                    lambda p=path: _py7zr_open_list(p),
+                    rounds=7,
+                )
+            else:
+                wall, _ = timed_with_optional_warmup(_ay)
+                std_wall, _ = timed_with_optional_warmup(
+                    lambda p=path: _py7zr_open_list(p)
+                )
+            results.append(
+                CaseResult(
+                    case,
+                    "7z",
+                    "open_list",
+                    wall,
+                    bdec,
+                    seeks,
+                    stdlib_wall_s=std_wall,
+                    wall_ratio=(wall / std_wall) if std_wall > 0 else None,
+                    notes=notes,
+                )
+            )
+        else:
+            wall, _ = timed_with_optional_warmup(_ay)
+            results.append(
+                CaseResult(
+                    case,
+                    "7z",
+                    "open_list",
+                    wall,
+                    bdec,
+                    seeks,
+                    notes=f"{notes}; skipped peer: py7zr not installed",
+                )
+            )
+
+    # Many-member solid COPY listing — regression guard for per-folder caches.
+    # The LZMA2 solid fixture above is too few members for this signal to clear noise.
+    if fixtures.many_7z is not None:
+        n = fixtures.scale.list_members
+        _append_7z_open_list(
+            "sevenzip_many_open_list",
+            fixtures.many_7z,
+            notes=(
+                f"vs py7zr.list; {n} tiny COPY members (solid); "
+                "listing-cost regression guard"
+            ),
+        )
+
+    # Non-solid listing negative control (7z -ms=off): cache misses every member.
+    if fixtures.nonsolid_7z is not None:
+        n = fixtures.scale.nonsolid_list_members
+        _append_7z_open_list(
+            "sevenzip_nonsolid_open_list",
+            fixtures.nonsolid_7z,
+            notes=(
+                f"vs py7zr.list; {n} store members (-ms=off); "
+                "negative control (no per-folder amortize)"
+            ),
+        )
+
     # --- RAR open_list vs rarfile (committed fixture for a stable peer; independent
     # of the optional ``rar`` writer used for solid data-path cases below) ---
     rar_list_path = ROOT / "tests" / "fixtures" / "rar" / "basic_solid__.rar"
@@ -1215,6 +1294,8 @@ def format_text_report(payload: dict[str, Any]) -> str:
                 f"- gzip size: {_fmt_bytes(detail.get('gzip_size'))}",
                 f"- solid members: {detail.get('solid_members', '?')} × "
                 f"{_fmt_bytes(detail.get('solid_member_size'))}",
+                f"- 7z list members: {detail.get('list_members', '?')} solid COPY / "
+                f"{detail.get('nonsolid_list_members', '?')} nonsolid",
             ]
         )
 
@@ -1388,6 +1469,8 @@ def main(argv: list[str] | None = None) -> int:
             "gzip_size": fixtures.scale.gzip_size,
             "solid_members": fixtures.scale.solid_members,
             "solid_member_size": fixtures.scale.solid_member_size,
+            "list_members": fixtures.scale.list_members,
+            "nonsolid_list_members": fixtures.scale.nonsolid_list_members,
         },
         "fixture_root": str(fixtures.root),
         "warmup": warmup,

--- a/src/archivey/internal/backends/sevenzip_methods.py
+++ b/src/archivey/internal/backends/sevenzip_methods.py
@@ -151,6 +151,16 @@ def is_bcj(method_id: bytes) -> bool:
     return entry is not None and entry.pybcj_attr is not None
 
 
+def is_aes(method_id: bytes) -> bool:
+    """True when ``method_id`` is 7z AES (primary id or any registered alias).
+
+    Prefer this over ``lookup(...).kind is MethodKind.AES`` on listing hot paths:
+    one id compare plus an empty-tuple check today, while still staying correct if
+    AES ever gains aliases the way BCJ already does.
+    """
+    return method_id == METHOD_AES.method_id or method_id in METHOD_AES.aliases
+
+
 def is_lzma_family(method_id: bytes) -> bool:
     entry = lookup(method_id)
     return entry is not None and entry.kind is MethodKind.LZMA_FAMILY

--- a/src/archivey/internal/backends/sevenzip_parser.py
+++ b/src/archivey/internal/backends/sevenzip_parser.py
@@ -42,8 +42,8 @@ from typing import BinaryIO
 
 from archivey.exceptions import CorruptionError, UnsupportedFeatureError
 from archivey.internal.backends.sevenzip_methods import (
-    METHOD_AES,
     METHOD_COPY,
+    is_aes,
     lookup,
 )
 from archivey.internal.streams.streamtools import read_exact
@@ -126,10 +126,6 @@ class SevenZipFileRecord:
     crc32: int | None
     compressed_size: int | None
     is_encrypted: bool
-    is_solid: bool
-    # Filled with raw on-disk method **bytes** here; the reader rebuilds public
-    # ``CompressionMethod`` tuples for ArchiveMember.compression.
-    compression_methods: tuple[bytes | CompressionMethod, ...]
 
 
 @dataclass(slots=True)
@@ -529,11 +525,10 @@ def folder_is_encrypted(folder: SevenZipFolder) -> bool:
     Lives here (not in ``sevenzip_methods``) so it can be typed against the folder
     dataclass: the registry module is a pure leaf and must not import these types.
 
-    Compare method ids directly (hot path in ``_map_files_to_folders`` for solid
-    archives with many members); avoid a ``lookup()`` per coder per file.
+    Uses :func:`is_aes` (id + aliases) rather than ``lookup()`` — listing hot path
+    in ``_map_files_to_folders`` for solid archives with many members.
     """
-    aes_id = METHOD_AES.method_id
-    return any(coder.method == aes_id for coder in folder.coders)
+    return any(is_aes(coder.method) for coder in folder.coders)
 
 
 def compression_method_for_coder(coder: SevenZipCoder) -> CompressionMethod:
@@ -1009,8 +1004,6 @@ def _file_record_from_props(props: _FileProps) -> SevenZipFileRecord:
         crc32=None,
         compressed_size=None,
         is_encrypted=False,
-        is_solid=False,
-        compression_methods=(),
     )
 
 
@@ -1030,8 +1023,6 @@ def _map_files_to_folders(
     # Folder-level fields are identical for every substream in a solid folder —
     # compute once when entering the folder (listing hot path for many-member 7z).
     folder_encrypted = False
-    folder_methods: tuple[bytes, ...] = ()
-    folder_solid = False
     folder_compressed: int | None = None
     folder_bound = -1
 
@@ -1046,8 +1037,6 @@ def _map_files_to_folders(
         if folder_index != folder_bound:
             folder = folders[folder_index]
             folder_encrypted = folder_is_encrypted(folder)
-            folder_methods = tuple(coder.method for coder in folder.coders)
-            folder_solid = num_unpackstreams_folders[folder_index] > 1
             folder_compressed = folder_compressed_sizes[folder_index]
             folder_bound = folder_index
 
@@ -1059,8 +1048,6 @@ def _map_files_to_folders(
         )
         file_record.compressed_size = folder_compressed
         file_record.is_encrypted = folder_encrypted
-        file_record.is_solid = folder_solid
-        file_record.compression_methods = folder_methods
 
         file_in_folder += 1
         substream_index += 1

--- a/src/archivey/internal/backends/sevenzip_parser.py
+++ b/src/archivey/internal/backends/sevenzip_parser.py
@@ -91,7 +91,7 @@ class _Property(IntEnum):
     DUMMY = 0x19
 
 
-@dataclass
+@dataclass(slots=True)
 class SevenZipCoder:
     method: bytes
     num_in_streams: int
@@ -99,7 +99,7 @@ class SevenZipCoder:
     properties: bytes | None
 
 
-@dataclass
+@dataclass(slots=True)
 class SevenZipFolder:
     coders: list[SevenZipCoder]
     bind_pairs: list[tuple[int, int]]
@@ -109,7 +109,7 @@ class SevenZipFolder:
     digest_defined: bool
 
 
-@dataclass
+@dataclass(slots=True)
 class SevenZipFileRecord:
     filename: str
     emptystream: bool
@@ -132,7 +132,7 @@ class SevenZipFileRecord:
     compression_methods: tuple[bytes | CompressionMethod, ...]
 
 
-@dataclass
+@dataclass(slots=True)
 class SevenZipArchive:
     major_version: int
     minor_version: int
@@ -150,7 +150,7 @@ class SevenZipArchive:
     has_encrypted_folders: bool
 
 
-@dataclass
+@dataclass(slots=True)
 class _StreamsInfo:
     pack_pos: int = 0
     pack_sizes: list[int] | None = None
@@ -161,7 +161,7 @@ class _StreamsInfo:
     digests: list[int | None] | None = None
 
 
-@dataclass
+@dataclass(slots=True)
 class SignatureInfo:
     """Result of reading the 32-byte signature + locating the next-header bytes."""
 
@@ -170,14 +170,14 @@ class SignatureInfo:
     header_data: bytes  # empty when nextHeaderSize == 0
 
 
-@dataclass
+@dataclass(slots=True)
 class EncodedHeader:
     """ENCODED_HEADER streams info; packed data still lives on the archive file."""
 
     streams: _StreamsInfo
 
 
-@dataclass
+@dataclass(slots=True)
 class PlainHeader:
     streams: _StreamsInfo
     files: list[SevenZipFileRecord]
@@ -187,7 +187,7 @@ class PlainHeader:
 HeaderBlock = EncodedHeader | PlainHeader
 
 
-@dataclass
+@dataclass(slots=True)
 class _FileProps:
     filename: str = ""
     emptystream: bool = False
@@ -528,8 +528,12 @@ def folder_is_encrypted(folder: SevenZipFolder) -> bool:
 
     Lives here (not in ``sevenzip_methods``) so it can be typed against the folder
     dataclass: the registry module is a pure leaf and must not import these types.
+
+    Compare method ids directly (hot path in ``_map_files_to_folders`` for solid
+    archives with many members); avoid a ``lookup()`` per coder per file.
     """
-    return any(lookup(coder.method) is METHOD_AES for coder in folder.coders)
+    aes_id = METHOD_AES.method_id
+    return any(coder.method == aes_id for coder in folder.coders)
 
 
 def compression_method_for_coder(coder: SevenZipCoder) -> CompressionMethod:
@@ -1023,6 +1027,13 @@ def _map_files_to_folders(
     folder_index = 0
     file_in_folder = 0
     substream_index = 0
+    # Folder-level fields are identical for every substream in a solid folder —
+    # compute once when entering the folder (listing hot path for many-member 7z).
+    folder_encrypted = False
+    folder_methods: tuple[bytes, ...] = ()
+    folder_solid = False
+    folder_compressed: int | None = None
+    folder_bound = -1
 
     for file_record in files:
         if file_record.emptystream:
@@ -1032,17 +1043,24 @@ def _map_files_to_folders(
         if substream_index >= len(unpack_sizes):
             raise CorruptionError("7z file table references a missing substream")
 
-        folder = folders[folder_index]
+        if folder_index != folder_bound:
+            folder = folders[folder_index]
+            folder_encrypted = folder_is_encrypted(folder)
+            folder_methods = tuple(coder.method for coder in folder.coders)
+            folder_solid = num_unpackstreams_folders[folder_index] > 1
+            folder_compressed = folder_compressed_sizes[folder_index]
+            folder_bound = folder_index
+
         file_record.folder_index = folder_index
         file_record.file_in_folder = file_in_folder
         file_record.uncompressed_size = unpack_sizes[substream_index]
         file_record.crc32 = (
             digests[substream_index] if substream_index < len(digests) else None
         )
-        file_record.compressed_size = folder_compressed_sizes[folder_index]
-        file_record.is_encrypted = folder_is_encrypted(folder)
-        file_record.is_solid = num_unpackstreams_folders[folder_index] > 1
-        file_record.compression_methods = tuple(coder.method for coder in folder.coders)
+        file_record.compressed_size = folder_compressed
+        file_record.is_encrypted = folder_encrypted
+        file_record.is_solid = folder_solid
+        file_record.compression_methods = folder_methods
 
         file_in_folder += 1
         substream_index += 1

--- a/src/archivey/internal/backends/sevenzip_reader.py
+++ b/src/archivey/internal/backends/sevenzip_reader.py
@@ -42,7 +42,7 @@ from archivey.exceptions import (
     TruncatedError,
     UnsupportedFeatureError,
 )
-from archivey.internal.backends.sevenzip_methods import METHOD_AES
+from archivey.internal.backends.sevenzip_methods import is_aes
 from archivey.internal.backends.sevenzip_parser import (
     EncodedHeader,
     PlainHeader,
@@ -207,10 +207,7 @@ class SevenZipReader(BaseArchiveReader):
         self._shared = SharedSource(source, wrap_handle=self._seek_handle_wrapper())
         self._volume_count = getattr(source, "volume_count", 1)
         self._archive = self._load_archive()
-        self._folder_pack_starts = self._folder_pack_start_indices(self._archive)
-        # Public CompressionMethod tuples are identical for every member in a
-        # folder — build once (solid many-member listing hot path).
-        self._folder_compression = self._build_folder_compression(self._archive)
+        self._init_folder_caches(self._archive)
         self._members = self._build_members()
         self._folder_members = self._members_by_folder()
 
@@ -277,6 +274,18 @@ class SevenZipReader(BaseArchiveReader):
                 ) from exc
             raise EncryptionError("Password(s) rejected for the 7z header") from exc
 
+    def _init_folder_caches(self, archive: SevenZipArchive) -> None:
+        """Derive per-folder indexes used by listing and open.
+
+        Kept as one helper so unit tests that construct a reader via
+        ``object.__new__`` can populate the same derived state ``__init__`` does
+        without hand-maintaining each cache field.
+        """
+        self._folder_pack_starts = self._folder_pack_start_indices(archive)
+        # Public CompressionMethod tuples are identical for every member in a
+        # folder — build once (solid many-member listing hot path).
+        self._folder_compression = self._build_folder_compression(archive)
+
     @staticmethod
     def _folder_pack_start_indices(archive: SevenZipArchive) -> list[int]:
         starts: list[int] = []
@@ -291,12 +300,13 @@ class SevenZipReader(BaseArchiveReader):
         archive: SevenZipArchive,
     ) -> list[tuple[CompressionMethod, ...]]:
         """One public compression-chain tuple per folder (shared by its members)."""
-        aes_id = METHOD_AES.method_id
         out: list[tuple[CompressionMethod, ...]] = []
         for folder in archive.folders:
             methods: list[CompressionMethod] = []
             for coder in folder.coders:
-                if coder.method == aes_id:
+                # Skip AES before lookup: METHOD_AES.algorithm is UNKNOWN, so the
+                # filter below would drop it too, but only after a registry hit.
+                if is_aes(coder.method):
                     continue
                 method = compression_method_for_coder(coder)
                 if method.algo is not CompressionAlgorithm.UNKNOWN:
@@ -384,7 +394,9 @@ class SevenZipReader(BaseArchiveReader):
         # bag so listing-limit accounting does not walk a per-member dict.
         ts_issues: list[_TimestampIssue] = []
         modified = accessed = created = None
-        # Only convert defined FILETIMEs (common archives store mtime alone).
+        # Hot-path shortcut only: filetime_to_datetime also treats 0/None as unset.
+        # Keep these guards equivalent to that helper so ZIP (unconditional call)
+        # and 7z cannot diverge if the shared 0-handling rule ever changes.
         if record.last_write_time:
             modified, issue = _filetime_to_datetime(
                 record.last_write_time, presented_name, field="modified"

--- a/src/archivey/internal/backends/sevenzip_reader.py
+++ b/src/archivey/internal/backends/sevenzip_reader.py
@@ -27,7 +27,6 @@ import stat
 import zlib
 from collections.abc import Iterator, Mapping
 from dataclasses import dataclass
-from datetime import datetime
 from pathlib import Path
 from typing import BinaryIO
 
@@ -48,7 +47,6 @@ from archivey.internal.backends.sevenzip_parser import (
     EncodedHeader,
     PlainHeader,
     SevenZipArchive,
-    SevenZipCoder,
     SevenZipFileRecord,
     SevenZipFolder,
     compression_method_for_coder,
@@ -97,6 +95,7 @@ from archivey.types import (
     ArchiveInfo,
     ArchiveMember,
     CompressionAlgorithm,
+    CompressionMethod,
     CreateSystem,
     HashAlgorithm,
     MagicSignature,
@@ -209,6 +208,9 @@ class SevenZipReader(BaseArchiveReader):
         self._volume_count = getattr(source, "volume_count", 1)
         self._archive = self._load_archive()
         self._folder_pack_starts = self._folder_pack_start_indices(self._archive)
+        # Public CompressionMethod tuples are identical for every member in a
+        # folder — build once (solid many-member listing hot path).
+        self._folder_compression = self._build_folder_compression(self._archive)
         self._members = self._build_members()
         self._folder_members = self._members_by_folder()
 
@@ -284,6 +286,24 @@ class SevenZipReader(BaseArchiveReader):
             index += len(folder.packed_indices)
         return starts
 
+    @staticmethod
+    def _build_folder_compression(
+        archive: SevenZipArchive,
+    ) -> list[tuple[CompressionMethod, ...]]:
+        """One public compression-chain tuple per folder (shared by its members)."""
+        aes_id = METHOD_AES.method_id
+        out: list[tuple[CompressionMethod, ...]] = []
+        for folder in archive.folders:
+            methods: list[CompressionMethod] = []
+            for coder in folder.coders:
+                if coder.method == aes_id:
+                    continue
+                method = compression_method_for_coder(coder)
+                if method.algo is not CompressionAlgorithm.UNKNOWN:
+                    methods.append(method)
+            out.append(tuple(methods))
+        return out
+
     def _build_members(self) -> list[ArchiveMember]:
         # is_current is stamped by BaseArchiveReader's shared last-entry-wins pass.
         return [self._to_member(record) for record in self._archive.files]
@@ -350,14 +370,9 @@ class SevenZipReader(BaseArchiveReader):
             backslash_is_separator=True,
         )
         raw_name = record.filename.encode("utf-16le", errors="surrogateescape")
-        compression = tuple(
-            method
-            for method in (
-                compression_method_for_coder(coder)
-                for coder in self._folder_coders(record)
-                if coder.method != METHOD_AES.method_id
-            )
-            if method.algo is not CompressionAlgorithm.UNKNOWN
+        folder_index = record.folder_index
+        compression = (
+            self._folder_compression[folder_index] if folder_index is not None else ()
         )
         hashes: dict[HashAlgorithm, bytes] = {}
         if record.crc32 is not None:
@@ -365,20 +380,26 @@ class SevenZipReader(BaseArchiveReader):
         attrs = record.attributes
         unix_mode = (attrs >> 16) if attrs is not None and attrs >> 16 else None
         mode = stat.S_IMODE(unix_mode) if unix_mode is not None else None
-        extra: dict[str, object] = {}
-        if record.folder_index is not None:
-            extra["7z.folder_index"] = record.folder_index
-        if record.file_in_folder is not None:
-            extra["7z.file_in_folder"] = record.file_in_folder
+        # Folder/substream indices live on ``_raw``; skip the unused public extra
+        # bag so listing-limit accounting does not walk a per-member dict.
         ts_issues: list[_TimestampIssue] = []
-        timestamps: dict[str, datetime | None] = {}
-        for field, value in (
-            ("modified", record.last_write_time),
-            ("accessed", record.last_access_time),
-            ("created", record.creation_time),
-        ):
-            timestamps[field], issue = _filetime_to_datetime(
-                value, presented_name, field=field
+        modified = accessed = created = None
+        # Only convert defined FILETIMEs (common archives store mtime alone).
+        if record.last_write_time:
+            modified, issue = _filetime_to_datetime(
+                record.last_write_time, presented_name, field="modified"
+            )
+            if issue is not None:
+                ts_issues.append(issue)
+        if record.last_access_time:
+            accessed, issue = _filetime_to_datetime(
+                record.last_access_time, presented_name, field="accessed"
+            )
+            if issue is not None:
+                ts_issues.append(issue)
+        if record.creation_time:
+            created, issue = _filetime_to_datetime(
+                record.creation_time, presented_name, field="created"
             )
             if issue is not None:
                 ts_issues.append(issue)
@@ -388,9 +409,9 @@ class SevenZipReader(BaseArchiveReader):
             raw_name=raw_name,
             size=record.uncompressed_size,
             compressed_size=record.compressed_size,
-            modified=timestamps["modified"],
-            accessed=timestamps["accessed"],
-            created=timestamps["created"],
+            modified=modified,
+            accessed=accessed,
+            created=created,
             mode=mode,
             compression=compression,
             is_encrypted=record.is_encrypted,
@@ -399,8 +420,7 @@ class SevenZipReader(BaseArchiveReader):
             else CreateSystem.WINDOWS_NTFS,
             windows_attrs=attrs & 0xFFFF if attrs is not None else None,
             hashes=hashes,
-            extra=extra,
-            _raw=_MemberRaw(record, record.folder_index, record.file_in_folder),
+            _raw=_MemberRaw(record, folder_index, record.file_in_folder),
         )
         emit_member_name_normalized(
             self._diagnostics_collector,
@@ -431,8 +451,8 @@ class SevenZipReader(BaseArchiveReader):
         if (
             record.is_encrypted
             and record.crc32 is None
-            and record.folder_index is not None
-            and not self._archive.folders[record.folder_index].digest_defined
+            and folder_index is not None
+            and not self._archive.folders[folder_index].digest_defined
         ):
             self._diagnostics_collector.emit(
                 code=DiagnosticCode.DIGEST_UNVERIFIABLE,
@@ -470,11 +490,6 @@ class SevenZipReader(BaseArchiveReader):
         if record.is_directory:
             return MemberType.DIRECTORY
         return MemberType.FILE
-
-    def _folder_coders(self, record: SevenZipFileRecord) -> tuple[SevenZipCoder, ...]:
-        if record.folder_index is None:
-            return ()
-        return tuple(self._archive.folders[record.folder_index].coders)
 
     def _folder_pack_view(self, folder_index: int) -> BinaryIO:
         folder = self._archive.folders[folder_index]

--- a/tests/test_benchmark_gate.py
+++ b/tests/test_benchmark_gate.py
@@ -47,6 +47,12 @@ def test_benchmark_structural_gate(tmp_path: Path) -> None:
     assert sequential is not None, "expected sevenzip_solid_sequential case"
     assert sequential.bytes_decompressed <= (sequential.unpacked_bytes or 0) * 2
 
+    # Many-member COPY listing is the regression guard for per-folder caches.
+    assert "sevenzip_many_open_list" in by_case
+    # Non-solid listing needs the 7z CLI (-ms=off); soft-skip when absent.
+    if fixtures.nonsolid_7z is not None:
+        assert "sevenzip_nonsolid_open_list" in by_case
+
     random = by_case.get("sevenzip_solid_random")
     assert random is not None
     # Random opens re-decode; recorded, not failed — but must be visible.

--- a/tests/test_crypto_findings.py
+++ b/tests/test_crypto_findings.py
@@ -337,6 +337,9 @@ def test_f2_no_anchor_encrypted_member_emits_diagnostic() -> None:
         is_header_encrypted=False,
         has_encrypted_folders=True,
     )
+    reader._folder_compression = SevenZipReader._build_folder_compression(  # noqa: SLF001
+        reader._archive  # noqa: SLF001
+    )
     record = SevenZipFileRecord(
         filename="store.txt",
         emptystream=False,

--- a/tests/test_crypto_findings.py
+++ b/tests/test_crypto_findings.py
@@ -337,9 +337,7 @@ def test_f2_no_anchor_encrypted_member_emits_diagnostic() -> None:
         is_header_encrypted=False,
         has_encrypted_folders=True,
     )
-    reader._folder_compression = SevenZipReader._build_folder_compression(  # noqa: SLF001
-        reader._archive  # noqa: SLF001
-    )
+    reader._init_folder_caches(reader._archive)  # noqa: SLF001
     record = SevenZipFileRecord(
         filename="store.txt",
         emptystream=False,
@@ -356,8 +354,6 @@ def test_f2_no_anchor_encrypted_member_emits_diagnostic() -> None:
         crc32=None,
         compressed_size=4,
         is_encrypted=True,
-        is_solid=False,
-        compression_methods=(),
     )
     member = reader._to_member(record)  # noqa: SLF001
     assert member.hashes == {}

--- a/tests/test_sevenzip_reader.py
+++ b/tests/test_sevenzip_reader.py
@@ -1194,6 +1194,92 @@ def test_decode_utf16_names_bulk() -> None:
         _decode_utf16_names(blob[1:], expected_count=3)
 
 
+def test_is_aes_matches_primary_id_and_aliases() -> None:
+    from archivey.internal.backends.sevenzip_methods import METHOD_AES, is_aes
+
+    assert is_aes(METHOD_AES.method_id)
+    assert not is_aes(b"\x00")
+    # AES has no aliases today; the helper still checks ``aliases`` so a future
+    # short/long id pair (as BCJ already uses) cannot silently break encryption
+    # detection that switched off ``lookup()``.
+    assert METHOD_AES.aliases == ()
+
+
+def test_map_files_to_folders_solid_and_nonsolid() -> None:
+    """Per-folder cache must assign indices correctly for both folder shapes."""
+    from archivey.internal.backends.sevenzip_parser import (
+        SevenZipCoder,
+        SevenZipFileRecord,
+        SevenZipFolder,
+        _map_files_to_folders,
+    )
+
+    def _record() -> SevenZipFileRecord:
+        return SevenZipFileRecord(
+            filename="x",
+            emptystream=False,
+            is_anti=False,
+            is_directory=False,
+            is_empty_file=False,
+            attributes=None,
+            creation_time=None,
+            last_access_time=None,
+            last_write_time=None,
+            folder_index=None,
+            file_in_folder=None,
+            uncompressed_size=0,
+            crc32=None,
+            compressed_size=None,
+            is_encrypted=False,
+        )
+
+    def _folder() -> SevenZipFolder:
+        return SevenZipFolder(
+            coders=[
+                SevenZipCoder(
+                    method=b"\x00",
+                    num_in_streams=1,
+                    num_out_streams=1,
+                    properties=None,
+                )
+            ],
+            bind_pairs=[],
+            packed_indices=[0],
+            unpack_sizes=[1],
+            crc=None,
+            digest_defined=False,
+        )
+
+    n = 8
+    # Solid: one folder, n substreams.
+    solid_files = [_record() for _ in range(n)]
+    solid = _map_files_to_folders(
+        solid_files,
+        folders=[_folder()],
+        pack_sizes=[n],
+        num_unpackstreams_folders=[n],
+        unpack_sizes=[1] * n,
+        digests=[None] * n,
+    )
+    assert [f.folder_index for f in solid] == [0] * n
+    assert [f.file_in_folder for f in solid] == list(range(n))
+    assert all(f.compressed_size == n for f in solid)
+
+    # Non-solid: n folders, one substream each (cache miss every member).
+    nonsolid_files = [_record() for _ in range(n)]
+    nonsolid = _map_files_to_folders(
+        nonsolid_files,
+        folders=[_folder() for _ in range(n)],
+        pack_sizes=[1] * n,
+        num_unpackstreams_folders=[1] * n,
+        unpack_sizes=[1] * n,
+        digests=[None] * n,
+    )
+    assert [f.folder_index for f in nonsolid] == list(range(n))
+    assert [f.file_in_folder for f in nonsolid] == [0] * n
+    assert all(f.compressed_size == 1 for f in nonsolid)
+
+
 def test_lz4_without_lz4_package_raises(monkeypatch: pytest.MonkeyPatch) -> None:
     reader = _reader_for_unit_tests()
     monkeypatch.setattr(codecs, "_lz4_frame", None)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Investigated why native 7z member listing lagged py7zr on many-member archives, then applied targeted hot-path fixes. Follow-up commit addresses the `/code-review-skill` findings on #216.

**Findings (direct `SevenZipReader`, format detection excluded):**

| Members | archivey open+list | archivey parse only | py7zr `list()` | py7zr open | ratio before → after |
| --- | ---: | ---: | ---: | ---: | ---: |
| 1k | ~7.2 ms | ~2.2 ms | ~6.2 ms | ~3.3 ms | ~1.7× → **~1.16×** |
| 10k | ~78 ms | ~23 ms | ~61 ms | ~32 ms | ~1.8× → **~1.3×** |

Header parse was already competitive (often *faster* than py7zr open). The gap was almost entirely **per-member `ArchiveMember` construction** on solid folders.

## Changes

- Cache public `CompressionMethod` tuples once per folder; compute folder-level map fields once per folder
- `is_aes()` (id + aliases) for encryption detection without `lookup()`
- Drop write-only `SevenZipFileRecord.is_solid` / `compression_methods`; drop unused `extra["7z.*"]`
- Convert only defined FILETIMEs (documented coupling with `filetime_to_datetime`)
- `_init_folder_caches` shared by `__init__` and unit tests
- Harness: `sevenzip_many_open_list` (1k ci / 10k realistic solid COPY) + `sevenzip_nonsolid_open_list` (`7z -ms=off` negative control)
- `slots=True` on 7z parser dataclasses

## Review follow-ups

Agreed and landed: F1 (dead fields), F2 (`is_aes`), F3 (listing guards), F4 (comment), F5 (`_init_folder_caches`).
Kept AES early-skip before lookup (F6) with an explicit comment — not fully redundant with the UNKNOWN filter.

## Test plan

- [x] `pytest tests/test_sevenzip_reader.py tests/test_crypto_findings.py tests/test_benchmark_gate.py`
- [x] structural baseline updated for new listing cases
- [ ] CI matrix
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a7545d2e-3213-44ec-b907-e4a75e8a02f0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a7545d2e-3213-44ec-b907-e4a75e8a02f0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

