### PR TITLE
Keep the probe-unconfirmed diagnostic deduped under a raising policy (review F13)

### DIFF
--- a/openspec/changes/brotli-probe-framing-gate/specs/diagnostics/spec.md
+++ b/openspec/changes/brotli-probe-framing-gate/specs/diagnostics/spec.md
@@ -105,6 +105,19 @@ Default disposition is COLLECT. When a caller's policy resolves this code to RAI
 via `escalate_as` (carrying `format_unconfirmed=True`) rather than
 `DiagnosticRaisedError`. The diagnostic is emitted at most once per reader.
 
+That once-per-reader bound SHALL hold under **every** policy, RAISE included: an
+escalating emit MUST NOT leave a second count, retention, log line or callback behind on
+a later occurrence.
+
+The per-code policy contract's deduplication rule (*"deduplication is a presentation
+concern; escalation is not"*) is what makes that safe to state. Its guarantee is that no
+qualifying occurrence passes **silently** under RAISE — a guard that disarms after firing
+once is not a guard. For this code the raise does not come from the diagnostic: every
+qualifying occurrence re-raises the stamped typed error with `format_unconfirmed=True`
+whether or not the diagnostic fires again, so the second and later reads stop the caller
+exactly as the first did. The escalation obligation is therefore met by the read path
+itself, and re-emitting would buy a duplicate record rather than a stop.
+
 #### Scenario: dual channel
 
 | Case | Expected |
@@ -113,3 +126,4 @@ via `escalate_as` (carrying `format_unconfirmed=True`) rather than
 | Corroborated decode failure | `exc.format_unconfirmed is False`; no probe-unconfirmed diagnostic |
 | `pedantic()`, probe-only decode failure | Same typed `TruncatedError`/`CorruptionError` with `format_unconfirmed=True` — not `DiagnosticRaisedError` |
 | Three retried reads on one probe-only member | Diagnostic count stays 1; each exception still has `format_unconfirmed=True` |
+| `pedantic()`, three retried reads on one probe-only member | Count and retention stay 1; every read still raises the typed error with `format_unconfirmed=True` |

--- a/src/archivey/internal/base_reader.py
+++ b/src/archivey/internal/base_reader.py
@@ -985,6 +985,15 @@ class BaseArchiveReader(ArchiveReader):
                 "format_unconfirmed": True,
             }
 
+        # Set before emitting: under RAISE the emit does not return, and a flag set
+        # afterwards would never be reached — every retried read would record the
+        # diagnostic again. `diagnostics` splits those concerns ("deduplication is a
+        # presentation concern; escalation is not"), and normally a deduplicated code
+        # still escalates on later occurrences via `escalate_only`. This code needs no
+        # such re-escalation: the caller re-raises the stamped `exc` — same type, same
+        # `format_unconfirmed=True` — on every occurrence, so a caller who asked to be
+        # stopped is stopped whether or not the diagnostic fires a second time.
+        self._probe_unconfirmed_emitted = True
         self._emit_unconfirmed_format(
             "content_probe",
             self._format.display_name,
@@ -992,7 +1001,6 @@ class BaseArchiveReader(ArchiveReader):
             escalate_message=escalate_message,
             escalate_kwargs=escalate_kwargs,
         )
-        self._probe_unconfirmed_emitted = True
 
     def _publish_materialized(
         self,

--- a/tests/test_brotli_framing_gate.py
+++ b/tests/test_brotli_framing_gate.py
@@ -268,6 +268,39 @@ def test_probe_unconfirmed_diagnostic_emitted_once_across_retries() -> None:
 
 
 @requires("brotli")
+def test_probe_unconfirmed_dedup_holds_under_a_raising_policy() -> None:
+    # The dedup bound covers counting/retention, and a RAISE policy must not smuggle a
+    # second record in through the escalating emit. Each retry still raises the typed
+    # error, which is what stops a caller who asked to be stopped.
+    from archivey import ArchiveyConfig, DiagnosticPolicy
+    from archivey.exceptions import DiagnosticRaisedError
+
+    framing = parse_first_metablock(b"/**\n")
+    assert framing.consumed is not None and framing.declared_length is not None
+    need = framing.consumed + framing.declared_length
+    blob = b"/**\n" + b"x" * (need + 64)
+    cfg = ArchiveyConfig(diagnostic_policy=DiagnosticPolicy.pedantic())
+    with open_archive(io.BytesIO(blob), config=cfg) as reader:
+        stream = reader.open(next(iter(reader)))
+        for _ in range(3):
+            with pytest.raises((TruncatedError, CorruptionError)) as caught:
+                stream.read()
+            assert not isinstance(caught.value, DiagnosticRaisedError)
+            assert caught.value.format_unconfirmed is True
+        assert reader.diagnostics.counts[DiagnosticCode.PROBE_FORMAT_UNCONFIRMED] == 1
+        assert (
+            len(
+                [
+                    d
+                    for d in reader.diagnostics.retained
+                    if d.code is DiagnosticCode.PROBE_FORMAT_UNCONFIRMED
+                ]
+            )
+            == 1
+        )
+
+
+@requires("brotli")
 def test_probe_unconfirmed_context_carries_detected_format() -> None:
     framing = parse_first_metablock(b"/**\n")
     assert framing.consumed is not None and framing.declared_length is not None


### PR DESCRIPTION
Targets **#259's branch**, not `main` — merge it there and the fix rides along with that PR.

## Summary

Fixes review finding **F13** on #259: `_mark_format_unconfirmed` set `_probe_unconfirmed_emitted` *after* calling `_emit_unconfirmed_format`, but under a policy that resolves `PROBE_FORMAT_UNCONFIRMED` to RAISE the emit escalates (via the F1 `escalate_as` fix) and never returns — so the flag was never set and every retried read recorded the diagnostic again.

Measured on `560c7fe`, three reads on one probe-only member:

| policy | counts | retained |
| --- | --- | --- |
| default (COLLECT) | 1 | 1 |
| `pedantic()` | **3** | **3** |

That is the count/retention inflation F3 was about, and the half of the live `diagnostics` deduplication rule that says a second RAISE occurrence "raises again; **still no second record**".

## What changed

- `src/archivey/internal/base_reader.py` — set the flag before emitting, with a comment on why re-escalation is not needed here: the read path re-raises the stamped typed error (same type, `format_unconfirmed=True`) on every occurrence, so a caller who asked to be stopped is stopped whether or not the diagnostic fires again.
- `tests/test_brotli_framing_gate.py` — `test_probe_unconfirmed_dedup_holds_under_a_raising_policy`: three reads under `pedantic()`, each raising the typed error, with count *and* retention pinned at 1. Red–green verified — it fails on `560c7fe` and passes with the fix.
- `openspec/changes/brotli-probe-framing-gate/specs/diagnostics/spec.md` — states that the once-per-reader bound holds under every policy, explains how the escalation obligation is still met, and adds the `pedantic()` + retries scenario row.

## Verification

- `./scripts/check.sh` — clean (ruff, pyrefly, ty, `openspec validate` 27/27, docs nav + build)
- `./scripts/test.sh` `[all]` — **2530 passed, 23 skipped, 3 deselected**
- Not run locally: `--all-configs`. The change touches no optional dependency, but the three-config gate is still worth a run before #259 merges.

## One thing for the maintainer

The live *Complete per-code policy and delivery contract* requirement says the dedup bound applies to presentation only and that policy "SHALL be evaluated on **every** occurrence … for **every** once-per-stream code, not a per-code exception". This fix satisfies the *purpose* of that rule — no occurrence passes silently, because the read raises regardless — but not its letter, since the diagnostic itself does not re-escalate. I wrote the delta to explain that rather than rewrite the live requirement: generalising it (something like "unless the occurrence already raises independently") is a cross-cutting contract move that deserves its own change, and this seemed like your call, not mine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TvTBZWH3nwqzw2opqrrckm

---
_Generated by [Claude Code](https://claude.ai/code/session_01TvTBZWH3nwqzw2opqrrckm)_