### PR TITLE
openspec: extraction results become authoritative; write the diagnostics ceiling

### DIFF
--- a/openspec/changes/extraction-results-authoritative/brief.md
+++ b/openspec/changes/extraction-results-authoritative/brief.md
@@ -1,0 +1,16 @@
+<!--
+The "coffee brief": a spoken-word-friendly summary of this change, readable (or
+read aloud) in under a minute. Prose only — NO tables, NO code blocks, minimal
+symbols — so text-to-speech reads cleanly. Aim for ~200–280 words. Derive it from
+proposal.md / design.md / tasks.md; do not introduce new decisions here.
+-->
+
+# extraction-results-authoritative — one channel per fact, and a written ceiling for diagnostics
+
+**Status:** Ready to implement. Breaking, pre-one-point-zero, wants to land before the first tag. Effort: medium.
+
+**Why it matters:** The diagnostics system has a rule saying everything advisory must become a code, and no rule saying what does not qualify. The one attempt at a ceiling, that diagnostics are about the archive rather than about your call, was contradicted by the taxonomy on the day it was written. Three reviewers looked at this independently and all three rejected that cut. They also found a real defect underneath it: extraction is the one operation that returns a structured per-member report, and it reports blocked and failed members twice, once in the report and once as an advisory, with nothing saying which one wins. Worse, a replace-policy collision is genuinely silent in the report today. Both members come back marked extracted at the same path, and only the advisory records which one lost.
+
+**What it does:** Writes the missing ceiling as two clauses, one about admission and one about placement, so a future proposal has a test to fail. Then it applies the placement clause: extraction leaves the advisory channel entirely, four codes are deleted, and every fact moves into the extraction result. A new overwritten status marks the member a later write clobbered, a presented name field records a portability rewrite, and hardlink grouping moves across.
+
+**What it preserves:** Escalation. A new abort-on setting lets a caller still be stopped by a blocked member, a collision, or a rewrite. That also turns an accidental behaviour, which the library's own docstring claims is unimplemented, into a named one. Named strict and pedantic policy presets replace hand-curating twenty-two overrides.

--- a/openspec/changes/extraction-results-authoritative/design.md
+++ b/openspec/changes/extraction-results-authoritative/design.md
@@ -145,9 +145,24 @@ honest response is to write it down: new codes MAY appear in minor releases, so
 `default=RAISE` is not version-stable and the presets — whose membership is versioned
 alongside the taxonomy — are the documented strict mode.
 
-## Open discrepancy (not resolved here)
+### D7 — Fold in the `MEMBER_NAME_ENCODING_INFERRED` drift rather than defer it
 
-`DiagnosticCode.MEMBER_NAME_ENCODING_INFERRED` exists in the enum but has no row in
-the `diagnostics` spec's context table, and no `MODIFIED` block here touches it.
-Per `AGENTS.md`, a spec/code disagreement is surfaced to the maintainer rather than
-silently resolved. It needs its own change.
+`DiagnosticCode.MEMBER_NAME_ENCODING_INFERRED` had no row in the `diagnostics` spec's
+context table, although the enum member (`diagnostics.py:61`), `NameEncodingContext`
+(`:116`), the kind-map entry (`:359`) and the emission site
+(`internal/backends/zip_reader.py:695`) all ship.
+
+Surfacing alone stopped being sufficient once this change named the code in
+`ARCHIVE_INTEGRITY_CODES`: the preset and the same capability's "closed" table would
+have contradicted each other on the day they landed, recreating in miniature exactly
+the rule-versus-taxonomy debt this change exists to pay off.
+
+The row is therefore added here. `AGENTS.md`'s pause-and-ask rule guards against
+silently choosing between competing designs; there is no competition here — the
+implementation is complete and consistent, and the spec simply omitted a row. The
+discrepancy was disclosed to the maintainer and the fix was chosen deliberately, which
+is what the rule asks for. Adding the row records shipped reality.
+
+Rejected: excluding the code from the preset (ships a knowingly incomplete `strict()`,
+when an inferred name encoding is precisely an archive-integrity fact); a separate
+prerequisite change (correct sequencing, but a round trip for one table row).

--- a/openspec/changes/extraction-results-authoritative/design.md
+++ b/openspec/changes/extraction-results-authoritative/design.md
@@ -1,0 +1,153 @@
+# Design — extraction-results-authoritative
+
+## Context
+
+Three reviewer responses to `dev-docs/discussions/diagnostics-archive-vs-usage.md`
+agreed on more than they disagreed on. This change implements the union of what they
+agreed, plus the two proposals that survived a check against the tree.
+
+Verified before designing (repo at `9b170c0`):
+
+- `SUPERSEDED` means a non-current duplicate, decided from `is_current` at listing
+  time before any write is attempted (`extraction.py:365-370`), yielding
+  `path=None, error=None` (`safe-extraction/spec.md:597-599`). It is **not** a free
+  slot for a destination collision, which is a different event at a different stage.
+- `requested_path != path and status == EXTRACTED` is the defined `RENAME` marker
+  (`safe-extraction/spec.md:603-606`), and `requested` is computed from the
+  already-sanitized name (`extraction.py:565`), so it is both occupied and currently
+  equal for a sanitized member.
+- A `REPLACE` collision is silent in `results` by design (`extraction.py:591-597`).
+  Repro — a ZIP holding `A.txt` and `a.txt` under `OverwritePolicy.REPLACE`:
+
+  ```
+  member='A.txt'  status=extracted  path='A.txt'  requested='A.txt'
+  member='a.txt'  status=extracted  path='A.txt'  requested='A.txt'
+  on disk → 'A.txt': 'second member content'
+  ```
+
+- The dual channel is normative, not drift: `safe-extraction/spec.md:608-609`
+  requires exactly one matching diagnostic per continued `BLOCKED`/`FAILED` result.
+
+## Decisions
+
+### D1 — Two clauses, not one
+
+Option A's drafted ceiling ("not determinable from the declared contract, and
+actionable") is the test that has actually been applied three times, and it is right
+for **admission**. It is not sufficient on its own: all four extraction codes pass it
+and were still misplaced. The missing axis is **placement** — an operation that
+returns a structured per-item report already has a home for per-item outcomes.
+
+Splitting the two also fixes a flaw in reviewer 2's single-clause formulation, which
+let "would a caller want to escalate this?" override placement and so kept
+`EXTRACTION_MEMBER_BLOCKED` alive. Escalation is a *capability question*, answered
+separately by D4, not a reason to duplicate a fact.
+
+Rejected: keeping the archive-vs-usage cut in any normative form. It is an accurate
+description of the taxonomy's shapes and has never decided anything; all three
+reviewers rejected it independently.
+
+### D2 — `OVERWRITTEN` as a new status, revised retroactively
+
+The clobbered member is the only participant whose outcome is currently wrong: it
+reports `EXTRACTED` for content that no longer exists. A new status is the smallest
+honest signal, and it completes the family — `NOT_OVERWRITTEN` (existing destination
+kept, this member not written), `SUPERSEDED` (non-current, never written),
+`OVERWRITTEN` (written, then replaced by a later member).
+
+`path=None`, because nothing at that path is this member's content any more;
+`requested_path` retains the destination it wrote to, so a caller can join the pair
+to the replacing member's `path`. That join is now typed rather than inferred from
+two `EXTRACTED` rows sharing a path.
+
+The revision is retroactive: the earlier member's result already exists when the
+collision is detected. `collision_map` currently stores `key -> Path`
+(`extraction.py:337, 715`) and must become `key -> (Path, result_index)`; the
+coordinator already revises `results` by index in `_resolve_orphan`, so the mechanism
+exists. Result order stays member-processing order.
+
+The other three resolutions need no new signal: `RENAME` is the existing
+`requested_path != path` marker, `SKIP` yields `NOT_OVERWRITTEN` with `requested_path`
+set, `ERROR` yields `FAILED` with the error. So the full `{renamed, replaced, skipped,
+errored}` vocabulary the diagnostic carried is derivable from results once
+`OVERWRITTEN` exists.
+
+Rejected: reusing `SUPERSEDED` (occupied — reviewer 1 checked and is right); a
+`replaced_by` member reference (heavier, and the path join already answers it).
+
+### D3 — `presented_name` for portable rewrites
+
+A caller `filter` rename produces **three** names: the archive name
+(`result.member.name`), the filter's output, and the portable rewrite
+(`result.path`). The removed diagnostic recorded the middle-to-final pair, so for a
+filtered member the pair is not reconstructible from the result at all. A dedicated
+`presented_name: str | None` field — the full relative name before portable
+rewriting, `None` when no rewrite occurred — is the only signal that covers the
+filtered case.
+
+Rejected: reviewer 3's `requested_path != path`. That comparison is already the
+`RENAME` marker, and overloading it makes one signal mean two things — the defect
+this change exists to remove.
+
+### D4 — `abort_on`, one parameter, not a second policy engine
+
+Moving a fact out of diagnostics removes its escalation, because dispositions apply
+to diagnostics only. That trade was accepted for the blocked member (a named knob
+replaces it) but nobody had proposed a replacement for collision and sanitize; left
+alone, this change would silently delete a caller's ability to abort on a silent
+overwrite.
+
+`abort_on: Collection[AbortOn]` is one parameter carrying a small closed enum. It is
+deliberately **not** a per-event disposition map: that would rebuild `DiagnosticPolicy`
+inside extraction under a different name, moving the duplication rather than removing
+it. The only choice offered is fatal-or-not.
+
+`AbortOn.BLOCKED_MEMBER` re-raises the underlying `FilterRejectionError`, matching
+`OnError.STOP`'s propagate-the-original behaviour. `NAME_COLLISION` and
+`NAME_SANITIZED` raise new `NameCollisionError` / `NameRewrittenError`
+(`ExtractionError` subclasses), since neither has an underlying exception.
+
+`MEMBER_FAILED` is deliberately absent: `OnError.STOP` is already the named knob for
+"raise on the first failure", and adding a second spelling would be the same
+multiplication D4 avoids.
+
+This also converts an accident into a contract. `RAISE` on
+`EXTRACTION_MEMBER_BLOCKED` already implements abort-on-first-unsafe-member — the
+behaviour `OnError`'s own docstring (`extraction_types.py:83`) and
+`safe-extraction/spec.md:640-641` both describe as unimplemented, and which
+`test_raise_disposition_stops_despite_continue` locks in without naming.
+
+### D5 — Presets over a `subject` field
+
+All three reviewers rejected adding a `subject` axis to the frozen public
+`Diagnostic`. Reviewer 3's argument for what to do instead is the strongest evidence
+in any of the notes: a per-code override map requires reading the whole taxonomy and
+re-forming an opinion every release, so the blanket `default=RAISE` is the only strict
+mode most callers can express — and under it, speculatively passing `password=` to
+every call (ordinary in a pipeline that sees a mix of encrypted and plain archives)
+raises on every unencrypted archive.
+
+Presets put the distinction in library-maintained, versioned data instead of a frozen
+field, keep boundary events from forcing a binary verdict, and are a one-way door in
+the safe direction: a field can later be derived from the sets, but a shipped field
+cannot be withdrawn.
+
+`EMPTY_ARCHIVE` is excluded from `strict()` deliberately. An empty tar is legitimate —
+the `diagnostics` spec goes out of its way to say the library must not treat zero
+members as an error — so raising on it under a preset named "strict" would be
+surprising. It is in `pedantic()` only.
+
+### D6 — Taxonomy growth is a documented hazard, not a fixable one
+
+Adding any code makes a previously-working `default=RAISE` start raising. That is
+inherent and permanent, independent of how this change classifies anything. The
+honest response is to write it down: new codes MAY appear in minor releases, so
+`default=RAISE` is not version-stable and the presets — whose membership is versioned
+alongside the taxonomy — are the documented strict mode.
+
+## Open discrepancy (not resolved here)
+
+`DiagnosticCode.MEMBER_NAME_ENCODING_INFERRED` exists in the enum but has no row in
+the `diagnostics` spec's context table, and no `MODIFIED` block here touches it.
+Per `AGENTS.md`, a spec/code disagreement is surfaced to the maintainer rather than
+silently resolved. It needs its own change.

--- a/openspec/changes/extraction-results-authoritative/proposal.md
+++ b/openspec/changes/extraction-results-authoritative/proposal.md
@@ -75,7 +75,11 @@ hit occupied slots: `SUPERSEDED` already means *non-current duplicate* (decided 
 - Tests: the extraction/diagnostic suites assert the pairing that this change removes;
   `test_raise_disposition_stops_despite_continue` locks the accidental abort behaviour
   and becomes an `abort_on` test.
-- **Out of scope, surfaced not fixed:** `MEMBER_NAME_ENCODING_INFERRED` exists in the
-  `DiagnosticCode` enum but has no row in the `diagnostics` spec's context table. That
-  is a pre-existing spec/code drift; per `AGENTS.md` it is reported rather than silently
-  resolved here.
+- **Pre-existing drift, folded in:** `MEMBER_NAME_ENCODING_INFERRED` had no row in the
+  `diagnostics` spec's context table, though the code, `NameEncodingContext`, the
+  kind-map entry and the ZIP emission site all ship. The row is added here rather than
+  deferred, because this change names the code in `ARCHIVE_INTEGRITY_CODES` and would
+  otherwise ship a preset contradicting its own "closed" table. Adding it records
+  shipped reality; it does not pick a winner between competing designs, so
+  `AGENTS.md`'s pause-and-ask rule is satisfied by the disclosure rather than by
+  deferral.

--- a/openspec/changes/extraction-results-authoritative/proposal.md
+++ b/openspec/changes/extraction-results-authoritative/proposal.md
@@ -1,0 +1,81 @@
+## Why
+
+The diagnostics taxonomy has an inclusion floor ("no advisory SHALL be log-only")
+and no ceiling. The only written admission rule — *"diagnostics are archive-related,
+not usage-related"* (`review/docs/observations.md`, O-23) — was contradicted by the
+taxonomy on the day it was written, and three separate reviews have since rederived
+the same unwritten test. `dev-docs/discussions/diagnostics-archive-vs-usage.md` and
+the three reviewer responses circulated the question; all three reject the
+archive-vs-usage cut, and all three converge on a knowability ceiling.
+
+The reviews also isolated a real defect the ceiling alone does not fix. Extraction is
+the one operation that **returns a structured per-item report**, and it reports the
+same facts twice: `ExtractionReport.results` carries per-member `status`/`error`, and
+the diagnostics channel re-reports blocked and failed members. Verified against the
+tree: the duplication is normative (`safe-extraction` requires one matching diagnostic
+per continued `BLOCKED`/`FAILED` result), and a `REPLACE` collision is genuinely
+silent in `results` — both members report a plain `EXTRACTED` at the same path, with
+the diagnostic carrying the only labelled record of which one lost.
+
+Two facts therefore have no result-side home today, and two attempts to give them one
+hit occupied slots: `SUPERSEDED` already means *non-current duplicate* (decided from
+`is_current` at listing time), and `requested_path != path` is already the defined
+`OverwritePolicy.RENAME` marker.
+
+## What Changes
+
+- **Write the missing ceiling** into `diagnostics`, as two clauses rather than one: an
+  **admission** rule (report only what the caller could not determine from the declared
+  contract and can act on) and a **placement** rule (when an operation returns a
+  structured per-item report, that report is the sole carrier of per-item outcomes).
+- **Extraction leaves the diagnostics channel.** Remove `EXTRACTION_MEMBER_BLOCKED`,
+  `EXTRACTION_MEMBER_FAILED`, `EXTRACTION_NAME_COLLISION`, `EXTRACTION_NAME_SANITIZED`
+  and their `ExtractionOutcomeContext` / `NameCollisionContext` / `NameSanitizedContext`
+  variants. 22 codes → 18.
+- **Relocate every fact into `ExtractionResult`**, with new signals rather than reused
+  ones: `ExtractionStatus.OVERWRITTEN` for the member a later `REPLACE` clobbered
+  (revised retroactively, `path=None`), `presented_name` for a portable rewrite, and
+  `failure_group_id` / `failure_group_size` for hardlink fan-out.
+- **Preserve escalation with a named opt-in.** Add `abort_on: Collection[AbortOn]` to
+  `extract()` / `extract_all()`. `AbortOn.BLOCKED_MEMBER` is the fail-closed
+  "abort on the first unsafe member" that `OnError`'s docstring has promised as a
+  "separate future opt-in" — and that `RAISE` on `EXTRACTION_MEMBER_BLOCKED`
+  implements today by accident. `NAME_COLLISION` / `NAME_SANITIZED` replace the
+  escalation lost when those facts leave the diagnostics channel.
+- **Add named policy presets.** `DiagnosticPolicy.strict()` (raise on the
+  archive-integrity set) and `.pedantic()` (raise on everything), with
+  `ARCHIVE_INTEGRITY_CODES` exported. Document that new codes may appear in minor
+  releases, so a bare `default=RAISE` is not version-stable and the presets are the
+  documented strict mode.
+- **Retire the O-23 sentence** so in-flight work stops citing it as settled.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `diagnostics` — four codes and three context variants removed; admission + placement
+  ceiling; named presets and the taxonomy-growth contract
+- `safe-extraction` — `ExtractionStatus.OVERWRITTEN`; `presented_name` and
+  failure-group fields on `ExtractionResult`; `abort_on` opt-in; collision and
+  sanitize recorded in results rather than diagnostics
+
+## Impact
+
+- **Breaking** public API: four `DiagnosticCode` members and three context dataclasses
+  removed; `ExtractionStatus` gains a member (a caller exhaustively matching statuses
+  must handle it). Pre-1.0, no aliases. All of it is tag-gated and wants to land before
+  `0.2.0`.
+- Modules: `diagnostics.py` (codes, contexts, presets), `internal/extraction_types.py`
+  (`ExtractionStatus`, `ExtractionResult`, `AbortOn`), `internal/extraction.py`
+  (collision map carries the prior writer's result index; emission sites become result
+  revisions), `exceptions.py` (`NameCollisionError`, `NameRewrittenError`),
+  `cli/extract_cmd.py` (new status label).
+- Docs: `docs/errors-and-diagnostics.md`, `docs/safe-extraction.md`,
+  `docs/extracting.md` (the `OnError` "future opt-in" wording is now wrong).
+- Tests: the extraction/diagnostic suites assert the pairing that this change removes;
+  `test_raise_disposition_stops_despite_continue` locks the accidental abort behaviour
+  and becomes an `abort_on` test.
+- **Out of scope, surfaced not fixed:** `MEMBER_NAME_ENCODING_INFERRED` exists in the
+  `DiagnosticCode` enum but has no row in the `diagnostics` spec's context table. That
+  is a pre-existing spec/code drift; per `AGENTS.md` it is reported rather than silently
+  resolved here.

--- a/openspec/changes/extraction-results-authoritative/specs/diagnostics/spec.md
+++ b/openspec/changes/extraction-results-authoritative/specs/diagnostics/spec.md
@@ -1,0 +1,188 @@
+## MODIFIED Requirements
+
+### Requirement: Immutable diagnostic values with stable codes and safe typed context
+
+Every advisory event SHALL be an immutable `Diagnostic`: opaque process-local
+`occurrence_id`, stable `DiagnosticCode`, `DiagnosticSeverity`, human `message`,
+and code-specific frozen `DiagnosticContext`. Codes are the machine contract;
+messages are not stable.
+
+Contexts are a closed typed union of JSON-safe immutable scalar/tuple values.
+Raw bytes use an explicitly named base64 field. `to_dict()` on diagnostic and
+context SHALL be `json.dumps`-safe without a custom encoder.
+
+| Code | Variant and required fields |
+| --- | --- |
+| `MEMBER_NAME_NORMALIZED` | `NameNormalizationContext`: `kind="name_normalization"`, `archive_name`, `member_name`, `member_id`, `raw_name_base64`, `presented_name`, `normalized_name` |
+| `MEMBER_NAME_BIDI_CONTROL` | `MemberNameControlsContext`: `kind="member_name_controls"`, `archive_name`, `member_name`, `member_id`, `raw_name_base64`, `controls` |
+| `FORMAT_EXTENSION_CONFLICT` | `FormatConflictContext`: `kind="format_conflict"`, `source_name`, `extension`, `extension_format`, `detected_format` |
+| `EXPLICIT_FORMAT_LISTED_EMPTY` | `UnconfirmedFormatContext`: `kind="unconfirmed_format"`, `archive_name`, `format`, `chosen_by="argument"`, `detected_format` |
+| `EXTENSION_FORMAT_UNCONFIRMED` | `UnconfirmedFormatContext`: `kind="unconfirmed_format"`, `archive_name`, `format`, `chosen_by="extension"`, `detected_format=None` |
+| `EMPTY_ARCHIVE` | `EmptyArchiveContext`: `kind="empty_archive"`, `archive_name`, `format` |
+| `ENCODING_ARGUMENT_UNUSED` | `UnusedArgumentContext`: `kind="unused_argument"`, `archive_name`, `argument="encoding"`, `format`, `reason` |
+| `PASSWORD_ARGUMENT_UNUSED` | `UnusedArgumentContext`: `kind="unused_argument"`, `archive_name`, `argument="password"`, `format`, `reason` |
+| `SCAN_DIRECTORY_VANISHED` | `ScanRaceContext`: `kind="scan_race"`, `archive_name`, `relative_path`, `entry_kind="directory"` |
+| `SCAN_ENTRY_VANISHED` | `ScanRaceContext`: `kind="scan_race"`, `archive_name`, `relative_path`, `entry_kind="entry"` |
+| `ARCHIVE_EOF_MARKER_MISSING` | `ArchiveEofContext`: `kind="archive_eof"`, `archive_name`, `format`, `expected_marker`, `expected_bytes`, `observed_bytes`, `observed_kind` |
+| `ARCHIVE_TRAILING_DATA` | `ArchiveEofContext`: `kind="archive_eof"`, `archive_name`, `format`, `expected_marker="zeros_to_eof"`, `expected_bytes=0`, `observed_bytes`, `observed_kind="nonzero"` |
+| `MEMBER_TIMESTAMP_INVALID` | `MemberTimestampContext`: `kind="member_timestamp"`, `archive_name`, `member_name`, `member_id`, `field`, `source`, `value_repr` |
+| `SYMLINK_TARGET_UNAVAILABLE` | `SymlinkTargetContext`: `kind="symlink_target"`, `archive_name`, `member_name`, `member_id`, `reason` |
+| `DIGEST_UNVERIFIABLE` | `DigestContext`: `kind="digest"`, `archive_name`, `member_name`, `member_id`, `algorithm`, `reason` |
+| `SEEK_INDEX_DEGRADED` | `SeekIndexContext`: `kind="seek_index"`, `archive_name`, `member_name`, `member_id`, `codec`, `scan`, `error_type` |
+| `STREAM_REWIND_REDECOMPRESSES` | `StreamRewindContext`: `kind="stream_rewind"`, `archive_name`, `member_name`, `member_id`, `codec`, `from_offset`, `to_offset`, `accelerator` |
+
+(`str | None` / `int | None` as in the typed variants.) `DiagnosticContext` is
+exactly this union — no backend-defined variants. `observed_kind` ∈
+`{"absent","short","nonzero"}`. `expected_marker` is symbolic (`"two_zero_blocks"` for the trailer check,
+`"zeros_to_eof"` for the strict trailing-bytes check, whose `observed_bytes` is the
+offset of the first non-zero byte past the trailer). `member_id` MAY be `None` only before registration.
+`controls` SHALL be the comma-joined `U+XXXX` spellings of the bidi codepoints
+found, in the order they occur, so a caller can tell an override from a mark
+without re-scanning the name. `chosen_by` ∈ `{"argument","extension"}`;
+`detected_format` is `None` when detection refuses the bytes outright.
+
+`ExtractionOutcomeContext`, `NameCollisionContext` and `NameSanitizedContext` SHALL
+NOT exist: per-member extraction outcomes are carried by `ExtractionResult` (see
+`safe-extraction`), not by this channel.
+
+No diagnostic surface SHALL contain passwords, candidates, provider returns, keys,
+KDF material, or decrypted secrets. `PASSWORD_ARGUMENT_UNUSED` therefore records
+that a password argument was supplied and unused — never how many candidates, and
+never any candidate value.
+
+Copies on multiple surfaces MAY share `occurrence_id` by value; object identity
+and cross-run id stability are not promised.
+
+#### Scenario: value-model matrix
+
+| Case | Expected |
+| --- | --- |
+| Name normalization | `MEMBER_NAME_NORMALIZED` + typed JSON-safe context; no backend/mutable mapping |
+| Same occurrence on aggregate + member | Same `occurrence_id`; value equality; no object-identity promise |
+| Encrypted symlink unavailable | May use reason `"password_required"` + member name; no secret material |
+| Member blocked by a universal/policy check | No diagnostic; a `BLOCKED` `ExtractionResult` is the whole record |
+| `password=["a","b"]` on a format with no encryption | `PASSWORD_ARGUMENT_UNUSED`; context carries no candidate value and no count |
+| Non-zero byte past a complete TAR trailer under `strict_archive_eof` | `ARCHIVE_TRAILING_DATA` sharing `ArchiveEofContext`; distinguished by `expected_marker` |
+
+### Requirement: Lifecycle-aware aggregation and attachment
+
+The system SHALL own diagnostic aggregation per lifetime as follows:
+
+| Lifetime | Collector ownership |
+| --- | --- |
+| Standalone `detect_format` | One collector; final summary on `FormatInfo` |
+| `open_archive` + auto-detect | Prospective-reader collector created before detection, passed in, owned by successful reader — no seed/merge/replay/copy. Same counters, retained tuple, ids, order, one-time budget charges |
+| Reader-owned stream | Operation-filtered view over the reader collector (no second aggregate retain) |
+| Standalone stream | Own stream-lifetime collector |
+| Top-level `extract()` | One collector for the whole call (see `safe-extraction`) |
+
+Attachment rules:
+
+- Natural member-metadata diagnostics MAY attach to `ArchiveMember.diagnostics`
+  under the shared budget.
+- `ExtractionResult` has **no** diagnostics field, and no per-member extraction
+  outcome is emitted as a diagnostic at all: `status`, `error`, `requested_path`,
+  `presented_name` and the failure-group fields are the whole record.
+- Detection conflict attaches to `FormatInfo`.
+- Runtime rewind, seek-index degradation, scan race, archive EOF: aggregate-only —
+  never attached to frozen `CostReceipt` or `ArchiveInfo`.
+
+`ExtractionReport.diagnostics` SHALL remain a real summary: reading an archive during
+extraction still emits reading diagnostics (invalid timestamps, unresolvable symlinks,
+unverifiable digests, rewinds), and those stay in the aggregate. What leaves the
+channel is the per-member *extraction outcome*, not everything observed while
+extracting.
+
+#### Scenario: lifetime matrix
+
+| Case | Expected |
+| --- | --- |
+| `open_archive` detects conflict, opens reader | One collector/budget; conflict one aggregate slot; visible on reader summary; no copy |
+| Top-level `extract()` detect→open→extract | One collector from before detection; report is watermark range; no phase-local merge |
+| Reader-owned stream rewinds | On stream op snapshot + cumulative reader; `CostReceipt`/`ArchiveInfo` unchanged |
+| Extraction hits a member with an invalid timestamp and a blocked member | Timestamp diagnostic in the report summary; the block appears only as a `BLOCKED` result |
+
+### Requirement: Complete initial warning taxonomy
+
+The initial `DiagnosticCode` set SHALL cover the library's advisory emissions via
+the codes in the closed table above. Multiple call sites share a code only with the
+same machine meaning; typed context distinguishes variants.
+
+**No advisory SHALL be log-only.** Every condition the library reports as advice to
+the caller SHALL be emitted through the central diagnostic path with a code, so it is
+queryable on `reader.diagnostics` and escalatable by `DiagnosticPolicy`; the WARNING
+log line is the projection of that emission, never a substitute for it.
+
+That rule is a floor. The following two clauses are its ceiling, and a proposed code
+SHALL satisfy both.
+
+**Admission.** A `DiagnosticCode` SHALL report something the caller could not have
+determined from the declared contract of the call, and can act on. It MAY describe a
+property of the archive, or an outcome of the caller's request meeting the archive —
+the archive-versus-caller distinction is descriptive and SHALL NOT be used as an
+admission test. It SHALL NOT restate advice the API surface already carries.
+
+**Placement.** When an operation returns a structured per-item report, that report
+SHALL be the authoritative and sole carrier of per-item outcomes; the diagnostics
+channel carries only facts with no return-value home. A fact SHALL have exactly one
+authoritative channel. Where a fact would otherwise be reported twice, the return
+value wins and the code SHALL NOT exist.
+
+Where relocating a fact out of this channel would remove a caller's ability to be
+stopped by it, the owning capability SHALL provide a named opt-in rather than
+retaining the code for its escalation alone (see `safe-extraction`'s `AbortOn`).
+
+No unused future codes reserved.
+
+#### Scenario: taxonomy coverage
+
+| Case | Expected |
+| --- | --- |
+| Advisory path that formerly logged only | Emits one of the initial codes through the central path |
+| Member name containing a bidi formatting control | `MEMBER_NAME_BIDI_CONTROL` on the aggregate, not only a `logger.warning` |
+| Proposed code restating a `CostReceipt` fact already returned at open time | Refused by the admission clause |
+| Proposed code for a per-member outcome of an operation that returns a per-item report | Refused by the placement clause; the fact belongs in the result |
+| A caller wants to be stopped by a fact that placement moved into a return value | A named opt-in on the owning capability, not a retained code |
+
+## ADDED Requirements
+
+### Requirement: Named diagnostic policy presets and taxonomy-growth contract
+
+The system SHALL provide named `DiagnosticPolicy` constructors so a caller can express
+a coarse strictness without enumerating the taxonomy:
+
+```python
+ARCHIVE_INTEGRITY_CODES: frozenset[DiagnosticCode]
+
+DiagnosticPolicy.strict()    # RAISE on ARCHIVE_INTEGRITY_CODES, COLLECT otherwise
+DiagnosticPolicy.pedantic()  # RAISE on every code
+```
+
+`ARCHIVE_INTEGRITY_CODES` SHALL be a public frozen set covering the codes that report
+the archive's own bytes or metadata as anomalous:
+
+| In `ARCHIVE_INTEGRITY_CODES` | Excluded |
+| --- | --- |
+| `MEMBER_NAME_NORMALIZED`, `MEMBER_NAME_ENCODING_INFERRED`, `MEMBER_NAME_BIDI_CONTROL`, `FORMAT_EXTENSION_CONFLICT`, `EXTENSION_FORMAT_UNCONFIRMED`, `SCAN_DIRECTORY_VANISHED`, `SCAN_ENTRY_VANISHED`, `ARCHIVE_EOF_MARKER_MISSING`, `ARCHIVE_TRAILING_DATA`, `MEMBER_TIMESTAMP_INVALID`, `SYMLINK_TARGET_UNAVAILABLE`, `DIGEST_UNVERIFIABLE`, `SEEK_INDEX_DEGRADED` | `EMPTY_ARCHIVE` (an empty archive is legitimate), `EXPLICIT_FORMAT_LISTED_EMPTY`, `ENCODING_ARGUMENT_UNUSED`, `PASSWORD_ARGUMENT_UNUSED`, `STREAM_REWIND_REDECOMPRESSES` |
+
+Presets SHALL return ordinary frozen `DiagnosticPolicy` values with per-code
+overrides — no new resolution axis, and no field on `Diagnostic`. A caller MAY build
+its own policy from `ARCHIVE_INTEGRITY_CODES`.
+
+**Taxonomy growth.** New `DiagnosticCode` members MAY be added in minor releases. A
+policy with `default=RAISE` therefore SHALL NOT be described as version-stable: a
+caller running it starts raising on events their working program never produced. The
+documentation SHALL state this, and SHALL present `strict()` — whose membership is
+versioned alongside the taxonomy — as the recommended strict mode. Removing a code
+remains a breaking change.
+
+#### Scenario: preset matrix
+
+| Case | Expected |
+| --- | --- |
+| `strict()`, archive with a truncated TAR trailer | `DiagnosticRaisedError` on `ARCHIVE_EOF_MARKER_MISSING` |
+| `strict()`, unencrypted archive opened with `password=` | No raise; `PASSWORD_ARGUMENT_UNUSED` is collected |
+| `pedantic()`, same call | `DiagnosticRaisedError` on `PASSWORD_ARGUMENT_UNUSED` |
+| `strict()`, legitimately empty tar | No raise; `EMPTY_ARCHIVE` collected |
+| Preset value compared to an equivalent hand-built policy | Equal; presets add no resolution axis |
+| A new code added in a later minor release | `strict()` membership is explicit; a `default=RAISE` policy silently gains it |

--- a/openspec/changes/extraction-results-authoritative/specs/diagnostics/spec.md
+++ b/openspec/changes/extraction-results-authoritative/specs/diagnostics/spec.md
@@ -14,6 +14,7 @@ context SHALL be `json.dumps`-safe without a custom encoder.
 | Code | Variant and required fields |
 | --- | --- |
 | `MEMBER_NAME_NORMALIZED` | `NameNormalizationContext`: `kind="name_normalization"`, `archive_name`, `member_name`, `member_id`, `raw_name_base64`, `presented_name`, `normalized_name` |
+| `MEMBER_NAME_ENCODING_INFERRED` | `NameEncodingContext`: `kind="name_encoding"`, `archive_name`, `member_name`, `member_id`, `raw_name_base64`, `inferred_encoding`, `declared_encoding` |
 | `MEMBER_NAME_BIDI_CONTROL` | `MemberNameControlsContext`: `kind="member_name_controls"`, `archive_name`, `member_name`, `member_id`, `raw_name_base64`, `controls` |
 | `FORMAT_EXTENSION_CONFLICT` | `FormatConflictContext`: `kind="format_conflict"`, `source_name`, `extension`, `extension_format`, `detected_format` |
 | `EXPLICIT_FORMAT_LISTED_EMPTY` | `UnconfirmedFormatContext`: `kind="unconfirmed_format"`, `archive_name`, `format`, `chosen_by="argument"`, `detected_format` |

--- a/openspec/changes/extraction-results-authoritative/specs/diagnostics/spec.md
+++ b/openspec/changes/extraction-results-authoritative/specs/diagnostics/spec.md
@@ -165,6 +165,16 @@ the archive's own bytes or metadata as anomalous:
 | --- | --- |
 | `MEMBER_NAME_NORMALIZED`, `MEMBER_NAME_ENCODING_INFERRED`, `MEMBER_NAME_BIDI_CONTROL`, `FORMAT_EXTENSION_CONFLICT`, `EXTENSION_FORMAT_UNCONFIRMED`, `SCAN_DIRECTORY_VANISHED`, `SCAN_ENTRY_VANISHED`, `ARCHIVE_EOF_MARKER_MISSING`, `ARCHIVE_TRAILING_DATA`, `MEMBER_TIMESTAMP_INVALID`, `SYMLINK_TARGET_UNAVAILABLE`, `DIGEST_UNVERIFIABLE`, `SEEK_INDEX_DEGRADED` | `EMPTY_ARCHIVE` (an empty archive is legitimate), `EXPLICIT_FORMAT_LISTED_EMPTY`, `ENCODING_ARGUMENT_UNUSED`, `PASSWORD_ARGUMENT_UNUSED`, `STREAM_REWIND_REDECOMPRESSES` |
 
+Each exclusion is deliberate, and the reason SHALL be recorded so the boundary is not
+rediscovered: `EMPTY_ARCHIVE` because an empty archive is legitimate and this spec
+forbids treating zero members as an error; `ENCODING_ARGUMENT_UNUSED` and
+`PASSWORD_ARGUMENT_UNUSED` because they report argument hygiene, and a pipeline that
+speculatively passes a password to every call would otherwise raise on every
+unencrypted archive; `EXPLICIT_FORMAT_LISTED_EMPTY` because `format=` is an override
+and an override that halts the caller is not an override; and
+`STREAM_REWIND_REDECOMPRESSES` because it reports the caller's access pattern rather
+than the archive, and is most useful as a deliberately targeted tripwire.
+
 Presets SHALL return ordinary frozen `DiagnosticPolicy` values with per-code
 overrides — no new resolution axis, and no field on `Diagnostic`. A caller MAY build
 its own policy from `ARCHIVE_INTEGRITY_CODES`.

--- a/openspec/changes/extraction-results-authoritative/specs/safe-extraction/spec.md
+++ b/openspec/changes/extraction-results-authoritative/specs/safe-extraction/spec.md
@@ -320,6 +320,16 @@ class AbortOn(str, Enum):
 | `NAME_COLLISION` | a second member resolves to an already-written collision key (non-`TRUSTED`) | `NameCollisionError` |
 | `NAME_SANITIZED` | a name is rewritten to its portable spelling | `NameRewrittenError` |
 
+`NAME_SANITIZED` is deliberately unlike the other two: it fires on a **successful**
+safety rewrite rather than on a refusal or an ambiguity. It SHALL ship anyway,
+because dropping it is the only place this change would remove escalation that
+exists today, and preserving escalation is why `abort_on` exists. It SHALL be
+documented as a narrow escape hatch for callers who refuse any on-disk name
+differing from the archive's — mirroring tools, forensic extracts, byte-fidelity
+checks — and SHALL NOT be presented as part of ordinary strict extraction or implied
+by any preset or policy level. A caller wanting to *audit* rewrites reads
+`presented_name`; only a caller who wants them to be **fatal** sets this.
+
 `NAME_COLLISION` SHALL fire on **every** non-`TRUSTED` collision event, whatever
 `OverwritePolicy` resolution follows — replaced, skipped, errored or renamed. The
 trigger is the collision itself, not its outcome. This is deliberate parity with the

--- a/openspec/changes/extraction-results-authoritative/specs/safe-extraction/spec.md
+++ b/openspec/changes/extraction-results-authoritative/specs/safe-extraction/spec.md
@@ -320,6 +320,13 @@ class AbortOn(str, Enum):
 | `NAME_COLLISION` | a second member resolves to an already-written collision key (non-`TRUSTED`) | `NameCollisionError` |
 | `NAME_SANITIZED` | a name is rewritten to its portable spelling | `NameRewrittenError` |
 
+`NAME_COLLISION` SHALL fire on **every** non-`TRUSTED` collision event, whatever
+`OverwritePolicy` resolution follows — replaced, skipped, errored or renamed. The
+trigger is the collision itself, not its outcome. This is deliberate parity with the
+escalation this change relocates: the removed diagnostic fired on all four
+resolutions, so escalating it stopped the caller on all four. `TRUSTED` keys on the
+exact path and produces no collision event, so it never aborts.
+
 `NameCollisionError` and `NameRewrittenError` SHALL subclass `ExtractionError`.
 `BLOCKED_MEMBER` SHALL propagate the original rejection unchanged, matching
 `OnError.STOP`'s propagate-the-original behaviour.
@@ -328,6 +335,16 @@ Abort SHALL be immediate: partial output for the triggering member is removed, n
 later member is processed, and no `ExtractionReport` is returned. `abort_on` SHALL be
 independent of `OnError` and of `DiagnosticPolicy` — a blocked member aborts under
 either `OnError` value when `BLOCKED_MEMBER` is set, and never aborts when it is not.
+
+Output written for **earlier** members SHALL remain on disk, matching `OnError.STOP`:
+abort stops the run, it does not roll it back. For a collision abort this means the
+first member's bytes are typically still present at the contested path, since that
+member completed normally before the collision was detected.
+
+Because no report is returned, an abort SHALL have no observable result-side effect:
+in particular the earlier member is not revised to `OVERWRITTEN` anywhere the caller
+can see. `OVERWRITTEN` is a property of a completed report, and `abort_on` and
+`OVERWRITTEN` are therefore mutually exclusive for the same collision.
 
 `AbortOn` SHALL NOT carry a member for extraction *failures*: `OnError.STOP` already
 expresses "raise on the first failure", and a second spelling of one behaviour is
@@ -339,7 +356,11 @@ what this change exists to remove.
 | --- | --- |
 | Absolute-path member, `abort_on={BLOCKED_MEMBER}`, `OnError.CONTINUE` | `FilterRejectionError` raised at that member; no report; later members untouched |
 | Same archive, `abort_on=()` | `BLOCKED` result; extraction completes; report returned |
-| `REPLACE` collision, `abort_on={NAME_COLLISION}` | `NameCollisionError` at the second member; no report |
+| `REPLACE` collision, `abort_on={NAME_COLLISION}` | `NameCollisionError` at the second member; no report; first member's bytes remain on disk |
+| `SKIP` collision, `abort_on={NAME_COLLISION}` | Aborts — the trigger is the collision, not the resolution |
+| `RENAME` collision, `abort_on={NAME_COLLISION}` | Aborts, even though the rename loses nothing; parity with the escalation this replaces |
+| `ERROR` collision, `abort_on={NAME_COLLISION}` | Aborts with `NameCollisionError`, not the overwrite error |
+| Any aborted collision | No result is observable; the earlier member is never seen as `OVERWRITTEN` |
 | Trailing-dot name under `STRICT`, `abort_on={NAME_SANITIZED}` | `NameRewrittenError` at that member; no report |
 | Collision under `TRUSTED`, `abort_on={NAME_COLLISION}` | No collision event, so no abort |
 | `abort_on={BLOCKED_MEMBER}` with `OnError.STOP` and a corrupt member | Failure still raises via `OnError`; abort applies only to blocks |

--- a/openspec/changes/extraction-results-authoritative/specs/safe-extraction/spec.md
+++ b/openspec/changes/extraction-results-authoritative/specs/safe-extraction/spec.md
@@ -1,5 +1,97 @@
 ## MODIFIED Requirements
 
+### Requirement: Non-Bypassable Universal Path-Safety Constraints
+
+The system SHALL run universal safety checks on the faithful stored
+`member.name` before any policy transform, user filter, or filesystem write;
+`ExtractionPolicy.TRUSTED` does not bypass them. The default path-safety behavior
+is reject/raise. A future sanitize policy is outside v1 scope and is not part of
+this contract.
+
+The implementation SHALL enforce defense in depth: first a string check rejects
+absolute paths, Windows drive/UNC roots, any `..` component split on `/` or `\`,
+null bytes, and names/link targets the platform filesystem encoding cannot represent; then
+`(dest / member.name).parent.resolve()` must remain within `dest.resolve()` to catch
+symlinked intermediate components without following a final-component symlink; link
+targets are rechecked as described in the symlink and hardlink requirements. These
+string checks SHALL raise typed `FilterRejectionError` subclasses, never a raw
+`UnicodeEncodeError`/`ValueError`.
+
+| Constraint | Violation type | Condition |
+| --- | --- | --- |
+| Path traversal | `PathTraversalError` | Any `..` component, escaping or internal |
+| Absolute path | `PathTraversalError` | Leading `/`, Windows drive path, or UNC path |
+| Null byte | `PathTraversalError` | `member.name` contains `\x00` |
+| Unrepresentable name | `PathTraversalError` | `member.name` cannot be encoded by the platform filesystem encoding |
+| Link-target NUL / unrepresentable | `SymlinkEscapeError` | SYMLINK/HARDLINK `link_target` contains `\x00` or cannot be encoded by the platform filesystem encoding |
+| Symlink escape | `SymlinkEscapeError` | SYMLINK whose fully resolved target escapes `dest` |
+| Hardlink escape | `SymlinkEscapeError` | HARDLINK whose target path resolves outside `dest` |
+| Special file | `SpecialFileError` | `MemberType.OTHER` device/FIFO/socket/etc. |
+
+**Bidi overrides are rejected by the *policy*, not universally.** Every other
+constraint in this requirement makes the **write itself** dangerous or impossible — it
+escapes the destination, carries a NUL the OS truncates on, or names a device. A bidi
+override does neither: the member lands inside `dest` under exactly its stored bytes, and
+what is compromised is the name a person **reads back afterwards**. That is a
+presentation property, and presentation is the axis `ExtractionPolicy` owns.
+
+The rejection therefore lives in the portable-name policy below, which means
+`ExtractionPolicy.TRUSTED` — defined as *faithful bytes, no name rejection or rewrite* —
+SHALL extract such a member unchanged, while `STRICT` (the default) and `STANDARD` SHALL
+reject it with `DeceptiveNameError`. Running after the caller filter also means a filter
+that renames the member rescues it, which is the natural remedy for a name that is a lie.
+
+Without this split a caller who wants the bytes — a mirroring tool, a format converter, a
+forensic extract — has no route at *any* policy. That is the outcome ADR 0013 rejected for
+unrepresentable names ("extracting beats refusing"), and it would couple two unrelated
+axes. See ADR 0017.
+
+**The rejected set is the reordering controls only.** Unicode bidi controls are not one
+category, and the difference is load-bearing:
+
+| Subset | Codepoints | Extraction |
+| --- | --- | --- |
+| Overrides and isolates — reorder *surrounding* text; what a `…gnp.exe` disguise requires | U+202A–U+202E, U+2066–U+2069 | **Rejected** |
+| Directional marks — set the direction of one neutral character, reorder nothing, and occur in legitimate Arabic and Hebrew filenames | U+061C, U+200E, U+200F | **Accepted**; `MEMBER_NAME_BIDI_CONTROL` already reported it at listing |
+
+The reject set SHALL be defined by enumerating those two ranges, and MUST NOT be derived
+by subtracting from the library's broader advisory set: a subtraction leaves the three
+marks one editing mistake away from rejecting legitimate RTL filenames.
+
+Right-to-left **script** is unaffected: an Arabic or Hebrew filename takes its direction
+from its own letters' properties, and contains no bidi control at all.
+
+Listing and reading SHALL continue to present the name exactly as stored. Rejection
+belongs to extraction, which is where a name becomes a filesystem path a person will
+read back.
+
+#### Scenario: universal safety matrix
+
+| Case | Expected |
+| --- | --- |
+| `"../evil"` or `"../../etc/passwd"` | `PathTraversalError`; no write; all policies |
+| `"foo/../bar"` | `PathTraversalError` under reject/raise behavior even if it would stay in root |
+| Leading `/`, Windows drive, UNC path | `PathTraversalError`; no write; all policies |
+| Earlier member creates symlink `foo` outside `dest`; later member writes `foo/x` | Parent resolution rejects `foo/x` with `PathTraversalError` |
+| Name with lone surrogate unencodable by the platform filesystem encoding | `PathTraversalError` before path resolution; never raw `UnicodeEncodeError` |
+| SYMLINK/HARDLINK `link_target` with `\x00` or unencodable surrogate | `SymlinkEscapeError`; never raw `ValueError`/`UnicodeEncodeError` |
+| Name using only `surrogateescape` round-trip low surrogates (`\udc80`–`\udcff`) | Accepted when otherwise safe (representable on disk) |
+| `MemberType.OTHER` | `SpecialFileError`; all policies |
+
+#### Scenario: bidi name matrix
+
+| Case | Expected |
+| --- | --- |
+| `"invoice‮cod.exe"` extracted under `STRICT` / `STANDARD` | `apply_name_policy` raises `DeceptiveNameError`; a `BLOCKED` result and no write |
+| The same member extracted under `TRUSTED` | **Extracts**, under the stored name, unmodified — faithful bytes |
+| `"a⁦b⁩.txt"` (isolates) extracted | Same split |
+| Symlink whose `link_target` contains U+202E | Same split |
+| A caller filter renames it to a clean name | Extracts at every policy — the check runs on the final name, after the filter |
+| `"‏דוח.pdf"` (RLM, a directional mark) extracted | Extracts; `MEMBER_NAME_BIDI_CONTROL` was reported at listing |
+| `"فهرس.txt"` (Arabic script, no controls) extracted | Extracts; no diagnostic, no rejection |
+| Any of the above listed rather than extracted | Name presented exactly as stored |
+| `DeceptiveNameError` under either `OnError` | `BLOCKED` result, like any other `FilterRejectionError`; extraction proceeds unless `AbortOn.BLOCKED_MEMBER` is set |
+
 ### Requirement: Per-ArchiveMember ExtractionResult with Status
 
 `ExtractionReport.results` SHALL contain one `ExtractionResult` for every
@@ -18,7 +110,7 @@ class ExtractionResult:
     error: ArchiveyError | OSError | None = None
     requested_path: Path | None = None
     presented_name: str | None = None
-    failure_group_id: int | None = None
+    failure_group_id: str | None = None
     failure_group_size: int | None = None
 
 class ExtractionStatus(str, Enum):
@@ -60,7 +152,11 @@ only `presented_name` records the middle one.
 
 `failure_group_id` / `failure_group_size` SHALL both be set only when one failed
 hardlink source causes `N` `FAILED` link results, which SHALL share one group id and
-`failure_group_size=N`; otherwise both are `None`.
+`failure_group_size=N`; otherwise both are `None`. The id SHALL keep the shipped
+`str` shape and generation (`uuid.uuid4().hex`) it has on
+`ExtractionOutcomeContext` today — the field moves, its type does not change. It is
+opaque: callers MAY compare ids for equality to join a group, and SHALL NOT rely on
+ordering, format, or cross-run stability.
 
 `ExtractionResult` has no diagnostics field; `status`, `error` and the fields above
 are the per-result outcome.
@@ -106,7 +202,14 @@ and proceeds.
 
 Under `STOP`, a genuine member failure raises immediately and is not converted to a
 continued result. Logging-handler and diagnostic-callback exceptions propagate
-unchanged. Global resource guards (`ResourceLimitError` for cumulative bytes,
+unchanged.
+
+Diagnostic disposition SHALL remain authoritative for the diagnostics that still fire
+during extraction. Per-member extraction *outcomes* are no longer diagnostics, but
+reading an archive while extracting still emits reading diagnostics (invalid
+timestamps, unresolvable symlinks, unverifiable digests, stream rewinds); a `RAISE`
+disposition on any of those SHALL emit `DiagnosticRaisedError` and halt immediately,
+even under `OnError.CONTINUE`, returning no report. Global resource guards (`ResourceLimitError` for cumulative bytes,
 archive-wide/live ratio, and max entries), `KeyboardInterrupt`, `MemoryError`, and
 unexpected programming exceptions are always-stop and are not swallowed.
 
@@ -122,6 +225,7 @@ unexpected programming exceptions are always-stop and are not swallowed.
 | Filesystem `OSError` while writing under `CONTINUE` | Partial output removed; `FAILED` result; extraction proceeds |
 | Cumulative bytes/live ratio/max entries exceed limit under any `OnError` | `ResourceLimitError` propagates and halts; no later member processed |
 | Mixed good/corrupt/blocked archive under `CONTINUE` | Extractable members written; report includes `EXTRACTED` plus `FAILED`/`BLOCKED`; no per-member exception escapes |
+| Reading diagnostic resolves to `RAISE` under `CONTINUE` (e.g. `MEMBER_TIMESTAMP_INVALID`) | `DiagnosticRaisedError` halts; no report returned |
 
 ### Requirement: Cross-platform name safety is deterministic across policy levels
 

--- a/openspec/changes/extraction-results-authoritative/specs/safe-extraction/spec.md
+++ b/openspec/changes/extraction-results-authoritative/specs/safe-extraction/spec.md
@@ -1,0 +1,241 @@
+## MODIFIED Requirements
+
+### Requirement: Per-ArchiveMember ExtractionResult with Status
+
+`ExtractionReport.results` SHALL contain one `ExtractionResult` for every
+selected member the coordinator processes when the operation completes, including
+members blocked by universal/policy checks before the user filter. Selector
+exclusions are outside the operation and have no result; a user `filter` that
+returns `None` likewise drops the member with **no** `ExtractionResult` (it is a
+caller-elected exclusion, not an extraction outcome).
+
+```python
+@dataclass(frozen=True)
+class ExtractionResult:
+    member: ArchiveMember
+    path: Path | None
+    status: ExtractionStatus
+    error: ArchiveyError | OSError | None = None
+    requested_path: Path | None = None
+    presented_name: str | None = None
+    failure_group_id: int | None = None
+    failure_group_size: int | None = None
+
+class ExtractionStatus(str, Enum):
+    EXTRACTED = "extracted"
+    NOT_OVERWRITTEN = "not_overwritten"
+    SUPERSEDED = "superseded"
+    OVERWRITTEN = "overwritten"
+    BLOCKED = "blocked"
+    FAILED = "failed"
+```
+
+`ExtractionReport.results` SHALL be the **sole authoritative record** of per-member
+extraction outcomes. No per-member extraction fact SHALL additionally be reported
+through the diagnostics channel.
+
+Statuses SHALL mean: `EXTRACTED` created an entry (`path` set, `error=None`);
+`NOT_OVERWRITTEN` left an existing destination in place because
+`OverwritePolicy.SKIP` found one (`path=None`, `error=None`); `SUPERSEDED` is a
+non-current duplicate skipped by the hardwired last-entry-wins rule (`path=None`,
+`error=None`); `OVERWRITTEN` was written and then had its destination replaced by a
+later member under `OverwritePolicy.REPLACE` (`path=None`, `error=None`);
+`BLOCKED` is a continued `FilterRejectionError` (a universal path-safety check or a
+policy filter blocked the member); `FAILED` is a continued non-rejection per-member
+`ArchiveyError` or permitted filesystem `OSError`. `NOT_OVERWRITTEN`, `SUPERSEDED`
+and `OVERWRITTEN` are not failures.
+
+`requested_path` carries the destination the coordinator intended before
+overwrite/rename resolution; it equals `path` for an ordinary write, and
+`requested_path != path and status == EXTRACTED` marks an `OverwritePolicy.RENAME`
+(see the cross-platform name-safety requirement). On an `OVERWRITTEN` result it
+retains the destination the member did write to, so a caller can join it to the
+replacing member's `path`.
+
+`presented_name` SHALL carry the member's full relative name **before** portable
+rewriting, and SHALL be `None` when no rewrite occurred. It is distinct from
+`member.name` (the archive's spelling) and from `path` (the final on-disk spelling):
+a caller `filter` rename followed by a portable rewrite produces three spellings, and
+only `presented_name` records the middle one.
+
+`failure_group_id` / `failure_group_size` SHALL both be set only when one failed
+hardlink source causes `N` `FAILED` link results, which SHALL share one group id and
+`failure_group_size=N`; otherwise both are `None`.
+
+`ExtractionResult` has no diagnostics field; `status`, `error` and the fields above
+are the per-result outcome.
+
+#### Scenario: result/status matrix
+
+| Case | Expected |
+| --- | --- |
+| User filter returns `None` | No `ExtractionResult`; no result-count impact (like a selector exclusion) |
+| Selector excludes member | No `ExtractionResult`; no result-count impact |
+| Member blocked by `PathTraversalError` under `CONTINUE` | Result is `BLOCKED` with matching error; no diagnostic emitted |
+| Member write raises `OSError` under `CONTINUE` | Result is `FAILED` with matching error; no diagnostic emitted |
+| Member written successfully | Result is `EXTRACTED`, `path` points to created entry |
+| Existing destination under `OverwritePolicy.SKIP` | Result is `NOT_OVERWRITTEN`, `path=None` |
+| One failed source causes three hardlink results to fail | Three `FAILED` results sharing one `failure_group_id` with `failure_group_size=3` |
+
+#### Scenario: replaced-member matrix
+
+| Case | Expected |
+| --- | --- |
+| `A.txt` then `a.txt` under `REPLACE` (non-`TRUSTED`) | `A.txt` revised to `OVERWRITTEN` (`path=None`, `requested_path` kept); `a.txt` is `EXTRACTED` at that path |
+| Same pair under `SKIP` | `A.txt` stays `EXTRACTED`; `a.txt` is `NOT_OVERWRITTEN` with `requested_path` set |
+| Same pair under `RENAME` | Both `EXTRACTED`; second has `requested_path != path` |
+| Same pair under `ERROR` | `A.txt` stays `EXTRACTED`; `a.txt` is `FAILED` with the error |
+| Same pair under `TRUSTED` | No collision event; local OS behavior; no `OVERWRITTEN` |
+| Result ordering after a retroactive revision | Results stay in member-processing order; only the revised member's fields change |
+
+### Requirement: Error Policy (OnError) for extraction failures
+
+`OnError.STOP` and `OnError.CONTINUE` SHALL govern per-member **failures** only — a
+non-rejection member-scoped `ArchiveyError`, a permitted read/write `OSError`, or a
+per-member ratio violation. A policy **block** (a `FilterRejectionError` from a universal
+path-safety check or a policy filter) is NOT a failure: it SHALL always be recorded as a
+`BLOCKED` `ExtractionResult`, have its partial output removed, and let extraction
+proceed — under **either** `OnError.STOP` or `OnError.CONTINUE`. `OnError.STOP`
+therefore never raises on a blocked member; a STOP run can complete and return an
+`ExtractionReport` whose results include `BLOCKED`. Aborting the whole extraction on the
+first unsafe member (fail-closed strict security) SHALL be expressed through
+`AbortOn.BLOCKED_MEMBER`, not through `OnError`.
+
+Under `CONTINUE`, a member-scoped failure records `FAILED`, removes partial output,
+and proceeds.
+
+Under `STOP`, a genuine member failure raises immediately and is not converted to a
+continued result. Logging-handler and diagnostic-callback exceptions propagate
+unchanged. Global resource guards (`ResourceLimitError` for cumulative bytes,
+archive-wide/live ratio, and max entries), `KeyboardInterrupt`, `MemoryError`, and
+unexpected programming exceptions are always-stop and are not swallowed.
+
+#### Scenario: OnError matrix
+
+| Case | Expected |
+| --- | --- |
+| Member blocked by policy/path-safety under `STOP` | `BLOCKED` result; partial output removed; extraction does **not** halt; later members continue |
+| Member blocked by policy/path-safety under `CONTINUE` | `BLOCKED` result; partial output removed; later members continue |
+| First member blocked, remaining members extractable, under `STOP` | Run completes; report contains `BLOCKED` + later `EXTRACTED`; no exception escapes |
+| Corrupt member under `CONTINUE` | Partial output removed; `FAILED` result; later members continue |
+| Default `STOP` member failure (e.g. `CorruptionError`) | Original error propagates immediately; failing partial file removed; earlier outputs remain |
+| Filesystem `OSError` while writing under `CONTINUE` | Partial output removed; `FAILED` result; extraction proceeds |
+| Cumulative bytes/live ratio/max entries exceed limit under any `OnError` | `ResourceLimitError` propagates and halts; no later member processed |
+| Mixed good/corrupt/blocked archive under `CONTINUE` | Extractable members written; report includes `EXTRACTED` plus `FAILED`/`BLOCKED`; no per-member exception escapes |
+
+### Requirement: Cross-platform name safety is deterministic across policy levels
+
+Extraction SHALL handle destination-name hazards deterministically on every platform,
+keyed off `ExtractionPolicy`, so the same archive yields the same logical outcome
+(collision events, rejections, normalized spellings) regardless of the runner OS. These
+rules compose with — and never bypass — the non-bypassable path-safety constraints.
+
+**Collision determinism (O2).** Under `STRICT` and `STANDARD`, the coordinator SHALL track
+a `casefold(NFC(path))` key per written destination and treat a second member resolving to
+the same key as an existing destination on **all** platforms, applying `OverwritePolicy`
+deliberately and recording the outcome on both members' `ExtractionResult`. `REPLACE`
+SHALL NOT silently merge distinct members on case-insensitive filesystems: the earlier
+member's result SHALL be revised to `ExtractionStatus.OVERWRITTEN` so the merge is
+observable in `results`. Under `TRUSTED` the coordinator SHALL key on the exact `Path`
+and defer to the local OS (today's behavior), so genuinely distinct files on a
+case-sensitive filesystem both extract.
+
+`OverwritePolicy` SHALL add a `RENAME` member that extracts a colliding entry under a
+deterministic derived name, using the same collision key, for archives with intentional
+duplicates. The derived name SHALL insert ` (N)` (`N` = 1, 2, …) **before the final suffix**
+(`Path.stem` + `Path.suffix` semantics): `photo.jpg` → `photo (1).jpg`; a name with no
+suffix → `photo (1)`; a leading-dot dotfile (`.bashrc`) → `.bashrc (1)` (the leading dot is
+not treated as a suffix); a multi-suffix name (`archive.tar.gz`) → `archive.tar (1).gz`
+(single final suffix); a directory appends to the whole segment. `N` SHALL increment to the
+first name free **both on disk and in the collision map**, in member-processing order.
+
+**Portable-name enforcement (O3/O4).** Windows-reserved device names (`CON`, `PRN`, `AUX`,
+`NUL`, `COM1`–`COM9`, `LPT1`–`LPT9`; case-insensitive, with or without extension) and `:`
+within a segment are **unsafe** (device capture / NTFS alternate data stream) and SHALL be
+rejected under `STRICT` and `STANDARD` on **every** platform. A trailing dot or space is a
+legitimate macOS/Linux name that Win32 merely trims; rejecting it would halt a legitimate
+archive, so under `STRICT` each path segment's trailing dot/space SHALL be **stripped** to
+its portable spelling (`stuff_etc.` → `stuff_etc`) deterministically on every platform,
+collision-tracked as above, and recorded as `ExtractionResult.presented_name`; a
+segment that is entirely dots/spaces (e.g. `...`) has no portable spelling and SHALL be
+rejected. `STANDARD` and `TRUSTED` SHALL keep the trailing dot/space faithful (written if
+the OS allows).
+
+**Portable-name representability (O7).** Under `STRICT` and `STANDARD`, a name carrying
+bytes that cannot be represented portably on the destination filesystem SHALL be normalized
+to a deterministic, reversible portable spelling — each non-UTF-8 byte (a surrogateescape
+char U+DC80–U+DCFF mapping to raw byte 0x80–0xFF) percent-escaped as `%XX` (uppercase hex),
+and a literal `%` escaped as `%25` — applied on **every** platform, collision-tracked as
+above, and recorded as `ExtractionResult.presented_name`. The scheme SHALL touch only
+non-decodable bytes; valid-but-non-portable Unicode (NFC/NFD forms) SHALL NOT be rewritten
+(its cross-platform folding is the O2 collision concern). `TRUSTED` SHALL attempt the
+faithful bytes and let the OS decide. The reversibility SHALL be a documented property; a
+public un-escape API is out of scope. Either way the outcome SHALL be deterministic and
+typed (never a bare `OSError`); a name that cannot be `os.fsencode`d at all remains
+rejected by the universal check.
+
+`ExtractionResult.requested_path` carries the destination the coordinator intended before
+overwrite/rename resolution. A rename SHALL be observable as `requested_path != path and
+status == EXTRACTED`; a collision resolved by `SKIP`/`ERROR` SHALL set `requested_path`
+with `path=None`. `presented_name` SHALL NOT be expressed through `requested_path`: the
+two signals are independent, and a member MAY carry both (a portable rewrite whose
+rewritten name then collides and is renamed).
+
+#### Scenario: cross-platform name matrix
+
+| Case | `STRICT` / `STANDARD` | `TRUSTED` |
+| --- | --- | --- |
+| `README` and `readme` in one archive | Second is a collision event on all platforms; `OverwritePolicy` applied; `requested_path` recorded | Local OS behavior (both extract on a case-sensitive FS) |
+| NFC `café` and NFD `café` | Treated as a collision on all platforms | Local OS behavior |
+| Member named `NUL` / `COM1` | Rejected on all platforms (typed error) | Written if the OS allows |
+| Trailing dot/space (`foo.`, `foo `) | `STRICT` strips to portable spelling (`foo`), `presented_name="foo."`; `STANDARD` keeps faithful | Written if the OS allows |
+| Segment of only dots/spaces (`.../x`) | Rejected on all platforms (no portable spelling) | Written if the OS allows |
+| Name containing `:` (`file:hidden`) | Rejected on all platforms | Local OS behavior (NTFS ADS) |
+| Surrogateescape `caf\udce9.txt` | Sanitized to `caf%E9.txt`; `presented_name` keeps the pre-rewrite spelling; collision-tracked | Faithful bytes attempted; OS decides |
+| `REPLACE` with a casefold collision | Not a silent merge; earlier member revised to `OVERWRITTEN` | Local OS behavior |
+| `RENAME` with a collision (case/NFC or exact) | Second entry written as `name (1)` before the suffix; `requested_path` = intended name | Same |
+| Filter rename, then a portable rewrite | `member.name`, `presented_name`, and `path.name` are all three spellings | Faithful bytes attempted |
+
+## ADDED Requirements
+
+### Requirement: Abort-on-event opt-in for extraction
+
+`extract()` and `extract_all()` SHALL accept `abort_on: Collection[AbortOn] = ()`,
+halting the whole extraction the first time a named event occurs.
+
+```python
+class AbortOn(str, Enum):
+    BLOCKED_MEMBER = "blocked_member"
+    NAME_COLLISION = "name_collision"
+    NAME_SANITIZED = "name_sanitized"
+```
+
+| Member | Fires when | Raises |
+| --- | --- | --- |
+| `BLOCKED_MEMBER` | a member is blocked by a universal path-safety check or a policy filter | the underlying `FilterRejectionError` |
+| `NAME_COLLISION` | a second member resolves to an already-written collision key (non-`TRUSTED`) | `NameCollisionError` |
+| `NAME_SANITIZED` | a name is rewritten to its portable spelling | `NameRewrittenError` |
+
+`NameCollisionError` and `NameRewrittenError` SHALL subclass `ExtractionError`.
+`BLOCKED_MEMBER` SHALL propagate the original rejection unchanged, matching
+`OnError.STOP`'s propagate-the-original behaviour.
+
+Abort SHALL be immediate: partial output for the triggering member is removed, no
+later member is processed, and no `ExtractionReport` is returned. `abort_on` SHALL be
+independent of `OnError` and of `DiagnosticPolicy` — a blocked member aborts under
+either `OnError` value when `BLOCKED_MEMBER` is set, and never aborts when it is not.
+
+`AbortOn` SHALL NOT carry a member for extraction *failures*: `OnError.STOP` already
+expresses "raise on the first failure", and a second spelling of one behaviour is
+what this change exists to remove.
+
+#### Scenario: abort-on matrix
+
+| Case | Expected |
+| --- | --- |
+| Absolute-path member, `abort_on={BLOCKED_MEMBER}`, `OnError.CONTINUE` | `FilterRejectionError` raised at that member; no report; later members untouched |
+| Same archive, `abort_on=()` | `BLOCKED` result; extraction completes; report returned |
+| `REPLACE` collision, `abort_on={NAME_COLLISION}` | `NameCollisionError` at the second member; no report |
+| Trailing-dot name under `STRICT`, `abort_on={NAME_SANITIZED}` | `NameRewrittenError` at that member; no report |
+| Collision under `TRUSTED`, `abort_on={NAME_COLLISION}` | No collision event, so no abort |
+| `abort_on={BLOCKED_MEMBER}` with `OnError.STOP` and a corrupt member | Failure still raises via `OnError`; abort applies only to blocks |

--- a/openspec/changes/extraction-results-authoritative/tasks.md
+++ b/openspec/changes/extraction-results-authoritative/tasks.md
@@ -62,6 +62,9 @@
 - [ ] 6.2 Update `docs/errors-and-diagnostics.md` (four codes gone; presets; the
       taxonomy-growth note), `docs/safe-extraction.md` and `docs/extracting.md`
       (`abort_on`, the new status, the corrected "future opt-in" wording)
+- [ ] 6.5 Document `AbortOn.NAME_SANITIZED` as a narrow escape hatch for callers who
+      refuse any rewritten on-disk name — never as part of ordinary strict extraction.
+      Point auditing callers at `presented_name` instead
 - [ ] 6.3 Grep `docs/` for the four removed code names
 - [ ] 6.4 Decide whether `abort_on` gets a CLI flag (`VISION` treats the CLI as the
       first consumer, so a safety opt-in the CLI cannot reach is a wedge gap) — either

--- a/openspec/changes/extraction-results-authoritative/tasks.md
+++ b/openspec/changes/extraction-results-authoritative/tasks.md
@@ -1,0 +1,88 @@
+## 1. Ceiling rules and doctrine cleanup
+
+- [ ] 1.1 Add the admission + placement clauses to `openspec/specs/diagnostics/spec.md`
+      (via the delta), so a proposed code has a written test to fail
+- [ ] 1.2 Retire the O-23 sentence in `review/docs/observations.md` — replace
+      "diagnostics are archive-related, not usage-related" with a pointer to the
+      ceiling, noting the archive/usage split is descriptive only
+- [ ] 1.3 Cross-reference the discussion doc and the three reviewer opinions in
+      `dev-docs/discussions/` from the decision record
+
+## 2. `ExtractionResult` becomes authoritative
+
+- [ ] 2.1 Add `ExtractionStatus.OVERWRITTEN` (`"overwritten"`) in
+      `internal/extraction_types.py`
+- [ ] 2.2 Add `presented_name`, `failure_group_id`, `failure_group_size` to
+      `ExtractionResult` (appended, defaulting to `None`)
+- [ ] 2.3 Change `collision_map` to carry the prior writer's result index
+      (`extraction.py:337`, `_register_collision_key` at `:701`), so the earlier
+      member's result can be revised
+- [ ] 2.4 On a `REPLACE`-resolved collision, revise the earlier member's result to
+      `OVERWRITTEN` with `path=None`, keeping `requested_path`; leave result ordering
+      in member-processing order
+- [ ] 2.5 Populate `presented_name` at the portable-rewrite site
+      (`_transform`, `extraction.py:543-546`) with the pre-rewrite full name
+- [ ] 2.6 Move hardlink failure-group metadata from `ExtractionOutcomeContext` onto the
+      `FAILED` results
+
+## 3. Extraction leaves the diagnostics channel
+
+- [ ] 3.1 Remove `EXTRACTION_MEMBER_BLOCKED`, `EXTRACTION_MEMBER_FAILED`,
+      `EXTRACTION_NAME_COLLISION`, `EXTRACTION_NAME_SANITIZED` from `DiagnosticCode`
+- [ ] 3.2 Remove `ExtractionOutcomeContext`, `NameCollisionContext`,
+      `NameSanitizedContext` and their entries in the context union / validators
+- [ ] 3.3 Delete the emission sites in `internal/extraction.py` (`_emit_collision`,
+      `_emit_name_sanitized`, and the blocked/failed outcome emissions), keeping the
+      result-side records from §2
+- [ ] 3.4 Confirm `ExtractionReport.diagnostics` still carries reading diagnostics
+      observed during extraction (timestamps, symlinks, digests, rewinds)
+
+## 4. `abort_on` opt-in
+
+- [ ] 4.1 Add `AbortOn` to `internal/extraction_types.py` and export it
+- [ ] 4.2 Add `NameCollisionError` / `NameRewrittenError` (`ExtractionError`
+      subclasses) to `exceptions.py`
+- [ ] 4.3 Thread `abort_on: Collection[AbortOn] = ()` through `extract()`,
+      `extract_all()` and the coordinator
+- [ ] 4.4 Implement immediate abort: remove the triggering member's partial output,
+      process no later member, return no report
+- [ ] 4.5 Fix the `OnError` docstring (`extraction_types.py:83`) that calls
+      abort-on-blocked "a separate future opt-in" — it now exists and is named
+
+## 5. Policy presets
+
+- [ ] 5.1 Add `ARCHIVE_INTEGRITY_CODES` and the `DiagnosticPolicy.strict()` /
+      `.pedantic()` constructors in `diagnostics.py`
+- [ ] 5.2 Assert a preset equals the equivalent hand-built policy (no new axis)
+
+## 6. CLI and docs
+
+- [ ] 6.1 Add the `OVERWRITTEN` label to `cli/extract_cmd.py`; surface
+      `presented_name` where the CLI reports rewritten names
+- [ ] 6.2 Update `docs/errors-and-diagnostics.md` (four codes gone; presets; the
+      taxonomy-growth note), `docs/safe-extraction.md` and `docs/extracting.md`
+      (`abort_on`, the new status, the corrected "future opt-in" wording)
+- [ ] 6.3 Grep `docs/` and `openspec/specs/` for the four removed code names
+
+## 7. Tests
+
+- [ ] 7.1 Replace the BLOCKED/FAILED diagnostic-pairing assertions across the
+      extraction/diagnostic suites with result-side assertions
+- [ ] 7.2 Convert `test_raise_disposition_stops_despite_continue` into an
+      `abort_on={AbortOn.BLOCKED_MEMBER}` test — same behaviour, now named
+- [ ] 7.3 Lock the `REPLACE` collision case: `A.txt` + `a.txt`, first result
+      `OVERWRITTEN` with `path=None`, second `EXTRACTED` at that path (this is
+      the case that is silent today)
+- [ ] 7.4 Cover the three-spelling case: caller `filter` rename followed by a
+      portable rewrite yields distinct `member.name` / `presented_name` / `path.name`
+- [ ] 7.5 Cover `abort_on` for each member, including that `TRUSTED` produces no
+      collision event and so no abort
+- [ ] 7.6 Cover the presets, including `strict()` not raising on `EMPTY_ARCHIVE`
+      or `PASSWORD_ARGUMENT_UNUSED`
+- [ ] 7.7 `uv run --no-sync pytest`; `ruff format` / `ruff check`;
+      `uv run --no-sync pyrefly check` and `uv run --no-sync ty check`
+
+## 8. Verify
+
+- [ ] 8.1 `openspec validate --strict extraction-results-authoritative`
+- [ ] 8.2 Sync main specs from this change's deltas (`diagnostics`, `safe-extraction`)

--- a/openspec/changes/extraction-results-authoritative/tasks.md
+++ b/openspec/changes/extraction-results-authoritative/tasks.md
@@ -62,7 +62,10 @@
 - [ ] 6.2 Update `docs/errors-and-diagnostics.md` (four codes gone; presets; the
       taxonomy-growth note), `docs/safe-extraction.md` and `docs/extracting.md`
       (`abort_on`, the new status, the corrected "future opt-in" wording)
-- [ ] 6.3 Grep `docs/` and `openspec/specs/` for the four removed code names
+- [ ] 6.3 Grep `docs/` for the four removed code names
+- [ ] 6.4 Decide whether `abort_on` gets a CLI flag (`VISION` treats the CLI as the
+      first consumer, so a safety opt-in the CLI cannot reach is a wedge gap) — either
+      add the flag to `cli/extract_cmd.py` or record library-only as deliberate
 
 ## 7. Tests
 
@@ -85,4 +88,8 @@
 ## 8. Verify
 
 - [ ] 8.1 `openspec validate --strict extraction-results-authoritative`
-- [ ] 8.2 Sync main specs from this change's deltas (`diagnostics`, `safe-extraction`)
+- [ ] 8.2 Gate before archive: `rg 'EXTRACTION_MEMBER_|EXTRACTION_NAME_|ExtractionOutcomeContext|NameCollisionContext|NameSanitizedContext' openspec/specs/`
+      MUST return nothing once the deltas are applied. Archiving applies deltas only,
+      so any parent requirement naming a removed code must be MODIFIED here rather
+      than swept afterwards
+- [ ] 8.3 Sync main specs from this change's deltas (`diagnostics`, `safe-extraction`)


### PR DESCRIPTION
Acts on the decision from the archive-vs-usage discussion in #233 and its three reviewer opinions. **OpenSpec change proposal only — no source changes.**

## Why

The diagnostics taxonomy has an inclusion floor ("no advisory SHALL be log-only") and no ceiling. The only written admission rule — *"diagnostics are archive-related, not usage-related"* (`review/docs/observations.md`, O-23) — was contradicted by the taxonomy on the day it was written. All three reviewers rejected that cut independently and converged on a knowability ceiling.

The reviews also isolated a defect the ceiling alone does not fix. Extraction is the one operation that returns a structured per-item report, and it reports the same facts twice. Verified against the tree:

- The duplication is **normative**, not drift — `safe-extraction/spec.md:608-609` requires one matching diagnostic per continued `BLOCKED`/`FAILED` result.
- A `REPLACE` collision is **genuinely silent** in `results`. Reproduced with a ZIP holding `A.txt` and `a.txt`:

  ```
  member='A.txt'  status=extracted  path='A.txt'  requested='A.txt'
  member='a.txt'  status=extracted  path='A.txt'  requested='A.txt'
  on disk → 'A.txt': 'second member content'
  ```

  The first member's content is gone and its result still reads plainly `EXTRACTED`.

Two facts therefore had no result-side home, and both proposed relocations hit **occupied slots**: `SUPERSEDED` already means *non-current duplicate* (decided from `is_current` at listing time), and `requested_path != path` is already the defined `RENAME` marker. Both relocations here use new signals instead.

## What changes

- **Two ceiling clauses**, not one. **Admission**: report only what the caller could not determine from the declared contract and can act on. **Placement**: when an operation returns a structured per-item report, that report is the sole carrier of per-item outcomes. Splitting them matters — all four extraction codes *pass* admission and were still misplaced.
- **Extraction leaves the diagnostics channel.** Four codes and three context variants removed; 22 codes → 18.
- **Facts relocate into `ExtractionResult`**: `ExtractionStatus.OVERWRITTEN` (revised retroactively onto the clobbered member, `path=None`), `presented_name` for portable rewrites, and the hardlink failure-group fields.
- **Escalation preserved** via `abort_on: Collection[AbortOn]` on `extract()` / `extract_all()`. `AbortOn.BLOCKED_MEMBER` is the fail-closed abort that `OnError`'s docstring calls "a separate future opt-in" — and that `RAISE` on `EXTRACTION_MEMBER_BLOCKED` implements today by accident.
- **`DiagnosticPolicy.strict()` / `.pedantic()` presets** plus `ARCHIVE_INTEGRITY_CODES`, and a written taxonomy-growth contract: new codes may appear in minor releases, so a bare `default=RAISE` is not version-stable.
- **Retire the O-23 sentence** so in-flight work stops citing it.

## Design notes worth reviewing

- **`presented_name` covers a case nothing else does.** A caller `filter` rename followed by a portable rewrite produces *three* spellings; the removed diagnostic recorded the middle one, so for filtered members it is otherwise unreconstructible.
- **`abort_on` is deliberately one parameter with a closed enum**, not a per-event disposition map — that would rebuild `DiagnosticPolicy` inside extraction, moving the duplication rather than removing it.
- **`EMPTY_ARCHIVE` is excluded from `strict()`** on purpose: an empty tar is legitimate and the spec explicitly forbids treating zero members as an error.
- **The collision is not *entirely* invisible today** — two `EXTRACTED` rows sharing a path is a detectable signature. What is missing is the *labelled* fact. `OVERWRITTEN` makes the join typed rather than inferred.

## Surfaced, not fixed

`DiagnosticCode.MEMBER_NAME_ENCODING_INFERRED` exists in the enum but has no row in the `diagnostics` spec's context table. Pre-existing spec/code drift; per `AGENTS.md` it is reported rather than silently resolved here, and needs its own change.

## Impact

**Breaking, tag-gated**: four `DiagnosticCode` members and three context dataclasses removed; `ExtractionStatus` gains a member. Pre-1.0, no aliases. Wants to land before `0.2.0`.

## Verification

Docs-only; no source touched. `openspec validate --strict extraction-results-authoritative` passes. Every quoted spec clause and line reference was read from the tree at `9b170c0`; the `REPLACE` collision repro was run, not reasoned about.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013beR5MRh6dx9rK5xpPa2Vs

---
_Generated by [Claude Code](https://claude.ai/code/session_013beR5MRh6dx9rK5xpPa2Vs)_