### PR TITLE
Stop treating "never ran" as a measurement, and provision the tooling so it doesn't happen

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Claude Code SessionStart hook — provisions a web session's container.
+#
+# Runs the same bootstrap as Cursor Cloud (scripts/setup-dev-env.sh) so a session
+# never starts with a partial toolchain. That matters more than it sounds: RAR data
+# tests and the benchmark gate's rar_* cases *skip* when `unrar` is missing, so an
+# unprovisioned container reports green while testing less than it claims.
+#
+# Local sessions are left alone — a developer's machine is their own.
+set -euo pipefail
+
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+  exit 0
+fi
+
+exec "${CLAUDE_PROJECT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}/scripts/setup-dev-env.sh"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,14 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.cursor/install.sh
+++ b/.cursor/install.sh
@@ -1,36 +1,11 @@
 #!/usr/bin/env bash
 # Cursor Cloud update/install script (see .cursor/environment.json).
 # Must stay idempotent — runs on every agent boot after the workspace is checked out.
+#
+# The work itself lives in scripts/setup-dev-env.sh, shared with the Claude Code
+# SessionStart hook (.claude/hooks/session-start.sh) so the two provisioning paths
+# cannot drift on what gets installed. Environment-specific steps, if any are ever
+# needed, belong here; anything a plain checkout needs belongs in the shared script.
 set -euo pipefail
 
-# Official uv installer lands here; keep it first for non-login shells.
-export PATH="${HOME}/.local/bin:${PATH}"
-
-# Cloud VMs sometimes boot with a skewed clock; apt then rejects Release files as
-# "not valid yet". Prefer correcting the clock from an HTTP Date header; if that
-# fails, still allow a generous future skew so package installs can proceed.
-if date_hdr="$(
-  curl -fsSI --max-time 10 https://archive.ubuntu.com/ubuntu/ \
-    | awk -F': ' 'tolower($1) == "date" { print $2; exit }'
-)"; then
-  sudo date -s "${date_hdr}" >/dev/null 2>&1 || true
-fi
-
-# unrar: RAR member-data tests (multiverse). p7zip-full: encrypted ZIP fixture builds.
-sudo apt-get \
-  -o Acquire::Max-FutureTime=604800 \
-  -o Acquire::Check-Valid-Until=false \
-  update
-sudo apt-get install -y unrar p7zip-full
-
-npm install -g --prefix "${HOME}/.local" @fission-ai/openspec
-
-# JIT / snapshot-less Cloud images may not ship uv; bootstrap if missing.
-if ! command -v uv >/dev/null 2>&1; then
-  curl -LsSf https://astral.sh/uv/install.sh | sh
-fi
-
-uv sync --group dev --extra all
-
-# Auto ruff fix+format on commit (Cursor remaps core.hooksPath; this install is aware).
-./scripts/install-git-hooks.sh
+exec "$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/scripts/setup-dev-env.sh"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,8 +52,13 @@ benchmarks/`). **Do not commit without formatting.**
 
 Non-obvious gotchas:
 
-- The startup update script is committed at `.cursor/install.sh` (wired via
-  `.cursor/environment.json`). It bootstraps `uv` if missing (JIT Cloud images may
+- The startup script is committed at `scripts/setup-dev-env.sh` and is shared by every
+  environment that provisions a workspace, so they cannot drift on what is installed:
+  Cursor Cloud calls it from `.cursor/install.sh` (wired via `.cursor/environment.json`),
+  Claude Code web from the `SessionStart` hook `.claude/hooks/session-start.sh`
+  (registered in `.claude/settings.json`; it no-ops unless `CLAUDE_CODE_REMOTE=true`,
+  leaving a developer's own machine alone). Run it directly after a manual clone.
+  It bootstraps `uv` if missing (JIT Cloud images may
   not ship it), installs `unrar` + `p7zip-full`, the `openspec` CLI, runs
   `uv sync --group dev --extra all`, and `./scripts/install-git-hooks.sh`, so the
   format-on-commit hook is present without a manual step. It also best-effort
@@ -64,7 +69,13 @@ Non-obvious gotchas:
 - **`7z`** (system binary, from `p7zip-full`) is required by tests that build encrypted
   ZIP fixtures by shelling out to it (`tests/test_password.py`, the encrypted corpus
   entries in `tests/test_corpus_sweep.py`); they skip cleanly when it is absent.
-  The Cloud install script installs `p7zip-full` automatically.
+  The setup script installs `p7zip-full` automatically.
+- Both of the above skip **quietly**, which is the trap: a container without them ran
+  1900 passed / 167 skipped where a provisioned one runs 2009 / 58 — ~109 tests gone
+  with the suite still green. `--update-baselines` in that state would also rewrite
+  `structural.json` without the `rar_*` cases (it now refuses instead). If you are
+  unsure whether the environment is complete, run `scripts/setup-dev-env.sh`; its
+  closing verification block names anything missing.
 - **`openspec` CLI** lives at `~/.local/bin` (on `PATH`). `CLAUDE.md`'s
   `npm install -g @fission-ai/openspec` fails with `EACCES` here because the global npm
   prefix is not user-writable — the update script instead installs it into a writable,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,20 +31,36 @@ v1 tree is [`davitf/archivey-old`](https://github.com/davitf/archivey-old).
   behaviour-focused tests, red-green TDD, the pause-and-ask-on-discrepancies rule).
 - `IDEAS.md` — speculative future/backlog ideas (not committed, not in `PLAN.md`).
 
+## Session setup (`unrar`, `7z`, `openspec`, deps)
+
+`scripts/setup-dev-env.sh` provisions everything: the `unrar` and `7z` system
+binaries, the `openspec` CLI, `uv sync --group dev --extra all`, and the
+format-on-commit git hook. It runs automatically — Claude Code web sessions via
+the `SessionStart` hook (`.claude/hooks/session-start.sh`), Cursor Cloud via
+`.cursor/install.sh`. Both call the same script so they cannot drift. Run it by
+hand after a manual clone; it is idempotent.
+
+**Do not skip this.** RAR data tests and the benchmark gate's `rar_*` cases *skip*
+when `unrar` is absent, and encrypted-ZIP fixtures skip without `7z` — quietly. A
+container missing them runs ~109 fewer tests while still reporting all-green, and
+`--update-baselines` there would rewrite `structural.json` without those cases. The
+script ends by printing what is missing; read that line.
+
 ## OpenSpec CLI
 
-The `openspec` CLI (used to list/validate the specs and changes under
-`openspec/`) is **not preinstalled** in the session container, and the container
-is ephemeral — reclone, so it must be reinstalled at the start of each session.
-It ships as the npm package `@fission-ai/openspec` (Node is available):
+Installed by the setup script above. If you need it manually, it ships as the npm
+package `@fission-ai/openspec` (Node is available):
 
 ```bash
 npm install -g @fission-ai/openspec
 ```
 
 The bare `openspec` package on npm is an unrelated empty stub — install the
-`@fission-ai/...` scoped package, not that one. Verify with `openspec --version`
-(known-good: 1.4.1). Common commands, run from the repo root:
+`@fission-ai/...` scoped package, not that one. On images where the global npm
+prefix is not user-writable this fails with `EACCES`; use
+`npm install -g --prefix "$HOME/.local" @fission-ai/openspec` instead (what the
+setup script does). Verify with `openspec --version` (known-good: 1.4.1). Common
+commands, run from the repo root:
 
 ```bash
 openspec list                 # in-flight changes + task progress

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,8 +49,11 @@ reports problems; it does not rewrite files.
 `pre-commit` framework's own installer, but on Cursor Cloud it can land in the
 remapped `core.hooksPath`; `./scripts/install-git-hooks.sh` is the supported path.)
 
-RAR *data* tests need the system `unrar` binary (`apt-get install -y unrar`, etc.);
-without it those tests skip cleanly.
+RAR *data* tests need the system `unrar` binary, and encrypted-ZIP fixtures need `7z`
+(`p7zip-full`). Without them those tests skip cleanly — which is the problem: the suite
+still reports green while running ~109 fewer tests. Run `scripts/setup-dev-env.sh` to
+provision both (it is idempotent, and prints anything still missing at the end); agent
+environments run it automatically at session start.
 
 **Before pushing, run the suite in all three dependency configurations CI runs** —
 optional libraries change behaviour by their presence *and* their version, so a change

--- a/benchmarks/harness.py
+++ b/benchmarks/harness.py
@@ -7,6 +7,11 @@ Run::
     uv run --extra all python -m benchmarks.harness --mode structural
     uv run --extra all python -m benchmarks.harness --mode full --scale realistic
 
+``--update-baselines`` requires the *complete* toolchain (all extras **and** RARLAB
+``unrar`` on PATH) and refuses up front otherwise: a partial run would rewrite
+``structural.json`` without the cases it could not measure, quietly shrinking what the
+gate covers. ``missing_baseline_requirements()`` names what is absent.
+
 Modes:
 
 - ``structural`` (default for CI/PR): **the automated gate** — seek-count baselines,
@@ -399,6 +404,35 @@ def _unrar_available() -> bool:
 def _crypto_available() -> bool:
     """True when the ``cryptography`` package is importable (``[crypto]`` extra)."""
     return importlib.util.find_spec("cryptography") is not None
+
+
+def missing_baseline_requirements() -> list[str]:
+    """Optional tooling whose absence would make a baseline rewrite *partial*.
+
+    Every entry gates cases that are in the committed ``structural.json``. Without the
+    tool those cases either never reach the file (dropped outright) or arrive as skip
+    rows, and the next run gates against a baseline describing less than the suite
+    actually measures — silently, since a shorter file still validates.
+    """
+    checks = (
+        (
+            _rapidgzip_available(),
+            "rapidgzip — the accelerator ON cases; install the [seekable] extra",
+        ),
+        (
+            _py7zr_available(),
+            "py7zr — builds the solid 7z fixture behind the sevenzip_* cases",
+        ),
+        (
+            _crypto_available(),
+            "cryptography — zip_aes_read_all / encrypted RAR; install the [crypto] extra",
+        ),
+        (
+            _unrar_available(),
+            "unrar — the RARLAB binary on PATH; the rar_* data cases",
+        ),
+    )
+    return [why for available, why in checks if not available]
 
 
 def run_cases(
@@ -1286,7 +1320,21 @@ def _wall_drift_checks(
 
 
 def write_baselines(results: list[CaseResult]) -> None:
-    """Rewrite the committed structural (seek/bytes) baseline only."""
+    """Rewrite the committed structural (seek/bytes) baseline only.
+
+    Refuses to write anything when a case did not run. Dropping such a row would leave
+    a baseline that no longer covers it, and *keeping* it would bake a "didn't run"
+    zero in — after which a later run with the tool installed reads as a regression.
+    Neither is recoverable by inspection: both produce a well-formed file. Fail instead,
+    and let the operator install what is missing (``missing_baseline_requirements``).
+    """
+    skipped = sorted(r.case for r in results if r.skipped)
+    if skipped:
+        raise ValueError(
+            "refusing to write a partial structural baseline; these cases did not "
+            f"run: {', '.join(skipped)}. Install the full benchmark toolchain "
+            "(uv sync --group dev --extra all, plus RARLAB unrar on PATH) and re-run."
+        )
     BASELINES_DIR.mkdir(parents=True, exist_ok=True)
     structural: dict[str, Any] = {
         "solid_decode_factor": SOLID_DECODE_FACTOR,
@@ -1296,10 +1344,6 @@ def write_baselines(results: list[CaseResult]) -> None:
         "cases": {},
     }
     for r in results:
-        if r.skipped:
-            # Never bake a "didn't run" zero into the committed baseline: a later run
-            # *with* the extra would then look like a regression against it.
-            continue
         structural["cases"][r.case] = {
             "bytes_decompressed": r.bytes_decompressed,
             "source_seek_count": r.source_seek_count,
@@ -1549,6 +1593,26 @@ def main(argv: list[str] | None = None) -> int:
             file=sys.stderr,
         )
         return 2
+
+    # Checked up front rather than at write time: the run takes minutes, and a
+    # regeneration that can only produce a partial file should cost seconds to reject.
+    if args.update_baselines:
+        missing = missing_baseline_requirements()
+        if missing:
+            print(
+                "--update-baselines needs the full benchmark toolchain — a partial "
+                "run would drop the affected cases from structural.json, leaving the "
+                "gate measuring less than it claims. Missing:",
+                file=sys.stderr,
+            )
+            for item in missing:
+                print(f"  - {item}", file=sys.stderr)
+            print(
+                "Install with: uv sync --group dev --extra all "
+                "(plus RARLAB unrar on PATH), then re-run.",
+                file=sys.stderr,
+            )
+            return 2
 
     warmup = args.warmup or args.scale == "realistic"
     fixtures = materialize_fixtures(args.fixture_dir, scale=args.scale)

--- a/benchmarks/harness.py
+++ b/benchmarks/harness.py
@@ -1213,7 +1213,9 @@ def _wall_checks(
     """Sanity ceiling (+ optional informational VISION-band messages as failures)."""
     failures: list[str] = []
     for r in results:
-        if r.wall_ratio is None:
+        # A skipped row measured nothing. Its wall_ratio happens to be None today, but
+        # the contract in CaseResult.skipped is on the flag, not on that coincidence.
+        if r.skipped or r.wall_ratio is None:
             continue
         if r.wall_ratio > WALL_RATIO_BUDGET:
             failures.append(
@@ -1268,7 +1270,8 @@ def _wall_drift_checks(
         return []
     failures: list[str] = []
     for r in results:
-        if r.wall_ratio is None:
+        # See _wall_checks: skipped rows are not measurements, regardless of ratio.
+        if r.skipped or r.wall_ratio is None:
             continue
         old = prior.get(r.case)
         if old is None or old <= 0:
@@ -1423,10 +1426,15 @@ def format_text_report(payload: dict[str, Any]) -> str:
     )
     for r in results:
         notes = r.notes.replace("|", "\\|") if r.notes else ""
+        # Printing 0 for a case that never ran recreates in the table the exact
+        # ambiguity the structural gate stopped treating as data; the reason is in
+        # notes, so the numeric columns should not claim a measurement.
+        bytes_dec = "—" if r.skipped else _fmt_bytes(r.bytes_decompressed)
+        seeks = "—" if r.skipped else str(r.source_seek_count)
         lines.append(
             f"| `{r.case}` | {r.format} | {r.operation} | "
-            f"{_fmt_seconds(r.wall_s)} | {_fmt_bytes(r.bytes_decompressed)} | "
-            f"{r.source_seek_count} | {notes} |"
+            f"{_fmt_seconds(r.wall_s)} | {bytes_dec} | "
+            f"{seeks} | {notes} |"
         )
 
     if other_cases and any(r.case.endswith("_sequential") for r in other_cases):

--- a/benchmarks/harness.py
+++ b/benchmarks/harness.py
@@ -112,10 +112,42 @@ class CaseResult:
     wall_ratio: float | None = None
     notes: str = ""
 
+    skipped: bool = False
+    """True when the case could not run (missing optional dependency).
+
+    Its axes are then all zero, meaning *no data* — not a measurement of zero. Every
+    structural rule must ignore such a row: a zero that means "never ran" is otherwise
+    indistinguishable from a real short read or a non-engaging accelerator, and gets
+    reported as one. Carry the reason in ``notes``.
+    """
+
 
 def _as_base(reader: Any) -> BaseArchiveReader:
     assert isinstance(reader, BaseArchiveReader)
     return reader
+
+
+def _accel_skipped_case(case: str, fmt: str) -> CaseResult:
+    """Row for an accelerator-ON case that could not run (no rapidgzip installed).
+
+    Emitted rather than omitted so a local report still shows *why* the accelerator
+    case is absent; the structural gate fails closed on it in CI. ``skipped=True`` and
+    a ``None`` ``unpacked_bytes`` keep it out of the structural rules — it once carried
+    the fixture's real size (that size *is* a property of the fixture, so filling it in
+    looked harmless), which made a missing extra surface as
+    ``bytes_decompressed=0 < unpacked=...``: a codec-shaped failure for a
+    packaging-shaped cause.
+    """
+    return CaseResult(
+        case,
+        fmt,
+        "read_all",
+        0.0,
+        0,
+        0,
+        notes="skipped: rapidgzip not installed ([seekable] extra)",
+        skipped=True,
+    )
 
 
 def _op_open_list(path: Path) -> tuple[int, int]:
@@ -584,6 +616,8 @@ def run_cases(
                 notes="rapidgzip accelerator ON for in-ZIP deflate ([seekable])",
             )
         )
+    else:
+        results.append(_accel_skipped_case("zip_read_all_accel_on", "zip"))
 
     # --- TAR (plain / uncompressed — harness peer is tarfile r:) ---
     _m_wall, (bdec, seeks) = timed_with_optional_warmup(
@@ -693,23 +727,7 @@ def run_cases(
             )
         )
         if not has_accel:
-            # unpacked_bytes stays None: nothing was decoded, so the case must not be
-            # measured against the read_all under-decode rule. Carrying the real size
-            # here made a missing extra surface as
-            # ``bytes_decompressed=0 < unpacked=...`` — a codec-shaped failure for a
-            # packaging-shaped cause. The row is still emitted (not omitted) so the
-            # report shows *why* the accelerator case is absent.
-            results.append(
-                CaseResult(
-                    f"{label}_read_all_accel_on",
-                    fmt,
-                    "read_all",
-                    0.0,
-                    0,
-                    0,
-                    notes="skipped: rapidgzip not installed ([seekable] extra)",
-                )
-            )
+            results.append(_accel_skipped_case(f"{label}_read_all_accel_on", fmt))
             continue
         cfg_on = _accel_config(enabled=True)
         # seekable_members so AUTO would also engage; ON engages either way. Matches
@@ -1098,6 +1116,9 @@ def _structural_checks(
     failures: list[str] = []
     cases = (baseline or {}).get("cases", {}) if baseline else {}
     for r in results:
+        if r.skipped:
+            # No data, not a measurement of zero — see CaseResult.skipped.
+            continue
         if r.case.endswith("_sequential") and r.unpacked_bytes:
             limit = int(r.unpacked_bytes * SOLID_DECODE_FACTOR)
             if r.bytes_decompressed > limit:
@@ -1171,7 +1192,10 @@ def _structural_checks(
         by_case = {r.case: r for r in results}
         accel_off = by_case.get("zip_read_all_accel_off")
         accel_on = by_case.get("zip_read_all_accel_on")
-        if accel_off is not None and accel_on is not None:
+        # A skipped ON row seeks 0 times because it never ran; that is not evidence
+        # the accelerator failed to engage (this check predates skip rows, when a
+        # missing rapidgzip omitted the case entirely).
+        if accel_off is not None and accel_on is not None and not accel_on.skipped:
             if accel_on.source_seek_count <= accel_off.source_seek_count:
                 failures.append(
                     f"zip_read_all_accel_on: source_seek_count="
@@ -1269,6 +1293,10 @@ def write_baselines(results: list[CaseResult]) -> None:
         "cases": {},
     }
     for r in results:
+        if r.skipped:
+            # Never bake a "didn't run" zero into the committed baseline: a later run
+            # *with* the extra would then look like a regression against it.
+            continue
         structural["cases"][r.case] = {
             "bytes_decompressed": r.bytes_decompressed,
             "source_seek_count": r.source_seek_count,

--- a/benchmarks/harness.py
+++ b/benchmarks/harness.py
@@ -693,6 +693,12 @@ def run_cases(
             )
         )
         if not has_accel:
+            # unpacked_bytes stays None: nothing was decoded, so the case must not be
+            # measured against the read_all under-decode rule. Carrying the real size
+            # here made a missing extra surface as
+            # ``bytes_decompressed=0 < unpacked=...`` — a codec-shaped failure for a
+            # packaging-shaped cause. The row is still emitted (not omitted) so the
+            # report shows *why* the accelerator case is absent.
             results.append(
                 CaseResult(
                     f"{label}_read_all_accel_on",
@@ -701,7 +707,6 @@ def run_cases(
                     0.0,
                     0,
                     0,
-                    unpacked_bytes=unpacked,
                     notes="skipped: rapidgzip not installed ([seekable] extra)",
                 )
             )

--- a/scripts/setup-dev-env.sh
+++ b/scripts/setup-dev-env.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# Shared dev-environment bootstrap: system binaries + Python toolchain + git hooks.
+#
+# Called by every environment that provisions a workspace, so they cannot drift:
+#   - Cursor Cloud     → .cursor/install.sh (via .cursor/environment.json)
+#   - Claude Code web  → .claude/hooks/session-start.sh (SessionStart hook)
+#   - a human, locally → ./scripts/setup-dev-env.sh
+#
+# Must stay idempotent: it runs on every agent boot, not just first provision.
+#
+# Why this matters beyond convenience: the RAR *data* tests and the benchmark
+# gate's rar_* cases skip cleanly when `unrar` is absent. A skip is quiet, so an
+# environment missing it silently tests less than it appears to — and
+# `--update-baselines` there would rewrite structural.json without those cases.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${REPO_ROOT}"
+
+# Official uv installer lands here; keep it first for non-login shells.
+export PATH="${HOME}/.local/bin:${PATH}"
+
+log() { printf '\n=== %s\n' "$1"; }
+
+# Root in most containers, an ordinary user on a laptop.
+if [ "$(id -u)" -eq 0 ]; then
+  SUDO=""
+elif command -v sudo >/dev/null 2>&1; then
+  SUDO="sudo"
+else
+  SUDO=""
+fi
+
+install_linux_packages() {
+  # Cloud VMs sometimes boot with a skewed clock; apt then rejects Release files
+  # as "not valid yet". Prefer correcting the clock from an HTTP Date header; if
+  # that fails, still allow a generous future skew so installs can proceed.
+  if date_hdr="$(
+    curl -fsSI --max-time 10 https://archive.ubuntu.com/ubuntu/ \
+      | awk -F': ' 'tolower($1) == "date" { print $2; exit }'
+  )"; then
+    ${SUDO} date -s "${date_hdr}" >/dev/null 2>&1 || true
+  fi
+
+  # Third-party PPAs on a shared image can 403 through a proxy; a stale index is
+  # still usable, so do not let one broken source block the install below.
+  ${SUDO} apt-get \
+    -o Acquire::Max-FutureTime=604800 \
+    -o Acquire::Check-Valid-Until=false \
+    update || echo "! apt-get update reported errors; continuing with cached indexes" >&2
+  # unrar: RAR member-data tests (multiverse component).
+  # p7zip-full: encrypted ZIP fixtures built by shelling out to `7z`.
+  ${SUDO} apt-get install -y unrar p7zip-full
+}
+
+install_macos_packages() {
+  if ! command -v brew >/dev/null 2>&1; then
+    echo "! Homebrew not found; install unrar and p7zip manually" >&2
+    return 0
+  fi
+  # The rar formula ships both `rar` and `unrar`. archivey's finder requires the
+  # RARLAB build specifically — unar / 7z do not satisfy it.
+  command -v unrar >/dev/null 2>&1 || brew install rar
+  command -v 7z >/dev/null 2>&1 || brew install p7zip
+}
+
+install_windows_packages() {
+  if ! command -v choco >/dev/null 2>&1; then
+    echo "! Chocolatey not found; install unrar manually" >&2
+    return 0
+  fi
+  command -v unrar >/dev/null 2>&1 || choco install unrar -y
+}
+
+log "system packages"
+# Non-fatal on purpose: a transient apt/brew outage should not stop a session from
+# starting at all. The verification block below reports anything still missing, so
+# the failure stays visible instead of turning into quietly-skipped tests.
+system_packages_ok=1
+case "$(uname -s)" in
+  Linux*) install_linux_packages || system_packages_ok=0 ;;
+  Darwin*) install_macos_packages || system_packages_ok=0 ;;
+  MINGW* | MSYS* | CYGWIN*) install_windows_packages || system_packages_ok=0 ;;
+  *) echo "! unsupported OS $(uname -s); skipping system packages" >&2 ;;
+esac
+if [ "${system_packages_ok}" -eq 0 ]; then
+  echo "! system package install failed; see the verification block below" >&2
+fi
+
+# JIT / snapshot-less images may not ship uv; bootstrap if missing.
+if ! command -v uv >/dev/null 2>&1; then
+  log "uv"
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+fi
+
+# The global npm prefix is not user-writable on some images (EACCES); install
+# into a writable prefix that is already on PATH.
+if ! command -v openspec >/dev/null 2>&1 && command -v npm >/dev/null 2>&1; then
+  log "openspec CLI"
+  # The bare `openspec` package on npm is an unrelated empty stub.
+  npm install -g --prefix "${HOME}/.local" @fission-ai/openspec
+fi
+
+log "python dependencies"
+uv sync --group dev --extra all
+
+log "git hooks"
+./scripts/install-git-hooks.sh
+
+# Report rather than assume: a missing binary here is the difference between
+# "tests passed" and "tests silently skipped", and it is worth seeing at boot.
+log "verification"
+uv run --no-sync python - <<'PY'
+import shutil
+
+from benchmarks.harness import missing_baseline_requirements
+
+for tool in ("unrar", "7z"):
+    found = shutil.which(tool)
+    print(f"{'ok  ' if found else 'MISSING'} {tool}{f': {found}' if found else ''}")
+
+missing = missing_baseline_requirements()
+if missing:
+    print("\nIncomplete benchmark toolchain — these cases cannot be measured:")
+    for item in missing:
+        print(f"  - {item}")
+else:
+    print("ok   benchmark toolchain complete")
+PY

--- a/tests/test_benchmark_gate.py
+++ b/tests/test_benchmark_gate.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import pytest
 
+from benchmarks import harness
 from benchmarks.fixtures import materialize_fixtures
 from benchmarks.harness import (
     STRUCTURAL_BASELINE,
@@ -24,6 +25,12 @@ _RAR_DATA_CASES = (
     "rar_solid_sequential",
     "rar_solid_random",
     "rar_encrypted_read_all",
+)
+
+_ACCEL_ON_CASES = (
+    "zip_read_all_accel_on",
+    "targz_read_all_accel_on",
+    "tarbz2_read_all_accel_on",
 )
 
 
@@ -80,8 +87,24 @@ def test_benchmark_structural_gate(tmp_path: Path) -> None:
         assert "zip_aes_read_all" in by_case
     assert "zip_lzma_read_all" in by_case
     assert "zip_read_all_accel_off" in by_case
+
+    # Accelerator ON cases: soft locally without rapidgzip, fail-closed in CI (and
+    # whenever it is installed) so a resolution change to the ``[seekable]`` extra
+    # cannot silently drop accelerator coverage. A skipped case is *present but
+    # unmeasured* (unpacked_bytes is None), so presence alone is not enough.
+    unmeasured_accel = [
+        name
+        for name in _ACCEL_ON_CASES
+        if name not in by_case or by_case[name].unpacked_bytes is None
+    ]
+    if unmeasured_accel and (_running_in_ci() or _rapidgzip_available()):
+        pytest.fail(
+            "accelerator ON cases did not run: "
+            f"{unmeasured_accel}. Install the '[seekable]' extra (rapidgzip>=0.16.0); "
+            "the CI matrix gets it via --extra all."
+        )
+
     if _rapidgzip_available():
-        assert "zip_read_all_accel_on" in by_case
         # Engagement signal: ON seeks more than OFF on the same deflate ZIP.
         assert (
             by_case["zip_read_all_accel_on"].source_seek_count
@@ -90,6 +113,39 @@ def test_benchmark_structural_gate(tmp_path: Path) -> None:
 
     failures = _structural_checks(results, load_json(STRUCTURAL_BASELINE))
     assert not failures, "structural gate failures:\n" + "\n".join(failures)
+
+
+@pytest.mark.timeout(120)
+def test_accel_on_skip_is_not_reported_as_under_decode(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A missing ``[seekable]`` extra must not look like a codec short read.
+
+    The accel-ON cases are skipped when rapidgzip is absent. The skip placeholder
+    used to carry the real ``unpacked_bytes`` alongside ``bytes_decompressed=0``, so
+    the read_all under-decode rule reported
+    ``targz_read_all_accel_on: bytes_decompressed=0 < unpacked=32768`` — a fabricated
+    defect pointing at the codec instead of at the missing extra, and expensive to
+    diagnose because ``_structural_checks`` failures do not carry the case notes.
+    """
+    monkeypatch.setattr(harness, "_rapidgzip_available", lambda: False)
+    fixtures = materialize_fixtures(tmp_path / "fixtures")
+    work = tmp_path / "work"
+    work.mkdir()
+    results = run_cases(fixtures, work)
+
+    failures = _structural_checks(results, load_json(STRUCTURAL_BASELINE))
+    assert not [f for f in failures if "accel_on" in f], (
+        "skipped accel-ON cases must not produce structural failures:\n"
+        + "\n".join(failures)
+    )
+
+    # The skip must still be *visible* — a silently absent row is how coverage
+    # evaporates unnoticed (see the fail-closed guard in the structural gate).
+    by_case = {r.case: r for r in results}
+    skipped = by_case["targz_read_all_accel_on"]
+    assert skipped.unpacked_bytes is None, "a skipped case measured nothing"
+    assert "rapidgzip not installed" in skipped.notes
 
 
 def test_structural_baseline_committed() -> None:

--- a/tests/test_benchmark_gate.py
+++ b/tests/test_benchmark_gate.py
@@ -13,12 +13,14 @@ from benchmarks.fixtures import materialize_fixtures
 from benchmarks.harness import (
     STRUCTURAL_BASELINE,
     CaseResult,
+    _accel_skipped_case,
     _crypto_available,
     _rapidgzip_available,
     _structural_checks,
     _unrar_available,
     load_json,
     run_cases,
+    write_baselines,
 )
 
 _RAR_DATA_CASES = (
@@ -153,6 +155,41 @@ def test_accel_on_skip_is_not_reported_as_under_decode(
         assert "rapidgzip not installed" in skipped.notes
 
 
+def test_write_baselines_omits_skipped_cases(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """``--write-baseline`` without ``[seekable]`` must not bake zeros into the pin.
+
+    A skipped accel-ON row would otherwise be committed as
+    ``bytes_decompressed=0``, after which every later run *with* rapidgzip reads as a
+    regression against it. That is the worst of the three variants of this bug: it
+    survives in a committed file, and a zero looks enough like a measurement to pass
+    diff review.
+    """
+    baseline = tmp_path / "structural.json"
+    monkeypatch.setattr(harness, "BASELINES_DIR", tmp_path)
+    monkeypatch.setattr(harness, "STRUCTURAL_BASELINE", baseline)
+
+    measured = CaseResult(
+        case="zip_read_all_accel_off",
+        format="zip",
+        operation="read_all",
+        wall_s=0.01,
+        bytes_decompressed=32768,
+        source_seek_count=28,
+        unpacked_bytes=32768,
+    )
+    write_baselines([measured, _accel_skipped_case("zip_read_all_accel_on", "zip")])
+
+    cases = json.loads(baseline.read_text())["cases"]
+    assert "zip_read_all_accel_on" not in cases, (
+        "a case that never ran must not enter the committed baseline"
+    )
+    # ...while a real measurement alongside it is still written unchanged.
+    assert cases["zip_read_all_accel_off"]["bytes_decompressed"] == 32768
+    assert cases["zip_read_all_accel_off"]["source_seek_count"] == 28
+
+
 def test_structural_baseline_committed() -> None:
     assert STRUCTURAL_BASELINE.is_file()
     data = json.loads(STRUCTURAL_BASELINE.read_text())
@@ -168,7 +205,10 @@ def test_structural_baseline_committed() -> None:
         "zip_aes_read_all",
         "zip_lzma_read_all",
         "zip_read_all_accel_off",
-        "zip_read_all_accel_on",
+        # All three accel-ON cases, matching the fail-closed guard's set: a
+        # no-rapidgzip regeneration drops them together, so pinning only ZIP left the
+        # tar keys protected by coincidence rather than by the assertion.
+        *_ACCEL_ON_CASES,
     ):
         assert name in cases, f"missing structural baseline case {name}"
 
@@ -272,6 +312,19 @@ def test_format_text_report_table() -> None:
                 "wall_ratio": None,
                 "notes": "solid invariant",
             },
+            {
+                "case": "zip_read_all_accel_on",
+                "format": "zip",
+                "operation": "read_all",
+                "wall_s": 0.0,
+                "bytes_decompressed": 0,
+                "source_seek_count": 0,
+                "unpacked_bytes": None,
+                "stdlib_wall_s": None,
+                "wall_ratio": None,
+                "notes": "skipped: rapidgzip not installed ([seekable] extra)",
+                "skipped": True,
+            },
         ],
     }
     report = format_text_report(payload)
@@ -283,6 +336,14 @@ def test_format_text_report_table() -> None:
     assert "solid invariant" in report
     assert "64 × 256.0 KiB" in report or "64 × 256 KiB" in report
     assert "wall-ratio *drift*" in report
+
+    # A skipped case reports "—" in the numeric columns rather than 0, which would
+    # read as "the accelerator decompressed nothing and never seeked".
+    skipped_row = next(
+        line for line in report.splitlines() if "`zip_read_all_accel_on`" in line
+    )
+    assert "| — | — |" in skipped_row, skipped_row
+    assert "rapidgzip not installed" in skipped_row
 
 
 def test_wall_drift_checks_regressions_and_noise() -> None:

--- a/tests/test_benchmark_gate.py
+++ b/tests/test_benchmark_gate.py
@@ -91,11 +91,9 @@ def test_benchmark_structural_gate(tmp_path: Path) -> None:
     # Accelerator ON cases: soft locally without rapidgzip, fail-closed in CI (and
     # whenever it is installed) so a resolution change to the ``[seekable]`` extra
     # cannot silently drop accelerator coverage. A skipped case is *present but
-    # unmeasured* (unpacked_bytes is None), so presence alone is not enough.
+    # unmeasured*, so presence alone is not enough.
     unmeasured_accel = [
-        name
-        for name in _ACCEL_ON_CASES
-        if name not in by_case or by_case[name].unpacked_bytes is None
+        name for name in _ACCEL_ON_CASES if name not in by_case or by_case[name].skipped
     ]
     if unmeasured_accel and (_running_in_ci() or _rapidgzip_available()):
         pytest.fail(
@@ -140,12 +138,19 @@ def test_accel_on_skip_is_not_reported_as_under_decode(
         + "\n".join(failures)
     )
 
-    # The skip must still be *visible* — a silently absent row is how coverage
-    # evaporates unnoticed (see the fail-closed guard in the structural gate).
+    # Every accel-ON case must still be *visible* as a skip — a silently absent row
+    # is how coverage evaporates unnoticed (see the fail-closed guard in the
+    # structural gate). ZIP used to omit its case entirely, which is why it never hit
+    # the under-decode bug but also left no trace of the missing extra.
     by_case = {r.case: r for r in results}
-    skipped = by_case["targz_read_all_accel_on"]
-    assert skipped.unpacked_bytes is None, "a skipped case measured nothing"
-    assert "rapidgzip not installed" in skipped.notes
+    for name in _ACCEL_ON_CASES:
+        assert name in by_case, f"{name} should be reported as skipped, not omitted"
+        skipped = by_case[name]
+        assert skipped.skipped, f"{name}: a case that never ran must say so"
+        assert skipped.unpacked_bytes is None, (
+            f"{name}: a skipped case measured nothing"
+        )
+        assert "rapidgzip not installed" in skipped.notes
 
 
 def test_structural_baseline_committed() -> None:

--- a/tests/test_benchmark_gate.py
+++ b/tests/test_benchmark_gate.py
@@ -40,6 +40,10 @@ def _running_in_ci() -> bool:
     return os.environ.get("CI", "").lower() in ("1", "true", "yes")
 
 
+def _unreachable_materialize_fixtures(*args: object, **kwargs: object) -> object:
+    raise AssertionError("--update-baselines must refuse before building fixtures")
+
+
 @pytest.mark.timeout(120)
 def test_benchmark_structural_gate(tmp_path: Path) -> None:
     """PR gate: solid sequential decode bound + common-path byte counts."""
@@ -155,16 +159,15 @@ def test_accel_on_skip_is_not_reported_as_under_decode(
         assert "rapidgzip not installed" in skipped.notes
 
 
-def test_write_baselines_omits_skipped_cases(
+def test_write_baselines_refuses_partial_update(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """``--write-baseline`` without ``[seekable]`` must not bake zeros into the pin.
+    """A run with a skipped case must not rewrite the baseline at all.
 
-    A skipped accel-ON row would otherwise be committed as
-    ``bytes_decompressed=0``, after which every later run *with* rapidgzip reads as a
-    regression against it. That is the worst of the three variants of this bug: it
-    survives in a committed file, and a zero looks enough like a measurement to pass
-    diff review.
+    Both ways of absorbing a skip are silently wrong and produce a well-formed file:
+    keeping the row bakes in ``bytes_decompressed=0`` (later runs *with* the tool then
+    read as regressions), and dropping it yields a baseline that no longer covers the
+    case. Refusing is the only outcome that cannot quietly weaken the gate.
     """
     baseline = tmp_path / "structural.json"
     monkeypatch.setattr(harness, "BASELINES_DIR", tmp_path)
@@ -179,15 +182,40 @@ def test_write_baselines_omits_skipped_cases(
         source_seek_count=28,
         unpacked_bytes=32768,
     )
-    write_baselines([measured, _accel_skipped_case("zip_read_all_accel_on", "zip")])
+    with pytest.raises(ValueError, match="zip_read_all_accel_on"):
+        write_baselines([measured, _accel_skipped_case("zip_read_all_accel_on", "zip")])
 
-    cases = json.loads(baseline.read_text())["cases"]
-    assert "zip_read_all_accel_on" not in cases, (
-        "a case that never ran must not enter the committed baseline"
+    assert not baseline.exists(), (
+        "a refused update must leave no file behind — a half-written baseline is "
+        "exactly what the refusal is protecting against"
     )
-    # ...while a real measurement alongside it is still written unchanged.
+
+    # The same results without the skip still write normally.
+    write_baselines([measured])
+    cases = json.loads(baseline.read_text())["cases"]
     assert cases["zip_read_all_accel_off"]["bytes_decompressed"] == 32768
     assert cases["zip_read_all_accel_off"]["source_seek_count"] == 28
+
+
+def test_update_baselines_refuses_before_running_when_tooling_missing(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Missing tooling fails the CLI up front, naming what to install.
+
+    The run takes minutes; a regeneration that can only produce a partial file should
+    be rejected in seconds. Returning before ``materialize_fixtures`` is what makes
+    this test cheap, and is the behaviour worth pinning.
+    """
+    monkeypatch.setattr(harness, "_rapidgzip_available", lambda: False)
+    monkeypatch.setattr(
+        harness, "materialize_fixtures", _unreachable_materialize_fixtures
+    )
+
+    assert harness.main(["--update-baselines"]) == 2
+
+    err = capsys.readouterr().err
+    assert "rapidgzip" in err and "[seekable]" in err
+    assert "structural.json" in err
 
 
 def test_structural_baseline_committed() -> None:


### PR DESCRIPTION
Follow-up from the #217 review. Started as a one-line fix for a misleading gate failure; the root cause turned out to be a pattern that had already produced two bugs and had a third waiting. The last commit fixes the environment gap that made the whole thing reachable in the first place.

> **Scope note:** the final commit (session provisioning) is a different concern from the first three (benchmark gate semantics). It landed here because it is the *cause* of the bug this PR fixes — the gate only ever fabricated failures because the tooling was missing — but it is cleanly separable if you would rather review it on its own. Say the word and I will split it into its own PR.

## The pattern

A benchmark case that **could not run** (missing optional dependency) was represented by a row whose axes were all zero. Nothing recorded that the zeros meant "no data" rather than "measured zero" — so every structural rule that inspects those axes reads a skipped case as a catastrophic result. The two are indistinguishable in every field a rule looks at.

Three separate consequences, all from that one cause:

**1. A missing `[seekable]` extra reported as a codec short read.** The skip row carried the fixture's real `unpacked_bytes` (that size *is* a property of the fixture, so filling it in looks harmless) alongside `bytes_decompressed=0`. `tar.gz` / `tar.bz2` are in the read_all under-decode rule's format set, so the gate reported:

```
targz_read_all_accel_on: bytes_decompressed=0 < unpacked=32768
tarbz2_read_all_accel_on: bytes_decompressed=0 < unpacked=32768
```

A codec-shaped failure for a packaging-shaped cause. The real reason was already in the row's `notes`, but `_structural_checks` failure strings never print notes, so diagnosing it meant re-running against a known-good tree.

**2. The same trap in the ZIP accelerator engagement check.** ZIP omitted its accel-ON case entirely when rapidgzip was absent, so `by_case.get(...)` returned `None` and the rule skipped — which is why ZIP never hit bug 1 either. Giving ZIP a skip row for parity immediately surfaced it:

```
zip_read_all_accel_on: source_seek_count=0 <= accel_off 28 (accelerator not engaged?)
```

Zero seeks because it never ran, reported as the accelerator failing to engage. This was latent, waiting for whoever added a ZIP placeholder later.

**3. `--update-baselines` could bake a "didn't run" zero into the committed baseline.** Regenerating without the extra would have written `bytes_decompressed=0` into `structural.json`, after which a later run *with* the extra reads as a regression against it. Silent and persistent.

## Changes

- **`CaseResult.skipped`**, documented as "no data, not a measurement of zero", so the row is self-identifying rather than inferred from zeros.
- `_structural_checks` skips such rows wholesale; the ZIP engagement check ignores a skipped ON row explicitly; `_wall_checks` / `_wall_drift_checks` key on the flag rather than relying on `wall_ratio` happening to be `None`.
- ZIP now emits a skip row like `tar.gz` / `tar.bz2`, via a shared `_accel_skipped_case` helper, so a missing extra leaves a visible trace locally instead of an absent case — and there is one place to get this right rather than three.
- The markdown report renders skipped rows as `—` instead of `0`, rather than recreating in the table the ambiguity the gate just stopped treating as data.
- The structural gate **fails closed** in CI (and wherever rapidgzip is installed) when an accel-ON case did not actually run, mirroring the existing `_RAR_DATA_CASES` guard. It keys on `.skipped`, since after this change "present" no longer implies "measured".

### Baseline regeneration refuses to run partial

For consequence 3, dropping the skipped rows was the first fix, but that is still a partial update: `structural.json` stays well-formed and validates while silently no longer covering the missing cases. So `write_baselines` now **refuses outright** when any case did not run, and `--update-baselines` checks the whole toolchain *before* running — the run costs minutes, and a regeneration that can only produce a partial file should be rejected in seconds.

The hazard is not rapidgzip-specific. Missing `unrar` drops the three RAR data cases, missing `cryptography` drops `zip_aes_read_all`, and missing `py7zr` drops the `sevenzip_*` fixture — all silently:

```
--update-baselines needs the full benchmark toolchain — a partial run would drop
the affected cases from structural.json, leaving the gate measuring less than it
claims. Missing:
  - rapidgzip — the accelerator ON cases; install the [seekable] extra
  - unrar — the RARLAB binary on PATH; the rar_* data cases
Install with: uv sync --group dev --extra all (plus RARLAB unrar on PATH), then re-run.
```

No CI workflow calls `--update-baselines`; it is a manual maintainer command.

### Why it was reachable: agent sessions had no `unrar`

The bootstrap that installs `unrar` + `p7zip-full` lived in `.cursor/install.sh`, wired via `.cursor/environment.json` — so **only Cursor Cloud ran it**. Claude Code web sessions started with neither binary, and both dependencies skip *quietly*:

| | passed | skipped |
| --- | ---: | ---: |
| unprovisioned container | 1900 | 167 |
| after installing `unrar` + `7z` | **2009** | **58** |

~109 tests were silently not running, with the suite reporting green throughout. That is also exactly why `--update-baselines` here would have rewritten `structural.json` without the `rar_*` cases.

Rather than add a second copy of the bootstrap that can drift from the first, the work moves into **`scripts/setup-dev-env.sh`**, and both entry points call it:

- Cursor Cloud → `.cursor/install.sh` (now a thin wrapper)
- Claude Code web → `.claude/hooks/session-start.sh`, registered in `.claude/settings.json`
- a human after a manual clone → run it directly; it is idempotent

The hook no-ops unless `CLAUDE_CODE_REMOTE=true`, so a developer's own machine is untouched. Two robustness changes over the original script: system-package installs are non-fatal (a transient apt outage should not stop a session from starting at all), and the script closes by printing which binaries and benchmark requirements are still missing, so an incomplete environment announces itself instead of turning into quietly-skipped tests:

```
=== verification
ok   unrar: /usr/bin/unrar
ok   7z: /usr/bin/7z
ok   benchmark toolchain complete
```

`CLAUDE.md`, `AGENTS.md` and `CONTRIBUTING.md` updated to match, including the skip counts — "tests pass" reads very differently at 167 skips.

## Testing

Red-green. The under-decode test patches `_rapidgzip_available` to `False` and reproduces the fabricated failure before the fix. It also pins that each accel-ON case stays *visible* as a skip, so a future change cannot "fix" a failure here by deleting the row and quietly losing the signal. The report-rendering and baseline-refusal changes were each confirmed to fail without their fix before being committed.

The fail-closed guard was verified in both directions against real `run_cases` output — no findings with rapidgzip present, all three cases flagged when it is patched out. An unverified guard would have repeated the exact failure mode this PR is about.

The committed-baseline pin now asserts all three accel-ON cases rather than ZIP alone, matching the guard's set; previously the tar keys were protected only by coincidence.

The setup script was validated end to end in a real session container: full run green, second run idempotent, and the `CLAUDE_CODE_REMOTE` guard confirmed to no-op both when unset and when explicitly false. `uv.lock` untouched by the sync.

Gates: `ruff format` / `ruff check` clean, pyrefly 0 errors, ty clean, suite green in all three dependency configurations — `[all]` 1900 passed / 167 skipped, `[all-lowest]` 1900 passed / 167 skipped, `[core-only]` 1530 passed / 480 skipped plus `check_zero_dep_core.py`. (Those counts predate installing `unrar`/`7z`; the `[all]` leg is 2009 / 58 on a provisioned container.)

## Notes

Benchmark harness, its gate, and environment provisioning — no library behaviour change, so no spec or OpenSpec delta. `structural.json` is unchanged: the new field is not serialized into it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ufs6C6Ncs6pxE4T7VCo8qT