### PR TITLE
review(docs-content): the step-4 checkpoint gates the fan-out, not a fan-in

### DIFF
--- a/review/docs-content/brief.md
+++ b/review/docs-content/brief.md
@@ -389,8 +389,10 @@ that is itself a finding — either the claim is wrong or the page is documentin
   reachable only by someone already reading the subsystem. That is these workers, once.
   **Cap it:** a bounded list per capability, no investigation, no chasing. A worker that
   starts researching a problem has stopped doing pass 1.
-- **The step-4 checkpoint is the fan-in.** A wrong split is cheap to correct there and
-  expensive to correct after the prose is written.
+- **The step-4 checkpoint gates the fan-out.** The coordinator builds `claims.md` alone
+  first — deduping needs every page in one view — and the workers fan out only after the
+  maintainer has seen it. A wrong split is cheap to correct there and expensive to correct
+  after the prose is written.
 - **The cross-page consistency pass is mandatory, whatever the topology.** #223's round-2
   re-review found four contradictions the splits change had created *in a single pass by a
   single agent* — `access-and-cost.md` said accelerator faults abort the process while the


### PR DESCRIPTION
One-line correction to `review/docs-content/brief.md` §How to run this, found while writing the step-3 handoff prompt.

## The defect

A safety rule read *"The step-4 checkpoint is the fan-in."* The topology in the same section puts the checkpoint **between** the coordinator's claim inventory and the worker fan-out — so it is the gate *before* the split, not a rendezvous after it. The sentence's own second half already said so (*"a wrong split is cheap to correct there"*), which is what makes this a mislabel rather than a disagreement about the plan.

## Why it mattered enough to fix now

An agent starting step 3 could reasonably have read "fan-in" as *fan out first, then converge* — producing per-page verdicts that cannot be deduplicated. That is exactly the O-2 failure the split-by-capability rule exists to prevent: four copies of one fact, each checked against its neighbour, two of them drifted.

## The fix

Reworded, with the ordering it implies now explicit: the coordinator builds `claims.md` alone because deduping needs every page in one view, and workers fan out only once the maintainer has seen the table.

## Verification

Docs-only, one paragraph in one file. `./scripts/check.sh --fix` passes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01B247iZ1FSwKjpHsSXCytgR)_