### PR TITLE
open-issues: correct P10 — the signature is enforced, the fabrication is the defect

### DIFF
--- a/dev-docs/open-issues.md
+++ b/dev-docs/open-issues.md
@@ -289,13 +289,29 @@ nor `DIRECTORY`. Original write-up below.
   `open_stream(format=…)`, which publicly accepts `StreamFormat | ArchiveFormat`
   (`src/archivey/core.py:374`): a caller holding a `StreamFormat` for that call may pass the
   same value here, and an untyped project gets no warning.
-- **Open question:** raise `ArchiveyUsageError` for an argument that is not an
-  `ArchiveFormat`; or accept `StreamFormat` and resolve it to its `RAW_STREAM` pair, on the
-  symmetry argument that `open_stream` already takes both; or leave it to the type checkers
-  and close this as won't-fix. The first is cheapest and matches ADR 0012. The second is a
-  public-surface widening and should not be taken casually pre-`0.2.0`. The third is
-  defensible precisely because the checkers do catch it — and is the option the original
-  filing hid by overstating the problem.
+- **DECIDED 2026-08-17 (maintainer): restrict to `ArchiveFormat` and raise a usage error
+  on any other type.** Not a public-surface widening — `open_stream` keeps accepting
+  `StreamFormat | ArchiveFormat` because a raw stream genuinely has no container, and that
+  asymmetry is the point rather than an inconsistency. Rejected: accepting `StreamFormat`
+  here and resolving it to the `RAW_STREAM` pair (widens the surface pre-`0.2.0` for a
+  caller error), and closing won't-fix (the field-type violation is real even though the
+  checkers catch the call).
+
+- **The sweep widens the fix to three entry points, failing two different ways.** Four
+  public functions take a format argument; `open_stream` is correct by design. The other
+  three all mishandle a wrong-typed one:
+
+  | Call | Today | Should be |
+  |---|---|---|
+  | `format_availability(StreamFormat.ZSTD)` | returns `NONE / missing=() / SEEKABLE` — a fabricated record whose `format` field violates its own declared type | `ArchiveyUsageError` |
+  | `open_archive(path, format=StreamFormat.ZSTD)` | `AttributeError: 'StreamFormat' object has no attribute 'container'` | `ArchiveyUsageError` |
+  | `extract(path, dest, format=StreamFormat.ZSTD)` | same `AttributeError` | `ArchiveyUsageError` |
+
+  The second shape is arguably worse than the one this entry was filed for: a raw
+  `AttributeError` naming a private attribute crosses the public boundary, which is the
+  error contract's "no internal leakage" rule (`CONTRIBUTING.md`) as well as ADR 0012's.
+  One validation helper at the boundary covers all three — this is a fix-the-cause case,
+  not three fixes.
 - **Severity, honestly:** low as a defect, moderate as an *honesty* question — a public
   query that invents an answer is the shape `VISION.md` rules out, even when the caller was
   wrong to ask that way.

--- a/dev-docs/open-issues.md
+++ b/dev-docs/open-issues.md
@@ -247,6 +247,106 @@ nor `DIRECTORY`. Original write-up below.
   [`review/docs-content/claims.md`](../review/docs-content/claims.md) **E-71**, a gap row —
   no page states the behaviour at all.
 
+### P10. `format_availability()` fabricates a verdict for a wrong-typed argument
+
+> **Corrected 2026-08-17**, same day it was filed. The original entry was titled *"answers
+> for a public type it does not know"* and implied the signature permits a `StreamFormat`.
+> It does not, and both project type checkers reject it. What survives is narrower and
+> still real: the failure mode on a wrong-typed call is a **fabricated record**, not an
+> exception. The overstated half is struck rather than deleted, because a register that
+> quietly rewrites itself teaches the next reader nothing.
+
+- **The two types are not siblings.** `ArchiveFormat` is a `(container, stream)` **pair**
+  (`src/archivey/types.py:76-88`) — `ArchiveFormat.ZST` *is*
+  `ArchiveFormat(ContainerFormat.RAW_STREAM, StreamFormat.ZSTD)`. `StreamFormat` is the
+  codec half of that pair. They live at different levels, so "both carry the value `'zst'`"
+  describes a containment relation, not a duplicate.
+- **The signature is correct and enforced.** `format_availability(fmt: ArchiveFormat)`
+  (`src/archivey/internal/registry.py:314`). Passing the component is a type error and
+  **both checkers catch it**:
+
+  ```
+  pyrefly check  -> 1 error   (argument type)
+  ty check       -> 1 diagnostic ("Parameter declared here")
+  ```
+
+  So a caller under either checker — which is every caller in this repo — is protected.
+- **What is still wrong.** Given the wrong type anyway, the call **fabricates a plausible
+  record instead of raising**:
+
+  ```
+  format_availability(ArchiveFormat.ZST)  -> FULL, missing=(), FORWARD_ONLY
+  format_availability(StreamFormat.ZSTD)  -> NONE, missing=(), SEEKABLE
+  ```
+
+  `support=NONE` with an empty `missing` is indistinguishable from a legitimate
+  "unsupported, and here is nothing to install about it", and `required_source` contradicts
+  the real record on the field `opening-and-listing.md:70-85` teaches callers to branch on.
+  `ArchiveyUsageError` exists for exactly this class (ADR 0012: caller mistakes sit outside
+  the `ArchiveyError` tree), and it is not raised.
+- **How a caller reaches it.** Not through the documented recipe — `detect_format()` returns
+  a `FormatInfo` whose `.format` is an `ArchiveFormat`. The realistic path is
+  `open_stream(format=…)`, which publicly accepts `StreamFormat | ArchiveFormat`
+  (`src/archivey/core.py:374`): a caller holding a `StreamFormat` for that call may pass the
+  same value here, and an untyped project gets no warning.
+- **Open question:** raise `ArchiveyUsageError` for an argument that is not an
+  `ArchiveFormat`; or accept `StreamFormat` and resolve it to its `RAW_STREAM` pair, on the
+  symmetry argument that `open_stream` already takes both; or leave it to the type checkers
+  and close this as won't-fix. The first is cheapest and matches ADR 0012. The second is a
+  public-surface widening and should not be taken casually pre-`0.2.0`. The third is
+  defensible precisely because the checkers do catch it — and is the option the original
+  filing hid by overstating the problem.
+- **Severity, honestly:** low as a defect, moderate as an *honesty* question — a public
+  query that invents an answer is the shape `VISION.md` rules out, even when the caller was
+  wrong to ask that way.
+- **Provenance:** found 2026-08-17 reconciling the baselines of two Topic 8 step-2/3 passes
+  (#246, #247). Recorded in
+  [`review/docs-content/claims.md`](../review/docs-content/claims.md) Part 1. Not a docs
+  defect: no published page passes a `StreamFormat` to this call.
+
+### P11. A RAR stream source silently costs a whole-archive disk copy, in no signal
+
+- **Today:** `unrar` needs a filesystem path, so `RarReader._ensure_archive_path()`
+  (`src/archivey/internal/backends/rar_reader.py:532-555`) writes the **entire archive**
+  to `tempfile.mkstemp(suffix=".rar")` the first time a member cannot be read directly.
+  Multi-volume stream sources go through `_materialize_stream_volumes()` (`:438-459`) into
+  a temp dir. Both are removed on reader close. Measured on a `rar -m5` archive read from a
+  `BytesIO`: the read succeeds, one temp `.rar` of full archive size appears, and
+
+  ```
+  reader.diagnostics      -> []
+  reader.cost             -> CostReceipt(..., notes=())      # byte-identical to a path source
+  ```
+
+- **Why it matters.** `VISION.md`'s load-bearing claim is one uniform interface with
+  **honest cost signals** — "behaviour differences are **data** (`None`, explicit fields,
+  diagnostics, `CostReceipt`), never silent guesses". A whole-archive copy to disk is the
+  largest hidden cost in the library, and it is in neither channel. A caller handing over a
+  4 GiB `BytesIO` gets a 4 GiB temp file with no way to have known.
+- **The trigger is per-member, which makes it worse.** A stored member from a stream costs
+  nothing (`_can_direct_read`); the next member in the same archive, compressed, costs a
+  full copy. Same call, same source, two very different costs, no signal distinguishing
+  them. Any member of a solid archive triggers it via `_iter_with_data` (`:673-679`).
+- **Not an ADR 0010 violation.** That decision forbids buffering a *non-seekable* source to
+  fake seekability; this is a *seekable* stream copied to satisfy an external binary — a
+  different trade-off that was never written down. Worth noting `docs/access-and-cost.md:142`
+  ("Archivey will not silently buffer the whole archive into memory or a temp file") is
+  scoped to the pipe case in context but reads as absolute.
+- **Open question:** a `CostReceipt.notes` entry, a diagnostic, or both. A note is the better
+  fit — the taxonomy's admission clause asks whether the caller could have determined it from
+  the declared contract, and *nothing* declares it today, but the placement clause prefers a
+  structured field where one exists and `notes` is exactly that field. A size threshold is a
+  third option and probably wrong: the cost is unbounded either way and a caller choosing a
+  stream source deserves to know before the first read, not after 1 MiB.
+- **Provenance:** found 2026-08-17 answering a maintainer question during Topic 8's step-4
+  checkpoint ("do we support extraction for rar files opened via a stream, since we rely on
+  the external unrar binary and presumably can't pass a stream to it?"). Neither step-2/3
+  pass had it: #246's E-43 captured temp materialization for *solid random opens* only, from
+  `formats.md:123-124`, and no page states the general case.
+- **The documentation half is separate** and belongs to Topic 8:
+  [`review/docs-content/claims.md`](../review/docs-content/claims.md) **E-71**, a gap row —
+  no page states the behaviour at all.
+
 ### P10. `format_availability()` answers for a public type it does not know
 
 - **Today:** `StreamFormat` and `ArchiveFormat` are both in `archivey.__all__`, and

--- a/review/docs-content/claims.md
+++ b/review/docs-content/claims.md
@@ -143,7 +143,11 @@ Two observations that become claim rows rather than findings here:
   wrong negative with nothing in `missing` to explain it, disagreeing with the real record
   on `required_source`, the field `opening-and-listing.md:70-85` teaches callers to branch
   on. This is a **library** question, not a docs claim: filed as
-  `dev-docs/open-issues.md` **P10**, not fixed here.
+  `dev-docs/open-issues.md` **P10** — whose framing was **corrected 2026-08-17**: the
+  signature takes an `ArchiveFormat` only and both `pyrefly` and `ty` reject a
+  `StreamFormat`, so a typed caller is protected. What remains is that the wrong-typed
+  call *fabricates* a record instead of raising `ArchiveyUsageError`. Read P10, not this
+  paragraph's original wording. Not fixed here.
 - **`format_availability()` is a per-format query, not a matrix dump.** `install.md`'s
   inbound §B row 2 ("the `format_availability()` support-level query", ~10 lines) has to
   be written against that signature; a reader cannot call it once and get a table. Noted


### PR DESCRIPTION
Corrects `dev-docs/open-issues.md` **P10**, filed and overstated on the same day in #248. Two of its claims do not survive checking, and both made the problem look bigger than it is.

## What was wrong

**`ArchiveFormat` and `StreamFormat` are not siblings.** `ArchiveFormat` is a `(container, stream)` **pair** (`src/archivey/types.py:76-88`) — `ArchiveFormat.ZST` *is* `ArchiveFormat(ContainerFormat.RAW_STREAM, StreamFormat.ZSTD)`, and `StreamFormat` is its codec half. "Both carry the value `'zst'`" describes a containment relation, not a duplicate, so the original framing invited the wrong mental model.

**The signature is correct and enforced.** `format_availability(fmt: ArchiveFormat)` takes the pair only, and **both project type checkers reject** passing the component:

```
pyrefly check  -> 1 error       (argument type)
ty check       -> 1 diagnostic  ("Parameter declared here")
```

Every caller in this repo is therefore protected. The original entry never established this, and it changes the severity materially.

## What survives

Given the wrong type anyway, the call **fabricates a plausible record instead of raising**:

```
format_availability(ArchiveFormat.ZST)  -> FULL, missing=(), FORWARD_ONLY
format_availability(StreamFormat.ZSTD)  -> NONE, missing=(), SEEKABLE
```

`NONE` with an empty `missing` is indistinguishable from a legitimate "unsupported, nothing to install". `ArchiveyUsageError` exists for exactly this class (ADR 0012), and is not raised.

**Severity, honestly:** low as a defect, moderate as an *honesty* question — a public query that invents an answer is the shape `VISION.md` rules out, even when the caller was wrong to ask that way.

## Why a struck-through note rather than a rewrite

The correction sits as a blockquote above the entry instead of silently replacing it. A register that quietly edits itself teaches the next reader nothing — and the overstated filing had hidden a legitimate third resolution: **close as won't-fix**, defensible precisely because the checkers do catch it.

`claims.md`'s Part 1 pointer now says to read P10 rather than its own original wording.

## Verification

`./scripts/check.sh --fix` passes. The type-checker results above were produced in-project (an earlier run outside the project config reported 0 errors and was discarded as untrustworthy).

---
_Generated by [Claude Code](https://claude.ai/code/session_01B247iZ1FSwKjpHsSXCytgR)_