### PR TITLE
Topic 10: problem catalogue — early checkpoint (history sample)

### DIFF
--- a/review/problem-catalogue/checkpoint-sample.md
+++ b/review/problem-catalogue/checkpoint-sample.md
@@ -1,0 +1,332 @@
+# Early checkpoint — sample entries + voice check
+
+**Stop point:** first ~18 draft entries after mining `dev-docs/history/`
+(ARCHITECTURE, ASYNC, COMPARISON, SPEC; `index.md` is a router). Investigations,
+threat-model, ADRs, and proposal `## Why` blocks are still `unread` in
+`sources.md`.
+
+**Ask for the maintainer:** does field 1 pass the neutrality test? The three
+worked examples in `brief.md` §The neutrality rule are the bar. If the voice is
+wrong, steer before the rest of the tree is translated.
+
+Entries below are **drafts** — not yet centrally deduped against later sources,
+and field 4 is provisional (history often names the answer; later ADRs/changes
+will refine it). IDs are temporary (`P-hist-NN`); stable catalogue IDs come at
+merge time.
+
+---
+
+## P-hist-01 — Late-bound member metadata
+
+- **Category:** format quirk · API and usage pattern
+- **Problem:** Some archive formats leave a member's final size, checksum, or
+  link target unknown until that member's payload has been read — gzip streams
+  and ZIP data-descriptor entries omit size/CRC from the local header; several
+  formats store symlink/hardlink targets inside (sometimes encrypted) member
+  data rather than in the directory entry. A caller who only saw the directory
+  listing therefore holds incomplete metadata until after the read.
+- **Symptom:** After listing, `size`/`crc`/`link_target` are missing or
+  provisional; they appear only after the member bytes are consumed. A frozen
+  snapshot taken at list time never receives the late values.
+- **Evidence:** `dev-docs/history/SPEC.md` §3.2 / §4.4 (late-bound fields);
+  `dev-docs/history/ARCHITECTURE.md` §2.1; ZIP APPNOTE data descriptors;
+  gzip RFC 1952 trailer CRC/ISIZE.
+- **How answered today (strippable):** Mutable member objects filled in place
+  during the streaming pass; callers treat as read-only and use copy-on-edit for
+  transforms. → ADR 0007; `archive-data-model`.
+
+## P-hist-02 — Solid compression shared blocks
+
+- **Category:** format quirk · performance & memory
+- **Problem:** Solid archives pack many files into one compressed block so that
+  reading member *N* requires decompressing from the start of that block (and
+  often earlier members). A full sequential pass can still be one decompression;
+  random per-member opens pay the block cost again.
+- **Symptom:** Opening the *k*-th file in a solid 7z/RAR (or a `.tar.gz`) is
+  much slower than opening an equivalent ZIP local entry; naive “open each by
+  name” loops re-decompress the same block repeatedly and can exhaust memory if
+  the implementation caches whole blocks.
+- **Evidence:** `dev-docs/history/SPEC.md` §3.2 memory-profile table and §4.5–4.6
+  (`SOLID` access cost); `dev-docs/history/COMPARISON.md` §4.4; 7-Zip and RAR
+  format docs on solid archives.
+- **How answered today (strippable):** Bound memory on sequential iteration
+  (decode once, demux); random `open` re-decodes from block start with a
+  warning; cost receipt exposes solidity. → ADRs 0001/0002; access-mode-and-cost.
+
+## P-hist-03 — Format detection consumes non-rewindable bytes
+
+- **Category:** API and usage pattern
+- **Problem:** Detecting an archive format requires reading a prefix of magic
+  (and sometimes a decompression probe). On a pipe, socket, or other
+  non-rewindable source those bytes are gone unless the caller buffered them;
+  the same source must then be handed to the reader still containing that
+  prefix.
+- **Symptom:** After a standalone “what format is this?” call on a pipe, the
+  subsequent open misses the header and fails or mis-parses; or detection
+  silently leaves the stream mid-header.
+- **Evidence:** `dev-docs/history/SPEC.md` §8.1 / §8.3; `dev-docs/history/ARCHITECTURE.md` §2.5.
+- **How answered today (strippable):** Opener wraps non-seekable sources in a
+  peek/replay buffer shared by detection and the backend; standalone detection
+  on a raw non-seekable stream requires the caller to supply that buffer.
+  → format-detection spec; ADR 0010 adjacent.
+
+## P-hist-04 — Platform streams that lie about seekability
+
+- **Category:** platform & filesystem
+- **Problem:** Some stream wrappers and OS pipe handles report themselves as
+  seekable when they are not. A `BufferedReader` over a non-seekable raw stream
+  can claim seekability; on Windows, an OS pipe reader may report
+  `seekable()==True` and even return plausible offsets from `seek()`, while
+  later reads still come from the unmoved position and `SEEK_END` yields a
+  bogus size.
+- **Symptom:** Code that trusts `seekable()` and repositions for random access
+  or size detection silently reads the wrong bytes or believes a pipe has a
+  finite size; POSIX pipes fail honestly with `ESPIPE`.
+- **Evidence:** `dev-docs/history/ARCHITECTURE.md` §2.5;
+  `tests/test_stream_inputs.py::test_windows_pipe_seek_characterization` (cited
+  there); Windows vs POSIX `lseek` behaviour on FIFOs.
+- **How answered today (strippable):** Central seekability predicate unwraps
+  buffers, special-cases mmap, and overrides pipe/FIFO claims via `fstat` when
+  `seekable()` is True. → streamtools `is_seekable`.
+
+## P-hist-05 — ZIP central directory lives at EOF
+
+- **Category:** format quirk
+- **Problem:** A ZIP's authoritative member index is the central directory at
+  the end of the file. A forward-only byte source that cannot rewind therefore
+  cannot open a ZIP in random-access mode without first materializing the whole
+  archive somewhere seekable.
+- **Symptom:** Opening a ZIP from a pipe/socket with “random access” requested
+  fails immediately; callers who expected streaming ZIP listing get a seek
+  error instead of a progressive member walk.
+- **Evidence:** `dev-docs/history/SPEC.md` §10.1 (non-seekable ZIP);
+  APPNOTE.TXT EOCD / central directory layout.
+- **How answered today (strippable):** Fail fast with a typed non-seekable
+  error; do not silently spool. Streaming mode / explicit buffering is the
+  escape. → format-zip; ADR 0010.
+
+## P-hist-06 — Path traversal and chained symlink escapes on extract
+
+- **Category:** security / hostile input
+- **Problem:** Archive member names can contain `..`, absolute paths, or drive
+  letters; members can also plant symlinks that later members write through,
+  so that a write intended for the destination tree lands outside it (classic
+  zip-slip / TOCTOU symlink chains).
+- **Symptom:** Extraction creates or overwrites files outside the chosen
+  directory; or an intermediate symlink redirects a later write after a naive
+  string check already passed.
+- **Evidence:** `dev-docs/history/SPEC.md` §7.1; `dev-docs/history/ARCHITECTURE.md`
+  §4.1; widely documented zip-slip class of bugs.
+- **How answered today (strippable):** Universal name checks, resolved-path
+  containment, post-symlink re-resolve; filter policies on top.
+  → safe-extraction.
+
+## P-hist-07 — Decompression bombs (ratio and total volume)
+
+- **Category:** security / hostile input
+- **Problem:** Highly compressible hostile payloads expand by orders of
+  magnitude relative to their packed size, and multi-member archives can sum to
+  enormous extracted volume even when each member looks modest. Tiny legitimate
+  files can also show extreme ratios, so a naive ratio check false-positives.
+- **Symptom:** Extract fills the disk or OOMs; or a 10-byte → 15 KiB text file
+  is rejected as a “bomb” by a ratio-only guard.
+- **Evidence:** `dev-docs/history/SPEC.md` §7.3; `dev-docs/history/ARCHITECTURE.md`
+  §4.2 / §5.5; classic 42.zip / zip-bomb literature.
+- **How answered today (strippable):** Cumulative byte + entry caps; per-member
+  ratio only after an activation floor. Limits apply to extract paths, not raw
+  `read`/`open`. → safe-extraction BombTracker.
+
+## P-hist-08 — Hardlinks refer only to earlier members
+
+- **Category:** format quirk
+- **Problem:** In the TAR hardlink model (and archives that follow it), a
+  hardlink entry always names a file already seen earlier in archive order. An
+  extractor that has not yet written that source, or that filtered the source
+  out while keeping the link, cannot create a correct link without extra policy.
+- **Symptom:** Extraction fails on hardlinks when the target was skipped by a
+  filter; or streaming extract cannot find a source that “should” exist later.
+- **Evidence:** `dev-docs/history/SPEC.md` §3.2 link-following / hardlink note;
+  `dev-docs/history/ARCHITECTURE.md` §2.6; POSIX/`tar` hardlink semantics.
+- **How answered today (strippable):** Single forward pass with recorded source
+  paths; if source unselected, stage content at first selected link without
+  leaking the excluded name. → safe-extraction / archive-reading.
+
+## P-hist-09 — Duplicate member names are legal
+
+- **Category:** format quirk · API and usage pattern
+- **Problem:** TAR and 7z (among others) allow multiple members with the same
+  path string. Name-keyed lookup cannot identify which member the caller meant;
+  hardlink resolution (“most recent earlier member with that name”) depends on
+  stable identity beyond the path.
+- **Symptom:** `get("foo")` returns one of several foos unpredictably; filters
+  or conversion pipelines collapse duplicates; hardlinks resolve to the wrong
+  payload.
+- **Evidence:** `dev-docs/history/COMPARISON.md` §4.2 (member_id);
+  `dev-docs/history/SPEC.md` member identity discussion in §4.4 area;
+  tar/7z allowing duplicate names in the wild.
+- **How answered today (strippable):** Stable per-member ids; name lookup returns
+  lists / last-wins policies documented; hardlink resolution by id order.
+  → archive-data-model.
+
+## P-hist-10 — Listing cost varies by format layout
+
+- **Category:** format quirk · performance & memory · API and usage pattern
+- **Problem:** Some formats carry an index (ZIP central directory, 7z header,
+  RAR headers) so listing is cheap; others (plain TAR, compressed TAR) require
+  scanning or decompressing the whole stream to know the member set. Callers
+  cannot assume “list then open one file” is cheap without knowing the layout.
+- **Symptom:** `members()` on a multi-gigabyte `.tar.gz` decompresses
+  everything; the same call on a ZIP is near-instant. Tools that always list
+  first surprise operators on sequential formats.
+- **Evidence:** `dev-docs/history/SPEC.md` §4.6 CostReceipt axes;
+  `dev-docs/history/ARCHITECTURE.md` §2.12.
+- **How answered today (strippable):** Cost receipt (listing / access /
+  stream capability) at open; streaming mode disables materializing APIs.
+  → access-mode-and-cost; ADR 0004.
+
+## P-hist-11 — Optional format support without hard dependency
+
+- **Category:** packaging & dependency
+- **Problem:** Supporting ISO, exotic codecs, or RAR *data* requires third-party
+  libraries or an external binary. Importing the archive library must still
+  succeed when those pieces are absent; attempting an unsupported format must
+  fail with an install hint, not an ImportError deep in a backend.
+- **Symptom:** `import archivey` crashes without pycdlib; or opening an ISO
+  raises a raw ImportError instead of “install archivey[iso]”.
+- **Evidence:** `dev-docs/history/SPEC.md` §2 / §9.1;
+  `dev-docs/history/ARCHITECTURE.md` §2.13; `dev-docs/history/COMPARISON.md` §4.11.
+- **How answered today (strippable):** Zero-dep core; optional backends register
+  only when importable; typed unsupported/missing-package errors naming the
+  extra or tool. → ADR 0011; packaging-and-extras.
+
+## P-hist-12 — RAR metadata vs proprietary decompression
+
+- **Category:** packaging & dependency · format quirk
+- **Problem:** RAR member payloads use a proprietary compressor; listing and
+  header crypto can be done from documented structures, but expanding member
+  bytes still needs a licensed decompressor (commonly the system `unrar`
+  binary). Environments without that binary can list but not read data.
+- **Symptom:** Listing a `.rar` works; `open()` / extract fails naming a missing
+  tool. CI without `unrar` silently skips data tests.
+- **Evidence:** `dev-docs/history/SPEC.md` §10.5;
+  `dev-docs/history/ARCHITECTURE.md` §5.7; RARLAB unrar requirement.
+- **How answered today (strippable):** Native metadata parse; data via `unrar`;
+  listing without the binary. → ADR 0002; format-rar.
+
+## P-hist-13 — Sync pull-driven C decoders block true async
+
+- **Category:** concurrency & lifetime · API and usage pattern
+- **Problem:** Python’s archive and codec stacks (`zipfile`, `tarfile`, stdlib
+  `lzma`/`bz2`/`zlib`, subprocess pipes) pull input through blocking `read()`
+  callbacks inside C code. There is no hook to await the next compressed chunk
+  mid-decode, so an archive library cannot be “async all the way down” without
+  rewriting those decoders.
+- **Symptom:** Putting `async` on the public API still blocks the event loop
+  during decode unless work is offloaded to a worker thread; naive async wrappers
+  give the illusion of concurrency without I/O overlap at the decoder.
+- **Evidence:** `dev-docs/history/ASYNC.md` §3; `dev-docs/history/ARCHITECTURE.md`
+  §5.3.
+- **How answered today (strippable):** Sync-only v1; `asyncio.to_thread` for
+  whole operations; async facade deferred as a leaf. → ADR 0005.
+
+## P-hist-14 — In-place archive append is fragile or impossible
+
+- **Category:** format quirk · API and usage pattern
+- **Problem:** ZIP append (rewrite central directory at EOF) corrupts the
+  archive if interrupted; 7z has no append mode; TAR “append” produces a
+  concatenation that is not a clean multi-stream archive. Callers who want
+  “update one file inside” cannot rely on a safe in-place mutate across formats.
+- **Symptom:** Interrupted ZIP update leaves an unreadable archive; “append to
+  7z” is simply unavailable; tools that mutate in place work for one format and
+  fail for others.
+- **Evidence:** `dev-docs/history/ARCHITECTURE.md` §5.4;
+  `dev-docs/history/COMPARISON.md` §4.8 (writer as create + convert).
+- **How answered today (strippable):** Create-only writers; conversion via
+  read→write pipeline. → archive-writing (when shipped).
+
+## P-hist-15 — Compressed-tar vs plain compressor ambiguity
+
+- **Category:** format quirk
+- **Problem:** A `.gz`/`.bz2`/`.xz`/`.zst` byte stream may be a single compressed
+  file or a compressed TAR. Magic alone names the compressor; distinguishing
+  “tar inside” requires probing decompressed content. Brotli (and similar) may
+  lack a reliable magic, so detection needs a trial decompress.
+- **Symptom:** Opening `foo.gz` as a single file when it is `foo.tar.gz` (or the
+  reverse) yields the wrong member model; brotli detection fails or false-matches
+  without a probe.
+- **Evidence:** `dev-docs/history/COMPARISON.md` §4.9; `dev-docs/history/SPEC.md`
+  §8 detection algorithm; `dev-docs/history/ARCHITECTURE.md` detection notes.
+- **How answered today (strippable):** Composite format `(container, stream)`;
+  compressed-tar probe; FormatInfo confidence/method. → format-detection.
+
+## P-hist-16 — SFX and embedded archives
+
+- **Category:** format quirk
+- **Problem:** Self-extracting executables and other binaries can embed a RAR/7z
+  (or similar) payload after a stub. Detection must find the archive payload
+  inside a larger file, not only at offset 0.
+- **Symptom:** Opening an `.exe` SFX as “not an archive”; or tools that only
+  check leading magic miss the embedded container.
+- **Evidence:** `dev-docs/history/COMPARISON.md` §4.9 (SFX detection in DEV);
+  format specs for SFX/RAR/7z embedded signatures.
+- **How answered today (strippable):** Detection scans for embedded signatures
+  (as implemented in the detection pipeline). → format-detection.
+
+## P-hist-17 — Per-library exception taxonomies
+
+- **Category:** upstream library defect · API and usage pattern
+- **Problem:** Each underlying codec/archive library raises its own exception
+  types and message shapes (`BadZipFile`, `TarError`, `LZMAError`, subprocess
+  failures, crypto errors). Callers of a uniform archive API need one typed
+  error tree, while filesystem/`KeyboardInterrupt`/`MemoryError` must not be
+  swallowed into “archive corrupt”.
+- **Symptom:** Callers catch a dozen unrelated exceptions; or a disk-full
+  `OSError` is mis-reported as corruption; or a library error leaks untyped.
+- **Evidence:** `dev-docs/history/ARCHITECTURE.md` §2.11;
+  `dev-docs/history/SPEC.md` §6; CONTRIBUTING error-contract (referenced from
+  architecture).
+- **How answered today (strippable):** Per-library translators + central context
+  stamping; non-decode exceptions propagate raw. → error-handling; ADR 0012
+  (usage errors outside the tree).
+
+## P-hist-18 — Random access inside compressed streams
+
+- **Category:** performance & memory · format quirk
+- **Problem:** A multi-gigabyte `.tar.xz` / `.tar.lz` / indexed gzip may have
+  internal indexes (XZ block index, lzip trailer, gzip index) that allow seeking
+  to a late member without decompressing from byte zero — but only if the reader
+  understands those indexes and the source is seekable. Without that, “extract
+  the last member” costs a full decompress.
+- **Symptom:** Extracting one late file from a huge tar.xz takes as long as
+  reading the whole archive; tools that know the XZ index are orders of magnitude
+  faster on the same file.
+- **Evidence:** `dev-docs/history/COMPARISON.md` §1 / §4.12 (seekable decompressor
+  streams); library-analysis cross-ref there.
+- **How answered today (strippable):** Seekable decompressor stream layer with
+  optional accelerators; cost/seek signals. → compressed-streams; ADR 0008
+  (accelerator choice) later.
+
+---
+
+## Neutrality self-check (author)
+
+| Entry | Archivey type/module/config named in field 1? | Notes |
+|---|---|---|
+| 01–18 | No (field 1) | Field 4 deliberately names ADRs/types; experiment strips it |
+| Closest risks | “streaming pass”, “cost receipt” | Kept out of field 1; used only in field 4 |
+
+If the maintainer wants field 2 more “user-visible symptom” and less
+“implementer symptom”, say so — several symptoms still read engineer-facing.
+
+## What I have not done yet
+
+- Investigations, threat-model O1–O9, known-issues, library-analysis, open-issues,
+  IDEAS, discussions
+- 17 ADR context sections and 72 proposal `## Why` blocks
+- 11 review SUMMARY.md files
+- Central dedupe (these 18 will absorb many later restatements)
+- Full neutrality second pass
+- `catalogue.md` / `catalogue-neutral.md` / `experiment.md` / `SUMMARY.md`
+- Topic 8 harvest (outstanding by design)
+
+Awaiting steer (or a short wait) before continuing.

--- a/review/problem-catalogue/sources.md
+++ b/review/problem-catalogue/sources.md
@@ -1,0 +1,261 @@
+# Sources inventory — Topic 10 problem catalogue
+
+Baseline: brief commissioned against `main` @ `d4668c3`. Inventory written before
+mining so coverage is checkable. States: `unread` | `mined` | `no problem statement
+(reason)`.
+
+**Session progress:** sources inventory written. `dev-docs/history/` mined for
+early-checkpoint sample (`checkpoint-sample.md`, 18 draft entries). **Paused for
+maintainer neutrality steer** before investigations / threat-model / ADRs /
+proposals. Next unread group after steer: §2 investigations + §3 threat-model.
+
+---
+
+## 1. `dev-docs/history/` (read first — natively neutral)
+
+| Document | State |
+|---|---|
+| `ARCHITECTURE.md` | mined — trade-offs §2/§4/§5, seekability, solid, bombs, errors, deps |
+| `ASYNC.md` | mined — sync C decoder constraint (§3) |
+| `COMPARISON.md` | mined — solid streaming, seekable compressors, detection/SFX, member identity, packaging |
+| `SPEC.md` | mined — late-bound fields, solid costs, detection, ZIP EOF, filters, bombs, per-format |
+| `index.md` | no problem statement — router / triage list only |
+
+Brief count: 5 files. Denominator matches.
+
+---
+
+## 2. `dev-docs/investigations/` (then — already problem-shaped)
+
+| Document | State |
+|---|---|
+| `adr-0014-investigation.md` | unread |
+| `parallel-reader.md` | unread |
+| `ppmd-exit-after-green-exploration.md` | unread |
+| `ppmd-native-investigation-brief.md` | unread |
+| `ppmd-native-investigation-results.md` | unread |
+| `pyppmd-upstream-report.md` | unread |
+| `rapidgzip-upstream-report.md` | unread |
+| `rar-corpus-sweep-diagnosis.md` | unread |
+
+Brief count: 8. Denominator matches.
+
+---
+
+## 3. `dev-docs/threat-model.md` (9 `O` entries)
+
+| Document / entry | State |
+|---|---|
+| `threat-model.md` (whole file) | unread |
+| O1 Listing-time resource exhaustion | unread |
+| O2 Case-insensitivity / Unicode-normalization collisions | unread |
+| O3 Windows name mangling | unread |
+| O4 NTFS alternate data streams | unread |
+| O5 Fuzzing | unread |
+| O6 Nested-archive amplification | unread |
+| O7 Names as bytes vs target filesystem | unread |
+| O8 7z wrong header-decryption password → empty archive | unread |
+| O9 Attacker-controlled bytes to terminal | unread |
+
+Brief count: 9 `O` entries. Denominator matches.
+
+---
+
+## 4. Standing registers
+
+| Document | State |
+|---|---|
+| `dev-docs/known-issues.md` (6 sections / 709 lines) | unread |
+| `dev-docs/library-analysis.md` (362 lines) | unread |
+| `dev-docs/open-issues.md` (310 lines) | unread |
+| `dev-docs/IDEAS.md` | unread |
+| `dev-docs/discussions/2026-08-diagnostics/diagnostics-archive-vs-usage.md` | unread |
+| `dev-docs/discussions/2026-08-diagnostics/reviewer-1-opinion.md` | unread |
+| `dev-docs/discussions/2026-08-diagnostics/reviewer-2-opinion.md` | unread |
+| `dev-docs/discussions/2026-08-diagnostics/reviewer-3-opinion.md` | unread |
+
+---
+
+## 5. ADRs — `dev-docs/decisions/` (17; `index.md` is router)
+
+| Document | State |
+|---|---|
+| `index.md` | unread — router, not a source (per brief) |
+| `0001-native-7z-not-py7zr.md` | unread |
+| `0002-native-rar-metadata-unrar-data.md` | unread |
+| `0003-member-streams-opt-in.md` | unread |
+| `0004-streaming-bool-not-intent-enum.md` | unread |
+| `0005-sync-only-v1.md` | unread |
+| `0006-stdlib-zipfile.md` | unread |
+| `0007-mutable-archive-member.md` | unread |
+| `0008-single-accelerator-rapidgzip.md` | unread |
+| `0009-zstd-stdlib-backports.md` | unread |
+| `0010-no-silent-buffer-nonseekable.md` | unread |
+| `0011-zero-dependency-core.md` | unread |
+| `0012-usage-errors-outside-archiveyerror.md` | unread |
+| `0013-cross-platform-name-safety-policies.md` | unread |
+| `0014-integrity-verdicts-from-reads-not-close.md` | unread |
+| `0015-zero-filled-files-are-valid-empty-tars.md` | unread |
+| `0016-committed-rar-corpus-fixtures.md` | unread |
+| `0017-bidi-override-rejection-is-policy-keyed.md` | unread |
+
+Brief count: 17 ADRs (+ index). Denominator matches.
+
+---
+
+## 6. Archived review `SUMMARY.md` (11)
+
+| Document | State |
+|---|---|
+| `review/archive/2026-07-12-codebase-deep-review/SUMMARY.md` | unread |
+| `review/archive/2026-07-16-crypto/SUMMARY.md` | unread |
+| `review/archive/2026-07-16-rar-reader/SUMMARY.md` | unread |
+| `review/archive/2026-07-16-stream-decoder/SUMMARY.md` | unread |
+| `review/archive/2026-07-17-cli/SUMMARY.md` | unread |
+| `review/archive/2026-07-19-api-coherence/SUMMARY.md` | unread |
+| `review/archive/2026-07-19-stream-layering/SUMMARY.md` | unread |
+| `review/archive/2026-07-20-cli-product/SUMMARY.md` | unread |
+| `review/archive/2026-07-28-debt-ledger/SUMMARY.md` | unread |
+| `review/archive/2026-07-28-performance/SUMMARY.md` | unread |
+| `review/archive/2026-08-15-simplicity-consistency/SUMMARY.md` | unread |
+
+Theme files under each archive are consulted when a SUMMARY finding needs evidence
+or a clearer problem statement; they are not separate denominator rows.
+
+Brief count: 11. Denominator matches.
+
+---
+
+## 7. Archived OpenSpec proposals with `## Why` (72)
+
+Each row is the proposal. `design.md` noted when present (brief: 57 of 72).
+
+| Change | design.md | State |
+|---|---|---|
+| `2026-06-19-phase-1-scaffold-and-spine` | no | unread |
+| `2026-06-21-phase-2-stream-layer` | no | unread |
+| `2026-06-27-stream-wrapper-base` | no | unread |
+| `2026-06-30-compression-library-evaluation` | no | unread |
+| `2026-06-30-package-layout-restructure` | no | unread |
+| `2026-06-30-phase-3-indexed-leaf-formats` | no | unread |
+| `2026-07-01-codec-descriptor-refactor` | no | unread |
+| `2026-07-01-zstd-stdlib-backend-migration` | no | unread |
+| `2026-07-03-minimal-name-normalization` | yes | unread |
+| `2026-07-03-phase-4-safe-extraction` | no | unread |
+| `2026-07-04-inner-tar-probe-block-codecs` | no | unread |
+| `2026-07-04-live-decompression-ratio-guard` | yes | unread |
+| `2026-07-07-phase-5-public-api` | yes | unread |
+| `2026-07-07-retire-dev-oracle` | yes | unread |
+| `2026-07-07-scan-members` | yes | unread |
+| `2026-07-10-parallel-reader-exploration` | yes | unread |
+| `2026-07-11-concurrent-member-streams` | yes | unread |
+| `2026-07-11-diagnostics-warnings-as-data` | yes | unread |
+| `2026-07-11-tar-concurrent-open` | yes | unread |
+| `2026-07-11-zip-multipassword-disambiguation` | yes | unread |
+| `2026-07-12-anti-member-type-and-nonfile-open` | yes | unread |
+| `2026-07-12-atheris-fuzz-harness` | yes | unread |
+| `2026-07-12-hypothesis-property-tests` | yes | unread |
+| `2026-07-12-listing-resource-limits` | yes | unread |
+| `2026-07-12-native-7z-reader` | yes | unread |
+| `2026-07-12-native-rar-reader` | yes | unread |
+| `2026-07-12-phase-4-tar-streaming` | no | unread |
+| `2026-07-12-promote-concurrent-member-streams` | yes | unread |
+| `2026-07-12-shared-source-streams` | yes | unread |
+| `2026-07-14-adversarial-string-corpus-contract` | yes | unread |
+| `2026-07-14-decompressor-stream-composition` | yes | unread |
+| `2026-07-14-rar-blake2sp-verification` | yes | unread |
+| `2026-07-14-refactor-sevenzip-reader` | yes | unread |
+| `2026-07-14-stored-digest-dedupe-parity` | yes | unread |
+| `2026-07-14-vendor-unix-compress-lzw` | yes | unread |
+| `2026-07-14-zip-name-encoding-sniffing` | yes | unread |
+| `2026-07-15-atheris-harness-depth` | yes | unread |
+| `2026-07-15-benchmark-gate` | yes | unread |
+| `2026-07-15-extraction-progress-in-file` | yes | unread |
+| `2026-07-15-rapidgzip-deflate-zlib-acceleration` | yes | unread |
+| `2026-07-15-rar-file-version-members` | yes | unread |
+| `2026-07-15-zip-aes-decryption` | yes | unread |
+| `2026-07-15-zip-native-codec-streams` | yes | unread |
+| `2026-07-16-cross-platform-name-safety` | yes | unread |
+| `2026-07-17-cli-v1` | yes | unread |
+| `2026-07-18-partial-members-and-errors` | yes | unread |
+| `2026-07-18-sevenzip-header-cursor-parse` | yes | unread |
+| `2026-07-19-clarify-extraction-status-names` | yes | unread |
+| `2026-07-19-decide-strict-archive-eof-default` | yes | unread |
+| `2026-07-19-surface-stored-stream-digests` | yes | unread |
+| `2026-07-20-stop-on-failure-not-policy` | yes | unread |
+| `2026-07-24-gzip-zlib-truncation-recovery` | yes | unread |
+| `2026-07-24-rapidgzip-truncation-investigation` | yes | unread |
+| `2026-07-24-unify-pass-driver` | yes | unread |
+| `2026-07-25-gzip-truncation-backstop-any-seekable` | yes | unread |
+| `2026-07-30-consolidate-optional-extras` | yes | unread |
+| `2026-07-30-member-stream-capability-booleans` | yes | unread |
+| `2026-07-31-rename-extras-in-remaining-specs` | yes | unread |
+| `2026-08-01-short-read-source-contract` | yes | unread |
+| `2026-08-03-docs-ia-unpublish-maintainer-tree` | yes | unread |
+| `2026-08-04-docs-ia-split-user-guide` | yes | unread |
+| `2026-08-06-close-member-streams-on-reader-close` | no | unread |
+| `2026-08-06-reject-format-override-on-directory` | no | unread |
+| `2026-08-06-spec-drop-unimplemented-solid-warning` | no | unread |
+| `2026-08-09-decouple-member-metadata-from-declared-seekability` | yes | unread |
+| `2026-08-09-format-availability-required-source` | yes | unread |
+| `2026-08-09-reject-bidi-overrides-in-safe-extraction` | yes | unread |
+| `2026-08-09-review-diagnostics-batch` | yes | unread |
+| `2026-08-09-rewind-diagnostic-redecode-cost` | yes | unread |
+| `2026-08-09-strict-archive-eof-trailing-bytes` | yes | unread |
+| `2026-08-15-escape-cli-log-records` | no | unread |
+| `2026-08-15-extraction-results-authoritative` | yes | unread |
+
+Brief count: 72 with `## Why`; 57 with `design.md`. Denominators match
+(72 Why rows; 57 design.md files under archive).
+
+### Archived changes without `## Why` (not in brief denominator)
+
+Mined only if a problem statement appears elsewhere in the change; otherwise marked
+explicitly so they are not silent gaps.
+
+| Change | State |
+|---|---|
+| `2026-07-12-reader-concurrency-coordination` | unread — no `## Why` |
+| `2026-07-12-support-lzma1-bcj` | unread — no `## Why` |
+| `2026-07-13-nameless-7z-member-names` | unread — no `## Why` |
+| `2026-07-13-sevenzip-lz4-codec` | unread — no `## Why` |
+| `2026-07-13-support-lzma-alone` | unread — no `## Why` |
+
+---
+
+## 8. Topic 8 harvest (`harvest/`)
+
+| Document | State |
+|---|---|
+| `harvest/README.md` | read — explains drops; not a problem source |
+| Per-capability drops | **outstanding** — Topic 8 capability workers have not run; directory empty aside from README. Recorded per Definition of done #5. Capabilities TBD by Topic 8 pass 0. |
+
+---
+
+## Coverage checklist (brief §Sources)
+
+| Source | Brief count | Inventory rows | Match |
+|---|---:|---:|---|
+| proposals with `## Why` | 72 | 72 | yes |
+| …of those with `design.md` | 57 | 57 | yes |
+| ADRs (excl. index) | 17 | 17 | yes |
+| review `SUMMARY.md` | 11 | 11 | yes |
+| investigations | 8 | 8 | yes |
+| threat-model `O` entries | 9 | 9 | yes |
+| known-issues | 1 file / 6 sections | listed | yes |
+| library-analysis | 1 file | listed | yes |
+| open-issues | 1 file | listed | yes |
+| history/ | 5 files | 5 | yes |
+| discussions + IDEAS | — | listed | yes |
+| Topic 8 harvest | ~136 comment sites | outstanding | noted |
+
+---
+
+## Extraction notes (for resume)
+
+- Read order (load-bearing): history → investigations + threat-model → ADRs +
+  proposal Why blocks → registers + review SUMMARYs → merge/dedupe → neutrality
+  pass → emit `catalogue-neutral.md` + `experiment.md`.
+- Early checkpoint: after first ~15–20 entries, pause for maintainer steer
+  (`checkpoint-sample.md`).
+- No code/spec changes. Unevidenced items → separate unverified list.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Start of Topic 10 (the problem catalogue): inventory every brief §Sources document in `sources.md`, mine `dev-docs/history/` first, and **pause for a neutrality steer** before translating ADRs / proposal Why blocks.

## Delivered so far

- `review/problem-catalogue/sources.md` — full denominator (72 Why proposals, 57 designs, 17 ADRs, 11 review SUMMARYs, 8 investigations, 9 threat-model O entries, registers, discussions). History marked mined; everything else still unread. Topic 8 harvest recorded outstanding.
- `review/problem-catalogue/checkpoint-sample.md` — **18 draft entries** (fields 1–4) drawn from ARCHITECTURE / ASYNC / COMPARISON / SPEC, written to the brief’s neutrality bar.

## Maintainer ask (blocking)

Please skim field 1 on a few entries in `checkpoint-sample.md` against `brief.md` §The neutrality rule (the three worked examples). Confirm voice / symptom register, or steer before the remaining ~160 documents are translated.

## Not yet

Investigations, threat-model, ADRs, 72 Why blocks, review SUMMARYs, central dedupe, `catalogue.md` / `catalogue-neutral.md` / `experiment.md` / `SUMMARY.md`.

## Constraints honored

No code/spec changes. No Topic 8 harvest wait. `./scripts/check.sh --fix` green.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c010116a-95ed-4600-b4ea-dd86969d9f7e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c010116a-95ed-4600-b4ea-dd86969d9f7e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

