### PR TITLE
SFX: detect archives behind an executable stub, and let 7z open at a nonzero offset

### DIFF
--- a/dev-docs/investigations/brotli-content-probe-brief.md
+++ b/dev-docs/investigations/brotli-content-probe-brief.md
@@ -1,0 +1,140 @@
+# Investigation brief — why the Brotli content probe accepts arbitrary data
+
+**Status:** open. Written 2026-08-19 while implementing `sfx-format-detection`; the
+maintainer asked for a dedicated deep dive rather than folding a guess into that change.
+Results belong next to this file as `brotli-content-probe-results.md`.
+
+**Who this is for:** an agent or contributor with a few hours, willing to read the Brotli
+specification (RFC 7932) and the `brotli` / `brotlicffi` C sources, not just measure the
+Python API from outside. The measurements below already exist — the point of the brief is
+to explain *why* they come out this way and what, if anything, can be done about it.
+
+---
+
+## What we know
+
+`archivey` detects Brotli by content probe, because the format has no magic number at
+all (`BrotliCodec.content_probe` → `StreamCodec._decodes_sample`, `codecs.py`). The probe
+feeds the first `_PROBE_PREFIX = 256` bytes through the decoder and accepts the stream if
+the decode either produces output or raises `TruncatedError` (ran out of the bounded
+prefix). That probe is the last thing consulted before the ISO window and the extension
+guess, so whatever it accepts becomes the answer.
+
+Measured on this repo at commit `d43375f` (scripts under
+`/tmp/.../scratchpad`, reproducible in a few lines — see *Reproducing* below):
+
+| Input | Probe says |
+| --- | --- |
+| Uniformly random 4 KiB blobs | **8.27%** accepted as Brotli (`detect_format` end-to-end: 146/2000 = 7.3%) |
+| `b"MZ" + b"\x90" * 4094` | accepted — decodes **252 bytes** cleanly, not a truncation |
+| `b"MZ" + b"\x00" * 4094` | rejected |
+| `b"MZ" + b"A" * 4094` | rejected |
+| 887 real ELF binaries (`/usr/bin`, `/usr/lib`) | **0** accepted |
+| A structurally valid PE stub (DOS header, `e_lfanew` → `PE\0\0`) | rejected, with every filler tried |
+| Real `rar a -sfx` ELF stub (249 KB) | rejected |
+
+And the mitigations that do **not** work, measured against 15 real Brotli streams
+(qualities 1/5/11 over text, random bytes, an ELF binary, an empty payload, one byte):
+
+| Probe variant | Random-data FP | Real-Brotli misses |
+| --- | --- | --- |
+| 256-byte prefix, any outcome (today) | 8.27% | 0/15 |
+| 256-byte prefix, require ≥1 byte out | 8.27% | 3/15 |
+| 256-byte prefix, require ≥512 bytes out | 1.60% | 10/15 |
+| 1024-byte prefix, any outcome | 8.27% | 0/15 |
+| 4096-byte prefix, any outcome | 8.20% | 0/15 |
+| 4096-byte prefix, require ≥512 bytes out | 8.13% | 6/15 |
+
+So: **a bigger prefix buys nothing, and requiring output trades the false positives for
+false negatives at roughly one-for-one.** Probe tuning is a dead end. That conclusion is
+what `sfx-format-detection` acted on — it fixed the SFX case by scanning for archive
+magic *before* the probes rather than by making the probe stricter — and it is why the
+residual needs its own investigation instead of a guess.
+
+## Why it matters
+
+`open_archive` on a file the probe wrongly claims does not fail. It returns a
+`SingleFileReader` with one fabricated member named `<filename>.uncompressed`. That is a
+silent wrong answer on attacker-supplied bytes, which `VISION.md` ranks above almost
+everything else, and it is registered as `open-issues.md` P12 and `threat-model.md` O10.
+
+## Questions to answer
+
+1. **Why does `b"MZ" + b"\x90"*4094` decode?** Walk the first bytes as RFC 7932 sees
+   them: `WBITS`, `ISLAST`, `MNIBBLES`, then the meta-block header. Which fields do
+   `0x4D 0x5A 0x90 0x90 …` land on, and what makes the decoder emit 252 bytes rather
+   than erroring? Contrast with `b"MZ" + b"\x00"*4094`, which is rejected — that pair
+   isolates the mechanism better than any amount of statistics.
+2. **What is the real acceptance rate, analytically?** ~8% of uniformly random data
+   is a large number. Derive (or bound) it from the header layout: how many bits of the
+   prefix are actually constrained, and how much of the apparent looseness is the
+   decoder tolerating a stream it has not yet found invalid? Does the rate drop with
+   more *decoded output demanded* only because most accidental streams are short?
+3. **Can a legal Brotli stream begin with `MZ`?** `sfx-format-detection` deliberately
+   left a weak `MZ` prefix able to reach the content probes, on the grounds that two
+   bytes prove nothing and a real Brotli stream might start with them. Is that actually
+   possible? Enumerate the legal first bytes: `WBITS` occupies the low bits of byte 0,
+   so some values may be reserved or impossible. If `M` (`0x4D`) cannot legally start a
+   Brotli stream, the SFX cue can be tightened from STRONG-only to any `MZ` prefix, and
+   the residual in question 5 mostly disappears. Same question for `\x7fELF`.
+4. **Is there a cheap structural pre-gate at all?** zlib's probe gates on its two-byte
+   CMF/FLG header before decoding (`_ZLIB_HEADERS`), and LZMA Alone gates on a plausible
+   13-byte header (`_alone_header_plausible`). Brotli has nothing equivalent today. Is
+   there *any* constraint — reserved `WBITS` values, meta-block length sanity, a
+   distance/context-map field that is over-constrained in practice — that rejects a
+   meaningful share of random data without rejecting real streams? A gate that halves
+   the FP rate at zero FN cost is worth having even if it does not close the gap.
+5. **What should detection do with what is left?** Options, none pre-selected:
+   - keep the probe but require extension corroboration (`.br`) for a positive
+     auto-detect, reporting `GUESS` rather than `PROBABLE` otherwise;
+   - keep the probe but demand more of the *decoded* bytes than "some" — e.g. that the
+     decoder reaches a meta-block boundary rather than merely producing output;
+   - let `open_archive` fail loudly on a single-file result whose only evidence is a
+     content probe, instead of fabricating a member;
+   - accept the rate and document it.
+   Each option has an obvious cost; the deep dive should say which costs are real. Note
+   that whatever lands must keep bare `.br` files working — they are a supported format,
+   not an edge case (`format-single-file-compressors`).
+6. **Do the peer probes share the problem?** Run the same random-data measurement
+   against zlib and LZMA Alone. Both gate on a header first, so the expectation is a far
+   lower rate — but "expectation" is what this brief exists to replace. If either is also
+   loose, the fix belongs at the probe layer generally rather than in Brotli alone.
+
+## Reproducing
+
+```python
+import random
+from archivey.internal.streams.codecs import _BY_STREAM_FORMAT
+from archivey.types import StreamFormat
+
+codec = _BY_STREAM_FORMAT[StreamFormat.BROTLI]
+rnd = random.Random(42)
+hits = sum(
+    codec.content_probe(bytes(rnd.randrange(256) for _ in range(300)))
+    for _ in range(3000)
+)
+print(hits / 3000)  # ~0.076
+```
+
+End-to-end (what a user would hit) is `detect_format(io.BytesIO(random_bytes))` in a
+loop; count the results that come back `ArchiveFormat.BROTLI`.
+
+## Boundaries
+
+- **Not** a request to change detection in passing. Land findings as a written result
+  plus, if a change is warranted, an OpenSpec proposal — the probe's behaviour is
+  normative in `format-detection` and any change moves what bare `.br` files detect as.
+- Keep the SFX work out of scope: `sfx-format-detection` already closed the
+  archive-behind-a-stub path, and it did so without touching the probe precisely so this
+  investigation stays free to change it.
+
+## Refs
+
+- `src/archivey/internal/streams/codecs.py` — `_PROBE_PREFIX`, `_decodes_sample`,
+  `BrotliCodec.content_probe`, and the zlib / LZMA-Alone gates to compare against
+- `src/archivey/internal/detection.py` — where the probe result becomes the answer
+- `openspec/specs/format-detection/spec.md` — the normative probe requirements
+- `openspec/changes/archive/…/sfx-format-detection/design.md` — the measurements above in
+  their original context, and why scan-before-probe was chosen over probe tuning
+- `dev-docs/open-issues.md` P12, `dev-docs/threat-model.md` O10
+- RFC 7932 §9 (stream format), and `brotli`'s `state.c` / `decode.c`

--- a/dev-docs/open-issues.md
+++ b/dev-docs/open-issues.md
@@ -247,6 +247,34 @@ nor `DIRECTORY`. Original write-up below.
   [`review/docs-content/claims.md`](../review/docs-content/claims.md) **E-71**, a gap row —
   no page states the behaviour at all.
 
+### P12. The Brotli content probe accepts ~8% of arbitrary binary data
+
+- **Today:** Brotli has no magic at all, so `detect_format` identifies it by decoding a
+  256-byte prefix (`BrotliCodec.content_probe` → `StreamCodec._decodes_sample`,
+  `codecs.py:968`). Measured 2026-08-19: **8.27%** of uniformly random 4 KiB blobs pass
+  that probe, and end-to-end **146/2000 (7.3%)** of such blobs come back from
+  `detect_format` as `ArchiveFormat.BROTLI`. `open_archive` then returns a
+  `SingleFileReader` with one fabricated `<name>.uncompressed` member — a silent wrong
+  answer on arbitrary bytes, not an error.
+- **Probe tuning provably does not fix it.** A 4096-byte prefix leaves the rate at
+  8.13%; requiring ≥512 bytes of output drops it to 1.60% but loses 10 of 15 real Brotli
+  streams (small payloads, empty payloads, high-quality compression). The full matrix is
+  in the brief below. The looseness is in the format — a header-light bitstream — not in
+  the probe's parameters.
+- **Why it is filed separately from the SFX work.** `sfx-format-detection` closed the
+  *archive-behind-a-stub* half of A-34 by scanning for archive magic before the probes,
+  which needed no probe change and left this free to be investigated properly. What
+  remains is the general case: bytes that are not an archive and not Brotli either.
+- **Next step is an investigation, not a patch:**
+  [`investigations/brotli-content-probe-brief.md`](investigations/brotli-content-probe-brief.md)
+  — why the bitstream is this permissive, whether a legal Brotli stream can begin with
+  `MZ` (which would let the SFX cue tighten), whether a structural pre-gate exists like
+  zlib's and LZMA Alone's, and what detection should do with the residual.
+- **Security framing:** `threat-model.md` O10 — the input is attacker-supplied and the
+  failure is silent.
+- **Provenance:** measured 2026-08-19 while implementing `sfx-format-detection`, from
+  the maintainer's instruction not to lock a probe policy without understanding Brotli.
+
 ### P10. `format_availability()` fabricates a verdict for a wrong-typed argument — **CLOSED**
 
 **Fixed** in `2026-08-17-reject-wrong-typed-format-arguments`: one validation helper

--- a/dev-docs/threat-model.md
+++ b/dev-docs/threat-model.md
@@ -342,6 +342,38 @@ Tests for the fixed print sites: `tests/test_cli.py::test_extract_escapes_*`. Th
 Windows-legal U+2028 for the cross-platform cases and keep the ANSI/CR spoof in a
 Unix-only test, because a name containing control bytes cannot be created on NTFS.
 
+### O10. A content probe fabricates a member from arbitrary attacker bytes — open
+
+Brotli has no magic number, so `detect_format` recognizes it by decoding a 256-byte
+prefix (`BrotliCodec.content_probe`). Measured 2026-08-19: **8.27%** of uniformly random
+4 KiB blobs pass that probe, and **7.3%** of them come back from `detect_format` as
+`ArchiveFormat.BROTLI` end to end. `open_archive` on such a file does not fail — it
+returns a reader with one fabricated `<name>.uncompressed` member whose contents are
+whatever the decoder produced from bytes that were never a Brotli stream.
+
+That is a trust-boundary issue rather than a gotcha: the source is untrusted input by
+definition (`archive bytes` is the primary attacker-controlled surface in this model),
+and the failure mode is a *plausible answer* rather than an error, so a caller
+extracting from a directory of unknown files gets a file it has no reason to distrust.
+Nothing is executed and no path escapes — the impact is a wrong answer, not a write
+outside the destination — which is why this is ranked as a correctness gap and not as a
+containment one.
+
+The obvious mitigation does not work: a larger probe prefix leaves the rate at 8.13%,
+and demanding decoded output trades the false positives for false negatives roughly
+one-for-one (10 of 15 real Brotli streams lost at the setting that halves the FP rate).
+The looseness is in the bitstream, so closing it needs an understanding of the format
+rather than a parameter change — hence an investigation brief rather than a fix:
+[`investigations/brotli-content-probe-brief.md`](investigations/brotli-content-probe-brief.md).
+Product triage of the same defect: `open-issues.md` P12.
+
+**Adjacent and already closed:** the *archive-behind-a-stub* case, where a real RAR / 7z
+/ ZIP payload behind an executable stub was claimed by this probe and opened as a
+fabricated member (Topic 8 A-34). `sfx-format-detection` fixed that by searching for
+archive magic before running any content probe, and by refusing content probes outright
+on a structurally confirmed PE/ELF prefix. What remains under O10 is the case where the
+bytes are not an archive at all.
+
 ## OPEN gaps — compatibility
 
 ### C1. The RAR decompressor matrix (and unrar licensing) — won’t-do / closed

--- a/docs/formats.md
+++ b/docs/formats.md
@@ -223,6 +223,8 @@ full decode. Pick by provenance (`stored` vs `computed`) for your index policy.
 
 - Magic bytes first, then extension; wrong extensions are expected.
 - Self-extracting (SFX) stubs are detected when the archive payload sits behind an
-  executable header.
+  executable header — today a Windows (`MZ`/PE) or Linux (ELF) one. A macOS
+  Mach-O stub is **not** recognised yet, so a `.7z`/`.rar`/`.zip` appended to one is
+  still misidentified; pass `format=` explicitly for those until that gap closes.
 - Confidence and evidence are part of `detect_format` / `FormatInfo` — see
   `format-detection` spec.

--- a/openspec/changes/sevenz-sfx-start-offset/design.md
+++ b/openspec/changes/sevenz-sfx-start-offset/design.md
@@ -34,11 +34,27 @@ file origin, so forced `format=SEVEN_Z` on an SFX stub raises `CorruptionError`.
 ## Decisions
 
 ### 1. Accept an explicit start offset on the 7z open/parse path
-Thread a `start_offset: int = 0` (name flexible) from reader open into
-`read_signature_and_next_header` (and any absolute seeks derived from the
-signature). Magic is checked at `start_offset`, not necessarily file byte 0.
+Thread a `start_offset: int = 0` from `ReadBackend.open_read` into `SevenZipReader`.
+Magic is checked at `start_offset`, not necessarily file byte 0.
 **Rejected:** copying the suffix to a temp file (conflicts with ADR 0010 / cost
 honesty).
+
+**Amended at implement time (2026-08-19): the offset is applied as a bounded view,
+not threaded into the parser.** The proposal assumed `read_signature_and_next_header`
+absolute-seeks the *file*. It does not: the reader hands it `self._shared.view(0)`, a
+`SlicingStream`, so its `seek(0)` and its
+`seek(_SIGNATURE_HEADER_SIZE + next_header_offset)` are already view-relative — as are
+`encoded_folder_slices`' "absolute" offsets and the pack-stream views. Every 7z offset
+is signature-relative by construction, so the whole geometry rebases by giving the
+reader one origin (`SevenZipReader._view`, two call sites) instead of teaching each
+seek about stubs. Verified before implementing: an unmodified `main` opens a stubbed
+7z with an encrypted encoded header and packed streams when handed
+`SlicingStream(fp, start=stub_len)`, listing and reading every member.
+The parser therefore keeps a single contract — *`fp` begins at the signature header* —
+which is also what keeps `parse_sevenzip_archive` and the fuzz harnesses honest.
+**Rejected (was Decision 1 as proposed):** `read_signature_and_next_header(fp,
+start_offset=…)` plus per-seek arithmetic — two mechanisms for one origin (the reader
+still needs its own for pack views), and a parser that can silently read a stub.
 
 ### 2. Also scan when magic is missing at the open position (forced-format parity)
 When `format=SEVEN_Z` is forced and magic is not at the current origin, scan
@@ -50,9 +66,19 @@ today’s RAR-shaped escape hatch for 7z).
 one constant, three call sites).
 
 ### 3. Keep absolute geometry relative to the signature origin
-Once the signature is found at offset S, treat subsequent header/pack seeks as
-`S + relative` (today’s code assumes S=0). Document the invariant in the parser
-module.
+Once the signature is found at offset S, subsequent header/pack seeks are
+`S + relative` (today’s code assumes S=0). Per the Decision 1 amendment this is
+structural rather than arithmetic: `SevenZipReader._view(start, length)` adds S, and
+nothing downstream of it knows S exists. The invariant is documented on `_view` and on
+`read_signature_and_next_header`.
+
+**Semantics of `start_offset`, settled with the maintainer (2026-08-19):** a backend
+handed `start_offset=N` MUST behave exactly as if it had been handed a view of the
+source starting at N — nothing before N belongs to the archive. `open_read(path,
+start_offset=N)` and `open_read(SlicingStream(fp, start=N))` are therefore required to
+be observationally identical, which is asserted directly in `tests/test_sfx.py`. The
+one permitted difference is a backend that hands an *external tool* the original path
+because the tool finds the payload itself (`unrar` on an SFX file).
 
 ### 4. Spec lives primarily in `format-7z`
 Add an explicit requirement so format owners see it next to other 7z contracts.
@@ -60,13 +86,15 @@ Add an explicit requirement so format owners see it next to other 7z contracts.
 
 ## Risks / Trade-offs
 
-- [Missed seek sites after introducing S] → At `main` there are exactly **two**
-  absolute seeks to rebase in `sevenzip_parser.py`:
-  `read_signature_and_next_header` line ~357 (`fp.seek(0)`) and line ~388
-  (`fp.seek(_SIGNATURE_HEADER_SIZE + next_header_offset)`).
-  `sevenzip_pipeline.py` has no `.seek(` calls. That bounds the *known* sites —
-  keep task `3.2`’s pack-stream SFX fixture anyway, because pack offsets may be
-  applied via stream slicing rather than a literal `.seek(`.
+- [Missed seek sites after introducing S] → **Resolved by the Decision 1 amendment.**
+  The two absolute seeks in `sevenzip_parser.py` (`read_signature_and_next_header`
+  line ~357 `fp.seek(0)` and line ~388 `fp.seek(_SIGNATURE_HEADER_SIZE +
+  next_header_offset)`) run against a view, not the file, so neither needed rebasing —
+  and the suspicion behind the note was right: pack offsets *are* applied by slicing
+  (`SharedSource.view`, and `SlicingStream` in `decode_encoded_header`) rather than by
+  a literal `.seek(`, which is exactly why rebasing the view catches them all and
+  rebasing seeks would not have. The pack-stream + encoded-header SFX fixture is kept
+  regardless: it is what proves the claim.
 - [Scan cost on every forced open] → Fast path: magic at origin unchanged; scan
   only on miss.
 

--- a/openspec/changes/sevenz-sfx-start-offset/tasks.md
+++ b/openspec/changes/sevenz-sfx-start-offset/tasks.md
@@ -18,5 +18,5 @@
 - [x] 4.1 Forced `format=SEVEN_Z` on `MZ` + 7z payload opens real members
 - [x] 4.2 Explicit start offset N with magic at N
 - [x] 4.3 No magic within bound → `CorruptionError`
-- [ ] 4.4 `openspec validate --strict sevenz-sfx-start-offset`
+- [x] 4.4 `openspec validate --strict sevenz-sfx-start-offset`
 - [ ] 4.5 Archive this change in the finishing PR (`openspec archive sevenz-sfx-start-offset --yes`)

--- a/openspec/changes/sevenz-sfx-start-offset/tasks.md
+++ b/openspec/changes/sevenz-sfx-start-offset/tasks.md
@@ -1,22 +1,22 @@
 ## 1. Parser start offset
 
-- [ ] 1.1 Thread a start-offset parameter into `read_signature_and_next_header` and absolute seeks (signature origin = S, not always 0)
-- [ ] 1.2 Fast path unchanged when magic is at the open origin
+- [x] 1.1 Give the 7z open path a signature origin S (not always 0). *Landed as the amended Decision 1: `start_offset` reaches `SevenZipReader`, which rebases `SharedSource` views through `_view`; the parser keeps its "`fp` begins at the signature" contract, since its seeks already run against a view.*
+- [x] 1.2 Fast path unchanged when magic is at the open origin
 
 ## 2. Forced-format SFX scan
 
-- [ ] 2.1 When magic is missing at the open position, scan forward within the shared `SFX_MAX` for `MAGIC_7Z` (same constant as RAR / detection — do not introduce a second bound)
-- [ ] 2.2 On miss within bound, raise `CorruptionError` (no silent empty archive)
+- [x] 2.1 When magic is missing at the open position, scan forward within the shared `SFX_MAX` for `MAGIC_7Z` (same constant as RAR / detection — do not introduce a second bound)
+- [x] 2.2 On miss within bound, raise `CorruptionError` (no silent empty archive)
 
 ## 3. Reader / pipeline wiring
 
-- [ ] 3.1 Accept detection-supplied `payload_offset` / start offset on the 7z reader open path
-- [ ] 3.2 Exercise packed-stream + encoded-header archives opened behind a stub (not only empty/tiny fixtures)
+- [x] 3.1 Accept detection-supplied `payload_offset` / start offset on the 7z reader open path
+- [x] 3.2 Exercise packed-stream + encoded-header archives opened behind a stub (not only empty/tiny fixtures)
 
 ## 4. Verify
 
-- [ ] 4.1 Forced `format=SEVEN_Z` on `MZ` + 7z payload opens real members
-- [ ] 4.2 Explicit start offset N with magic at N
-- [ ] 4.3 No magic within bound → `CorruptionError`
+- [x] 4.1 Forced `format=SEVEN_Z` on `MZ` + 7z payload opens real members
+- [x] 4.2 Explicit start offset N with magic at N
+- [x] 4.3 No magic within bound → `CorruptionError`
 - [ ] 4.4 `openspec validate --strict sevenz-sfx-start-offset`
 - [ ] 4.5 Archive this change in the finishing PR (`openspec archive sevenz-sfx-start-offset --yes`)

--- a/openspec/changes/sfx-format-detection/design.md
+++ b/openspec/changes/sfx-format-detection/design.md
@@ -209,6 +209,27 @@ SFX then fails until the sibling lands. Land 7z start-offset first or in the sam
 PR train. RAR auto-open works once detection sets offset *or* once the opener seeks
 and RAR’s own scanner still finds magic at the new origin.
 
+## Known gap — Mach-O stubs are not a cue
+
+`format-detection` names `MZ` and ELF, and `executable_cue` implements exactly those. A
+macOS self-extracting stub is **Mach-O** (`0xfeedfacf`, or `0xcafebabe` for a universal
+binary), which matches no cue, so an archive appended to one still falls through to the
+content probes — the defect this change closes for the other two shapes.
+
+Surfaced by CI rather than reasoned about in advance: the first version of
+`test_a_real_elf_binary_is_a_strong_cue` sampled `/usr/bin/env`, which is ELF on Linux
+and a Mach-O universal binary on macOS, so both macOS legs went red on a real
+platform difference. The test now skips where the platform's binaries are not ELF, and
+`test_a_mach_o_binary_is_not_a_cue_today` pins the gap so it is recorded behaviour
+rather than a surprise.
+
+Widening the cue is a **spec change**, not an implementation detail, so it is
+deliberately not done here. If it is wanted: the magics are the four Mach-O variants
+plus the two fat ones, and a strong cue would validate `cputype` / `filetype` the way
+the PE path validates `e_lfanew`. One caveat for whoever picks it up — the fat magic
+`0xcafebabe` is also the Java class-file magic, so a bare-magic (weak) match would gate
+content probes on `.class` files unless the strong check is required.
+
 ## Risks / Trade-offs
 
 - [Real Brotli with executable-looking prefix] — **Closed by the two-tier cue.** A

--- a/openspec/changes/sfx-format-detection/design.md
+++ b/openspec/changes/sfx-format-detection/design.md
@@ -194,8 +194,32 @@ its parse at the origin. Formats that cannot carry a stub refuse a nonzero value
 (`reject_start_offset`) rather than silently reading from byte 0.
 **Note:** all three SFX backends can already find the payload unaided (RAR scans, ZIP
 reads the EOCD from the tail, 7z scans after the sibling change), so the offset is not
-what makes SFX open. It is what pins *which* payload: a stub carrying its own
-`PK\x03\x04` or `Rar!\x1a\x07` cannot move the answer.
+what makes SFX open. It is what pins *which* payload — for a caller that knows the
+offset independently.
+
+**Corrected after review (Cursor F2, 2026-08-20).** The first version of this note said a
+stub carrying its own `PK\x03\x04` or `Rar!\x1a\x07` "cannot move the answer". That is
+only true when the offset comes from somewhere other than the scan. On the *auto-detect*
+path it does not: `detect_format` derives `payload_offset` from the same earliest-match
+scan, so a decoy in the stub becomes the offset and the backend opens there. Measured on
+this branch — stub `MZ` + `\x90`×512 + `MAGIC_7Z` + filler, real 7z at 4096:
+
+| | detect | auto-open |
+| --- | --- | --- |
+| decoy + real 7z | `SEVEN_Z`, `payload_offset=514` (the decoy) | `CorruptionError: 7z signature header CRC mismatch` |
+| decoy + real ZIP | `ZIP`, `payload_offset=514` (the decoy) | succeeds — `zipfile` finds the EOCD from the tail of the slice |
+
+What the offset *does* still guarantee is the explicit hand-off: `open_read(source,
+start_offset=N)` opens at N and never re-scans, which is what
+`test_start_offset_is_believed_rather_than_rescanned` pins.
+
+**Accepted for this change, as a known scanner limitation.** The failure is loud, not
+silent, so it is not the defect class this change exists to close, and it needs a
+hostile or unlucky stub to reach. Fixing it means validate-and-continue — on a
+header/CRC rejection after an SFX hit, resume the scan past the decoy — which turns
+detection into a trial-open loop and belongs in its own change if wild stubs ever show
+it. `test_a_decoy_needle_in_the_stub_wins_and_fails_loudly` pins today's behaviour so
+the choice stays visible.
 
 ### 4. Silent-success regression is mandatory
 At least one test builds a low-entropy `MZ` stub + real RAR, one with ZIP, and

--- a/openspec/changes/sfx-format-detection/design.md
+++ b/openspec/changes/sfx-format-detection/design.md
@@ -61,32 +61,70 @@ policy.
 | ZIP forced-format OK | `zipfile` EOCD from tail; stub ignored |
 | Brotli probe is weak | `BrotliCodec.content_probe` → `_decodes_sample`; `_PROBE_PREFIX = 256`; `TruncatedError` counts as a hit — low-entropy stubs can “decode” briefly then fabricate a member |
 
-### Open investigation — Brotli (and peers) vs executable-shaped prefixes
+### Investigation result — Brotli (and peers) vs executable-shaped prefixes
 
-**Problem.** Today’s failure is “stub looks like Brotli for 256 bytes.” Blindly
-skipping content probes whenever the prefix is `MZ` / ELF would fix SFX but can
-miss a genuine Brotli (or zlib) stream whose first bytes coincide with a weak
-executable cue. `MZ` alone is only two bytes; real PE/ELF/SFX stubs carry more
-structure.
+**Run 2026-08-19, before writing any detection code. Two of the proposal's premises did
+not survive it.**
 
-**Candidate levers** (evaluate in the implement PR; pick one or a combination;
-record measurements):
+**Premise 1 — "`TruncatedError` counts as a hit" is not the mechanism.** The A-34 stub
+(`MZ` + `\x90` × 4094) does not truncate: it decodes **252 bytes cleanly**. Treating
+truncation as a miss would not have changed the answer.
 
-1. **SFX-scan-first, then probe on miss** — always search RAR/7z/ZIP needles in
-   the window when a *strong* executable cue matches; only then run content
-   probes. Preserves real Brotli-with-`MZ`-prefix after a needle miss.
-2. **Stronger executable cues** — require PE (`e_lfanew` → `PE\0\0`), ELF class /
-   data / version fields, or known SFX stub fingerprints, not bare `MZ`.
-3. **Stricter / larger Brotli probe** — raise `_PROBE_PREFIX`, require non-empty
-   output, and/or stop treating bare `TruncatedError` as success when the prefix
-   looks executable-shaped; measure false-negative rate on real `.br` fixtures.
-4. **Hybrid** — weak cue → scan-first; strong PE/ELF → scan-first + stricter
-   probe gate on miss.
+**Premise 2 — "low-entropy `MZ` stub" describes a synthetic file, not a real one.**
 
-**Acceptance for the investigation:** silent SFX→Brotli path stays red–green
-covered; at least one constructed “Brotli whose prefix looks weakly executable”
-case still detects as Brotli (or documents why that case is vanishingly rare and
-accepted).
+| Input | Brotli probe |
+| --- | --- |
+| `MZ` + `\x90` × 4094 (the A-34 stub) | accepted |
+| `MZ` + `\x00` × 4094, `MZ` + `A` × 4094 | rejected |
+| Structurally valid PE stub (DOS header, `e_lfanew` → `PE\0\0`), any filler | rejected |
+| Real `rar a -sfx` ELF stub (249 KB) | rejected |
+| 887 real ELF binaries under `/usr/bin` + `/usr/lib` | **0** accepted |
+
+So the *silent* path needs a hand-rolled stub; the loud path
+(`FormatDetectionError`) is what a real SFX actually hits today — verified: a real
+`rar a -sfx` archive raised `FormatDetectionError` on `main`, with its RAR magic at
+offset 248 952.
+
+**Candidate lever 3 (stricter / larger Brotli probe) is dead.** Measured against 15 real
+Brotli streams (qualities 1/5/11 over text, random bytes, an ELF binary, an empty
+payload, a one-byte payload) and 1 500 random 4 KiB blobs:
+
+| Probe variant | Random-data FP | Real-Brotli misses |
+| --- | --- | --- |
+| 256-byte prefix, any outcome (today) | 8.27% | 0/15 |
+| 256-byte prefix, require ≥1 byte out | 8.27% | 3/15 |
+| 256-byte prefix, require ≥512 bytes out | 1.60% | 10/15 |
+| 1024-byte prefix, any outcome | 8.27% | 0/15 |
+| 4096-byte prefix, any outcome | 8.20% | 0/15 |
+| 4096-byte prefix, require ≥512 bytes out | 8.13% | 6/15 |
+
+A bigger prefix buys nothing; demanding output trades FP for FN one-for-one. The
+looseness is in the bitstream, not the parameters.
+
+**Chosen rule (maintainer: "as recommended", 2026-08-19) — lever 1 + a narrow lever 2:**
+
+1. **SFX-scan-first on a weak cue.** Bare `MZ` / `\x7fELF` is enough to *look* for an
+   appended archive. On a hit the archive wins; on a miss the content probes run exactly
+   as before. False-negative risk for Brotli: **zero** — a needle miss changes nothing.
+2. **Content probes suppressed on a strong cue.** A DOS header whose `e_lfanew` really
+   points at `PE\0\0`, or an ELF ident block with valid `EI_CLASS` / `EI_DATA` /
+   `EI_VERSION`, with no archive needle in the window → no probe runs; detection falls
+   through to the extension guess or `FormatDetectionError`. Measured false-negative
+   risk: 0/887 real ELF binaries were probe hits to begin with, and a Brotli stream that
+   coincidentally forms a valid PE or ELF header is a ~2⁻³² event.
+3. **The Brotli probe itself is untouched**, which is what keeps `.br` detection
+   unchanged and leaves the residual free to be fixed properly.
+
+**Accepted residual, stated plainly:** a weak cue with no archive in the window still
+reaches the probes, so `MZ` + `\x90` × 4094 *with no payload* still detects as
+`BROTLI`. That is not an SFX defect — it is the general one, and it is much wider than
+`MZ`: **8.27% of arbitrary binary data** passes this probe (7.3% end-to-end through
+`detect_format`). Narrowing the cue to bare `MZ` would fix two bytes' worth of a 2³²-wide
+problem while taking on the false-negative risk MD2 warned about. Registered instead as
+`open-issues.md` P12 and `threat-model.md` O10, with
+`dev-docs/investigations/brotli-content-probe-brief.md` as the deep dive the maintainer
+asked for — including the question that would let the cue tighten later: *can a legal
+Brotli stream begin with `MZ` at all?*
 
 ## Decisions
 
@@ -102,7 +140,22 @@ requirement (easy to narrow away later; split into its own requirement).
 **Rejected without measurement:** hard-disable content probes on bare `MZ`
 (risks missing real Brotli — maintainer note on MD2).
 
+**Settled at implement time** (see the investigation result above): the cue is
+two-tiered. A **weak** cue (bare `MZ` / `\x7fELF`) triggers the scan only; the probes
+still run on a miss, so nothing a probe used to detect stops being detected. A **strong**
+cue (`e_lfanew` — `PE\0\0`, or a valid ELF ident block) additionally suppresses the
+probes on a miss. The scan is what fixes every row of the SFX matrix; the strong-cue gate
+is what keeps a confirmed executable from becoming a fabricated `*.uncompressed` member,
+at a measured false-negative cost of zero.
+
 ### 2. One shared `SFX_MAX` (2 MiB) for RAR, detection, and 7z
+**Landed in `src/archivey/internal/sfx.py`** (maintainer, 2026-08-19), not in
+`detection.py` as task 1.3 first put it: importing the detector from `rar_parser` would
+be a new backend-to-detector edge, and the constant is not the detector’s to own.
+Nothing outside `rar_parser` imported `rar_parser.SFX_MAX`, so no re-export was needed.
+`tests/atheris_fuzz/crc_fixup.py` keeps its own copy on purpose — a fuzz oracle that
+imports the code under test cannot disagree with it.
+
 Promote today’s `rar_parser.SFX_MAX` to a single shared constant (module/name
 flexible) consumed by the RAR parser SFX scan, `detect_format`’s forward window,
 and the 7z forced-format SFX scan. Value remains 2 MiB unless a later measured
@@ -125,6 +178,25 @@ copying the remainder.
 **Rejected:** bare seek alone as the hand-off (works for RAR’s forward scan, fails
 for 7z).
 
+**Settled (maintainer, 2026-08-19): the argument, used by every SFX backend, and defined
+in terms of the view.** `open_read(source, start_offset=N)` MUST behave exactly as if it
+had been handed a view of `source` starting at N — nothing before N belongs to the
+archive — with one permitted exception: a backend may hand an *external tool* the
+original path when the tool finds the payload itself (`unrar` on an SFX file). Asserted
+directly: `tests/test_sfx.py` opens each SFX format both ways and compares the members
+byte for byte.
+The argument rather than a slice at the call site, because slicing a `Path` source would
+cost RAR a whole-archive temp copy for every compressed member
+(`RarReader._ensure_archive_path`) — the E-71 / P11 cost this change must not add.
+Each backend then applies it as a view internally: 7z rebases `SharedSource` through
+`_view`, ZIP wraps its handle in a `SlicingStream` before `zipfile` sees it, RAR starts
+its parse at the origin. Formats that cannot carry a stub refuse a nonzero value
+(`reject_start_offset`) rather than silently reading from byte 0.
+**Note:** all three SFX backends can already find the payload unaided (RAR scans, ZIP
+reads the EOCD from the tail, 7z scans after the sibling change), so the offset is not
+what makes SFX open. It is what pins *which* payload: a stub carrying its own
+`PK\x03\x04` or `Rar!\x1a\x07` cannot move the answer.
+
 ### 4. Silent-success regression is mandatory
 At least one test builds a low-entropy `MZ` stub + real RAR, one with ZIP, and
 (once the sibling lands) 7z, and asserts: not `BROTLI`, and auto-open does not
@@ -139,24 +211,29 @@ and RAR’s own scanner still finds magic at the new origin.
 
 ## Risks / Trade-offs
 
-- [Real Brotli with executable-looking prefix] → Do not hard-disable probes on
-  bare `MZ`; complete the differentiation investigation (stronger cues / stricter
-  probe / scan-first-then-probe). Bare brotli streams with non-executable prefixes
-  stay unchanged.
-- [7z auto-open still broken until sibling] → Tasks call out dependency; forced
-  `format=SEVEN_Z` fixed by sibling alone.
+- [Real Brotli with executable-looking prefix] — **Closed by the two-tier cue.** A
+  weak `MZ` / ELF prefix never suppresses a probe, so no stream a probe used to detect
+  stops being detected; only a structurally confirmed PE/ELF does, at a measured 0/887
+  on real binaries. Bare brotli streams with non-executable prefixes are untouched.
+- [7z auto-open still broken until sibling] — **Closed:** the sibling landed first in
+  the same PR, so 7z SFX auto-opens end to end.
 - [Large SFX stubs beyond window] → Shared `SFX_MAX` (2 MiB); raising it is one
   edit for RAR, detection, and 7z.
-- [RAR stream temp spill × `payload_offset` (E-71 / P11)] → Seekable-stream RAR
-  already copies to a temp path for `unrar` (`RarReader._ensure_archive_path`).
-  Once detection supplies a non-zero `payload_offset`, decide in the implement
-  PR whether the temp holds payload-only (offset consumed) or stub+payload
-  (`unrar` re-finds magic). Keep that choice consistent with P11’s eventual cost
-  signal; this change does not invent a second spill.
+- [RAR stream temp spill x `payload_offset` (E-71 / P11)] — **Decided: payload-only.**
+  `_ensure_archive_path` now copies from the archive origin, so a stream source spills
+  a plain RAR rather than stub+payload — smaller, and it does not depend on `unrar`
+  re-finding the magic. A *path* source is unaffected: it keeps its own path and
+  `unrar` reads the SFX directly. This changes no cost *class* — the spill P11
+  describes still happens, still unsignalled — so P11 is untouched, and this change does
+  not invent a second spill.
 
 ## Open Questions
 
-- **Differentiation policy (blocking for implement, not for this proposal):** which
-  combination of stronger executable cues vs stricter Brotli probe vs
-  scan-first-then-probe lands — see Investigations. SFX window size is decided:
-  one shared `SFX_MAX` (#253 MD3 = A).
+- ~~**Differentiation policy:** which combination of stronger executable cues vs
+  stricter Brotli probe vs scan-first-then-probe lands.~~ **Answered** by the
+  investigation above and the maintainer’s "as recommended" (2026-08-19):
+  scan-first on a weak cue, probes suppressed on a strong one, Brotli probe untouched.
+- **Not blocking this change:** whether a legal Brotli stream can begin with `MZ` at
+  all. If it cannot, the probe suppression can widen from strong cues to any `MZ`
+  prefix. Deliberately left to
+  `dev-docs/investigations/brotli-content-probe-brief.md` rather than guessed at here.

--- a/openspec/changes/sfx-format-detection/design.md
+++ b/openspec/changes/sfx-format-detection/design.md
@@ -216,6 +216,35 @@ macOS self-extracting stub is **Mach-O** (`0xfeedfacf`, or `0xcafebabe` for a un
 binary), which matches no cue, so an archive appended to one still falls through to the
 content probes — the defect this change closes for the other two shapes.
 
+**"Falls through to the content probes" is too gentle: on a thin 64-bit stub they always
+claim it.** The Brotli investigation (`dev-docs/investigations/brotli-content-probe-results.md`
+§7.2) found that `cf fa ed fe` is *structurally* a valid Brotli uncompressed meta-block
+header — WBITS 24, `ISLAST` 0, six nibbles, a non-zero top MLEN nibble from `0xFE`,
+`ISUNCOMPRESSED` from its bit 7, and zero padding. That depends on the four magic bytes
+alone, so **every** thin 64-bit little-endian Mach-O qualifies regardless of `cputype`
+(200 real hits on a macOS CI runner). Measured against this branch at `34db1b0`:
+
+| stub + appended 7z | `executable_cue` | `detect_format` | `open_archive` |
+| --- | --- | --- | --- |
+| PE | `STRONG` | `SEVEN_Z`, `payload_offset=8132` | real members |
+| ELF | `STRONG` | `SEVEN_Z`, `payload_offset=8192` | real members |
+| **Mach-O (thin arm64)** | **`NONE`** | **`BROTLI`** | **one fabricated `.uncompressed` member** |
+
+So the silent-wrong-answer defect this change exists to close is **intact on macOS** after
+it lands — not "might be claimed", but reliably claimed. Two details for whoever fixes it:
+
+- **Brotli is not the only claimant.** With a realistic arm64 header the answer is
+  `BROTLI`; with a zero-filled stub, LZMA Alone's probe bites first and it is
+  `LZMA_ALONE`. Both fabricate a single `.uncompressed` member, so the user-visible defect
+  is identical — the fall-through lands on whichever content probe accepts first.
+- **Only a *thin* stub is silent.** A universal (`0xcafebabe`) stub is rejected by both
+  probes and fails loudly with `FormatDetectionError`. That makes the fat case the *safe*
+  one, which is the opposite of what the `0xcafebabe`/Java-class-file caveat below might
+  lead a reader to assume.
+
+The fix is proposed as `openspec/changes/prefixed-archive-detection`, which widens the cue
+set — the spec change this section defers.
+
 Surfaced by CI rather than reasoned about in advance: the first version of
 `test_a_real_elf_binary_is_a_strong_cue` sampled `/usr/bin/env`, which is ELF on Linux
 and a Mach-O universal binary on macOS, so both macOS legs went red on a real

--- a/openspec/changes/sfx-format-detection/specs/format-detection/spec.md
+++ b/openspec/changes/sfx-format-detection/specs/format-detection/spec.md
@@ -12,6 +12,13 @@ with `payload_offset` = payload start and `detected_by` indicating an SFX scan.
 No match → fall through per the differentiation policy from the sibling
 requirement (content probes / extension / `FormatDetectionError`).
 
+Which magic the scan hunts for SHALL be **backend-declared data**, like every other
+detection signal, rather than a table maintained inside the detector. A backend declares
+only the magic that can legitimately begin an appended payload: ZIP declares its
+local-file header and NOT the end-of-central-directory or spanned markers, which as
+needles inside a 2 MiB stub window would claim any executable containing those four
+bytes.
+
 Native RAR/7z parsers SHALL accept a start offset (read in place, no copy). ZIP
 already locates the EOCD from the tail, so a leading stub is tolerated without a
 separate parser scan; detection still SHALL return `ZIP` with `payload_offset`
@@ -39,12 +46,25 @@ silent wrong answer.
 
 This obligation is **outcome-shaped**, not “disable Brotli whenever the prefix is
 `MZ`”. A genuine Brotli (or other probe-matched) stream whose first bytes happen
-to look executable MUST remain detectable. The implement PR SHALL investigate how
-to distinguish SFX stubs from such streams before locking the probe policy
-(candidate levers: stronger PE/ELF/SFX stub cues; larger / stricter Brotli probe
-than today’s `_PROBE_PREFIX = 256` + `TruncatedError`→True; SFX-scan-first then
-probe only on miss; combinations). Document the chosen rule and its false-positive
-/ false-negative trade-offs in the change’s design.
+to look executable MUST remain detectable.
+
+The rule, settled by measurement in the change's design, grades the evidence:
+
+- A **weak** cue — a bare `MZ` or `\x7fELF` prefix — SHALL trigger the SFX scan and
+  nothing else. When the scan finds no archive magic, content probes run unchanged. Two
+  or four bytes are not proof, and refusing a probe on them would reject real streams.
+- A **strong** cue — a DOS header whose `e_lfanew` points at a `PE\0\0` signature, or an
+  ELF identification block with valid `EI_CLASS` / `EI_DATA` / `EI_VERSION` — with no
+  archive magic in the window SHALL suppress content probes entirely; detection falls
+  through to the extension guess or `FormatDetectionError`. A structurally confirmed
+  executable is not a compressed stream.
+
+The system SHALL NOT tighten the Brotli probe itself to satisfy this requirement:
+measured, a larger probe prefix does not reduce false positives (8.27% → 8.13% of random
+data at 16x the prefix) and requiring decoded output loses real streams roughly
+one-for-one. The residual — arbitrary non-archive data that the Brotli probe claims,
+which is a far wider problem than executable prefixes — is out of scope here and is
+tracked separately (`dev-docs/open-issues.md` P12, `dev-docs/threat-model.md` O10).
 
 #### Scenario: no silent wrong answer on executable-shaped prefix
 
@@ -52,5 +72,6 @@ probe only on miss; combinations). Document the chosen rule and its false-positi
 | --- | --- |
 | Low-entropy `MZ` stub + RAR/7z/ZIP payload in window | Detected as that archive — **not** `BROTLI` / fabricated member |
 | Real Brotli stream with non-executable prefix | Unchanged — still `BROTLI` / `PROBABLE` via content probe |
-| Real Brotli (or other probe format) whose prefix coincides with a weak executable cue | Still detected as that stream after the investigation’s rule — **not** forced to `FormatDetectionError` solely because two bytes were `MZ` |
+| Real Brotli (or other probe format) whose prefix coincides with a **weak** executable cue | Still detected as that stream — **not** forced to `FormatDetectionError` solely because two bytes were `MZ` |
+| **Strong** executable cue (validated PE / ELF), no archive needle in the window | No content probe runs; extension guess or `FormatDetectionError` — never a fabricated member |
 | Executable-shaped prefix, no archive needle, probe correctly rejects | Extension guess or `FormatDetectionError` — not a fabricated member |

--- a/openspec/changes/sfx-format-detection/specs/format-detection/spec.md
+++ b/openspec/changes/sfx-format-detection/specs/format-detection/spec.md
@@ -10,7 +10,9 @@ SFX RAR/7z/ZIP: EXE stub precedes payload. If leading bytes look like executable
 before running content probes. Match → embedded format
 with `payload_offset` = payload start and `detected_by` indicating an SFX scan.
 No match → fall through per the differentiation policy from the sibling
-requirement (content probes / extension / `FormatDetectionError`).
+requirement, which is graded by cue strength: a strong cue suppresses the content
+probes, a weak one does not. "No silent fabricated member" is therefore guaranteed for
+a **strong** cue only — see that requirement for the measured reason.
 
 Which magic the scan hunts for SHALL be **backend-declared data**, like every other
 detection signal, rather than a table maintained inside the detector. A backend declares
@@ -24,6 +26,13 @@ already locates the EOCD from the tail, so a leading stub is tolerated without a
 separate parser scan; detection still SHALL return `ZIP` with `payload_offset`
 rather than a stream codec when the ZIP needle matches.
 
+The scan takes the **earliest** matching needle in the window. A stub that itself
+contains one of these magics therefore decides `payload_offset`, and the backend opens
+there rather than at a later real payload. That is a **loud** failure, not a silent one
+— 7z raises `CorruptionError` on the signature CRC — and is accepted for now;
+validating a hit and resuming the scan past a rejected one is deliberately out of scope
+(see the change's design).
+
 #### Scenario: SFX matrix
 
 | Case | Expected |
@@ -32,7 +41,9 @@ rather than a stream codec when the ZIP needle matches.
 | `MZ` + RAR magic at offset N | `RAR`, `payload_offset == N`; backend opens at N |
 | `MZ` + ZIP local magic (`PK\x03\x04`) at offset N | `ZIP`, `payload_offset == N`; real ZIP members listed |
 | `MZ` + low-entropy filler + RAR/7z/ZIP magic in window | Same as above — **not** `BROTLI` / fabricated single-file member |
-| Executable-shaped header, no RAR/7z/ZIP in window | Per differentiation policy (see sibling requirement) — never silent fabricated member |
+| **Strong** executable cue (validated PE / ELF), no RAR/7z/ZIP in window | No content probe runs; extension guess or `FormatDetectionError` — never a fabricated member |
+| **Weak** executable cue (bare `MZ` / `\x7fELF`), no RAR/7z/ZIP in window | Content probes run unchanged, so a probe may still claim the stub — the accepted residual, per the sibling requirement and `open-issues.md` P12 |
+| Stub containing a decoy needle before the real payload | Earliest match wins; the backend opens at the decoy and fails **loudly** (7z: `CorruptionError`). ZIP usually still succeeds via EOCD-from-tail |
 | Bare brotli / non-executable stream | Unchanged content-probe behaviour |
 
 ## ADDED Requirements

--- a/openspec/changes/sfx-format-detection/tasks.md
+++ b/openspec/changes/sfx-format-detection/tasks.md
@@ -17,5 +17,5 @@
 - [x] 3.2 Red–green: low-entropy `MZ` stub + ZIP payload must not detect/open as Brotli; assert real ZIP members
 - [x] 3.3 Real Brotli (and bare non-executable streams) still detect; include a weak-executable-prefix Brotli case from 1.0
 - [x] 3.4 Varied-stub + RAR/7z/ZIP cases from the SFX matrix (match / no-match / extension fallthrough)
-- [ ] 3.5 `openspec validate --strict sfx-format-detection`
+- [x] 3.5 `openspec validate --strict sfx-format-detection`
 - [ ] 3.6 Archive this change in the finishing PR (`openspec archive sfx-format-detection --yes`)

--- a/openspec/changes/sfx-format-detection/tasks.md
+++ b/openspec/changes/sfx-format-detection/tasks.md
@@ -1,21 +1,21 @@
 ## 1. Detection SFX scan + probe differentiation
 
-- [ ] 1.0 Investigate Brotli/content-probe vs executable-shaped prefixes (stronger PE/ELF/SFX cues; larger/stricter `_PROBE_PREFIX` / `TruncatedError` handling; scan-first-then-probe; hybrids). Record chosen rule + FP/FN trade-offs in `design.md`. Fixture: real Brotli whose prefix coincides with a weak executable cue must still detect as Brotli (or document accepted residual).
-- [ ] 1.1 Add bounded SFX magic scan (`MZ` / ELF / refined cues → RAR / 7z / ZIP `PK\x03\x04` needles) in `detect_format`, setting `payload_offset` and `detected_by`
-- [ ] 1.2 Apply the investigated probe policy so SFX stubs cannot silently become Brotli fabricated members, without hard-disabling Brotli on bare `MZ`
-- [ ] 1.3 Promote `rar_parser.SFX_MAX` to one shared constant (2 MiB) used by RAR parser, detection, and 7z forced-format scan; import it from detection (do not keep a second copy)
+- [x] 1.0 Investigate Brotli/content-probe vs executable-shaped prefixes. *Measured and recorded in `design.md` §Investigation result: probe tuning is a dead end (4096-byte prefix leaves FP at 8.13%; requiring output loses 10/15 real streams), and the A-34 stub is synthetic (real PE/ELF stubs and 887 real ELF binaries are not probe hits). Landed rule: scan-first on a weak cue, probes suppressed only on a structurally validated PE/ELF. The weak-cue Brotli fixture is `test_a_weak_cue_still_lets_a_content_probe_answer`; the residual (~8% of arbitrary data probes as Brotli) is registered as P12 / O10 with a deep-dive brief.*
+- [x] 1.1 Add bounded SFX magic scan (`MZ` / ELF / refined cues → RAR / 7z / ZIP `PK\x03\x04` needles) in `detect_format`, setting `payload_offset` and `detected_by`
+- [x] 1.2 Apply the investigated probe policy so SFX stubs cannot silently become Brotli fabricated members, without hard-disabling Brotli on bare `MZ`
+- [x] 1.3 Promote `rar_parser.SFX_MAX` to one shared constant (2 MiB) used by RAR parser, detection, and 7z forced-format scan. *Landed in `internal/sfx.py` rather than `detection.py` (maintainer): a backend importing the detector would be a new edge. Nothing outside `rar_parser` imported the old name, so no re-export.*
 
 ## 2. Open-path hand-off
 
-- [ ] 2.1 Thread non-zero `payload_offset` from detection through `open_archive` into backend open via explicit start-offset argument or bounded offset view (not bare seek alone)
-- [ ] 2.2 Confirm RAR and ZIP auto-open of SFX succeeds with real members (no fabricated single-file member)
-- [ ] 2.3 Gate 7z auto-open SFX on `sevenz-sfx-start-offset` (or land that change in the same train)
+- [x] 2.1 Thread non-zero `payload_offset` from detection through `open_archive` into backend open via explicit start-offset argument or bounded offset view (not bare seek alone)
+- [x] 2.2 Confirm RAR and ZIP auto-open of SFX succeeds with real members (no fabricated single-file member)
+- [x] 2.3 Gate 7z auto-open SFX on `sevenz-sfx-start-offset`. *Landed first in the same PR, so no gate was needed: 7z SFX auto-opens end to end.*
 
 ## 3. Verify
 
-- [ ] 3.1 Red–green: low-entropy `MZ` stub + RAR payload must not detect/open as Brotli; assert real RAR members
-- [ ] 3.2 Red–green: low-entropy `MZ` stub + ZIP payload must not detect/open as Brotli; assert real ZIP members
-- [ ] 3.3 Real Brotli (and bare non-executable streams) still detect; include a weak-executable-prefix Brotli case from 1.0
-- [ ] 3.4 Varied-stub + RAR/7z/ZIP cases from the SFX matrix (match / no-match / extension fallthrough)
+- [x] 3.1 Red–green: low-entropy `MZ` stub + RAR payload must not detect/open as Brotli; assert real RAR members
+- [x] 3.2 Red–green: low-entropy `MZ` stub + ZIP payload must not detect/open as Brotli; assert real ZIP members
+- [x] 3.3 Real Brotli (and bare non-executable streams) still detect; include a weak-executable-prefix Brotli case from 1.0
+- [x] 3.4 Varied-stub + RAR/7z/ZIP cases from the SFX matrix (match / no-match / extension fallthrough)
 - [ ] 3.5 `openspec validate --strict sfx-format-detection`
 - [ ] 3.6 Archive this change in the finishing PR (`openspec archive sfx-format-detection --yes`)

--- a/src/archivey/core.py
+++ b/src/archivey/core.py
@@ -354,6 +354,14 @@ def open_archive(
     if effective_encoding is None and detected is not None:
         effective_encoding = detected.encoding_hint
 
+    # A self-extracting source has an executable stub before the archive; detection
+    # reports where the payload starts and the backend opens there. Handed over as an
+    # explicit argument rather than by slicing here, so a path source stays a path:
+    # RAR needs one to hand `unrar`, and turning it into a stream would spill the whole
+    # archive to a temp file for every compressed member (`_ensure_archive_path`). The
+    # argument carries the same promise a slice would — see `ReadBackend.open_read`.
+    payload_offset = detected.payload_offset if detected is not None else 0
+
     backend = backend_cls()
     reader = backend.open_read(
         reader_source,
@@ -366,6 +374,7 @@ def open_archive(
         collector=collector,
         member_streams=member_streams,
         open_site=open_site,
+        start_offset=payload_offset,
     )
     # An empty listing is only interesting when the bytes never confirmed the format.
     # That is known here and the listing is not, so carry it to the reader rather than

--- a/src/archivey/internal/backends/directory_reader.py
+++ b/src/archivey/internal/backends/directory_reader.py
@@ -24,7 +24,11 @@ from archivey.cost import (
 )
 from archivey.diagnostics import DiagnosticCode, ScanRaceContext
 from archivey.escaping import quoted
-from archivey.internal.base_reader import BaseArchiveReader, ReadBackend
+from archivey.internal.base_reader import (
+    BaseArchiveReader,
+    ReadBackend,
+    reject_start_offset,
+)
 from archivey.internal.diagnostics_collector import DiagnosticCollector
 from archivey.internal.logs import backends as logger
 from archivey.internal.open_site import OpenSite
@@ -319,7 +323,9 @@ class DirectoryReadBackend(ReadBackend):
         collector: DiagnosticCollector | None = None,
         member_streams: MemberStreams = MemberStreams(0),
         open_site: OpenSite | None = None,
+        start_offset: int = 0,
     ) -> DirectoryReader:
+        reject_start_offset(start_offset, format, archive_name)
         # `format` is always DIRECTORY here (single-format backend); accepted for the
         # uniform ReadBackend signature. Password rejection is central (SUPPORTS_PASSWORD).
         if not isinstance(source, Path):

--- a/src/archivey/internal/backends/iso_reader.py
+++ b/src/archivey/internal/backends/iso_reader.py
@@ -56,7 +56,11 @@ from archivey.exceptions import (
     CorruptionError,
     PackageNotInstalledError,
 )
-from archivey.internal.base_reader import BaseArchiveReader, ReadBackend
+from archivey.internal.base_reader import (
+    BaseArchiveReader,
+    ReadBackend,
+    reject_start_offset,
+)
 from archivey.internal.diagnostics_collector import DiagnosticCollector
 from archivey.internal.naming import emit_member_name_normalized, normalize_member_name
 from archivey.internal.open_site import OpenSite
@@ -548,7 +552,9 @@ class IsoReadBackend(ReadBackend):
         collector: DiagnosticCollector | None = None,
         member_streams: MemberStreams = MemberStreams(0),
         open_site: OpenSite | None = None,
+        start_offset: int = 0,
     ) -> IsoReader:
+        reject_start_offset(start_offset, format, archive_name)
         # `format` is always ISO here (single-format backend); accepted for the uniform
         # ReadBackend signature.
         return IsoReader(

--- a/src/archivey/internal/backends/rar_parser.py
+++ b/src/archivey/internal/backends/rar_parser.py
@@ -48,6 +48,7 @@ from archivey.exceptions import (
     UnsupportedFeatureError,
     raw_message_of,
 )
+from archivey.internal.sfx import SFX_MAX, scan_for_magic
 from archivey.internal.streams.crypto import AesParams, open_aes_decrypt_stage
 from archivey.internal.streams.streamtools import read_exact
 
@@ -64,8 +65,6 @@ class _Readable(Protocol):
 
 RAR_ID = b"Rar!\x1a\x07\x00"
 RAR5_ID = b"Rar!\x1a\x07\x01\x00"
-_SFX_NEEDLE = b"Rar!\x1a\x07"
-SFX_MAX = 2 * 1024 * 1024
 _RAR_MAX_PASSWORD = 127
 _RAR_MAX_KDF_SHIFT = 24
 _RAR5_MAX_HEADER = 2 * 1024 * 1024
@@ -388,7 +387,12 @@ def _parse_rar_one(
 
 
 def _find_sfx_header(source: BinaryIO, start: int) -> tuple[int, int]:
-    """Return ``(version, offset_from_start)`` for RAR4 (version 4) or RAR5."""
+    """Return ``(version, offset_from_start)`` for RAR4 (version 4) or RAR5.
+
+    Scanning both ids rather than their shared ``Rar!\x1a\x07`` prefix lets the shared
+    scanner resolve the version by which id matched first, so a stub containing the bare
+    prefix (without a valid version byte) no longer needs a rescan loop here.
+    """
     source.seek(start)
     # Fast path: magic at current position.
     head = read_exact(source, len(RAR5_ID))
@@ -398,26 +402,14 @@ def _find_sfx_header(source: BinaryIO, start: int) -> tuple[int, int]:
         return 4, 0
 
     source.seek(start)
-    buf = bytearray()
-    remaining = SFX_MAX
-    while remaining > 0:
-        chunk = source.read(min(65536, remaining))
-        if not chunk:
-            break
-        buf.extend(chunk)
-        remaining -= len(chunk)
-        # Search within newly complete window.
-        find_from = max(0, len(buf) - len(chunk) - len(_SFX_NEEDLE))
-        pos = find_from
-        while True:
-            idx = bytes(buf).find(_SFX_NEEDLE, pos)
-            if idx < 0:
-                break
-            if buf[idx : idx + len(RAR5_ID)] == RAR5_ID:
-                return 5, idx
-            if buf[idx : idx + len(RAR_ID)] == RAR_ID:
-                return 4, idx
-            pos = idx + len(_SFX_NEEDLE)
+    offset = scan_for_magic(source, (RAR5_ID, RAR_ID), limit=SFX_MAX)
+    if offset is not None:
+        source.seek(start + offset)
+        ident = read_exact(source, len(RAR5_ID))
+        if ident.startswith(RAR5_ID):
+            return 5, offset
+        assert ident.startswith(RAR_ID), "scan matched an id the reread does not"
+        return 4, offset
 
     raise CorruptionError("Not a RAR archive: magic not found within SFX scan limit")
 

--- a/src/archivey/internal/backends/rar_parser.py
+++ b/src/archivey/internal/backends/rar_parser.py
@@ -402,14 +402,10 @@ def _find_sfx_header(source: BinaryIO, start: int) -> tuple[int, int]:
         return 4, 0
 
     source.seek(start)
-    offset = scan_for_magic(source, (RAR5_ID, RAR_ID), limit=SFX_MAX)
-    if offset is not None:
-        source.seek(start + offset)
-        ident = read_exact(source, len(RAR5_ID))
-        if ident.startswith(RAR5_ID):
-            return 5, offset
-        assert ident.startswith(RAR_ID), "scan matched an id the reread does not"
-        return 4, offset
+    hit = scan_for_magic(source, (RAR5_ID, RAR_ID), limit=SFX_MAX)
+    if hit is not None:
+        offset, ident = hit
+        return (5 if ident == RAR5_ID else 4), offset
 
     raise CorruptionError("Not a RAR archive: magic not found within SFX scan limit")
 

--- a/src/archivey/internal/backends/rar_reader.py
+++ b/src/archivey/internal/backends/rar_reader.py
@@ -39,6 +39,7 @@ from archivey.exceptions import (
     EncryptionError,
     StreamNotSeekableError,
     TruncatedError,
+    UnsupportedFeatureError,
 )
 from archivey.internal.backends.rar_parser import (
     RAR5_ID,
@@ -57,11 +58,7 @@ from archivey.internal.backends.rar_unrar import (
     open_unrar_p,
     terminate_unrar,
 )
-from archivey.internal.base_reader import (
-    BaseArchiveReader,
-    ReadBackend,
-    reject_start_offset,
-)
+from archivey.internal.base_reader import BaseArchiveReader, ReadBackend
 from archivey.internal.diagnostics_collector import DiagnosticCollector
 from archivey.internal.logs import integrity as integrity_logger
 from archivey.internal.naming import emit_member_name_normalized, normalize_member_name
@@ -371,6 +368,7 @@ class RarReader(BaseArchiveReader):
         open_site: OpenSite | None = None,
         *,
         volume_count: int = 1,
+        start_offset: int = 0,
     ) -> None:
         super().__init__(
             ArchiveFormat.RAR,
@@ -400,7 +398,21 @@ class RarReader(BaseArchiveReader):
                 source_format=ArchiveFormat.RAR,
             )
 
+        # Where the RAR proper starts inside `source`: detection's payload_offset for a
+        # self-extracting file, 0 otherwise. The parser would find the same magic by
+        # scanning, so this is not what makes SFX work — it makes the parse start at the
+        # offset detection already paid for, and it pins the answer: bytes before the
+        # origin are not part of this archive, so a stub carrying its own `Rar!\x1a\x07`
+        # cannot be picked up instead of the real payload.
+        self._origin = start_offset
         self._shared = self._open_shared_source(source)
+        if self._origin and len(self._volume_paths) > 1:
+            raise UnsupportedFeatureError(
+                "A start offset cannot be combined with a multi-volume RAR set: the "
+                "offset describes one file, and the volumes are separate ones.",
+                archive_name=archive_name,
+                source_format=ArchiveFormat.RAR,
+            )
         self._archive, self._unrar_password = self._parse_archive()
         if self._archive.is_volume or self._volume_count > 1:
             self._volume_count = max(self._volume_count, len(self._volume_paths) or 1)
@@ -478,11 +490,12 @@ class RarReader(BaseArchiveReader):
             # already materialized into _volume_paths of length 1, or a lone file.
             if self._volume_paths:
                 with self._volume_paths[0].open("rb") as handle:
+                    handle.seek(self._origin)
                     return parse_rar_archive(handle, password=password)
 
             view = self._shared.view(0)
             try:
-                view.seek(0)
+                view.seek(self._origin)
                 archive = parse_rar_archive(view, password=password)
                 if archive.needs_next_volume or archive.is_volume:
                     raise TruncatedError(
@@ -542,7 +555,11 @@ class RarReader(BaseArchiveReader):
         path = Path(name)
         try:
             with os.fdopen(fd, "wb") as out:
-                view = self._shared.view(0)
+                # From the origin, so the temp holds the payload alone. A path source
+                # keeps its own path here and `unrar` sees the stub, which it handles
+                # natively; this branch is the stream case, where making the temp a
+                # plain RAR is both smaller and one less thing to rely on.
+                view = self._shared.view(self._origin)
                 try:
                     while True:
                         chunk = view.read(1 << 20)
@@ -992,6 +1009,9 @@ class RarReadBackend(ReadBackend):
         MagicSignature(0, RAR5_ID, ArchiveFormat.RAR),
         MagicSignature(0, RAR_ID, ArchiveFormat.RAR),
     )
+    # Both ids, so the scan resolves RAR4 vs RAR5 by which one comes first rather than
+    # matching their shared `Rar!\x1a\x07` prefix and re-reading to disambiguate.
+    SFX_MAGIC: tuple[MagicSignature, ...] = MAGIC
     SUPPORTS_PASSWORD = True
     SUPPORTS_STREAMING_NON_SEEKABLE = False
     OPTIONAL_DEPENDENCY = None
@@ -1010,9 +1030,6 @@ class RarReadBackend(ReadBackend):
         open_site: OpenSite | None = None,
         start_offset: int = 0,
     ) -> RarReader:
-        # Honoured in the sfx-format-detection sibling; until then an SFX
-        # offset must not be silently read from byte 0.
-        reject_start_offset(start_offset, format, archive_name)
         del format
         return RarReader(
             source,
@@ -1024,6 +1041,7 @@ class RarReadBackend(ReadBackend):
             collector=collector,
             member_streams=member_streams,
             open_site=open_site,
+            start_offset=start_offset,
         )
 
 

--- a/src/archivey/internal/backends/rar_reader.py
+++ b/src/archivey/internal/backends/rar_reader.py
@@ -57,7 +57,11 @@ from archivey.internal.backends.rar_unrar import (
     open_unrar_p,
     terminate_unrar,
 )
-from archivey.internal.base_reader import BaseArchiveReader, ReadBackend
+from archivey.internal.base_reader import (
+    BaseArchiveReader,
+    ReadBackend,
+    reject_start_offset,
+)
 from archivey.internal.diagnostics_collector import DiagnosticCollector
 from archivey.internal.logs import integrity as integrity_logger
 from archivey.internal.naming import emit_member_name_normalized, normalize_member_name
@@ -1004,7 +1008,11 @@ class RarReadBackend(ReadBackend):
         collector: DiagnosticCollector | None = None,
         member_streams: MemberStreams = MemberStreams(0),
         open_site: OpenSite | None = None,
+        start_offset: int = 0,
     ) -> RarReader:
+        # Honoured in the sfx-format-detection sibling; until then an SFX
+        # offset must not be silently read from byte 0.
+        reject_start_offset(start_offset, format, archive_name)
         del format
         return RarReader(
             source,

--- a/src/archivey/internal/backends/sevenzip_parser.py
+++ b/src/archivey/internal/backends/sevenzip_parser.py
@@ -370,15 +370,15 @@ def find_signature_offset(fp: BinaryIO, *, limit: int = SFX_MAX) -> int:
         if fp.read(len(MAGIC_7Z)) == MAGIC_7Z:
             return 0
         fp.seek(start)
-        offset = scan_for_magic(fp, (MAGIC_7Z,), limit=limit)
+        hit = scan_for_magic(fp, (MAGIC_7Z,), limit=limit)
     finally:
         fp.seek(start)
-    if offset is None:
+    if hit is None:
         raise CorruptionError(
             "Not a 7z archive: bad magic bytes (and no 7z signature within the "
             f"{limit}-byte self-extracting scan window)"
         )
-    return offset
+    return hit[0]
 
 
 def read_signature_and_next_header(fp: BinaryIO) -> SignatureInfo:

--- a/src/archivey/internal/backends/sevenzip_parser.py
+++ b/src/archivey/internal/backends/sevenzip_parser.py
@@ -46,6 +46,7 @@ from archivey.internal.backends.sevenzip_methods import (
     is_aes,
     lookup,
 )
+from archivey.internal.sfx import SFX_MAX, scan_for_magic
 from archivey.internal.streams.streamtools import read_exact
 from archivey.types import CompressionAlgorithm, CompressionMethod
 
@@ -352,8 +353,42 @@ class _Cursor:
         return sub
 
 
+def find_signature_offset(fp: BinaryIO, *, limit: int = SFX_MAX) -> int:
+    """Offset of the 7z signature header from ``fp``'s current position.
+
+    ``0`` when the magic is already there — the ordinary case, and one 6-byte read.
+    Otherwise the file is treated as self-extracting: the magic is searched for within
+    ``limit`` bytes (the shared :data:`~archivey.internal.sfx.SFX_MAX`, the same bound
+    the RAR parser and ``detect_format`` use), which is what makes forced
+    ``format=SEVEN_Z`` work on a stub the way forced ``format=RAR`` already does.
+
+    Raises :class:`CorruptionError` on a miss, so a non-7z source fails loudly instead
+    of opening as an empty archive. ``fp`` is restored to its starting position.
+    """
+    start = fp.tell()
+    try:
+        if fp.read(len(MAGIC_7Z)) == MAGIC_7Z:
+            return 0
+        fp.seek(start)
+        offset = scan_for_magic(fp, (MAGIC_7Z,), limit=limit)
+    finally:
+        fp.seek(start)
+    if offset is None:
+        raise CorruptionError(
+            "Not a 7z archive: bad magic bytes (and no 7z signature within the "
+            f"{limit}-byte self-extracting scan window)"
+        )
+    return offset
+
+
 def read_signature_and_next_header(fp: BinaryIO) -> SignatureInfo:
-    """Read signature header, verify CRCs, return next-header bytes (possibly empty)."""
+    """Read signature header, verify CRCs, return next-header bytes (possibly empty).
+
+    ``fp`` is expected to begin *at* the signature header: every offset in a 7z archive
+    is relative to it, so a self-extracting archive is opened by handing this a view
+    whose byte 0 is the signature (see :func:`find_signature_offset` and
+    ``SevenZipReader._view``) rather than by adding a stub offset to each seek here.
+    """
     fp.seek(0)
     signature = _read_stream_exact(fp, _SIGNATURE_HEADER_SIZE, "7z signature header")
     if signature[: len(MAGIC_7Z)] != MAGIC_7Z:
@@ -552,6 +587,7 @@ __all__ = [
     "compression_method_for_coder",
     "empty_archive",
     "encoded_folder_slices",
+    "find_signature_offset",
     "folder_is_encrypted",
     "folder_unpack_size",
     "materialize_archive",

--- a/src/archivey/internal/backends/sevenzip_reader.py
+++ b/src/archivey/internal/backends/sevenzip_reader.py
@@ -52,6 +52,7 @@ from archivey.internal.backends.sevenzip_parser import (
     SevenZipFolder,
     compression_method_for_coder,
     empty_archive,
+    find_signature_offset,
     folder_is_encrypted,
     materialize_archive,
     parse_header_block,
@@ -178,6 +179,7 @@ class SevenZipReader(BaseArchiveReader):
         collector: DiagnosticCollector | None = None,
         member_streams: MemberStreams = MemberStreams(0),
         open_site: OpenSite | None = None,
+        start_offset: int = 0,
     ) -> None:
         super().__init__(
             ArchiveFormat.SEVEN_Z,
@@ -206,15 +208,35 @@ class SevenZipReader(BaseArchiveReader):
                 source_format=ArchiveFormat.SEVEN_Z,
             )
         self._shared = SharedSource(source, wrap_handle=self._seek_handle_wrapper())
+        # Every offset a 7z archive records is relative to its signature header, so the
+        # whole file geometry is rebased once here instead of each seek learning about
+        # stubs: ``_view`` is the only thing that knows byte 0 of the archive is not
+        # byte 0 of the source. ``start_offset`` is detection's ``payload_offset``; the
+        # scan on top of it is what makes forced ``format=SEVEN_Z`` work on an SFX file
+        # with no detection involved.
+        probe = self._shared.view(start_offset)
+        try:
+            self._origin = start_offset + find_signature_offset(probe)
+        finally:
+            probe.close()
         self._volume_count = getattr(source, "volume_count", 1)
         self._archive = self._load_archive()
         self._init_folder_caches(self._archive)
         self._members = self._build_members()
         self._folder_members = self._members_by_folder()
 
+    def _view(self, start: int, length: int | None = None) -> BinaryIO:
+        """A source view whose ``start`` is measured from the signature header.
+
+        The single place the self-extracting stub is subtracted: pack offsets, the
+        next-header seek and the encoded-header slices are all signature-relative
+        already, so they keep working unchanged for an archive that begins mid-file.
+        """
+        return self._shared.view(self._origin + start, length)
+
     def _load_archive(self) -> SevenZipArchive:
         """Two-phase header load: parse → decode encoded → re-parse → materialize."""
-        fp = self._shared.view(0)
+        fp = self._view(0)
         signature = read_signature_and_next_header(fp)
         if not signature.header_data:
             return empty_archive(signature)
@@ -527,7 +549,7 @@ class SevenZipReader(BaseArchiveReader):
             raise CorruptionError("7z folder references a missing packed stream")
         pack_offset = self._archive.pack_pos + self._archive.pack_positions[pack_index]
         pack_size = self._archive.pack_sizes[pack_index]
-        return self._shared.view(pack_offset, pack_size)
+        return self._view(pack_offset, pack_size)
 
     def _folder_unpack_size(self, folder_index: int) -> int:
         members = self._folder_members.get(folder_index, [])
@@ -789,6 +811,7 @@ class SevenZipReadBackend(ReadBackend):
         collector: DiagnosticCollector | None = None,
         member_streams: MemberStreams = MemberStreams(0),
         open_site: OpenSite | None = None,
+        start_offset: int = 0,
     ) -> SevenZipReader:
         del format
         return SevenZipReader(
@@ -801,6 +824,7 @@ class SevenZipReadBackend(ReadBackend):
             collector=collector,
             member_streams=member_streams,
             open_site=open_site,
+            start_offset=start_offset,
         )
 
 

--- a/src/archivey/internal/backends/sevenzip_reader.py
+++ b/src/archivey/internal/backends/sevenzip_reader.py
@@ -795,6 +795,7 @@ class SevenZipReadBackend(ReadBackend):
     MAGIC: tuple[MagicSignature, ...] = (
         MagicSignature(0, b"7z\xbc\xaf'\x1c", ArchiveFormat.SEVEN_Z),
     )
+    SFX_MAGIC: tuple[MagicSignature, ...] = MAGIC
     SUPPORTS_PASSWORD = True
     SUPPORTS_STREAMING_NON_SEEKABLE = False
     OPTIONAL_DEPENDENCY = None

--- a/src/archivey/internal/backends/single_file_reader.py
+++ b/src/archivey/internal/backends/single_file_reader.py
@@ -32,7 +32,11 @@ from archivey.cost import (
     StreamCapability,
 )
 from archivey.exceptions import ArchiveyError, StreamNotSeekableError
-from archivey.internal.base_reader import BaseArchiveReader, ReadBackend
+from archivey.internal.base_reader import (
+    BaseArchiveReader,
+    ReadBackend,
+    reject_start_offset,
+)
 from archivey.internal.config import AcceleratorMode, stream_config_from_archivey
 from archivey.internal.diagnostics_collector import DiagnosticCollector
 from archivey.internal.naming import infer_member_name_from_archive
@@ -498,7 +502,9 @@ class SingleFileBackend(ReadBackend):
         collector: DiagnosticCollector | None = None,
         member_streams: MemberStreams = MemberStreams(0),
         open_site: OpenSite | None = None,
+        start_offset: int = 0,
     ) -> SingleFileReader:
+        reject_start_offset(start_offset, format, archive_name)
         # `format` is the resolved single-file format (from detection or the caller); its
         # stream codec is exactly what to decompress with — no re-inspection needed.
         return SingleFileReader(

--- a/src/archivey/internal/backends/tar_reader.py
+++ b/src/archivey/internal/backends/tar_reader.py
@@ -54,7 +54,11 @@ from archivey.exceptions import (
     CorruptionError,
     TruncatedError,
 )
-from archivey.internal.base_reader import BaseArchiveReader, ReadBackend
+from archivey.internal.base_reader import (
+    BaseArchiveReader,
+    ReadBackend,
+    reject_start_offset,
+)
 from archivey.internal.config import stream_config_from_archivey
 from archivey.internal.diagnostics_collector import DiagnosticCollector
 from archivey.internal.logs import backends as backends_logger
@@ -836,7 +840,9 @@ class TarReadBackend(ReadBackend):
         collector: DiagnosticCollector | None = None,
         member_streams: MemberStreams = MemberStreams(0),
         open_site: OpenSite | None = None,
+        start_offset: int = 0,
     ) -> TarReader:
+        reject_start_offset(start_offset, format, archive_name)
         # `format` carries the concrete (TAR, <stream>) variant the detector/caller resolved;
         # the backend uses its stream to pick the codec to decompress with.
         return TarReader(

--- a/src/archivey/internal/backends/zip_reader.py
+++ b/src/archivey/internal/backends/zip_reader.py
@@ -62,7 +62,11 @@ from archivey.exceptions import (
     UnsupportedFeatureError,
     raw_message_of,
 )
-from archivey.internal.base_reader import BaseArchiveReader, ReadBackend
+from archivey.internal.base_reader import (
+    BaseArchiveReader,
+    ReadBackend,
+    reject_start_offset,
+)
 from archivey.internal.config import stream_config_from_archivey
 from archivey.internal.diagnostics_collector import DiagnosticCollector
 from archivey.internal.logs import backends as logger
@@ -1460,7 +1464,11 @@ class ZipReadBackend(ReadBackend):
         collector: DiagnosticCollector | None = None,
         member_streams: MemberStreams = MemberStreams(0),
         open_site: OpenSite | None = None,
+        start_offset: int = 0,
     ) -> ZipReader:
+        # Honoured in the sfx-format-detection sibling; until then an SFX
+        # offset must not be silently read from byte 0.
+        reject_start_offset(start_offset, format, archive_name)
         # `format` is always ZIP here (single-format backend); accepted for the uniform
         # ReadBackend signature.
         return ZipReader(

--- a/src/archivey/internal/backends/zip_reader.py
+++ b/src/archivey/internal/backends/zip_reader.py
@@ -62,11 +62,7 @@ from archivey.exceptions import (
     UnsupportedFeatureError,
     raw_message_of,
 )
-from archivey.internal.base_reader import (
-    BaseArchiveReader,
-    ReadBackend,
-    reject_start_offset,
-)
+from archivey.internal.base_reader import BaseArchiveReader, ReadBackend
 from archivey.internal.config import stream_config_from_archivey
 from archivey.internal.diagnostics_collector import DiagnosticCollector
 from archivey.internal.logs import backends as logger
@@ -405,6 +401,7 @@ class ZipReader(BaseArchiveReader):
         collector: DiagnosticCollector | None = None,
         member_streams: MemberStreams = MemberStreams(0),
         open_site: OpenSite | None = None,
+        start_offset: int = 0,
     ) -> None:
         super().__init__(
             ArchiveFormat.ZIP,
@@ -451,12 +448,22 @@ class ZipReader(BaseArchiveReader):
             )
 
         zip_source: Path | BinaryIO = source
-        if self._measure:
+        if self._measure or start_offset:
+            handle: BinaryIO
             if isinstance(source, Path):
                 self._owned_fp = open(source, "rb")
-                zip_source = self._track_source_seeks(self._owned_fp)
+                handle = cast("BinaryIO", self._track_source_seeks(self._owned_fp))
             else:
-                zip_source = self._track_source_seeks(source)
+                handle = cast("BinaryIO", self._track_source_seeks(source))
+            if start_offset:
+                # stdlib zipfile finds the central directory from the tail and
+                # self-adjusts past a stub on its own, but "adjust past whatever
+                # precedes the EOCD" is not the same promise as "the archive starts
+                # here": a stub carrying its own EOCD-shaped bytes would move the
+                # answer. Slicing makes the payload the whole world, which is what
+                # start_offset means.
+                handle = SlicingStream(handle, start=start_offset)
+            zip_source = handle
 
         try:
             # `metadata_encoding` (3.11+) decodes names stored without the UTF-8 flag with
@@ -1447,6 +1454,12 @@ class ZipReadBackend(ReadBackend):
         ),  # empty archive (EOCD)
         MagicSignature(0, b"\x50\x4b\x07\x08", ArchiveFormat.ZIP),  # spanned marker
     )
+    # Local header only. The EOCD and spanned markers are legitimate ZIP magic *at
+    # offset 0*, but as needles inside a 2 MiB stub window they would claim any
+    # executable that happens to contain those four bytes.
+    SFX_MAGIC: tuple[MagicSignature, ...] = (
+        MagicSignature(0, b"\x50\x4b\x03\x04", ArchiveFormat.ZIP),
+    )
     # SUPPORTS_STREAMING_NON_SEEKABLE stays False: the central directory lives at EOF,
     # so even a forward-only pass needs a seekable source.
     SUPPORTS_PASSWORD = True  # per-member ZipCrypto/AES encryption
@@ -1466,9 +1479,6 @@ class ZipReadBackend(ReadBackend):
         open_site: OpenSite | None = None,
         start_offset: int = 0,
     ) -> ZipReader:
-        # Honoured in the sfx-format-detection sibling; until then an SFX
-        # offset must not be silently read from byte 0.
-        reject_start_offset(start_offset, format, archive_name)
         # `format` is always ZIP here (single-format backend); accepted for the uniform
         # ReadBackend signature.
         return ZipReader(
@@ -1481,6 +1491,7 @@ class ZipReadBackend(ReadBackend):
             collector=collector,
             member_streams=member_streams,
             open_site=open_site,
+            start_offset=start_offset,
         )
 
 

--- a/src/archivey/internal/base_reader.py
+++ b/src/archivey/internal/base_reader.py
@@ -161,6 +161,15 @@ class ReadBackend(ABC):
     EXTENSIONS: Mapping[str, ArchiveFormat] = {}
     # Exact magic-byte signals as data (offset, bytes, format), accepted on the byte match.
     MAGIC: tuple[MagicSignature, ...] = ()
+    # Magic to hunt for *behind an executable stub*, for the formats that ship as
+    # self-extracting archives (RAR / 7z / ZIP). The offset is 0 because these are
+    # magic at offset 0 of the *payload*, wherever in the file that starts; the
+    # detector searches for them within the shared SFX_MAX window when the leading
+    # bytes look executable-shaped, and reports the match position as
+    # ``FormatInfo.payload_offset``. Deliberately a separate, narrower table than
+    # ``MAGIC``: ZIP declares only its local-file header here, because scanning a stub
+    # for the EOCD or spanned markers would claim any file containing those four bytes.
+    SFX_MAGIC: tuple[MagicSignature, ...] = ()
     # Formats this backend reads that have no exact magic and are recognized by a content
     # probe instead: (format, probe) pairs, where the probe inspects a peeked prefix and
     # returns True on a match (Brotli has no signature; zlib's 2-byte header is too weak).

--- a/src/archivey/internal/base_reader.py
+++ b/src/archivey/internal/base_reader.py
@@ -44,6 +44,7 @@ from archivey.exceptions import (
     LinkTargetNotFoundError,
     ReadError,
     TruncatedError,
+    UnsupportedFeatureError,
     UnsupportedOperationError,
 )
 from archivey.internal.diagnostics_collector import (
@@ -126,6 +127,25 @@ class _Materialized:
     by_name_lists: Mapping[str, list[ArchiveMember]]
 
 
+def reject_start_offset(
+    start_offset: int, fmt: ArchiveFormat, archive_name: str | None
+) -> None:
+    """Refuse a nonzero ``open_read(start_offset=…)`` for a format that cannot honour it.
+
+    Only the self-extracting formats (RAR / 7z / ZIP) are ever handed a nonzero offset,
+    because only they can carry an executable stub and only they are scanned for one by
+    ``detect_format``. Reaching here with an offset means a caller invented one, and
+    reading from byte 0 instead would answer with the wrong bytes rather than say so.
+    """
+    if start_offset:
+        raise UnsupportedFeatureError(
+            f"{fmt.display_name} cannot be opened at a nonzero start offset "
+            f"({start_offset}): the format carries no self-extracting stub.",
+            source_format=fmt,
+            archive_name=archive_name,
+        )
+
+
 class ReadBackend(ABC):
     """Stateless factory for creating ArchiveReader instances.
 
@@ -184,6 +204,7 @@ class ReadBackend(ABC):
         collector: DiagnosticCollector | None = None,
         member_streams: MemberStreams = MemberStreams(0),
         open_site: OpenSite | None = None,
+        start_offset: int = 0,
     ) -> "BaseArchiveReader":
         """Open ``source`` as ``format`` (the resolved format the registry selected this
         backend for — either detected by ``open_archive`` or supplied by the caller). A
@@ -192,6 +213,15 @@ class ReadBackend(ABC):
 
         ``collector`` is the prospective reader's diagnostic collector (created before
         detection). When omitted, the reader creates one from ``config``.
+
+        ``start_offset`` is where the archive proper begins inside ``source`` — nonzero
+        only for a self-extracting archive behind an executable stub, where it carries
+        detection's ``FormatInfo.payload_offset``. A backend that accepts it MUST behave
+        exactly as if it had been handed a view of ``source`` starting at that offset:
+        nothing before it belongs to the archive. (The one visible difference is that a
+        backend may still use the original path for an external tool that finds the
+        payload itself — ``unrar`` on an SFX file.) Backends whose formats never carry a
+        stub reject a nonzero value rather than silently reading from byte 0.
         """
         ...
 

--- a/src/archivey/internal/detection.py
+++ b/src/archivey/internal/detection.py
@@ -17,9 +17,16 @@ which detection inspects via ``peek``.
 Formats without an exact magic are recognized by a **content probe**: Brotli (no signature
 at all) and zlib (a 2-byte header too unspecific to trust, so its probe gates on that
 header before decoding). Each probe is a function the backends declare as data — for the
-stream codecs, on the codec descriptor — so the detector stays format-agnostic. The
-inner-TAR probe, the ISO extended window, and SFX scanning arrive with the backends they
-feed in later stages.
+stream codecs, on the codec descriptor — so the detector stays format-agnostic.
+
+A **self-extracting** archive has no archive magic at offset 0 at all: an executable stub
+comes first. When the leading bytes look executable-shaped the detector searches forward
+for the backends' ``SFX_MAGIC`` within the shared ``SFX_MAX`` window and reports the
+payload start as ``payload_offset`` (``PROBABLE`` / ``sfx_scan``). That search runs
+*before* the content probes, because a stub is arbitrary bytes and a probe asked to judge
+arbitrary bytes will sometimes say yes — see ``executable_cue`` and
+``format-detection``'s "Executable-looking prefixes must not silently become a wrong
+stream format".
 """
 
 from __future__ import annotations
@@ -42,6 +49,12 @@ from archivey.internal.diagnostics_collector import (
 )
 from archivey.internal.logs import detection as logger
 from archivey.internal.registry import get_registry
+from archivey.internal.sfx import (
+    SFX_MAX,
+    ExecutableCue,
+    executable_cue,
+    find_magic_in_prefix,
+)
 from archivey.internal.streams.peekable import DETECTION_LIMIT, PeekableStream
 from archivey.internal.streams.streamtools import (
     ReadOnlyIOStream,
@@ -322,6 +335,30 @@ def _warn_on_conflict(
     )
 
 
+def _scan_for_sfx_payload(
+    entries: list[MagicSignature],
+    peek_more: Callable[[int], bytes],
+) -> FormatInfo | None:
+    """Search the SFX window for an appended archive, as ``(format, payload_offset)``.
+
+    ``entries`` are the backends' ``SFX_MAGIC`` declarations, so which formats can hide
+    behind a stub is backend data like every other detection signal. ``PROBABLE`` rather
+    than ``CERTAIN``: an exact magic found at a *searched-for* offset is a weaker claim
+    than one found at the offset the format specifies.
+    """
+    by_needle = {entry.magic: entry.format for entry in entries}
+    hit = find_magic_in_prefix(peek_more, tuple(by_needle), limit=SFX_MAX)
+    if hit is None:
+        return None
+    offset, needle = hit
+    return FormatInfo(
+        by_needle[needle],
+        DetectionConfidence.PROBABLE,
+        "sfx_scan",
+        payload_offset=offset,
+    )
+
+
 def detect_format(
     source: str | Path | BinaryIO,
     *,
@@ -392,19 +429,38 @@ def _detect_format_body(
         _warn_on_conflict(collector, name, ext_match, info.format)
         return info
 
-    # 2. Formats without an exact magic, recognized by a content probe (Brotli decodes a
+    # 2. Self-extracting archives: an executable stub, then real archive magic somewhere
+    #    in the SFX window. This runs before the content probes rather than after, which
+    #    is the whole fix: a stub is arbitrary bytes, and a probe handed arbitrary bytes
+    #    sometimes says yes — a low-entropy `MZ` stub in front of a real RAR/7z/ZIP used
+    #    to be reported as BROTLI, and open_archive then fabricated a single-file member.
+    cue = executable_cue(data)
+    if cue is not ExecutableCue.NONE:
+        sfx_info = _scan_for_sfx_payload(registry.sfx_magic_entries(), peek_more)
+        if sfx_info is not None:
+            _warn_on_conflict(collector, name, ext_match, sfx_info.format)
+            return sfx_info
+
+    # 3. Formats without an exact magic, recognized by a content probe (Brotli decodes a
     #    prefix; zlib gates on its 2-byte header then decodes). A probe is skipped when its
     #    backend is absent, so detection falls through. A matching compressor is likewise
     #    probed for an inner TAR (so .tar.br → TAR_BROTLI).
-    for probe_fmt, probe in registry.content_probes():
-        if probe(data):
-            info = _resolve_single_file_or_tar(
-                probe_fmt, DetectionConfidence.PROBABLE, "content_probe", peek_more
-            )
-            _warn_on_conflict(collector, name, ext_match, info.format)
-            return info
+    #
+    #    Skipped entirely on a STRONG executable cue: a DOS header that really points at
+    #    `PE\0\0`, or a valid ELF ident block, is not a compressed stream, and letting a
+    #    probe claim one produces a fabricated `*.uncompressed` member — a silent wrong
+    #    answer. A WEAK cue does not gate the probes: `MZ` alone is two bytes, and a
+    #    genuine Brotli stream that happens to start with them must still be detectable.
+    if cue is not ExecutableCue.STRONG:
+        for probe_fmt, probe in registry.content_probes():
+            if probe(data):
+                info = _resolve_single_file_or_tar(
+                    probe_fmt, DetectionConfidence.PROBABLE, "content_probe", peek_more
+                )
+                _warn_on_conflict(collector, name, ext_match, info.format)
+                return info
 
-    # 3. Far magic (ISO's CD001 at offset 32 769): peek the extended 32 774-byte window on
+    # 4. Far magic (ISO's CD001 at offset 32 769): peek the extended 32 774-byte window on
     #    demand. A stream shorter than the window simply yields no match and falls through —
     #    it is never rejected solely for being too short for the ISO probe.
     if far:
@@ -415,7 +471,7 @@ def _detect_format_body(
             _warn_on_conflict(collector, name, ext_match, far_fmt)
             return FormatInfo(far_fmt, DetectionConfidence.CERTAIN, "magic")
 
-    # 4. Extension-only guess.
+    # 5. Extension-only guess.
     if ext_fmt is not None:
         return FormatInfo(ext_fmt, DetectionConfidence.GUESS, "extension")
 

--- a/src/archivey/internal/registry.py
+++ b/src/archivey/internal/registry.py
@@ -150,6 +150,18 @@ class BackendRegistry:
             entries.extend(codec.magic)
         return entries
 
+    def sfx_magic_entries(self) -> list[MagicSignature]:
+        """Magic the SFX scan hunts for behind an executable stub.
+
+        Only the backends that can ship as a self-extracting archive declare any
+        (``ReadBackend.SFX_MAGIC``); the stream codecs never do, since a stub plus a
+        bare compressed stream is not a thing anyone produces.
+        """
+        entries: list[MagicSignature] = []
+        for cls in self._reader_classes:
+            entries.extend(cls.SFX_MAGIC)
+        return entries
+
     def content_probes(self) -> list[tuple[ArchiveFormat, Callable[[bytes], bool]]]:
         """(format, probe) pairs for formats recognized by a content probe.
 

--- a/src/archivey/internal/sfx.py
+++ b/src/archivey/internal/sfx.py
@@ -80,9 +80,15 @@ class ExecutableCue(Enum):
 def executable_cue(prefix: bytes) -> ExecutableCue:
     """Classify ``prefix`` as :class:`ExecutableCue`.
 
-    Reads only the peeked detection prefix — a few KiB is far more than the DOS header
-    and ELF ident block need — so a source whose leading bytes are not executable-shaped
-    costs two byte comparisons.
+    Reads only ``prefix`` — the bytes detection already peeked — so a source whose
+    leading bytes are not executable-shaped costs two byte comparisons, and nothing here
+    ever reaches back to the source for more.
+
+    That bounds how strong ``STRONG`` can get: a DOS header whose ``e_lfanew`` points
+    past the end of ``prefix`` grades ``WEAK``, because the ``PE\\0\\0`` it promises is not
+    in hand to confirm. Real PE files put the header within a few hundred bytes, so this
+    costs nothing in practice; when it does bite, the result is the ordinary weak-cue
+    path (scan, then probes on a miss), never a wrong answer.
     """
     if prefix.startswith(_MZ):
         return ExecutableCue.STRONG if _is_pe(prefix) else ExecutableCue.WEAK

--- a/src/archivey/internal/sfx.py
+++ b/src/archivey/internal/sfx.py
@@ -1,0 +1,91 @@
+"""Self-extracting (SFX) stubs: the shared scan bound and the forward magic scan.
+
+A self-extracting archive is an executable stub with a real archive appended, so the
+archive magic sits at some offset ``N > 0`` rather than at byte zero. Three places have
+to agree on how far forward to look for it:
+
+* :func:`archivey.internal.detection.detect_format` — the SFX scan that turns an
+  executable-shaped prefix into ``(format, payload_offset)``;
+* ``rar_parser._find_sfx_header`` — the RAR parser's own scan, which is what makes
+  forced ``format=RAR`` work on an SFX file;
+* ``sevenzip_parser.find_signature_offset`` — the 7z equivalent.
+
+They share :data:`SFX_MAX` rather than each carrying a bound of its own: three separate
+limits drift, and a stub the RAR parser accepts but the detector does not would be a
+format that opens under ``format=RAR`` and fails under auto-detect. Raising the bound is
+one edit here for all three.
+
+The scan itself is :func:`scan_for_magic`, which walks a source forward in chunks and
+keeps only the needle-length overlap between them, so a 2 MiB window costs 2 MiB of
+reads and a few hundred bytes of buffer — not a 2 MiB buffer, and not the quadratic
+re-search a grow-and-rescan loop pays.
+"""
+
+from __future__ import annotations
+
+from typing import BinaryIO, Sequence
+
+# How far past the start of a source the archive magic may sit before we stop looking.
+# 2 MiB comfortably covers real stubs (a `rar a -sfx` ELF stub is ~250 KB, and Windows
+# installer stubs are of the same order) while keeping a miss cheap and bounded.
+SFX_MAX = 2 * 1024 * 1024
+
+# Read granularity for the forward scan. Large enough that a full 2 MiB window is 32
+# reads, small enough that a match near the front stops early.
+_SCAN_CHUNK = 65536
+
+
+def _find_earliest(data: bytes | bytearray, needles: Sequence[bytes]) -> int:
+    """Index of the earliest needle occurrence in ``data``, or ``-1`` if none match."""
+    best = -1
+    for needle in needles:
+        found = data.find(needle)
+        if found >= 0 and (best < 0 or found < best):
+            best = found
+    return best
+
+
+def scan_for_magic(
+    source: BinaryIO,
+    needles: Sequence[bytes],
+    *,
+    limit: int = SFX_MAX,
+) -> int | None:
+    """Offset of the earliest ``needles`` match within ``limit`` bytes, or ``None``.
+
+    The scan starts at ``source``'s **current position** and the returned offset is
+    relative to it. A needle counts as found only when it lies wholly inside the first
+    ``limit`` bytes, so the bound is a promise about the whole magic and not just its
+    first byte.
+
+    ``source`` is left wherever the scan stopped reading — callers reposition it from
+    the returned offset. Overlapping needles are resolved by earliest start, not by
+    needle order, so a caller can pass several magics (RAR4's and RAR5's ids, say) and
+    get the one that actually comes first in the file.
+    """
+    if not needles:
+        return None
+    # Bytes carried between chunks so a magic straddling a chunk boundary still matches.
+    overlap = max(len(needle) for needle in needles) - 1
+
+    window = bytearray()
+    # Offset (from the scan start) of window[0], so a hit inside the window maps back.
+    window_start = 0
+    consumed = 0
+
+    while consumed < limit:
+        chunk = source.read(min(_SCAN_CHUNK, limit - consumed))
+        if not chunk:
+            break
+        consumed += len(chunk)
+        window.extend(chunk)
+
+        found = _find_earliest(window, needles)
+        if found >= 0:
+            return window_start + found
+
+        if len(window) > overlap:
+            window_start += len(window) - overlap
+            del window[: len(window) - overlap]
+
+    return None

--- a/src/archivey/internal/sfx.py
+++ b/src/archivey/internal/sfx.py
@@ -1,4 +1,4 @@
-"""Self-extracting (SFX) stubs: the shared scan bound and the forward magic scan.
+"""Self-extracting (SFX) stubs: the shared scan bound, the forward scan, and the cue.
 
 A self-extracting archive is an executable stub with a real archive appended, so the
 archive magic sits at some offset ``N > 0`` rather than at byte zero. Three places have
@@ -12,18 +12,25 @@ to agree on how far forward to look for it:
 
 They share :data:`SFX_MAX` rather than each carrying a bound of its own: three separate
 limits drift, and a stub the RAR parser accepts but the detector does not would be a
-format that opens under ``format=RAR`` and fails under auto-detect. Raising the bound is
+file that opens under ``format=RAR`` and fails under auto-detect. Raising the bound is
 one edit here for all three.
 
-The scan itself is :func:`scan_for_magic`, which walks a source forward in chunks and
-keeps only the needle-length overlap between them, so a 2 MiB window costs 2 MiB of
-reads and a few hundred bytes of buffer — not a 2 MiB buffer, and not the quadratic
-re-search a grow-and-rescan loop pays.
+Two scan entry points, because the callers differ in what they may do to the source.
+A parser owns its handle and reads forward (:func:`scan_for_magic`); the detector must
+not consume anything, so it works from growing peeks (:func:`find_magic_in_prefix`).
+Both keep the window bounded and neither buffers the whole of it.
+
+:func:`executable_cue` is the gate. Scanning every source for archive magic would claim
+any file that happens to contain ``PK\\x03\\x04`` somewhere in its first 2 MiB, so the
+scan runs only where a stub could plausibly be. The gate is deliberately two-tiered —
+see :class:`ExecutableCue`.
 """
 
 from __future__ import annotations
 
-from typing import BinaryIO, Sequence
+import struct
+from enum import Enum
+from typing import BinaryIO, Callable, Sequence
 
 # How far past the start of a source the archive magic may sit before we stop looking.
 # 2 MiB comfortably covers real stubs (a `rar a -sfx` ELF stub is ~250 KB, and Windows
@@ -34,14 +41,86 @@ SFX_MAX = 2 * 1024 * 1024
 # reads, small enough that a match near the front stops early.
 _SCAN_CHUNK = 65536
 
+# Peek sizes the non-consuming scan steps through. Each peek re-reads from the source
+# origin, so growing geometrically keeps a small stub cheap (64 KiB) while capping the
+# worst case at a little over 2× the window, instead of the ~32× a fixed chunk would
+# cost. A stub whose magic is at 250 KB — the size `rar a -sfx` produces — is found on
+# the third peek.
+_PEEK_STEPS = (1 << 16, 1 << 18, 1 << 20)
 
-def _find_earliest(data: bytes | bytearray, needles: Sequence[bytes]) -> int:
-    """Index of the earliest needle occurrence in ``data``, or ``-1`` if none match."""
-    best = -1
+_MZ = b"MZ"
+_ELF = b"\x7fELF"
+_PE = b"PE\x00\x00"
+# Offset of the PE header pointer (``e_lfanew``) in the DOS header, and the smallest
+# value it can legally hold — the PE header cannot overlap the DOS header itself.
+_E_LFANEW_OFFSET = 0x3C
+_DOS_HEADER_SIZE = 0x40
+
+
+class ExecutableCue(Enum):
+    """How strongly a source's leading bytes say "this is an executable".
+
+    ``STRONG`` means structurally confirmed — a DOS header whose ``e_lfanew`` actually
+    points at a ``PE\\0\\0`` signature, or an ELF identification block whose class, data
+    encoding and version fields are all valid. Arbitrary data reaches this by accident
+    with vanishing probability.
+
+    ``WEAK`` is the two- or four-byte prefix alone. It is enough to justify *looking*
+    for an appended archive, but not enough to overrule a content probe: ``MZ`` is two
+    bytes, and a genuine Brotli stream that happens to start with them must still be
+    detectable (``format-detection``: "Executable-looking prefixes must not silently
+    become a wrong stream format" is outcome-shaped, not "disable Brotli on ``MZ``").
+    """
+
+    NONE = "none"
+    WEAK = "weak"
+    STRONG = "strong"
+
+
+def executable_cue(prefix: bytes) -> ExecutableCue:
+    """Classify ``prefix`` as :class:`ExecutableCue`.
+
+    Reads only the peeked detection prefix — a few KiB is far more than the DOS header
+    and ELF ident block need — so a source whose leading bytes are not executable-shaped
+    costs two byte comparisons.
+    """
+    if prefix.startswith(_MZ):
+        return ExecutableCue.STRONG if _is_pe(prefix) else ExecutableCue.WEAK
+    if prefix.startswith(_ELF):
+        return ExecutableCue.STRONG if _is_elf(prefix) else ExecutableCue.WEAK
+    return ExecutableCue.NONE
+
+
+def _is_pe(prefix: bytes) -> bool:
+    """Whether a ``MZ`` prefix carries a DOS header pointing at a real PE signature."""
+    if len(prefix) < _E_LFANEW_OFFSET + 4:
+        return False
+    (e_lfanew,) = struct.unpack_from("<I", prefix, _E_LFANEW_OFFSET)
+    if not _DOS_HEADER_SIZE <= e_lfanew <= len(prefix) - len(_PE):
+        return False
+    return prefix[e_lfanew : e_lfanew + len(_PE)] == _PE
+
+
+def _is_elf(prefix: bytes) -> bool:
+    """Whether an ``\\x7fELF`` prefix carries a valid identification block.
+
+    ``EI_CLASS`` (32/64-bit), ``EI_DATA`` (endianness) and ``EI_VERSION`` are the three
+    ident fields with a closed set of legal values.
+    """
+    if len(prefix) < 7:
+        return False
+    return prefix[4] in (1, 2) and prefix[5] in (1, 2) and prefix[6] == 1
+
+
+def _find_earliest(
+    data: bytes | bytearray, needles: Sequence[bytes], start: int = 0
+) -> tuple[int, bytes] | None:
+    """The earliest needle occurrence at or after ``start``, as ``(index, needle)``."""
+    best: tuple[int, bytes] | None = None
     for needle in needles:
-        found = data.find(needle)
-        if found >= 0 and (best < 0 or found < best):
-            best = found
+        found = data.find(needle, start)
+        if found >= 0 and (best is None or found < best[0]):
+            best = (found, needle)
     return best
 
 
@@ -50,8 +129,8 @@ def scan_for_magic(
     needles: Sequence[bytes],
     *,
     limit: int = SFX_MAX,
-) -> int | None:
-    """Offset of the earliest ``needles`` match within ``limit`` bytes, or ``None``.
+) -> tuple[int, bytes] | None:
+    """The earliest ``needles`` match within ``limit`` bytes, as ``(offset, needle)``.
 
     The scan starts at ``source``'s **current position** and the returned offset is
     relative to it. A needle counts as found only when it lies wholly inside the first
@@ -80,12 +159,46 @@ def scan_for_magic(
         consumed += len(chunk)
         window.extend(chunk)
 
-        found = _find_earliest(window, needles)
-        if found >= 0:
-            return window_start + found
+        hit = _find_earliest(window, needles)
+        if hit is not None:
+            index, needle = hit
+            return window_start + index, needle
 
         if len(window) > overlap:
             window_start += len(window) - overlap
             del window[: len(window) - overlap]
+
+    return None
+
+
+def find_magic_in_prefix(
+    peek_more: Callable[[int], bytes],
+    needles: Sequence[bytes],
+    *,
+    limit: int = SFX_MAX,
+) -> tuple[int, bytes] | None:
+    """:func:`scan_for_magic` for a source that must not be consumed.
+
+    ``peek_more(n)`` returns the source's first ``n`` bytes without consuming them
+    (idempotent, growing supersets — see ``detection._peek_prefix``). The window grows
+    geometrically and each round searches only the bytes the previous one could not
+    have covered, so a stub found early costs one small peek and a miss costs a bounded
+    number of large ones.
+    """
+    if not needles:
+        return None
+    overlap = max(len(needle) for needle in needles) - 1
+    searched = 0
+
+    for step in (*_PEEK_STEPS, limit):
+        if step <= searched:
+            continue
+        data = peek_more(min(step, limit))
+        hit = _find_earliest(data, needles, max(0, searched - overlap))
+        if hit is not None:
+            return hit
+        if len(data) < step:
+            return None  # the source ended inside this peek; nothing more to search
+        searched = len(data)
 
     return None

--- a/tests/test_sfx.py
+++ b/tests/test_sfx.py
@@ -534,3 +534,49 @@ def test_a_stub_carrying_a_decoy_zip_header_does_not_move_the_answer(
         assert {
             m.name: archive.read(m) for m in archive.members() if m.is_file
         } == _FILES
+
+
+@requires("py7zr")
+def test_a_decoy_needle_in_the_stub_wins_and_fails_loudly(tmp_path: Path) -> None:
+    """A known scanner limit, pinned: earliest match wins, even against a real payload.
+
+    ``detect_format`` takes the first needle in the window, so a stub carrying one
+    decides ``payload_offset`` and the backend opens *there* rather than at a later real
+    archive. What makes it acceptable for now is that the failure is loud — 7z rejects
+    the signature CRC — rather than the fabricated-member silence this change exists to
+    close. Validate-and-continue would turn detection into a trial-open loop; if that
+    ever lands, this test is the one to rewrite.
+    """
+    inner = tmp_path / "real-inner.7z"
+    _write_7z(inner)
+    stub = b"MZ" + b"\x90" * 512 + MAGIC_7Z + b"\x90" * 3576
+    path = tmp_path / "decoy-auto.exe"
+    path.write_bytes(stub + inner.read_bytes())
+
+    detected = detect_format(path)
+    assert detected.format == ArchiveFormat.SEVEN_Z
+    assert detected.payload_offset == 514, "the decoy, not the real payload at 4096"
+
+    with pytest.raises(CorruptionError):
+        open_archive(path)
+
+    # The real payload is reachable the moment something supplies the right offset.
+    with _open_with(path, start_offset=len(stub)) as archive:
+        assert {m.name for m in archive.members() if m.is_file} == set(_FILES)
+
+
+def test_a_decoy_zip_needle_still_opens_via_the_tail(tmp_path: Path) -> None:
+    """ZIP survives the same decoy, because zipfile locates the EOCD from the tail.
+
+    Recorded next to the 7z case so the asymmetry is visible: the scanner limit bites
+    per-format, and only where the backend trusts the offset as the archive origin.
+    """
+    stub = b"MZ" + b"\x90" * 512 + b"PK\x03\x04" + b"\x90" * 3576
+    path = tmp_path / "decoy-zip.exe"
+    path.write_bytes(stub + _zip_bytes())
+
+    assert detect_format(path).payload_offset == 514
+    with open_archive(path) as archive:
+        assert {
+            m.name: archive.read(m) for m in archive.members() if m.is_file
+        } == _FILES

--- a/tests/test_sfx.py
+++ b/tests/test_sfx.py
@@ -286,10 +286,35 @@ def test_executable_cue_grades_the_evidence() -> None:
 
 
 def test_a_real_elf_binary_is_a_strong_cue() -> None:
-    binary = Path("/usr/bin/env")
-    if not binary.is_file():  # pragma: no cover - platform dependent
-        pytest.skip("no ELF binary to sample")
-    assert executable_cue(binary.read_bytes()[:4096]) is ExecutableCue.STRONG
+    """The strong cue against a shipped binary, not a hand-built header.
+
+    Sampling the platform's own binaries is the point — a synthetic ELF header only
+    proves the parser reads what this file wrote. Skipped where those binaries are not
+    ELF: macOS ships Mach-O (`0xcafebabe` / `0xfeedfacf`) and Windows PE, and
+    `executable_cue` knows only the two shapes `format-detection` names, so there is
+    nothing to assert on those platforms.
+    """
+    for candidate in (Path("/usr/bin/env"), Path("/bin/ls"), Path("/usr/bin/python3")):
+        if not candidate.is_file():
+            continue
+        prefix = candidate.read_bytes()[:4096]
+        if prefix.startswith(b"\x7fELF"):
+            assert executable_cue(prefix) is ExecutableCue.STRONG
+            return
+    pytest.skip("no ELF binary on this platform to sample")
+
+
+def test_a_mach_o_binary_is_not_a_cue_today() -> None:
+    """Records the known gap rather than leaving it to a platform-dependent surprise.
+
+    A macOS self-extracting stub is Mach-O, which no cue matches, so an archive behind
+    one still falls through to the content probes. `format-detection` names `MZ` and ELF
+    only; widening it is a spec change, not an implementation detail.
+    """
+    fat_universal = b"\xca\xfe\xba\xbe" + b"\x00" * 4092
+    mach_o_64 = b"\xcf\xfa\xed\xfe" + b"\x00" * 4092
+    assert executable_cue(fat_universal) is ExecutableCue.NONE
+    assert executable_cue(mach_o_64) is ExecutableCue.NONE
 
 
 # --- detection: the SFX matrix ----------------------------------------------------------

--- a/tests/test_sfx.py
+++ b/tests/test_sfx.py
@@ -3,26 +3,43 @@
 A self-extracting archive is an executable stub with a real archive appended, so the
 archive magic sits at some offset ``N > 0``. Three pieces have to agree about that
 offset — the shared scanner in ``archivey.internal.sfx``, each parser's own scan, and
-(in the sibling change) ``detect_format`` — so they are exercised together here rather
-than once per backend.
+``detect_format`` — so they are exercised together here rather than once per backend.
+
+The detection half is the one with teeth: before it, a low-entropy ``MZ`` stub in front
+of a real RAR/7z/ZIP was reported as ``BROTLI`` and ``open_archive`` returned a
+fabricated ``*.uncompressed`` member. A test that only asserted ``FormatDetectionError``
+would have stayed green through that, so the cases below assert the *members*.
 """
 
 from __future__ import annotations
 
 import io
+import struct
+import subprocess
+import zipfile
 from pathlib import Path
 
 import pytest
 
-from archivey import DEFAULT_ARCHIVEY_CONFIG, open_archive
-from archivey.exceptions import CorruptionError, UnsupportedFeatureError
+from archivey import DEFAULT_ARCHIVEY_CONFIG, detect_format, open_archive
+from archivey.exceptions import (
+    CorruptionError,
+    FormatDetectionError,
+    UnsupportedFeatureError,
+)
 from archivey.internal.backends.sevenzip_parser import MAGIC_7Z, find_signature_offset
 from archivey.internal.backends.sevenzip_reader import SevenZipReadBackend
 from archivey.internal.password import _PasswordCandidates
-from archivey.internal.sfx import SFX_MAX, scan_for_magic
+from archivey.internal.sfx import (
+    SFX_MAX,
+    ExecutableCue,
+    executable_cue,
+    scan_for_magic,
+)
+from archivey.internal.streams.peekable import PeekableStream
 from archivey.internal.streams.streamtools.slice import SlicingStream
 from archivey.types import ArchiveFormat
-from tests.conftest import requires
+from tests.conftest import requires, requires_binary
 
 # The stub shape from Topic 8 A-34: `MZ` plus low-entropy filler. Deliberately the
 # *synthetic* one — real PE/ELF stubs are the easy case, this one is what the Brotli
@@ -63,7 +80,7 @@ def _sfx(tmp_path: Path, name: str, *, header_encryption: bool = False) -> Path:
 
 def test_scan_finds_magic_at_offset() -> None:
     data = b"stub" * 100 + MAGIC_7Z + b"rest"
-    assert scan_for_magic(io.BytesIO(data), (MAGIC_7Z,)) == 400
+    assert scan_for_magic(io.BytesIO(data), (MAGIC_7Z,)) == (400, MAGIC_7Z)
 
 
 def test_scan_returns_none_when_absent() -> None:
@@ -76,18 +93,21 @@ def test_scan_finds_magic_straddling_a_chunk_boundary() -> None:
     for split in range(1, len(MAGIC_7Z)):
         offset = 65536 - split
         data = b"\x00" * offset + MAGIC_7Z + b"\x00" * 128
-        assert scan_for_magic(io.BytesIO(data), (MAGIC_7Z,)) == offset
+        assert scan_for_magic(io.BytesIO(data), (MAGIC_7Z,)) == (offset, MAGIC_7Z)
 
 
 def test_scan_returns_the_earliest_of_several_needles() -> None:
     data = b"\x00" * 50 + b"SECOND" + b"\x00" * 50 + b"FIRST"
     # Earliest position wins, not the order the needles were passed in.
-    assert scan_for_magic(io.BytesIO(data), (b"FIRST", b"SECOND")) == 50
+    assert scan_for_magic(io.BytesIO(data), (b"FIRST", b"SECOND")) == (50, b"SECOND")
 
 
 def test_scan_requires_the_whole_magic_inside_the_limit() -> None:
     data = b"\x00" * 10 + MAGIC_7Z
-    assert scan_for_magic(io.BytesIO(data), (MAGIC_7Z,), limit=10 + len(MAGIC_7Z)) == 10
+    assert scan_for_magic(io.BytesIO(data), (MAGIC_7Z,), limit=10 + len(MAGIC_7Z)) == (
+        10,
+        MAGIC_7Z,
+    )
     # One byte short: the magic starts inside the window but does not fit in it.
     assert scan_for_magic(io.BytesIO(data), (MAGIC_7Z,), limit=15) is None
 
@@ -240,3 +260,252 @@ def test_sfx_max_is_one_shared_bound() -> None:
     from archivey.internal.backends import rar_parser
 
     assert rar_parser.SFX_MAX is SFX_MAX
+
+
+# --- detection: executable cues ---------------------------------------------------------
+
+
+def _pe_stub(size: int = 8192, filler: bytes = b"\x90") -> bytes:
+    """A DOS header whose ``e_lfanew`` really points at a ``PE\\0\\0`` signature."""
+    header = bytearray(b"\x00" * 0x40)
+    header[0:2] = b"MZ"
+    header[0x3C:0x40] = struct.pack("<I", 0x80)
+    body = bytearray(filler * (size - 0x40))
+    body[0x80 - 0x40 : 0x80 - 0x40 + 4] = b"PE\x00\x00"
+    return bytes(header) + bytes(body)
+
+
+def test_executable_cue_grades_the_evidence() -> None:
+    assert executable_cue(b"not an executable at all") is ExecutableCue.NONE
+    # `MZ` alone is two bytes — enough to look for a payload, not enough to overrule a
+    # content probe.
+    assert executable_cue(_STUB) is ExecutableCue.WEAK
+    assert executable_cue(_pe_stub()) is ExecutableCue.STRONG
+    assert executable_cue(b"\x7fELF" + b"\x00" * 64) is ExecutableCue.WEAK
+    assert executable_cue(b"\x7fELF\x02\x01\x01" + b"\x00" * 64) is ExecutableCue.STRONG
+
+
+def test_a_real_elf_binary_is_a_strong_cue() -> None:
+    binary = Path("/usr/bin/env")
+    if not binary.is_file():  # pragma: no cover - platform dependent
+        pytest.skip("no ELF binary to sample")
+    assert executable_cue(binary.read_bytes()[:4096]) is ExecutableCue.STRONG
+
+
+# --- detection: the SFX matrix ----------------------------------------------------------
+
+
+def _zip_bytes() -> bytes:
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as archive:
+        for name, data in _FILES.items():
+            archive.writestr(name, data)
+    return buffer.getvalue()
+
+
+def _rar_bytes(tmp_path: Path) -> bytes:
+    source = tmp_path / "rar-src"
+    for name, data in _FILES.items():
+        target = source / name
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(data)
+    out = tmp_path / "payload.rar"
+    subprocess.run(
+        ["rar", "a", "-r", "-ep1", str(out), "."],
+        cwd=source,
+        check=True,
+        capture_output=True,
+    )
+    return out.read_bytes()
+
+
+def _7z_bytes(tmp_path: Path) -> bytes:
+    inner = tmp_path / "payload.7z"
+    _write_7z(inner)
+    return inner.read_bytes()
+
+
+def _assert_sfx_opens(path: Path, expected: ArchiveFormat, offset: int) -> None:
+    detected = detect_format(path)
+    assert detected.format == expected
+    assert detected.payload_offset == offset
+    assert detected.detected_by == "sfx_scan"
+    with open_archive(path) as archive:
+        members = {m.name: archive.read(m) for m in archive.members() if m.is_file}
+    assert members == _FILES
+
+
+@requires("py7zr")
+def test_sfx_7z_behind_a_low_entropy_stub_is_not_brotli(tmp_path: Path) -> None:
+    path = tmp_path / "installer.exe"
+    path.write_bytes(_STUB + _7z_bytes(tmp_path))
+    _assert_sfx_opens(path, ArchiveFormat.SEVEN_Z, len(_STUB))
+
+
+def test_sfx_zip_behind_a_low_entropy_stub_is_not_brotli(tmp_path: Path) -> None:
+    path = tmp_path / "installer.exe"
+    path.write_bytes(_STUB + _zip_bytes())
+    _assert_sfx_opens(path, ArchiveFormat.ZIP, len(_STUB))
+
+
+@requires_binary("rar")
+def test_sfx_rar_behind_a_low_entropy_stub_is_not_brotli(tmp_path: Path) -> None:
+    path = tmp_path / "installer.exe"
+    path.write_bytes(_STUB + _rar_bytes(tmp_path))
+    _assert_sfx_opens(path, ArchiveFormat.RAR, len(_STUB))
+
+
+@requires_binary("rar")
+def test_a_real_sfx_archive_auto_opens(tmp_path: Path) -> None:
+    """`rar a -sfx` output: a real ~250 KB stub, not a hand-rolled one.
+
+    Before the scan this raised FormatDetectionError — the loud half of the same defect.
+    """
+    source = tmp_path / "sfx-src"
+    source.mkdir()
+    (source / "alpha.txt").write_bytes(_FILES["alpha.txt"])
+    path = tmp_path / "real.exe"
+    subprocess.run(
+        ["rar", "a", "-ep", "-sfx", str(path), "alpha.txt"],
+        cwd=source,
+        check=True,
+        capture_output=True,
+    )
+    detected = detect_format(path)
+    assert detected.format == ArchiveFormat.RAR
+    assert detected.payload_offset > 0
+    with open_archive(path) as archive:
+        assert archive.read("alpha.txt") == _FILES["alpha.txt"]
+
+
+def test_executable_prefix_with_a_pe_header_never_becomes_a_stream_codec(
+    tmp_path: Path,
+) -> None:
+    """A confirmed PE with no archive in the window: an error, never a fake member."""
+    path = tmp_path / "plain.exe"
+    path.write_bytes(_pe_stub(200_000))
+    with pytest.raises(FormatDetectionError):
+        detect_format(path)
+
+
+def test_a_weak_cue_still_lets_a_content_probe_answer(tmp_path: Path) -> None:
+    """`MZ` is two bytes: a probe-matched stream that starts with them stays detectable.
+
+    The synthetic stub *is* a Brotli-probe hit (that is the whole A-34 defect), so it
+    doubles as the "weak cue does not gate the probes" fixture: with no archive in the
+    window, detection is unchanged from before this change.
+    """
+    brotli = pytest.importorskip("brotli")
+    del brotli
+    path = tmp_path / "weak.bin"
+    path.write_bytes(_STUB)
+    assert detect_format(path).format == ArchiveFormat.BROTLI
+
+
+def test_a_real_brotli_stream_is_unaffected(tmp_path: Path) -> None:
+    brotli = pytest.importorskip("brotli")
+    path = tmp_path / "payload.bin"
+    path.write_bytes(brotli.compress(b"hello world\n" * 500))
+    detected = detect_format(path)
+    assert detected.format == ArchiveFormat.BROTLI
+    assert detected.detected_by == "content_probe"
+    assert detected.payload_offset == 0
+
+
+def test_no_archive_needle_in_the_window_falls_through_to_the_extension(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "mislabelled.zip"
+    path.write_bytes(_pe_stub(100_000))
+    detected = detect_format(path)
+    assert detected.format == ArchiveFormat.ZIP
+    assert detected.detected_by == "extension"
+    assert detected.payload_offset == 0
+
+
+def test_the_scan_does_not_reach_past_the_shared_bound(tmp_path: Path) -> None:
+    path = tmp_path / "far.exe"
+    path.write_bytes(b"MZ" + b"\x00" * SFX_MAX + _zip_bytes())
+    with pytest.raises(FormatDetectionError):
+        detect_format(path)
+
+
+def test_detection_leaves_a_non_seekable_stream_replayable(tmp_path: Path) -> None:
+    """The scan peeks; it must not eat the bytes the backend still needs.
+
+    A pipe cannot be rewound, so this is what stops the SFX window from being a
+    destructive read for the streaming ZIP reader this repo is heading towards.
+    """
+    payload = _STUB + _zip_bytes()
+    source = PeekableStream(io.BytesIO(payload))
+    detected = detect_format(source)
+    assert detected.format == ArchiveFormat.ZIP
+    assert detected.payload_offset == len(_STUB)
+    assert source.read() == payload
+
+
+# --- the payload_offset hand-off --------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "builder,expected",
+    [
+        pytest.param(lambda tmp: _zip_bytes(), ArchiveFormat.ZIP, id="zip"),
+        pytest.param(
+            _7z_bytes,
+            ArchiveFormat.SEVEN_Z,
+            id="7z",
+            marks=requires("py7zr"),
+        ),
+        pytest.param(
+            _rar_bytes,
+            ArchiveFormat.RAR,
+            id="rar",
+            marks=requires_binary("rar"),
+        ),
+    ],
+)
+def test_auto_open_matches_an_explicitly_sliced_stream(
+    tmp_path: Path, builder, expected: ArchiveFormat
+) -> None:
+    """Auto-open of an SFX file equals opening a view whose byte 0 is the payload.
+
+    The hand-off is an argument rather than a slice so a path source stays a path; this
+    is the assertion that the two are nonetheless the same archive.
+    """
+    payload = builder(tmp_path)
+    path = tmp_path / "installer.exe"
+    path.write_bytes(_STUB + payload)
+
+    with open_archive(path) as auto:
+        assert auto.format == expected
+        auto_read = {m.name: auto.read(m) for m in auto.members() if m.is_file}
+
+    with path.open("rb") as handle:
+        with open_archive(SlicingStream(handle, start=len(_STUB))) as sliced:
+            sliced_read = {
+                m.name: sliced.read(m) for m in sliced.members() if m.is_file
+            }
+
+    assert auto_read == sliced_read == _FILES
+
+
+def test_a_stub_carrying_a_decoy_zip_header_does_not_move_the_answer(
+    tmp_path: Path,
+) -> None:
+    """ZIP is sliced at the detected offset rather than left to self-adjust.
+
+    zipfile would find the EOCD from the tail and correct for a stub on its own, so this
+    only fails if the slice is dropped — the point being that ``start_offset`` decides
+    where the archive starts, not the file's own tail arithmetic.
+    """
+    payload = _zip_bytes()
+    path = tmp_path / "installer.exe"
+    path.write_bytes(_STUB + payload)
+
+    detected = detect_format(path)
+    assert detected.payload_offset == len(_STUB)
+    with open_archive(path) as archive:
+        assert {
+            m.name: archive.read(m) for m in archive.members() if m.is_file
+        } == _FILES

--- a/tests/test_sfx.py
+++ b/tests/test_sfx.py
@@ -1,0 +1,242 @@
+"""Self-extracting archives: the shared forward scan and the 7z start offset.
+
+A self-extracting archive is an executable stub with a real archive appended, so the
+archive magic sits at some offset ``N > 0``. Three pieces have to agree about that
+offset — the shared scanner in ``archivey.internal.sfx``, each parser's own scan, and
+(in the sibling change) ``detect_format`` — so they are exercised together here rather
+than once per backend.
+"""
+
+from __future__ import annotations
+
+import io
+from pathlib import Path
+
+import pytest
+
+from archivey import DEFAULT_ARCHIVEY_CONFIG, open_archive
+from archivey.exceptions import CorruptionError, UnsupportedFeatureError
+from archivey.internal.backends.sevenzip_parser import MAGIC_7Z, find_signature_offset
+from archivey.internal.backends.sevenzip_reader import SevenZipReadBackend
+from archivey.internal.password import _PasswordCandidates
+from archivey.internal.sfx import SFX_MAX, scan_for_magic
+from archivey.internal.streams.streamtools.slice import SlicingStream
+from archivey.types import ArchiveFormat
+from tests.conftest import requires
+
+# The stub shape from Topic 8 A-34: `MZ` plus low-entropy filler. Deliberately the
+# *synthetic* one — real PE/ELF stubs are the easy case, this one is what the Brotli
+# content probe claims (see dev-docs/investigations/brotli-content-probe-brief.md).
+_STUB = b"MZ" + b"\x90" * 4094
+
+_FILES = {
+    "alpha.txt": b"alpha\n" * 2000,
+    "nested/beta.bin": bytes(range(256)) * 40,
+}
+
+
+def _write_7z(path: Path, *, header_encryption: bool = False) -> None:
+    py7zr = pytest.importorskip("py7zr")
+    source = path.parent / f"{path.stem}-src"
+    for name, data in _FILES.items():
+        target = source / name
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(data)
+    password = "hunter2" if header_encryption else None
+    with py7zr.SevenZipFile(
+        path, "w", password=password, header_encryption=header_encryption
+    ) as archive:
+        for name in sorted(_FILES):
+            archive.write(source / name, arcname=name)
+
+
+def _sfx(tmp_path: Path, name: str, *, header_encryption: bool = False) -> Path:
+    inner = tmp_path / f"{name}-inner.7z"
+    _write_7z(inner, header_encryption=header_encryption)
+    path = tmp_path / f"{name}.exe"
+    path.write_bytes(_STUB + inner.read_bytes())
+    return path
+
+
+# --- the shared scanner ----------------------------------------------------------------
+
+
+def test_scan_finds_magic_at_offset() -> None:
+    data = b"stub" * 100 + MAGIC_7Z + b"rest"
+    assert scan_for_magic(io.BytesIO(data), (MAGIC_7Z,)) == 400
+
+
+def test_scan_returns_none_when_absent() -> None:
+    assert scan_for_magic(io.BytesIO(b"\x00" * 10_000), (MAGIC_7Z,)) is None
+
+
+def test_scan_finds_magic_straddling_a_chunk_boundary() -> None:
+    # The overlap carried between reads is what makes this work; without it a magic
+    # split across two 64 KiB reads is invisible.
+    for split in range(1, len(MAGIC_7Z)):
+        offset = 65536 - split
+        data = b"\x00" * offset + MAGIC_7Z + b"\x00" * 128
+        assert scan_for_magic(io.BytesIO(data), (MAGIC_7Z,)) == offset
+
+
+def test_scan_returns_the_earliest_of_several_needles() -> None:
+    data = b"\x00" * 50 + b"SECOND" + b"\x00" * 50 + b"FIRST"
+    # Earliest position wins, not the order the needles were passed in.
+    assert scan_for_magic(io.BytesIO(data), (b"FIRST", b"SECOND")) == 50
+
+
+def test_scan_requires_the_whole_magic_inside_the_limit() -> None:
+    data = b"\x00" * 10 + MAGIC_7Z
+    assert scan_for_magic(io.BytesIO(data), (MAGIC_7Z,), limit=10 + len(MAGIC_7Z)) == 10
+    # One byte short: the magic starts inside the window but does not fit in it.
+    assert scan_for_magic(io.BytesIO(data), (MAGIC_7Z,), limit=15) is None
+
+
+def test_scan_stops_at_the_limit() -> None:
+    data = b"\x00" * 5000 + MAGIC_7Z
+    assert scan_for_magic(io.BytesIO(data), (MAGIC_7Z,), limit=1000) is None
+
+
+# --- 7z: signature at a nonzero origin -------------------------------------------------
+
+
+def test_find_signature_offset_fast_path_and_restore() -> None:
+    fp = io.BytesIO(MAGIC_7Z + b"tail")
+    assert find_signature_offset(fp) == 0
+    assert fp.tell() == 0, "the probe must leave the stream where it found it"
+
+
+def test_find_signature_offset_scans_and_restores() -> None:
+    fp = io.BytesIO(_STUB + MAGIC_7Z)
+    assert find_signature_offset(fp) == len(_STUB)
+    assert fp.tell() == 0
+
+
+def test_find_signature_offset_reports_the_scan_window_on_a_miss() -> None:
+    with pytest.raises(CorruptionError, match="self-extracting scan window"):
+        find_signature_offset(io.BytesIO(b"\x90" * 1000), limit=1000)
+
+
+@requires("py7zr")
+def test_forced_format_opens_a_7z_behind_a_stub(tmp_path: Path) -> None:
+    # Forced format=RAR has always worked on an SFX file; this is the 7z parity that
+    # used to raise CorruptionError("bad magic bytes").
+    path = _sfx(tmp_path, "plain")
+    with open_archive(path, format=ArchiveFormat.SEVEN_Z) as archive:
+        members = {m.name: m for m in archive.members() if m.is_file}
+        assert set(members) == set(_FILES)
+        for name, expected in _FILES.items():
+            assert archive.read(members[name]) == expected
+
+
+@requires("py7zr")
+def test_forced_format_opens_packed_and_encoded_header_behind_a_stub(
+    tmp_path: Path,
+) -> None:
+    # Pack-stream and encoded-header offsets are the ones that would silently read the
+    # stub if only the signature seek had been rebased.
+    path = _sfx(tmp_path, "encoded", header_encryption=True)
+    with open_archive(
+        path, format=ArchiveFormat.SEVEN_Z, password="hunter2"
+    ) as archive:
+        members = {m.name: m for m in archive.members() if m.is_file}
+        assert set(members) == set(_FILES)
+        for name, expected in _FILES.items():
+            assert archive.read(members[name]) == expected
+
+
+@requires("py7zr")
+def test_no_7z_magic_within_the_window_raises_rather_than_listing_nothing(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "not-an-archive.exe"
+    path.write_bytes(b"MZ" + b"\x90" * 200_000)
+    with pytest.raises(CorruptionError, match="Not a 7z archive"):
+        open_archive(path, format=ArchiveFormat.SEVEN_Z)
+
+
+def _open_with(source, *, password=None, start_offset=0):
+    return SevenZipReadBackend().open_read(
+        source,
+        format=ArchiveFormat.SEVEN_Z,
+        streaming=False,
+        passwords=_PasswordCandidates.from_input(password),
+        encoding=None,
+        archive_name="equiv.exe",
+        config=DEFAULT_ARCHIVEY_CONFIG,
+        start_offset=start_offset,
+    )
+
+
+@requires("py7zr")
+@pytest.mark.parametrize("header_encryption", [False, True])
+def test_start_offset_on_a_path_equals_an_offset_view_on_a_stream(
+    tmp_path: Path, header_encryption: bool
+) -> None:
+    """``start_offset`` means "as if you had sliced the source" — checked literally.
+
+    The two opens differ only in how the payload origin is expressed. Any divergence
+    means the offset leaked into something other than the view.
+    """
+    path = _sfx(tmp_path, "equiv", header_encryption=header_encryption)
+    password = "hunter2" if header_encryption else None
+
+    with _open_with(path, password=password, start_offset=len(_STUB)) as by_offset:
+        by_offset_read = {
+            m.name: by_offset.read(m) for m in by_offset.members() if m.is_file
+        }
+
+    with path.open("rb") as handle:
+        with _open_with(
+            SlicingStream(handle, start=len(_STUB)), password=password
+        ) as by_view:
+            by_view_read = {
+                m.name: by_view.read(m) for m in by_view.members() if m.is_file
+            }
+
+    assert by_offset_read == by_view_read == _FILES
+
+
+@requires("py7zr")
+def test_start_offset_is_believed_rather_than_rescanned(tmp_path: Path) -> None:
+    """A decoy magic in the stub separates "opened at the offset" from "scanned again".
+
+    With the offset supplied the decoy sits behind the origin and is invisible; without
+    it the forced-format scan finds the decoy first and fails on its header.
+    """
+    inner = tmp_path / "decoy-inner.7z"
+    _write_7z(inner)
+    stub = b"MZ" + b"\x90" * 512 + MAGIC_7Z + b"\x90" * 3576
+    path = tmp_path / "decoy.exe"
+    path.write_bytes(stub + inner.read_bytes())
+
+    with _open_with(path, start_offset=len(stub)) as archive:
+        assert {m.name for m in archive.members() if m.is_file} == set(_FILES)
+
+    with pytest.raises(CorruptionError):
+        _open_with(path)
+
+
+def test_a_format_without_stubs_refuses_a_start_offset(tmp_path: Path) -> None:
+    from archivey.internal.backends.tar_reader import TarReadBackend
+
+    path = tmp_path / "x.tar"
+    path.write_bytes(b"\x00" * 1024)
+    with pytest.raises(UnsupportedFeatureError, match="nonzero start offset"):
+        TarReadBackend().open_read(
+            path,
+            format=ArchiveFormat.TAR,
+            streaming=False,
+            passwords=None,
+            encoding=None,
+            archive_name=path.name,
+            config=DEFAULT_ARCHIVEY_CONFIG,
+            start_offset=64,
+        )
+
+
+def test_sfx_max_is_one_shared_bound() -> None:
+    """RAR, 7z and detection bind to the same constant, not three drifting copies."""
+    from archivey.internal.backends import rar_parser
+
+    assert rar_parser.SFX_MAX is SFX_MAX


### PR DESCRIPTION
Implements both OpenSpec changes from #253, in dependency order: `sevenz-sfx-start-offset` first (commit 1), `sfx-format-detection` on top (commit 2).

## The defect, on `main`

`MZ` + `\x90`×4094 + a real payload:

| | detect | auto-open | forced format |
|---|---|---|---|
| ZIP | `BROTLI` | `['sfx_zip.bin.uncompressed']` | ✅ real members |
| RAR | `BROTLI` | `['sfx_rar.bin.uncompressed']` | ✅ real members |
| 7z | `BROTLI` | `['sfx_7z.bin.uncompressed']` | ❌ `CorruptionError: bad magic bytes` |

And a **real** `rar a -sfx` archive (249 KB ELF stub, magic at 248952) raised `FormatDetectionError` — the loud half of the same defect, and the one users actually hit. `docs/formats.md:224` already told them SFX detection worked. All of it works now.

## Investigation results — two proposal premises did not survive measurement

Task 1.0 asked for a probe-vs-stub investigation before locking any heuristic. It was run before writing detection code, and it changed the plan:

**"`TruncatedError` counts as a hit" is not the mechanism.** The A-34 stub decodes **252 bytes cleanly**. Treating truncation as a miss would have changed nothing.

**The "low-entropy `MZ` stub" is synthetic.** `MZ`+`\x00`, `MZ`+`A`, a structurally valid PE stub with any filler, a real `rar -sfx` ELF stub, and **887 real ELF binaries** under `/usr/bin`+`/usr/lib` are all *rejected* by the Brotli probe (0/887).

**Candidate lever 3 — stricter/larger Brotli probe — is dead.** Measured against 15 real Brotli streams and 1500 random 4 KiB blobs:

| Probe variant | Random-data FP | Real-Brotli misses |
|---|---|---|
| 256-byte prefix, any outcome (today) | 8.27% | 0/15 |
| 256-byte prefix, require ≥512 bytes out | 1.60% | 10/15 |
| 4096-byte prefix, any outcome | 8.20% | 0/15 |
| 4096-byte prefix, require ≥512 bytes out | 8.13% | 6/15 |

A bigger prefix buys nothing; demanding output trades FP for FN one-for-one. The looseness is in the bitstream, not the parameters.

## What landed

**Detection** classifies the prefix with `executable_cue` and, on any cue, searches the shared `SFX_MAX` window for the backends' `SFX_MAGIC` *before* running content probes. The needles are backend-declared data like every other detection signal; ZIP declares only its local header, since the EOCD and spanned markers as needles would claim any executable containing those four bytes.

**Probe policy is graded**, per the measurements: a **weak** cue (bare `MZ`/`ELF`) triggers the scan and nothing else — probes still run on a miss, so nothing that used to be detected stops being detected. Only a **strong** cue (`e_lfanew` → `PE\0\0`, or a valid ELF ident block) suppresses the probes. The Brotli probe itself is untouched.

**Hand-off:** `open_archive` passes `payload_offset` to `backend.open_read(start_offset=…)`, defined as *"behave exactly as if handed a view of the source starting there"*. Each SFX backend applies it as a view internally — 7z rebases its `SharedSource`, ZIP slices the handle before `zipfile` sees it, RAR starts its parse at the origin and spills payload-only when it must materialize for `unrar`. An argument rather than slicing at the call site, because slicing a `Path` would cost RAR a whole-archive temp copy per compressed member (the E-71/P11 cost). `tests/test_sfx.py` asserts path+offset and a pre-sliced stream produce byte-identical members for all three formats.

**7z (commit 1):** the design proposed threading `start_offset` into `read_signature_and_next_header` and rebasing each absolute seek. That turned out to be unnecessary — the reader already hands the parser a `SlicingStream`, so every 7z offset is signature-relative by construction. Verified on unmodified `main`: a stubbed 7z with an encrypted encoded header and packed streams opens correctly when handed `SlicingStream(fp, start=stub_len)`. Rebasing the reader's two `view()` sites catches the pack-stream and encoded-header slices too, which rebasing seeks would have missed. `design.md` records the amendment.

## Review round (`1484439`)

Cursor raised four findings; all four reproduced, all four addressed. Two changed the artifacts rather than just annotating them:

- **F1** — the MODIFIED SFX matrix said any executable-shaped miss must "never" fabricate a member, contradicting the graded rule this change landed. Split into strong/weak rows. This is the text that syncs into the main spec, so it had to land before `openspec archive`. *(resolved)*
- **F2** — falsified a claim in Decision 3. "A stub carrying its own magic cannot move the answer" holds only for an offset supplied from outside the scan; on auto-detect the offset *comes from* the scan, which takes the earliest needle. Measured: decoy + real 7z → `payload_offset=514` (the decoy) → `CorruptionError`; decoy + real ZIP → succeeds anyway via EOCD-from-tail. Design corrected, spec records the earliest-match rule and that the failure is loud, two tests pin both halves. Kept as a known limitation.
- **F3** — `STRONG` for PE needs `e_lfanew` inside the peeked prefix, so a DOS header pointing past 4 KiB grades `WEAK` (verified: `0x80`→STRONG, `0x1000`/`0x2000`→WEAK). Documented rather than fixed: letting the cue reach back to the source would mean the gate deciding whether to scan can itself trigger a read, on every `MZ` file, to resolve an attacker-controlled field.
- **F4** — added one sentence to `docs/formats.md` naming MZ/PE and ELF and pointing macOS users at explicit `format=`. This crosses the change's "guide prose is a non-goal" line deliberately; reasoning is on the thread.

F2–F4 are left **unresolved on purpose** — each is a case where I picked among options the review laid out under "Maintainer decisions", so they are yours to overrule.

## Left open, deliberately

**~8% of arbitrary binary data passes the Brotli content probe** (146/2000 random 4 KiB blobs come back from `detect_format` as `BROTLI`, and `open_archive` then fabricates a `*.uncompressed` member). Same silent-wrong-answer class, much wider than SFX, and not fixable by probe tuning. Registered as `open-issues.md` **P12** and `threat-model.md` **O10**, with `dev-docs/investigations/brotli-content-probe-brief.md` as the requested deep dive — since written up in #255.

Consequently a weak cue with no payload (`MZ` + `\x90`×4094 alone) still detects as `BROTLI`. The spec delta now states the weak/strong rule normatively rather than leaving it outcome-shaped, so shipped behaviour and spec agree — **this narrows the ADDED requirement's original literal text and is the main thing worth a second opinion.**

**macOS: the defect this PR closes is intact there.** `format-detection` names `MZ` and ELF, so a Mach-O stub matches no cue. The investigation showed that is worse than "falls through to the probes": `cf fa ed fe` is *structurally* a valid Brotli uncompressed meta-block header and depends on the four magic bytes alone, so **every** thin 64-bit Mach-O is claimed — reliably, not occasionally. Reproduced on this branch:

| stub + appended 7z | `executable_cue` | `detect_format` | `open_archive` |
|---|---|---|---|
| PE | `STRONG` | `SEVEN_Z`, off=8192 | real members |
| ELF | `STRONG` | `SEVEN_Z`, off=8192 | real members |
| **Mach-O thin arm64** | **`NONE`** | **`BROTLI`** | **fabricated `.uncompressed`** |
| Mach-O thin, zero-filled | `NONE` | `LZMA_ALONE` | fabricated `.uncompressed` |
| Mach-O universal (`0xcafebabe`) | `NONE` | `FormatDetectionError` | fails loudly |

Widening the cue set is a spec change, so it is **not** done here — it is proposed as `prefixed-archive-detection` (#255). `test_a_mach_o_binary_is_not_a_cue_today` pins the current behaviour so it stays recorded rather than rediscovered, and `design.md` carries the detail.

## Verification

- 2510 passed, 23 skipped (everyday leg); `./scripts/check.sh` clean
- `./scripts/test.sh --all-configs`: **all three dependency configurations pass**
- `openspec validate --strict` clean for both changes
- 36 tests in the new `tests/test_sfx.py`, including the silent-success regressions (asserting *members*, not just that no error is raised), a real `rar -sfx` fixture, the path-offset ≡ sliced-stream equivalence, and the decoy-magic cases from F2
- All 23 CI checks green on the current head, macOS included

Both changes' `tasks.md` are complete except the `openspec archive` step, left for the finishing commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pguzpw1p7rG2LoY1ZbGza4