### PR TITLE
OpenSpec: archive-origin-reporting — report the payload origin on ArchiveInfo

### DIFF
--- a/openspec/changes/archive-origin-reporting/.openspec.yaml
+++ b/openspec/changes/archive-origin-reporting/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: library
+created: 2026-08-31

--- a/openspec/changes/archive-origin-reporting/brief.md
+++ b/openspec/changes/archive-origin-reporting/brief.md
@@ -1,0 +1,13 @@
+# archive-origin-reporting — say where the archive actually started
+
+**Status:** Ready to implement once `prefixed-archive-detection` lands (it defines the enum this reuses). Blocks nothing. Additive to the public data model. Effort: small–medium.
+
+**Why it matters:** When an archive sits behind an executable stub, archivey opens it correctly and then forgets where it began. The opened archive's metadata says nothing about it, so archivey's own command-line tool detects the format a second time purely to print the offset. Worse, the two ways of opening know different amounts: pass the format explicitly and the parser searches for the payload, finds it, and discards the answer — so the caller who already knew the format ends up with less information than the one who did not. The same file, two doors, two different stories.
+
+**What it does:** The opened archive reports what preceded its payload and where the payload started, the same way on both doors. Where the answer genuinely is not known — a prefixed ZIP opened with an explicit format, where the standard library finds the payload without telling us where it was — it says *not established* rather than claiming byte zero. Underneath, the three formats that can carry a prefix stop resolving their origin three different ways: one shared resolver replaces the two hand-rolled copies, and the RAR version falls out of the same result instead of a second code path.
+
+**Decided:** An enum rather than an is-self-extracting flag, because there are three states and a flag can only hold two — and because a Python zipapp, an executable JAR and a JPEG with a ZIP stuck on the end all start after byte zero and none of them is self-extracting. The enum already exists for the detection result; duplicating the idea with a second, coarser spelling on the opened archive is the inconsistency this repo explicitly guards against.
+
+**Your call later:** Whether a forced-format ZIP should run a tail probe at open time so its origin becomes known too. Deliberately not done here — that would be new reading purely to fill in a metadata field, on the path a caller picked for speed.
+
+**Bottom line:** The offset is already computed on every path; this stops throwing it away and makes both doors tell the same story.

--- a/openspec/changes/archive-origin-reporting/design.md
+++ b/openspec/changes/archive-origin-reporting/design.md
@@ -2,9 +2,9 @@
 
 ## The shape of the problem
 
-Three formats can carry a prefix. Each resolves its origin differently, and none reports
-the result. Measured on `main` (`056c429`), 4 224-byte `MZ` stub, `scan_for_magic`
-instrumented:
+Three formats can carry a prefix **on today's `main`**, each resolves its origin
+differently, and none reports the result. Measured on `main` (`056c429`), 4 224-byte `MZ`
+stub, `scan_for_magic` instrumented:
 
 | case | detection `payload_offset` | scans during `open_archive` | members |
 | --- | --- | --- | --- |
@@ -15,6 +15,11 @@ instrumented:
 | ZIP SFX, auto-detect | 4 224 | 0 | 1 |
 | ZIP SFX, `format=ZIP` | — | 0 | 1 |
 | 7z / RAR plain | 0 | 0 | 1 |
+
+That census expires with `prefixed-archive-detection`, which makes a makeself `.run`
+(`#!` + tar.gz) detect as `TAR_GZ` at the gzip offset. Everything in this section describes
+the state the change starts from; the implementation must cover whatever that change can
+hand a `start_offset` (task 3.6), not this list of three.
 
 Two things worth keeping straight, because both look like defects and are not:
 
@@ -54,23 +59,71 @@ complementary and neither subsumes the other:
 `FormatInfo` needs two states (`prefix_kind is NONE` ⟺ `payload_offset == 0`). An opened
 archive needs three, because of one real case:
 
-- **forced `format=ZIP` on a prefixed ZIP.** `zip_reader` slices at `start_offset` when it
-  has one; with `format=` there is no offset, and stdlib `zipfile` locates the central
-  directory from the tail and self-adjusts past the stub on its own. The archive opens and
-  lists correctly, and archivey never learns where the payload began.
+- **an empty ZIP behind a prefix.** `payload_offset` is defined as the position of the
+  earliest local file header (`format-detection`); an archive with no members has none, so
+  there is nothing to measure from and no supplied offset to fall back on. The archive
+  opens and lists (as empty) correctly, and archivey cannot say where the payload began.
+
+Forced `format=ZIP` on a *non-empty* prefixed ZIP is **not** such a case, though it looks
+like one. Measured (stdlib `zipfile`, no archivey involvement):
+
+| fixture | true origin | `min(header_offset)` |
+| --- | --- | --- |
+| `zipapp` `.pyz` | 23 | 23 |
+| shebang + concatenated ZIP | 28 | 28 |
+| `MZ` stub + ZIP | 128 | 128 |
+| JPEG + appended ZIP | 2 004 | 2 004 |
+| plain ZIP | 0 | 0 |
+| `MZ` + **empty** ZIP | 502 | `None` |
+
+`zipfile` applies its prefix adjustment to every entry's `header_offset` while reading the
+central directory, so the smallest one *is* the origin in source coordinates — already
+parsed, no extra read. The tempting wrong answer is `concat`, the adjustment itself: it is
+`0` for a `zipapp` (member offsets written from byte 0), which is exactly the lie
+`format-detection`'s earliest-local-header definition exists to prevent.
 
 `is_sfx: bool` cannot hold that, and `payload_offset: int` would have to encode it as `0` —
-asserting "starts at byte zero" about a file that does not. Hence `int | None`, paired with
-`PrefixKind.UNKNOWN`:
+asserting "starts at byte zero" about a file that does not. Hence `int | None`.
+
+**The kind is spelled as absence, not as `UNKNOWN`.** `prefixed-archive-detection` already
+defines `UNKNOWN` as *a prefix that matched no cue, reachable only via the opt-in exhaustive
+scan* — which always has a positive offset. Reusing it for "we never established the origin"
+would give one member two meanings and make `ArchiveInfo.UNKNOWN` disagree with
+`FormatInfo.UNKNOWN`. So the field is `PrefixKind | None`:
 
 ```python
 prefix_kind is PrefixKind.NONE     <=>  payload_offset == 0
-prefix_kind is PrefixKind.UNKNOWN  <=>  payload_offset is None
-otherwise                                payload_offset > 0
+prefix_kind is None                <=>  payload_offset is None
+PrefixKind.UNKNOWN                      payload_offset > 0   (unclassified prefix)
+otherwise                               payload_offset > 0
 ```
 
 The invariant is stated in the spec so it can be asserted in the conformance sweep rather
-than left as a convention.
+than left as a convention. Note what it must *not* do: reject `UNKNOWN` with a positive
+offset. That is a legitimate PAD value, and an invariant written as `UNKNOWN <=> None`
+would fail on PAD's own exhaustive-scan fixtures.
+
+### The kind is not derivable from the offset
+
+`payload_offset` and `prefix_kind` answer different questions and are established by
+different work. The offset falls out of opening the archive: 7z and RAR resolve it with the
+bounded scan they already run, ZIP reads it off the central directory it already parsed. The
+kind requires *looking at the prefix*, which only detection does.
+
+So on a forced-`format=` open the offset is known and the kind is not. Three ways to fill
+that gap were considered:
+
+| option | cost | consequence |
+| --- | --- | --- |
+| sniff the first ~8 bytes for `MZ`/ELF/Mach-O/`#!` | one tiny read | covers SFX installers; a JPEG+ZIP still reports the wrong thing (`UNKNOWN`, where detection says `OTHER_FORMAT`) |
+| run the full classifier, including detecting the prefix's own format | a detection pass over the prefix | doors always agree; the forced path pays for work the caller passed `format=` to skip |
+| **report `prefix_kind is None`** | none | doors agree on the offset, and the kind is honestly absent rather than partly right |
+
+The third is chosen. The cost is that the two absences become independent — `prefix_kind is
+None` no longer implies `payload_offset is None` — which the spec states explicitly rather
+than leaving as a trap. The alternative was a field that is *sometimes* a cheap guess, and a
+partly-classified kind is worse than an absent one: a caller filtering "open installers,
+skip polyglots" would get the polyglot wrong on one door and right on the other, silently.
 
 ### Why not a second, simpler enum
 
@@ -102,17 +155,28 @@ def resolve_payload_origin(
     """
 ```
 
+`MagicHit.candidate_origin` is relative to `fp`'s position, which is **not** what
+`ArchiveInfo.payload_offset` reports. The reader owns the conversion: the reported value is
+`start_offset + hit.candidate_origin`, measured from the start of `source`. 7z already
+computes exactly that sum (`self._origin = start_offset + find_signature_offset(probe)`);
+RAR today does not (`self._origin = start_offset`, with the parser keeping its own
+`sfx_offset`), so the two RAR doors currently hold the value in different variables — `N`
+and `0` on auto-detect, `0` and `N` on forced. Reporting either component alone would make
+the doors disagree; the sum is the same on both.
+
 Returning `MagicHit` rather than `int` is what lets RAR share it: `hit.needle` is
 `RAR5_ID` or `RAR_ID`, which is the version, and the fast-path read already has those
 bytes. Today `_find_sfx_header` returns `tuple[int, int]` purely to carry the version
 alongside the offset; `MagicHit` carries it as data, so the wider signature disappears.
 
 `find_signature_offset` becomes a one-line wrapper (it is exported and used by tests and
-the fuzz harness) or is deleted with its callers updated — task 3.4 decides on the evidence
+the fuzz harness) or is deleted with its callers updated — task 2.5 decides on the evidence
 of what still imports it.
 
-ZIP does not join the resolver: it has no scan and needs none. Its contribution is
-reporting what it did — slice origin when given one, `UNKNOWN` otherwise.
+ZIP does not join the resolver: it has no scan and needs none. It reports the supplied
+slice origin when it has one, and otherwise the smallest `header_offset` in the central
+directory it already parsed — no extra read, and correct for `zipapp` where `concat` is
+not.
 
 ## Reporting the origin back
 
@@ -121,12 +185,13 @@ the options differ mostly in blast radius:
 
 | option | cost |
 | --- | --- |
-| A. reader attribute the base class reads when building `ArchiveInfo` | one attribute, set by the three prefix-capable backends, defaulted in the base |
+| A. reader attribute the base class reads when building `ArchiveInfo` | one attribute, set by each prefix-capable backend, defaulted in the base |
 | B. widen `open_read`'s return type | touches all seven backends for a fact four of them cannot produce |
 | C. `ArchiveInfo.extra["sfx.offset"]` | no schema change, but stringly-typed and outside the field the user asked for |
 
-**A**, with the default in `BaseArchiveReader` so the four `reject_start_offset` backends
-are unaffected. C is rejected on §2 grounds: `extra` is for format-specific metadata
+**A**, with the default in `BaseArchiveReader` so backends that never receive a start
+offset are unaffected. Derive that set from `reject_start_offset` at implementation time
+rather than from today's four: PAD moves TAR and the single-file codecs out of it. C is rejected on §2 grounds: `extra` is for format-specific metadata
 (`iso.namespace`), and a property three formats share and every format can be asked about
 is not format-specific.
 
@@ -144,13 +209,12 @@ in two halves means two public-shape changes where one would do.
 Not sequenced against `detection-result-surface`: they touch different objects
 (`ArchiveInfo` vs the reader's detection field) and neither reads the other's field.
 
-## Open question
+## Resolved: forced-format ZIP does learn its origin
 
-**Should forced-format ZIP learn its origin?** Once `prefixed-archive-detection` lands the
-format-bounded tail probe (EOCD comment length is a `uint16`, so 65 535 + 22 bytes is a
-hard ceiling), running it at open time for a forced `format=ZIP` would turn `UNKNOWN` into
-a real offset. Against: it is new I/O to populate a metadata field, on the path a caller
-chose to skip work; and `UNKNOWN` is an honest answer, not a wrong one. For: it removes the
-last asymmetry between the two doors, and the bound is small and format-derived rather than
-a constant we picked. Left to the maintainer; `UNKNOWN` is the v1 behaviour either way, so
-deciding later costs nothing.
+An earlier draft left this open, on the assumption that a forced `format=ZIP` open would
+need a tail probe to find the payload start. It does not — `min(header_offset)` over the
+already-parsed central directory is the answer, measured above. No tail probe, no extra
+read, and no asymmetry between the two doors except for an empty archive.
+
+The remaining `None` case (empty ZIP) is genuinely unestablished rather than a cost
+trade-off, so there is nothing left to decide here.

--- a/openspec/changes/archive-origin-reporting/design.md
+++ b/openspec/changes/archive-origin-reporting/design.md
@@ -85,54 +85,71 @@ parsed, no extra read. The tempting wrong answer is `concat`, the adjustment its
 `is_sfx: bool` cannot hold that, and `payload_offset: int` would have to encode it as `0` —
 asserting "starts at byte zero" about a file that does not. Hence `int | None`.
 
-**The kind is spelled as absence, not as `UNKNOWN`.** `prefixed-archive-detection` already
-defines `UNKNOWN` as *a prefix that matched no cue, reachable only via the opt-in exhaustive
-scan* — which always has a positive offset. Reusing it for "we never established the origin"
-would give one member two meanings and make `ArchiveInfo.UNKNOWN` disagree with
-`FormatInfo.UNKNOWN`. So the field is `PrefixKind | None`:
+**The kind is spelled as absence, not as `UNKNOWN`.** `prefixed-archive-detection` defines
+`UNKNOWN` as *a prefix that matched no cue*, which always has a positive offset. Reusing it
+for "we never established the origin" would give one member two meanings and make
+`ArchiveInfo.UNKNOWN` disagree with `FormatInfo.UNKNOWN`. So the field is `PrefixKind | None`:
 
 ```python
 prefix_kind is PrefixKind.NONE     <=>  payload_offset == 0
 prefix_kind is None                <=>  payload_offset is None
-PrefixKind.UNKNOWN                      payload_offset > 0   (unclassified prefix)
+PrefixKind.UNKNOWN                      payload_offset > 0   (no cue matched)
 otherwise                               payload_offset > 0
 ```
 
 The invariant is stated in the spec so it can be asserted in the conformance sweep rather
 than left as a convention. Note what it must *not* do: reject `UNKNOWN` with a positive
-offset. That is a legitimate PAD value, and an invariant written as `UNKNOWN <=> None`
-would fail on PAD's own exhaustive-scan fixtures.
+offset. That is a legitimate value, and an invariant written as `UNKNOWN <=> None` would
+fail on PAD's own fixtures.
 
-### The kind is not derivable from the offset
+### The kind is cheap, once `OTHER_FORMAT` is gone
 
-`payload_offset` and `prefix_kind` answer different questions and are established by
-different work. The offset falls out of opening the archive: 7z and RAR resolve it with the
-bounded scan they already run, ZIP reads it off the central directory it already parsed. The
-kind requires *looking at the prefix*, which only detection does.
+`payload_offset` and `prefix_kind` are established by different work. The offset falls out of
+opening the archive: 7z and RAR resolve it with the bounded scan they already run, ZIP reads
+it off the central directory it already parsed. The kind needs a look at the prefix — and how
+expensive that look is depends entirely on what the enum has to distinguish.
 
-So on a forced-`format=` open the offset is known and the kind is not. Three ways to fill
-that gap were considered:
+An earlier draft of this change left `prefix_kind` unset on the forced path, because the
+`OTHER_FORMAT` member then in `PrefixKind` meant "the prefix is itself a recognised format",
+which PAD's task 3.3 implements *by running the magic table against the prefix* — a real
+detection pass, on a path the caller chose to skip work. Sniffing only the cheap cues would
+then have produced a partly-classified kind that disagreed with detection on polyglots.
 
-| option | cost | consequence |
-| --- | --- | --- |
-| sniff the first ~8 bytes for `MZ`/ELF/Mach-O/`#!` | one tiny read | covers SFX installers; a JPEG+ZIP still reports the wrong thing (`UNKNOWN`, where detection says `OTHER_FORMAT`) |
-| run the full classifier, including detecting the prefix's own format | a detection pass over the prefix | doors always agree; the forced path pays for work the caller passed `format=` to skip |
-| **report `prefix_kind is None`** | none | doors agree on the offset, and the kind is honestly absent rather than partly right |
+With `OTHER_FORMAT` merged into `UNKNOWN`, classification collapses to a pure function of the
+leading bytes:
 
-The third is chosen. The cost is that the two absences become independent — `prefix_kind is
-None` no longer implies `payload_offset is None` — which the spec states explicitly rather
-than leaving as a trap. The alternative was a field that is *sometimes* a cheap guess, and a
-partly-classified kind is worse than an absent one: a caller filtering "open installers,
-skip polyglots" would get the polyglot wrong on one door and right on the other, silently.
+```
+MZ / ELF / Mach-O  -> EXECUTABLE
+#!                 -> SCRIPT
+anything else      -> UNKNOWN
+```
+
+That is one short read, and — crucially — it is the *same* function detection applies, so both
+doors produce the same answer for the same file, polyglots included. A JPEG+ZIP is `UNKNOWN`
+either way, because a JPEG matches no cue on either path.
+
+So the forced path classifies, the two absences stay coupled (`prefix_kind is None` ⟺
+`payload_offset is None`), and the invariant stays a simple pairing rather than a
+two-dimensional table. The one rule worth writing down is the negative one: the kind must come
+from that read, never from `payload_offset > 0`. A `zipapp`, an executable JAR and a
+JPEG-with-appended-ZIP all have a non-zero offset, and inferring `EXECUTABLE` from it is the
+`is_sfx` collapse this change exists to avoid.
+
+**Why the merge is right, briefly** (the decision itself belongs to PAD): `OTHER_FORMAT`'s own
+spec example is *"the prefix is itself a recognised format (e.g. an image)"*, but the magic
+table PAD's task classifies against holds 15 entries, all archive formats — ISO, RAR,
+`RAW_STREAM`, 7z, TAR, ZIP. A JPEG matches none of them, so the category could never classify
+the example it was written around. What remains reachable is an archive in front of an
+archive, which no caller has asked to distinguish.
 
 ### Why not a second, simpler enum
 
 A tempting alternative is `ArchiveInfo.is_prefixed: bool | None` and leaving `PrefixKind`
 to detection. It fails the same way the bool does, one level up: `prefixed-archive-detection`
-introduced the enum precisely because "offset > 0" bundles four different things — an
-executable SFX stub, a shebang script wrapper, another file format the archive was appended
-to, and an unclassifiable prefix. A caller sweeping a directory wants to open the installer
-and skip the polyglot JPEG; that decision needs the kind, not the bit. Describing the same
+introduced the enum precisely because "offset > 0" bundles distinct things — an executable
+SFX stub, a shebang script wrapper, and a prefix that matches no cue at all. A caller sweeping
+a directory wants to open the installer and skip the JPEG it is embedded in; that decision
+needs the kind, not the bit. Describing the same
 property with a rich enum on one object and a coarse bool on another is the cross-surface
 inconsistency §2 exists to prevent.
 

--- a/openspec/changes/archive-origin-reporting/design.md
+++ b/openspec/changes/archive-origin-reporting/design.md
@@ -1,0 +1,156 @@
+# Design — archive-origin-reporting
+
+## The shape of the problem
+
+Three formats can carry a prefix. Each resolves its origin differently, and none reports
+the result. Measured on `main` (`056c429`), 4 224-byte `MZ` stub, `scan_for_magic`
+instrumented:
+
+| case | detection `payload_offset` | scans during `open_archive` | members |
+| --- | --- | --- | --- |
+| 7z SFX, auto-detect | 4 224 | 0 | 1 |
+| 7z SFX, `format=SEVEN_Z` | — | 1 | 1 |
+| RAR SFX, auto-detect | 4 224 | 0 | 1 |
+| RAR SFX, `format=RAR` | — | 1 | 1 |
+| ZIP SFX, auto-detect | 4 224 | 0 | 1 |
+| ZIP SFX, `format=ZIP` | — | 0 | 1 |
+| 7z / RAR plain | 0 | 0 | 1 |
+
+Two things worth keeping straight, because both look like defects and are not:
+
+**The detected path does not re-scan.** Both parsers open with a fast-path read —
+`find_signature_offset` reads 6 bytes, `_find_sfx_header` reads 8 — and return offset 0
+when the magic is already at the open position. When detection supplied the offset, the
+view starts on the magic, so the fast path hits and the scan never runs. The scan is the
+*forced-path fallback*, not redundant work layered on detection.
+
+**The scan is not duplicated logic.** `scan_for_magic` and `SFX_MAX` are already shared
+from `internal/sfx.py`, and `detection-prefix-workspace` (#273) just moved both call sites
+onto one `MagicHit` return type. What is duplicated is the ~10-line wrapper around it, and
+what is missing is a single place that owns the answer so it can be reported.
+
+## Why `ArchiveInfo` and not the reader
+
+`archive-data-model` already fixes the boundary: *"`ArchiveInfo` SHALL NOT carry runtime
+diagnostics"*, with the scenario *"ArchiveInfo remains an open-time value"*. The payload
+origin is exactly an open-time structural fact about the archive — established before the
+first member is listed, immutable thereafter, and derived from the bytes rather than from
+how the open went. It sits with `is_solid` and `is_multivolume`, not with diagnostics.
+
+This is deliberately *not* the same surface as `detection-result-surface`. That change puts
+the **detection result** on the reader — evidence, confidence, provenance, and for a
+`format=` open it truthfully records `DECLARED_BY_CALLER` because detection did not run.
+It therefore cannot answer "where did this archive start" on the forced path, because on
+that path nothing detected anything: the *parser* found the origin. The two changes are
+complementary and neither subsumes the other:
+
+| question | answered by |
+| --- | --- |
+| why did archivey think this was a 7z? | `detection-result-surface` (reader's ledger) |
+| what preceded the payload, and where did it start? | this change (`ArchiveInfo`) |
+
+## The three-state field
+
+`FormatInfo` needs two states (`prefix_kind is NONE` ⟺ `payload_offset == 0`). An opened
+archive needs three, because of one real case:
+
+- **forced `format=ZIP` on a prefixed ZIP.** `zip_reader` slices at `start_offset` when it
+  has one; with `format=` there is no offset, and stdlib `zipfile` locates the central
+  directory from the tail and self-adjusts past the stub on its own. The archive opens and
+  lists correctly, and archivey never learns where the payload began.
+
+`is_sfx: bool` cannot hold that, and `payload_offset: int` would have to encode it as `0` —
+asserting "starts at byte zero" about a file that does not. Hence `int | None`, paired with
+`PrefixKind.UNKNOWN`:
+
+```python
+prefix_kind is PrefixKind.NONE     <=>  payload_offset == 0
+prefix_kind is PrefixKind.UNKNOWN  <=>  payload_offset is None
+otherwise                                payload_offset > 0
+```
+
+The invariant is stated in the spec so it can be asserted in the conformance sweep rather
+than left as a convention.
+
+### Why not a second, simpler enum
+
+A tempting alternative is `ArchiveInfo.is_prefixed: bool | None` and leaving `PrefixKind`
+to detection. It fails the same way the bool does, one level up: `prefixed-archive-detection`
+introduced the enum precisely because "offset > 0" bundles four different things — an
+executable SFX stub, a shebang script wrapper, another file format the archive was appended
+to, and an unclassifiable prefix. A caller sweeping a directory wants to open the installer
+and skip the polyglot JPEG; that decision needs the kind, not the bit. Describing the same
+property with a rich enum on one object and a coarse bool on another is the cross-surface
+inconsistency §2 exists to prevent.
+
+## One resolver
+
+```python
+# internal/sfx.py
+def resolve_payload_origin(
+    fp: BinaryIO,
+    needles: Sequence[bytes | ScanNeedle],
+    *,
+    limit: int = SFX_MAX,
+) -> MagicHit:
+    """Origin of the payload relative to ``fp``'s current position.
+
+    Fast path: the magic is already at the current position -> candidate_origin 0 and one
+    short read. Otherwise a bounded forward scan. Raises CorruptionError past ``limit`` so
+    a non-matching source fails loudly instead of opening as an empty archive. ``fp`` is
+    restored to its starting position.
+    """
+```
+
+Returning `MagicHit` rather than `int` is what lets RAR share it: `hit.needle` is
+`RAR5_ID` or `RAR_ID`, which is the version, and the fast-path read already has those
+bytes. Today `_find_sfx_header` returns `tuple[int, int]` purely to carry the version
+alongside the offset; `MagicHit` carries it as data, so the wider signature disappears.
+
+`find_signature_offset` becomes a one-line wrapper (it is exported and used by tests and
+the fuzz harness) or is deleted with its callers updated — task 3.4 decides on the evidence
+of what still imports it.
+
+ZIP does not join the resolver: it has no scan and needs none. Its contribution is
+reporting what it did — slice origin when given one, `UNKNOWN` otherwise.
+
+## Reporting the origin back
+
+`open_read` already takes `start_offset` *in*. The return direction needs a channel, and
+the options differ mostly in blast radius:
+
+| option | cost |
+| --- | --- |
+| A. reader attribute the base class reads when building `ArchiveInfo` | one attribute, set by the three prefix-capable backends, defaulted in the base |
+| B. widen `open_read`'s return type | touches all seven backends for a fact four of them cannot produce |
+| C. `ArchiveInfo.extra["sfx.offset"]` | no schema change, but stringly-typed and outside the field the user asked for |
+
+**A**, with the default in `BaseArchiveReader` so the four `reject_start_offset` backends
+are unaffected. C is rejected on §2 grounds: `extra` is for format-specific metadata
+(`iso.namespace`), and a property three formats share and every format can be asked about
+is not format-specific.
+
+## Sequencing
+
+Depends on `prefixed-archive-detection` for `PrefixKind`, and on `detection-prefix-workspace`
+(landed, #273) for `MagicHit`.
+
+If the order inverts and this lands first, the fallback is to ship the resolver
+unification and `payload_offset: int | None` alone, and add `prefix_kind` with the other
+change — `payload_offset` is well-defined without the enum, whereas the enum without
+`payload_offset` is not worth having. This is a fallback, not the plan: shipping the field
+in two halves means two public-shape changes where one would do.
+
+Not sequenced against `detection-result-surface`: they touch different objects
+(`ArchiveInfo` vs the reader's detection field) and neither reads the other's field.
+
+## Open question
+
+**Should forced-format ZIP learn its origin?** Once `prefixed-archive-detection` lands the
+format-bounded tail probe (EOCD comment length is a `uint16`, so 65 535 + 22 bytes is a
+hard ceiling), running it at open time for a forced `format=ZIP` would turn `UNKNOWN` into
+a real offset. Against: it is new I/O to populate a metadata field, on the path a caller
+chose to skip work; and `UNKNOWN` is an honest answer, not a wrong one. For: it removes the
+last asymmetry between the two doors, and the bound is small and format-derived rather than
+a constant we picked. Left to the maintainer; `UNKNOWN` is the v1 behaviour either way, so
+deciding later costs nothing.

--- a/openspec/changes/archive-origin-reporting/proposal.md
+++ b/openspec/changes/archive-origin-reporting/proposal.md
@@ -7,16 +7,17 @@ forgets where it started. Two things follow, both measured on `main` (`056c429`)
 **1. The caller cannot ask.** `ArchiveInfo` carries format, version, solidity, member
 count, comment, encryption, multivolume, cost and `extra` — nothing about the payload
 origin. The reader knows it (`SevenZipReader._origin`, `RarReader._origin`,
-`RarArchive.sfx_offset`) and drops it on the floor. Archivey's own CLI works around this
-by calling `detect_format()` a second time purely to print `sfx_offset`
-(`cli/info_cmd.py:57`).
+`RarArchive.sfx_offset`) and drops it on the floor. Archivey's own CLI works around this by
+calling `detect_format()` itself (`cli/info_cmd.py:52`) and printing `detected.payload_offset`
+— so the file is detected twice, once by the CLI and once inside `open_archive`, because the
+reader will not answer.
 
 **2. The two open paths know different amounts, and only one can be asked.** The same
 SFX file opened two ways:
 
 | | `payload_offset` reachable by caller | parser scan runs |
 | --- | --- | --- |
-| auto-detect | yes — via a second `detect_format()` call | **no** (magic already at the offset) |
+| auto-detect | only by detecting the file a second time yourself | **no** (magic already at the offset) |
 | `format=SEVEN_Z` / `format=RAR` | **no** | yes — the parser finds the origin, then discards it |
 | `format=ZIP` | **no** | none — stdlib `zipfile` self-adjusts; archivey never learns the offset |
 
@@ -53,11 +54,10 @@ the RAR parser having carried the same scan longer.
 
 - **`ArchiveInfo` gains `prefix_kind` and `payload_offset`**, so the origin is
   archive-level metadata a caller can read from the reader, on **either** open path. The
-  CLI stops detecting twice to print it.
+  CLI reads the origin from `reader.info` instead of from its own detection result.
 - **`payload_offset` is `int | None`**, with `None` meaning *not established* — the honest
-  answer for forced `format=ZIP`, where stdlib `zipfile` locates the central directory past
-  a stub without archivey ever learning where the payload began. Absence is data, not a
-  zero that would falsely claim "starts at byte 0".
+  answer for an empty ZIP behind a prefix, which has no local file header to measure from.
+  Absence is data, not a zero that would falsely claim "starts at byte 0".
 - **`prefix_kind` reuses `PrefixKind`** from `prefixed-archive-detection` rather than a new
   `is_sfx: bool`. A bool cannot express *not established*, and — more importantly — cannot
   separate a self-extracting archive from one merely embedded in something else, which is
@@ -68,10 +68,16 @@ the RAR parser having carried the same scan longer.
   past the bound. It returns the `MagicHit` that `detection-prefix-workspace` introduced,
   so RAR's version resolution falls out of `hit.needle` instead of a second code path.
 - **Backends report the origin they resolved** back to the reader, which is what lets the
-  forced path populate `ArchiveInfo` identically to the detected path.
+  forced path report the same `payload_offset` as the detected one. `prefix_kind` is a
+  separate question: classifying a prefix means inspecting it, which only detection does, so
+  a forced-`format=` open reports the offset and leaves the kind unestablished.
 - **`format-rar` gets the SFX/start-offset requirement it never had**, stated as the same
   contract `format-7z` already carries, so the two are specified as one behaviour rather
   than two coincidences.
+- **Every format that can receive a `start_offset` reports one**, not just ZIP / 7z / RAR.
+  Sequencing this after `prefixed-archive-detection` means TAR and the single-file codecs
+  become prefix-capable (a makeself `.run` detects as `TAR_GZ` at the gzip offset), so a
+  census frozen at today's three would recreate the same hole for them.
 
 Not in scope: changing *when* a scan runs, widening the cue set, or the ZIP tail probe —
 those are `prefixed-archive-detection`. This change moves no detection tier and changes no
@@ -84,17 +90,16 @@ detection answer.
 ### Modified Capabilities
 
 - `archive-data-model` — `ArchiveInfo` gains `prefix_kind` and `payload_offset`, with the
-  `NONE`/`UNKNOWN` ↔ `0`/`None` pairing stated as an invariant.
+  `NONE` ↔ `0` and `None` ↔ `None` pairings stated as an invariant, and `payload_offset`
+  defined as an offset from the start of `source`.
 - `archive-reading` — the payload-offset hand-off requirement gains its return half:
   backends report the origin they used, and `format=` no longer means "less information".
 - `format-7z` — the SFX requirement is restated against the shared resolver and gains the
   reporting obligation.
-- `format-zip` — a prefixed ZIP's origin is reported when known and explicitly `UNKNOWN`
-  when the stdlib located the payload for us.
-
-### Added Capabilities
-
-- `format-rar` — an explicit start-offset / SFX requirement, matching `format-7z`.
+- `format-zip` — a prefixed ZIP's origin is reported when known, and explicitly
+  not-established when the stdlib located the payload for us.
+- `format-rar` — gains an explicit start-offset / SFX requirement, matching `format-7z`.
+  The capability already exists; only the requirement is new.
 
 ## Decisions
 
@@ -105,16 +110,29 @@ detection answer.
   "offset > 0" and none of them is self-extracting. Two enums describing the same property
   on two objects would be the parity smell this repo names in §2, so `ArchiveInfo` reuses
   `PrefixKind`.
-- **`payload_offset` is `int | None`, and pairs with `prefix_kind`.** `prefix_kind is
-  NONE` ⟺ `payload_offset == 0`; `prefix_kind is UNKNOWN` ⟺ `payload_offset is None`;
-  otherwise `payload_offset > 0`. That mirrors the invariant `format-detection` already
-  states for `FormatInfo` and extends it by exactly the one state an opened archive can be
-  in that a detection result cannot.
-- **Report `UNKNOWN` for forced ZIP rather than scanning to find out.** Making the answer
-  known would mean running a tail probe at open time purely to populate a field — new I/O
-  for metadata, on a path the caller chose for speed. `prefixed-archive-detection` adds
-  that probe to detection; once it exists, reusing it here is a follow-up, not a reason to
-  add a second scanner now. Recorded because "just scan for it" is the obvious wrong answer.
+- **"Not established" is spelled as absence, and the two fields carry it independently.**
+  `prefix_kind is NONE` ⟺ `payload_offset == 0`; `payload_offset is None` ⟹ `prefix_kind is
+  None`, but **not** the converse — a forced-format open knows the offset and not the kind.
+  The extra state an opened archive can be in
+  that a detection result cannot is *not established*, and it gets its own spelling rather
+  than borrowing `UNKNOWN`. `prefixed-archive-detection` already defines `UNKNOWN` as a
+  prefix that matched no cue — which always has a positive offset — so overloading it would
+  make the same member mean different things on `FormatInfo` and `ArchiveInfo`. That is the
+  §2 inconsistency this change is otherwise arguing against.
+- **Forced `format=ZIP` reports the real origin, from data it already has.** No tail probe
+  and no extra read: `zipfile` adjusts every entry's `header_offset` while parsing the
+  central directory, so the smallest one is the payload start in source coordinates.
+  Measured correct for `zipapp`, shebang, `MZ` and JPEG prefixes (`design.md`). Recorded
+  because the obvious wrong answer is `concat`, `zipfile`'s adjustment value, which is `0`
+  for a `zipapp` and would report the headline prefixed case as unprefixed. `None` is left
+  for the one archive that truly cannot answer: an empty ZIP has no local file header.
+- **`prefix_kind` is never inferred from `payload_offset > 0`.** The cheap alternative —
+  sniff the first bytes for `MZ`/ELF/`#!` on the forced path — buys partial agreement and
+  gets polyglots wrong (a JPEG+ZIP would report `UNKNOWN` on one door and `OTHER_FORMAT` on
+  the other). A partly-classified kind is worse than an absent one for the caller this field
+  exists for: someone filtering "open installers, skip polyglots" would silently get a
+  different answer depending on which door they used. Absent is honest; `design.md` records
+  the two rejected options and their costs.
 - **The resolver returns `MagicHit`, not `int`.** RAR needs the *version* as well as the
   offset, and the fast-path read already has the bytes that answer both. Returning the hit
   keeps the two formats on one signature instead of forcing RAR to keep a wider one.

--- a/openspec/changes/archive-origin-reporting/proposal.md
+++ b/openspec/changes/archive-origin-reporting/proposal.md
@@ -1,0 +1,145 @@
+## Why
+
+An archive that starts after byte zero is opened correctly today, and then archivey
+forgets where it started. Two things follow, both measured on `main` (`056c429`) with a
+4 224-byte `MZ` stub in front of a real 7z / RAR / ZIP payload:
+
+**1. The caller cannot ask.** `ArchiveInfo` carries format, version, solidity, member
+count, comment, encryption, multivolume, cost and `extra` — nothing about the payload
+origin. The reader knows it (`SevenZipReader._origin`, `RarReader._origin`,
+`RarArchive.sfx_offset`) and drops it on the floor. Archivey's own CLI works around this
+by calling `detect_format()` a second time purely to print `sfx_offset`
+(`cli/info_cmd.py:57`).
+
+**2. The two open paths know different amounts, and only one can be asked.** The same
+SFX file opened two ways:
+
+| | `payload_offset` reachable by caller | parser scan runs |
+| --- | --- | --- |
+| auto-detect | yes — via a second `detect_format()` call | **no** (magic already at the offset) |
+| `format=SEVEN_Z` / `format=RAR` | **no** | yes — the parser finds the origin, then discards it |
+| `format=ZIP` | **no** | none — stdlib `zipfile` self-adjusts; archivey never learns the offset |
+
+The forced path is the sharper gap: the parser *does the work of finding the origin* and
+throws the answer away. A caller who passes `format=` — the path that skips detection
+precisely because they already know the format — ends up with strictly less information
+than one who did not.
+
+`archive-reading` states the divergence as a rule rather than a defect: *"An explicit
+`format=` that bypasses detection retains each backend's own start-offset / SFX rules."*
+That was the right call when the offset was only an internal open-time input. Once it is
+reportable metadata, "each backend's own rules" is a parity hole (§2 *no surprises*): the
+same archive gives a different answer depending on which door the caller used.
+
+**Why the resolution logic is also worth touching.** Origin resolution is done three
+different ways for the three formats that can carry a prefix:
+
+| | mechanism | forced-path fallback |
+| --- | --- | --- |
+| ZIP | `SlicingStream(handle, start=start_offset)` — a real view | none; relies on stdlib `zipfile` self-adjusting past the stub |
+| 7z | `_shared.view(start_offset)`, then `start_offset + find_signature_offset(probe)`, rebased through `_view` | bounded forward scan |
+| RAR | `self._origin = start_offset` plain, no view (`unrar` needs the original path) | bounded forward scan **plus** RAR4/RAR5 version resolution |
+
+The *scanning* is already shared (`internal/sfx.scan_for_magic`, one `SFX_MAX`). What is
+triplicated is the wrapper around it — "fast-path read, else scan, else raise" — in two
+shapes with different return types (`int` vs `tuple[version, offset]`) and different error
+messages, plus a third format that does not participate at all. That is also why the
+answer has nowhere to go: there is no one place that produces it.
+
+`format-7z` specifies its SFX/start-offset behaviour; `format-rar` specifies none, despite
+the RAR parser having carried the same scan longer.
+
+## What Changes
+
+- **`ArchiveInfo` gains `prefix_kind` and `payload_offset`**, so the origin is
+  archive-level metadata a caller can read from the reader, on **either** open path. The
+  CLI stops detecting twice to print it.
+- **`payload_offset` is `int | None`**, with `None` meaning *not established* — the honest
+  answer for forced `format=ZIP`, where stdlib `zipfile` locates the central directory past
+  a stub without archivey ever learning where the payload began. Absence is data, not a
+  zero that would falsely claim "starts at byte 0".
+- **`prefix_kind` reuses `PrefixKind`** from `prefixed-archive-detection` rather than a new
+  `is_sfx: bool`. A bool cannot express *not established*, and — more importantly — cannot
+  separate a self-extracting archive from one merely embedded in something else, which is
+  the distinction that change added the enum for. See Decisions.
+- **One origin resolver.** A shared `resolve_payload_origin()` in `internal/sfx.py`
+  replaces `sevenzip_parser.find_signature_offset` and `rar_parser._find_sfx_header`:
+  fast-path read at the open position, bounded scan on a miss, `CorruptionError` on a miss
+  past the bound. It returns the `MagicHit` that `detection-prefix-workspace` introduced,
+  so RAR's version resolution falls out of `hit.needle` instead of a second code path.
+- **Backends report the origin they resolved** back to the reader, which is what lets the
+  forced path populate `ArchiveInfo` identically to the detected path.
+- **`format-rar` gets the SFX/start-offset requirement it never had**, stated as the same
+  contract `format-7z` already carries, so the two are specified as one behaviour rather
+  than two coincidences.
+
+Not in scope: changing *when* a scan runs, widening the cue set, or the ZIP tail probe —
+those are `prefixed-archive-detection`. This change moves no detection tier and changes no
+detection answer.
+
+## Capabilities
+
+### New Capabilities
+
+### Modified Capabilities
+
+- `archive-data-model` — `ArchiveInfo` gains `prefix_kind` and `payload_offset`, with the
+  `NONE`/`UNKNOWN` ↔ `0`/`None` pairing stated as an invariant.
+- `archive-reading` — the payload-offset hand-off requirement gains its return half:
+  backends report the origin they used, and `format=` no longer means "less information".
+- `format-7z` — the SFX requirement is restated against the shared resolver and gains the
+  reporting obligation.
+- `format-zip` — a prefixed ZIP's origin is reported when known and explicitly `UNKNOWN`
+  when the stdlib located the payload for us.
+
+### Added Capabilities
+
+- `format-rar` — an explicit start-offset / SFX requirement, matching `format-7z`.
+
+## Decisions
+
+- **Enum, not `is_sfx: bool`.** Three states exist, not two: the archive starts at byte 0;
+  it starts later; or we opened it correctly without establishing where. A bool forces the
+  third into a lie. And `prefixed-archive-detection` already needs the finer split for
+  `FormatInfo` — a `.pyz`, a Spring Boot JAR and a JPEG with an appended ZIP are all
+  "offset > 0" and none of them is self-extracting. Two enums describing the same property
+  on two objects would be the parity smell this repo names in §2, so `ArchiveInfo` reuses
+  `PrefixKind`.
+- **`payload_offset` is `int | None`, and pairs with `prefix_kind`.** `prefix_kind is
+  NONE` ⟺ `payload_offset == 0`; `prefix_kind is UNKNOWN` ⟺ `payload_offset is None`;
+  otherwise `payload_offset > 0`. That mirrors the invariant `format-detection` already
+  states for `FormatInfo` and extends it by exactly the one state an opened archive can be
+  in that a detection result cannot.
+- **Report `UNKNOWN` for forced ZIP rather than scanning to find out.** Making the answer
+  known would mean running a tail probe at open time purely to populate a field — new I/O
+  for metadata, on a path the caller chose for speed. `prefixed-archive-detection` adds
+  that probe to detection; once it exists, reusing it here is a follow-up, not a reason to
+  add a second scanner now. Recorded because "just scan for it" is the obvious wrong answer.
+- **The resolver returns `MagicHit`, not `int`.** RAR needs the *version* as well as the
+  offset, and the fast-path read already has the bytes that answer both. Returning the hit
+  keeps the two formats on one signature instead of forcing RAR to keep a wider one.
+- **Sequenced after `prefixed-archive-detection`.** `PrefixKind` is defined there. Landing
+  this first would mean defining the enum in one change and its semantics in another. See
+  `design.md` §Sequencing for the fallback if the order is inverted.
+
+## Impact
+
+- Modules: `src/archivey/internal/sfx.py` (the shared resolver),
+  `src/archivey/internal/backends/sevenzip_parser.py` (`find_signature_offset` becomes a
+  thin wrapper or goes), `sevenzip_reader.py`, `rar_parser.py` (`_find_sfx_header` goes),
+  `rar_reader.py`, `zip_reader.py` (report the slice origin),
+  `src/archivey/internal/base_reader.py` (how a backend reports its origin back),
+  `src/archivey/types.py` (`ArchiveInfo`), `src/archivey/cli/info_cmd.py` (drop the second
+  `detect_format`).
+- Public API: `ArchiveInfo` gains two fields. Additive — `ArchiveInfo` is constructed by
+  backends, not by callers, so no positional-argument break for library users; the
+  dataclass gains defaults so backends that do not set them stay valid.
+- Tests: SFX 7z / RAR / ZIP each opened both auto-detected and with `format=`, asserting
+  the *same* `prefix_kind` and `payload_offset`; forced ZIP asserting `UNKNOWN` / `None`
+  rather than a wrong `0`; plain archives asserting `NONE` / `0`; a stub carrying a decoy
+  magic asserting the reported origin is the real payload; the RAR4/RAR5 version still
+  resolved through the shared resolver; `reject_start_offset` backends unchanged.
+- Docs: `docs/formats.md` self-extracting prose, and the CLI `info` output gaining the
+  field from the reader instead of a second detection.
+- Depends on `prefixed-archive-detection` (`PrefixKind`) and on
+  `detection-prefix-workspace` (`MagicHit`, already landed in #273).

--- a/openspec/changes/archive-origin-reporting/proposal.md
+++ b/openspec/changes/archive-origin-reporting/proposal.md
@@ -58,19 +58,20 @@ the RAR parser having carried the same scan longer.
 - **`payload_offset` is `int | None`**, with `None` meaning *not established* — the honest
   answer for an empty ZIP behind a prefix, which has no local file header to measure from.
   Absence is data, not a zero that would falsely claim "starts at byte 0".
-- **`prefix_kind` reuses `PrefixKind`** from `prefixed-archive-detection` rather than a new
-  `is_sfx: bool`. A bool cannot express *not established*, and — more importantly — cannot
-  separate a self-extracting archive from one merely embedded in something else, which is
-  the distinction that change added the enum for. See Decisions.
+- **`prefix_kind` reuses `PrefixKind`** from `prefixed-archive-detection` (`NONE` /
+  `EXECUTABLE` / `SCRIPT` / `UNKNOWN`) rather than a new `is_sfx: bool`. A bool cannot express
+  *not established*, and — more importantly — cannot separate a self-extracting archive from
+  one merely embedded in something else, which is the distinction that change added the enum
+  for. See Decisions.
 - **One origin resolver.** A shared `resolve_payload_origin()` in `internal/sfx.py`
   replaces `sevenzip_parser.find_signature_offset` and `rar_parser._find_sfx_header`:
   fast-path read at the open position, bounded scan on a miss, `CorruptionError` on a miss
   past the bound. It returns the `MagicHit` that `detection-prefix-workspace` introduced,
   so RAR's version resolution falls out of `hit.needle` instead of a second code path.
 - **Backends report the origin they resolved** back to the reader, which is what lets the
-  forced path report the same `payload_offset` as the detected one. `prefix_kind` is a
-  separate question: classifying a prefix means inspecting it, which only detection does, so
-  a forced-`format=` open reports the offset and leaves the kind unestablished.
+  forced path report the same `payload_offset` and `prefix_kind` as the detected one. A
+  forced open classifies the prefix from one short read of the source's leading bytes — the
+  same pure function detection applies — so the two doors agree on both fields.
 - **`format-rar` gets the SFX/start-offset requirement it never had**, stated as the same
   contract `format-7z` already carries, so the two are specified as one behaviour rather
   than two coincidences.
@@ -96,8 +97,8 @@ detection answer.
   backends report the origin they used, and `format=` no longer means "less information".
 - `format-7z` — the SFX requirement is restated against the shared resolver and gains the
   reporting obligation.
-- `format-zip` — a prefixed ZIP's origin is reported when known, and explicitly
-  not-established when the stdlib located the payload for us.
+- `format-zip` — a prefixed ZIP's origin is reported on both open paths, derived from the
+  central directory the reader already parsed; not-established only for an empty archive.
 - `format-rar` — gains an explicit start-offset / SFX requirement, matching `format-7z`.
   The capability already exists; only the requirement is new.
 
@@ -110,15 +111,13 @@ detection answer.
   "offset > 0" and none of them is self-extracting. Two enums describing the same property
   on two objects would be the parity smell this repo names in §2, so `ArchiveInfo` reuses
   `PrefixKind`.
-- **"Not established" is spelled as absence, and the two fields carry it independently.**
-  `prefix_kind is NONE` ⟺ `payload_offset == 0`; `payload_offset is None` ⟹ `prefix_kind is
-  None`, but **not** the converse — a forced-format open knows the offset and not the kind.
-  The extra state an opened archive can be in
-  that a detection result cannot is *not established*, and it gets its own spelling rather
-  than borrowing `UNKNOWN`. `prefixed-archive-detection` already defines `UNKNOWN` as a
-  prefix that matched no cue — which always has a positive offset — so overloading it would
-  make the same member mean different things on `FormatInfo` and `ArchiveInfo`. That is the
-  §2 inconsistency this change is otherwise arguing against.
+- **"Not established" is spelled as absence.** `prefix_kind is NONE` ⟺ `payload_offset ==
+  0`; `prefix_kind is None` ⟺ `payload_offset is None`. The extra state an opened archive can
+  be in that a detection result cannot is *not established*, and it gets its own spelling
+  rather than borrowing `UNKNOWN`. `prefixed-archive-detection` defines `UNKNOWN` as a prefix
+  that matched no cue — which always has a positive offset — so overloading it would make the
+  same member mean different things on `FormatInfo` and `ArchiveInfo`. That is the §2
+  inconsistency this change is otherwise arguing against.
 - **Forced `format=ZIP` reports the real origin, from data it already has.** No tail probe
   and no extra read: `zipfile` adjusts every entry's `header_offset` while parsing the
   central directory, so the smallest one is the payload start in source coordinates.
@@ -126,19 +125,23 @@ detection answer.
   because the obvious wrong answer is `concat`, `zipfile`'s adjustment value, which is `0`
   for a `zipapp` and would report the headline prefixed case as unprefixed. `None` is left
   for the one archive that truly cannot answer: an empty ZIP has no local file header.
-- **`prefix_kind` is never inferred from `payload_offset > 0`.** The cheap alternative —
-  sniff the first bytes for `MZ`/ELF/`#!` on the forced path — buys partial agreement and
-  gets polyglots wrong (a JPEG+ZIP would report `UNKNOWN` on one door and `OTHER_FORMAT` on
-  the other). A partly-classified kind is worse than an absent one for the caller this field
-  exists for: someone filtering "open installers, skip polyglots" would silently get a
-  different answer depending on which door they used. Absent is honest; `design.md` records
-  the two rejected options and their costs.
+- **`prefix_kind` is classified on both paths, and never inferred from the offset.** With
+  `OTHER_FORMAT` merged into `UNKNOWN` (`prefixed-archive-detection`), classification is a
+  pure function of the leading bytes — `MZ`/ELF/Mach-O → `EXECUTABLE`, `#!` → `SCRIPT`, else
+  `UNKNOWN` — so a forced-format open reaches the same answer detection does from one short
+  read, polyglots included. What stays forbidden is deriving the kind from `payload_offset >
+  0` without that read: a `zipapp`, an executable JAR and a JPEG-with-appended-ZIP all have
+  a non-zero offset and only the first two carry a cue.
 - **The resolver returns `MagicHit`, not `int`.** RAR needs the *version* as well as the
   offset, and the fast-path read already has the bytes that answer both. Returning the hit
   keeps the two formats on one signature instead of forcing RAR to keep a wider one.
-- **Sequenced after `prefixed-archive-detection`.** `PrefixKind` is defined there. Landing
-  this first would mean defining the enum in one change and its semantics in another. See
-  `design.md` §Sequencing for the fallback if the order is inverted.
+- **Sequenced after `prefixed-archive-detection`.** `PrefixKind` is defined there, and this
+  change assumes the member set that change is settling on — `NONE` / `EXECUTABLE` / `SCRIPT`
+  / `UNKNOWN`, with `OTHER_FORMAT` merged away. That merge is what makes classification cheap
+  enough to run on the forced path (`design.md`), so the two changes must agree on it; if
+  `OTHER_FORMAT` survives there, the forced-path classification here has to be revisited.
+  Landing this first would mean defining the enum in one change and its semantics in another.
+  See `design.md` §Sequencing for the fallback if the order is inverted.
 
 ## Impact
 

--- a/openspec/changes/archive-origin-reporting/specs/archive-data-model/spec.md
+++ b/openspec/changes/archive-origin-reporting/specs/archive-data-model/spec.md
@@ -27,47 +27,47 @@ class ArchiveInfo:
 `prefix_kind` and `payload_offset` SHALL describe where the archive proper begins inside
 the source, and SHALL be present on every archive regardless of format, so a caller may
 read them without first testing whether the format can carry a prefix. `PrefixKind` is the
-enum defined by `format-detection`, **with its meanings unchanged**: in particular
-`UNKNOWN` means *a prefix that matched no cue*, which always has `payload_offset > 0`.
+enum defined by `format-detection` — `NONE` / `EXECUTABLE` / `SCRIPT` / `UNKNOWN` — used here
+with its meanings unchanged: `UNKNOWN` means *a prefix that matched no cue*, which always has
+`payload_offset > 0`.
 
 *Not established* SHALL be spelled as **absence**, not as an enum member: `None`.
 Overloading `UNKNOWN` would give one member two meanings and make it disagree with
 `FormatInfo`, which is the cross-surface inconsistency this change exists to avoid.
 
-**The two fields are established independently.** Where the payload starts and what
-precedes it are answered by different work: the offset falls out of opening the archive,
-while the kind requires inspecting the prefix, which only detection does. A caller MUST
-therefore test them separately:
-
 | state | `prefix_kind` | `payload_offset` |
 | --- | --- | --- |
 | archive begins at the open position | `NONE` | `0` |
-| begins later, prefix classified by detection | `EXECUTABLE` / `SCRIPT` / `OTHER_FORMAT` | `> 0` |
+| begins later, prefix cue recognised | `EXECUTABLE` / `SCRIPT` | `> 0` |
 | begins later, prefix matched no cue | `UNKNOWN` | `> 0` |
-| begins later, kind never established | `None` | `> 0` |
 | origin never established | `None` | `None` |
 
 The invariants SHALL be:
 
 - `prefix_kind is NONE` ⟺ `payload_offset == 0`
-- `payload_offset is None` ⟹ `prefix_kind is None` (the converse does **not** hold)
-- `prefix_kind is None` SHALL mean *the kind was not established*, and SHALL NOT be read as
-  "no prefix" — that is `NONE`
+- `prefix_kind is None` ⟺ `payload_offset is None`
+- `prefix_kind is None` SHALL mean *not established*, and SHALL NOT be read as "no prefix" —
+  that is `NONE`
 
 Neither absence SHALL be reported as `NONE` / `0`: a backend that opened a prefixed archive
-without establishing where the payload began MUST NOT claim it started at byte zero, and one
-that did not inspect the prefix MUST NOT claim there was none. A format that cannot carry a
-prefix SHALL report `NONE` and `0`.
+without establishing where the payload began MUST NOT claim it started at byte zero. A format
+that cannot carry a prefix SHALL report `NONE` and `0`.
+
+Classifying a prefix is a pure function of its leading bytes — `MZ` / ELF / Mach-O →
+`EXECUTABLE`, `#!` → `SCRIPT`, anything else → `UNKNOWN` — so a backend that knows the offset
+can always establish the kind from one short read, and the two fields are established
+together. `prefix_kind` SHALL NOT be inferred from `payload_offset > 0` without that read:
+a `zipapp`, an executable JAR and a JPEG-with-appended-ZIP all have a non-zero offset and
+none is an executable stub.
 
 `payload_offset` SHALL be measured **from the start of `source` as handed to
 `open_archive`** (after any stream start-position fix-up) — not relative to a view, slice,
 or the position a parser was handed. A backend that resolves its origin inside a view
 SHALL report the sum, so the value does not depend on which door the caller used.
 
-These fields are open-time structural facts about the archive, not runtime diagnostics.
-`payload_offset` SHALL be populated identically whether the format was detected or supplied
-by the caller; `prefix_kind` SHALL be populated where the prefix was classified, which today
-means the detected path (`archive-reading`).
+These fields are open-time structural facts about the archive, not runtime diagnostics, and
+both SHALL be populated identically whether the format was detected or supplied by the
+caller (`archive-reading`).
 
 #### Scenario: archive info matrix
 
@@ -82,10 +82,10 @@ means the detected path (`archive-reading`).
 | --- | --- |
 | Plain 7z / RAR / ZIP / TAR | `prefix_kind is NONE` and `payload_offset == 0` |
 | SFX 7z at offset N, auto-detected | `prefix_kind is EXECUTABLE` and `payload_offset == N` |
-| SFX 7z at offset N, `format=SEVEN_Z` | `payload_offset == N` (same as auto-detect); `prefix_kind is None` — nothing classified the prefix |
-| SFX RAR at offset N, auto-detected | `prefix_kind is EXECUTABLE` and `payload_offset == N` |
-| Prefixed ZIP at offset N, auto-detected | `payload_offset == N` |
-| Prefixed ZIP at offset N, `format=ZIP` | `payload_offset == N`; `prefix_kind is None` |
+| SFX 7z at offset N, `format=SEVEN_Z` | Identical `prefix_kind` and `payload_offset` to the auto-detected open |
+| SFX RAR at offset N, either open path | `prefix_kind is EXECUTABLE` and `payload_offset == N` |
+| `zipapp` `.pyz`, either open path | `prefix_kind is SCRIPT` and `payload_offset` is the shebang length |
+| JPEG + appended ZIP, either open path | `prefix_kind is UNKNOWN` — no cue matched; **not** `EXECUTABLE` |
 | Empty ZIP behind a prefix, `format=ZIP` | `prefix_kind is None` and `payload_offset is None` |
 | Any archive | `(prefix_kind is NONE) == (payload_offset == 0)` |
-| Any archive | `payload_offset is None` implies `prefix_kind is None`; the converse does not hold |
+| Any archive | `(prefix_kind is None) == (payload_offset is None)` |

--- a/openspec/changes/archive-origin-reporting/specs/archive-data-model/spec.md
+++ b/openspec/changes/archive-origin-reporting/specs/archive-data-model/spec.md
@@ -1,0 +1,66 @@
+## MODIFIED Requirements
+
+### Requirement: ArchiveInfo carries open-time archive metadata
+
+The system SHALL define frozen `ArchiveInfo` for metadata available immediately
+after `open_archive()` without a full member scan:
+
+```python
+@dataclass(frozen=True)
+class ArchiveInfo:
+    format: ArchiveFormat
+    format_version: str | None
+    is_solid: bool
+    member_count: int | None
+    comment: str | None
+    is_encrypted: bool
+    is_multivolume: bool
+    cost: CostReceipt
+    prefix_kind: PrefixKind = PrefixKind.NONE
+    payload_offset: int | None = 0
+    extra: dict[str, Any] = field(default_factory=dict, compare=False)
+```
+
+`extra` keys SHALL be namespaced strings and excluded from equality.
+`member_count` SHALL be `None` when computing it requires a full scan.
+
+`prefix_kind` and `payload_offset` SHALL describe where the archive proper begins inside
+the source, and SHALL be present on every archive regardless of format, so a caller may
+read them without first testing whether the format can carry a prefix. `PrefixKind` is the
+enum defined by `format-detection`; the two fields SHALL satisfy:
+
+| state | `prefix_kind` | `payload_offset` |
+| --- | --- | --- |
+| archive begins at the open position | `NONE` | `0` |
+| archive begins later, prefix classified | `EXECUTABLE` / `SCRIPT` / `OTHER_FORMAT` | `> 0` |
+| archive begins later, prefix not classified | `UNKNOWN` | `> 0` |
+| origin not established | `UNKNOWN` | `None` |
+
+`payload_offset is None` SHALL mean *the origin was not established*, and SHALL NOT be
+reported as `0`: a backend that opened a prefixed archive without learning where the
+payload began (stdlib `zipfile` locating the central directory past a stub) MUST NOT claim
+the archive started at byte zero. A format that cannot carry a prefix SHALL report `NONE`
+and `0`.
+
+These fields are open-time structural facts about the archive, not runtime diagnostics, and
+SHALL be populated identically whether the format was detected or supplied by the caller
+(`archive-reading`).
+
+#### Scenario: archive info matrix
+
+| Case | Expected |
+| --- | --- |
+| TAR archive opens without central directory | `ar.info.member_count is None` |
+| ISO 9660 image richest namespace is Joliet | `ar.info.extra["iso.namespace"] == "joliet"` |
+
+#### Scenario: payload origin matrix
+
+| Case | Expected |
+| --- | --- |
+| Plain 7z / RAR / ZIP / TAR | `prefix_kind is NONE` and `payload_offset == 0` |
+| SFX 7z at offset N, auto-detected | `prefix_kind is EXECUTABLE` and `payload_offset == N` |
+| SFX 7z at offset N, `format=SEVEN_Z` | Identical `prefix_kind` and `payload_offset` to the auto-detected open |
+| SFX RAR at offset N, either open path | `prefix_kind is EXECUTABLE` and `payload_offset == N` |
+| Prefixed ZIP at offset N, auto-detected | `payload_offset == N` |
+| Prefixed ZIP, `format=ZIP` (stdlib located the payload) | `prefix_kind is UNKNOWN` and `payload_offset is None` |
+| Any archive | `(prefix_kind is NONE) == (payload_offset == 0)` |

--- a/openspec/changes/archive-origin-reporting/specs/archive-data-model/spec.md
+++ b/openspec/changes/archive-origin-reporting/specs/archive-data-model/spec.md
@@ -16,7 +16,7 @@ class ArchiveInfo:
     is_encrypted: bool
     is_multivolume: bool
     cost: CostReceipt
-    prefix_kind: PrefixKind = PrefixKind.NONE
+    prefix_kind: PrefixKind | None = PrefixKind.NONE
     payload_offset: int | None = 0
     extra: dict[str, Any] = field(default_factory=dict, compare=False)
 ```
@@ -27,24 +27,47 @@ class ArchiveInfo:
 `prefix_kind` and `payload_offset` SHALL describe where the archive proper begins inside
 the source, and SHALL be present on every archive regardless of format, so a caller may
 read them without first testing whether the format can carry a prefix. `PrefixKind` is the
-enum defined by `format-detection`; the two fields SHALL satisfy:
+enum defined by `format-detection`, **with its meanings unchanged**: in particular
+`UNKNOWN` means *a prefix that matched no cue*, which always has `payload_offset > 0`.
+
+*Not established* SHALL be spelled as **absence**, not as an enum member: `None`.
+Overloading `UNKNOWN` would give one member two meanings and make it disagree with
+`FormatInfo`, which is the cross-surface inconsistency this change exists to avoid.
+
+**The two fields are established independently.** Where the payload starts and what
+precedes it are answered by different work: the offset falls out of opening the archive,
+while the kind requires inspecting the prefix, which only detection does. A caller MUST
+therefore test them separately:
 
 | state | `prefix_kind` | `payload_offset` |
 | --- | --- | --- |
 | archive begins at the open position | `NONE` | `0` |
-| archive begins later, prefix classified | `EXECUTABLE` / `SCRIPT` / `OTHER_FORMAT` | `> 0` |
-| archive begins later, prefix not classified | `UNKNOWN` | `> 0` |
-| origin not established | `UNKNOWN` | `None` |
+| begins later, prefix classified by detection | `EXECUTABLE` / `SCRIPT` / `OTHER_FORMAT` | `> 0` |
+| begins later, prefix matched no cue | `UNKNOWN` | `> 0` |
+| begins later, kind never established | `None` | `> 0` |
+| origin never established | `None` | `None` |
 
-`payload_offset is None` SHALL mean *the origin was not established*, and SHALL NOT be
-reported as `0`: a backend that opened a prefixed archive without learning where the
-payload began (stdlib `zipfile` locating the central directory past a stub) MUST NOT claim
-the archive started at byte zero. A format that cannot carry a prefix SHALL report `NONE`
-and `0`.
+The invariants SHALL be:
 
-These fields are open-time structural facts about the archive, not runtime diagnostics, and
-SHALL be populated identically whether the format was detected or supplied by the caller
-(`archive-reading`).
+- `prefix_kind is NONE` ⟺ `payload_offset == 0`
+- `payload_offset is None` ⟹ `prefix_kind is None` (the converse does **not** hold)
+- `prefix_kind is None` SHALL mean *the kind was not established*, and SHALL NOT be read as
+  "no prefix" — that is `NONE`
+
+Neither absence SHALL be reported as `NONE` / `0`: a backend that opened a prefixed archive
+without establishing where the payload began MUST NOT claim it started at byte zero, and one
+that did not inspect the prefix MUST NOT claim there was none. A format that cannot carry a
+prefix SHALL report `NONE` and `0`.
+
+`payload_offset` SHALL be measured **from the start of `source` as handed to
+`open_archive`** (after any stream start-position fix-up) — not relative to a view, slice,
+or the position a parser was handed. A backend that resolves its origin inside a view
+SHALL report the sum, so the value does not depend on which door the caller used.
+
+These fields are open-time structural facts about the archive, not runtime diagnostics.
+`payload_offset` SHALL be populated identically whether the format was detected or supplied
+by the caller; `prefix_kind` SHALL be populated where the prefix was classified, which today
+means the detected path (`archive-reading`).
 
 #### Scenario: archive info matrix
 
@@ -59,8 +82,10 @@ SHALL be populated identically whether the format was detected or supplied by th
 | --- | --- |
 | Plain 7z / RAR / ZIP / TAR | `prefix_kind is NONE` and `payload_offset == 0` |
 | SFX 7z at offset N, auto-detected | `prefix_kind is EXECUTABLE` and `payload_offset == N` |
-| SFX 7z at offset N, `format=SEVEN_Z` | Identical `prefix_kind` and `payload_offset` to the auto-detected open |
-| SFX RAR at offset N, either open path | `prefix_kind is EXECUTABLE` and `payload_offset == N` |
+| SFX 7z at offset N, `format=SEVEN_Z` | `payload_offset == N` (same as auto-detect); `prefix_kind is None` — nothing classified the prefix |
+| SFX RAR at offset N, auto-detected | `prefix_kind is EXECUTABLE` and `payload_offset == N` |
 | Prefixed ZIP at offset N, auto-detected | `payload_offset == N` |
-| Prefixed ZIP, `format=ZIP` (stdlib located the payload) | `prefix_kind is UNKNOWN` and `payload_offset is None` |
+| Prefixed ZIP at offset N, `format=ZIP` | `payload_offset == N`; `prefix_kind is None` |
+| Empty ZIP behind a prefix, `format=ZIP` | `prefix_kind is None` and `payload_offset is None` |
 | Any archive | `(prefix_kind is NONE) == (payload_offset == 0)` |
+| Any archive | `payload_offset is None` implies `prefix_kind is None`; the converse does not hold |

--- a/openspec/changes/archive-origin-reporting/specs/archive-reading/spec.md
+++ b/openspec/changes/archive-origin-reporting/specs/archive-reading/spec.md
@@ -17,14 +17,27 @@ start-offset / SFX rules (`format-rar`, `format-7z`).
 
 **Backends SHALL report the origin they resolved.** Whether the offset arrived from
 detection or was discovered by the backend’s own start-offset rules, the reader SHALL
-surface it as `ArchiveInfo.prefix_kind` / `ArchiveInfo.payload_offset`
-(`archive-data-model`). A backend that discovers the origin and discards it is
-non-conforming: the two open paths SHALL NOT differ in what the caller can learn about
-where the archive began.
+surface it as `ArchiveInfo.payload_offset` (`archive-data-model`). A backend that discovers
+the origin and discards it is non-conforming: the two open paths SHALL NOT differ in what
+the caller can learn about **where** the archive began.
 
-Where the backend opened a prefixed archive without establishing the origin, it SHALL
-report `payload_offset is None` rather than `0`. Backends whose formats cannot carry a
-prefix SHALL report `NONE` / `0` and are unaffected.
+`ArchiveInfo.prefix_kind` is a separate question and SHALL NOT be inferred from the offset.
+Classifying a prefix requires inspecting it, which only detection does; a forced-`format=`
+open SHALL report `prefix_kind is None` (*not established*) rather than guessing a kind from
+`payload_offset > 0`. Collapsing every non-zero offset to `EXECUTABLE` would reintroduce the
+`is_sfx` conflation this change exists to avoid — a `zipapp`, an executable JAR and a
+JPEG-with-appended-ZIP are all non-zero and none is self-extracting.
+
+This SHALL hold for every prefix-capable backend, including on the forced path: 7z and RAR
+resolve the origin with their own bounded scan, and ZIP derives it from the central
+directory it already parsed (`format-zip`). Where a backend genuinely cannot establish the
+origin — an empty ZIP has no local file header to measure from — it SHALL report
+`payload_offset is None` and `prefix_kind is None` rather than `0`. Backends whose formats
+cannot carry a prefix SHALL report `NONE` / `0` and are unaffected.
+
+A backend SHALL NOT perform additional I/O solely to populate these fields: the origin is
+reported where it is already known or falls out of work the open performs anyway, and
+reported as unestablished otherwise.
 
 Because the reader carries the origin, `open_archive` callers SHALL NOT need a second
 `detect_format()` call to learn it, on either open path — including on non-seekable
@@ -43,8 +56,10 @@ sources, where re-detecting is not available at all.
 
 | Case | Expected |
 | --- | --- |
-| SFX 7z opened auto-detected vs `format=SEVEN_Z` | Same `info.prefix_kind` and `info.payload_offset` |
-| SFX RAR opened auto-detected vs `format=RAR` | Same `info.prefix_kind` and `info.payload_offset` |
+| SFX 7z opened auto-detected vs `format=SEVEN_Z` | Same `info.payload_offset`; `prefix_kind` classified on the detected path, `None` on the forced one |
+| SFX RAR opened auto-detected vs `format=RAR` | Same `info.payload_offset`; `prefix_kind` as above |
+| Forced-format open, non-zero offset | `prefix_kind is None` — never inferred as `EXECUTABLE` from the offset alone |
 | Forced-format open on a prefixed archive | Origin reported from the backend’s own resolution, not `None` merely because detection was skipped |
-| Backend cannot establish the origin | `payload_offset is None`; never a fabricated `0` |
+| Forced `format=ZIP` on a prefixed ZIP | `payload_offset == N` from the earliest local header, with no extra read |
+| Backend cannot establish the origin (empty ZIP, no members) | `payload_offset is None` and `prefix_kind is None`; never a fabricated `0` |
 | Reading the origin | No second `detect_format()` call required |

--- a/openspec/changes/archive-origin-reporting/specs/archive-reading/spec.md
+++ b/openspec/changes/archive-origin-reporting/specs/archive-reading/spec.md
@@ -21,12 +21,16 @@ surface it as `ArchiveInfo.payload_offset` (`archive-data-model`). A backend tha
 the origin and discards it is non-conforming: the two open paths SHALL NOT differ in what
 the caller can learn about **where** the archive began.
 
-`ArchiveInfo.prefix_kind` is a separate question and SHALL NOT be inferred from the offset.
-Classifying a prefix requires inspecting it, which only detection does; a forced-`format=`
-open SHALL report `prefix_kind is None` (*not established*) rather than guessing a kind from
-`payload_offset > 0`. Collapsing every non-zero offset to `EXECUTABLE` would reintroduce the
-`is_sfx` conflation this change exists to avoid — a `zipapp`, an executable JAR and a
-JPEG-with-appended-ZIP are all non-zero and none is self-extracting.
+**`ArchiveInfo.prefix_kind` SHALL be reported on both paths too.** Classifying a prefix is a
+pure function of its leading bytes (`format-detection`), so a backend that resolved a non-zero
+origin SHALL establish the kind from one short read of the source's first bytes rather than
+leaving it unset. On the auto-detect path the classification detection already performed SHALL
+be carried through rather than repeated.
+
+The kind SHALL NOT be inferred from `payload_offset > 0` without that read: collapsing every
+non-zero offset to `EXECUTABLE` would reintroduce the `is_sfx` conflation this change exists
+to avoid — a `zipapp`, an executable JAR and a JPEG-with-appended-ZIP are all non-zero, and
+only the first two carry a cue at all.
 
 This SHALL hold for every prefix-capable backend, including on the forced path: 7z and RAR
 resolve the origin with their own bounded scan, and ZIP derives it from the central
@@ -35,9 +39,10 @@ origin — an empty ZIP has no local file header to measure from — it SHALL re
 `payload_offset is None` and `prefix_kind is None` rather than `0`. Backends whose formats
 cannot carry a prefix SHALL report `NONE` / `0` and are unaffected.
 
-A backend SHALL NOT perform additional I/O solely to populate these fields: the origin is
-reported where it is already known or falls out of work the open performs anyway, and
-reported as unestablished otherwise.
+Beyond the bounded read that classifies a recognised prefix, a backend SHALL NOT perform
+additional I/O to populate these fields: the origin is reported where it is already known or
+falls out of work the open performs anyway, and reported as unestablished otherwise. In
+particular no scan or tail probe SHALL be run for the sake of the fields alone.
 
 Because the reader carries the origin, `open_archive` callers SHALL NOT need a second
 `detect_format()` call to learn it, on either open path — including on non-seekable
@@ -56,9 +61,9 @@ sources, where re-detecting is not available at all.
 
 | Case | Expected |
 | --- | --- |
-| SFX 7z opened auto-detected vs `format=SEVEN_Z` | Same `info.payload_offset`; `prefix_kind` classified on the detected path, `None` on the forced one |
-| SFX RAR opened auto-detected vs `format=RAR` | Same `info.payload_offset`; `prefix_kind` as above |
-| Forced-format open, non-zero offset | `prefix_kind is None` — never inferred as `EXECUTABLE` from the offset alone |
+| SFX 7z opened auto-detected vs `format=SEVEN_Z` | Same `info.payload_offset` **and** same `info.prefix_kind` |
+| SFX RAR opened auto-detected vs `format=RAR` | Same `info.payload_offset` and `prefix_kind` |
+| Forced-format open on a JPEG + appended ZIP | `prefix_kind is UNKNOWN` — classified from the leading bytes, never inferred as `EXECUTABLE` from the offset |
 | Forced-format open on a prefixed archive | Origin reported from the backend’s own resolution, not `None` merely because detection was skipped |
 | Forced `format=ZIP` on a prefixed ZIP | `payload_offset == N` from the earliest local header, with no extra read |
 | Backend cannot establish the origin (empty ZIP, no members) | `payload_offset is None` and `prefix_kind is None`; never a fabricated `0` |

--- a/openspec/changes/archive-origin-reporting/specs/archive-reading/spec.md
+++ b/openspec/changes/archive-origin-reporting/specs/archive-reading/spec.md
@@ -1,0 +1,50 @@
+## MODIFIED Requirements
+
+### Requirement: Honour detection payload_offset at open
+
+When `detect_format` returns `payload_offset > 0`, `open_archive` (auto-detect
+path) SHALL open the archive at that byte offset by either (a) passing an
+explicit start-offset argument into `backend.open_read`, or (b) handing the
+backend a bounded offset view / slice whose byte 0 *is* the payload. A bare
+`seek` on a shared handle is **not** sufficient: backends that perform absolute
+seeks (notably 7z’s `read_signature_and_next_header`, which `seek(0)`s then
+seeks to `_SIGNATURE_HEADER_SIZE + next_header_offset`) discard caller
+positioning. The system SHALL NOT copy the remainder of the source to a
+temporary file solely to strip an SFX stub.
+
+An explicit `format=` that bypasses detection retains each backend’s own
+start-offset / SFX rules (`format-rar`, `format-7z`).
+
+**Backends SHALL report the origin they resolved.** Whether the offset arrived from
+detection or was discovered by the backend’s own start-offset rules, the reader SHALL
+surface it as `ArchiveInfo.prefix_kind` / `ArchiveInfo.payload_offset`
+(`archive-data-model`). A backend that discovers the origin and discards it is
+non-conforming: the two open paths SHALL NOT differ in what the caller can learn about
+where the archive began.
+
+Where the backend opened a prefixed archive without establishing the origin, it SHALL
+report `payload_offset is None` rather than `0`. Backends whose formats cannot carry a
+prefix SHALL report `NONE` / `0` and are unaffected.
+
+Because the reader carries the origin, `open_archive` callers SHALL NOT need a second
+`detect_format()` call to learn it, on either open path — including on non-seekable
+sources, where re-detecting is not available at all.
+
+#### Scenario: payload_offset hand-off
+
+| Case | Expected |
+| --- | --- |
+| Auto-detect SFX RAR/7z/ZIP with `payload_offset == N` | Backend opens via start-offset arg or offset view; real members listed |
+| `payload_offset == 0` | Unchanged open-at-current-position behaviour |
+| Explicit `format=` | Detection skipped; backend SFX/start-offset rules apply |
+| Bare seek only (no start-offset / no offset view) | Insufficient for 7z; MUST NOT be the sole hand-off mechanism |
+
+#### Scenario: the two open paths report the same origin
+
+| Case | Expected |
+| --- | --- |
+| SFX 7z opened auto-detected vs `format=SEVEN_Z` | Same `info.prefix_kind` and `info.payload_offset` |
+| SFX RAR opened auto-detected vs `format=RAR` | Same `info.prefix_kind` and `info.payload_offset` |
+| Forced-format open on a prefixed archive | Origin reported from the backend’s own resolution, not `None` merely because detection was skipped |
+| Backend cannot establish the origin | `payload_offset is None`; never a fabricated `0` |
+| Reading the origin | No second `detect_format()` call required |

--- a/openspec/changes/archive-origin-reporting/specs/format-7z/spec.md
+++ b/openspec/changes/archive-origin-reporting/specs/format-7z/spec.md
@@ -1,0 +1,33 @@
+## MODIFIED Requirements
+
+### Requirement: Accept a non-zero archive start offset (SFX)
+
+The 7z reader SHALL accept an archive whose signature header (`7z\xBC\xAF'\x1C`)
+begins at a non-zero byte offset — whether supplied as an explicit start offset
+from detection (`payload_offset`) or discovered by a bounded forward scan when
+magic is absent at the open position (forced `format=SEVEN_Z` on an SFX stub).
+
+All absolute seeks derived from the signature header SHALL be relative to that
+signature origin. The system SHALL read in place and SHALL NOT copy the archive
+to a temporary file solely to strip a stub. The forced-format scan bound SHALL be
+the shared `SFX_MAX` constant (same binding as the RAR parser and
+`detect_format`; today 2 MiB).
+
+Origin resolution SHALL use the shared resolver in `internal/sfx.py` rather than a
+7z-private copy: a fast-path read at the open position, a bounded forward scan on a miss,
+and `CorruptionError` past the bound. When detection supplied a correct `payload_offset`
+the fast path SHALL hit, so the scan does not run on the detected path.
+
+The reader SHALL report the resolved origin as `ArchiveInfo.prefix_kind` /
+`ArchiveInfo.payload_offset` (`archive-data-model`), on both the detected and the
+forced-format path.
+
+#### Scenario: 7z SFX / start-offset matrix
+
+| Case | Expected |
+| --- | --- |
+| Magic at open origin (offset 0) | Unchanged success path |
+| Detection supplies `payload_offset == N` | Opens at N; no forward scan performed |
+| Forced `format=SEVEN_Z`, magic at N within `SFX_MAX` | Bounded scan finds N; members listed |
+| Forced `format=SEVEN_Z`, no magic within `SFX_MAX` | `CorruptionError`, not an empty archive |
+| Either path, magic at N | `info.payload_offset == N` and `info.prefix_kind` is not `NONE` |

--- a/openspec/changes/archive-origin-reporting/specs/format-7z/spec.md
+++ b/openspec/changes/archive-origin-reporting/specs/format-7z/spec.md
@@ -27,7 +27,8 @@ forced-format path.
 | Case | Expected |
 | --- | --- |
 | Magic at open origin (offset 0) | Unchanged success path |
-| Detection supplies `payload_offset == N` | Opens at N; no forward scan performed |
-| Forced `format=SEVEN_Z`, magic at N within `SFX_MAX` | Bounded scan finds N; members listed |
-| Forced `format=SEVEN_Z`, no magic within `SFX_MAX` | `CorruptionError`, not an empty archive |
-| Either path, magic at N | `info.payload_offset == N` and `info.prefix_kind` is not `NONE` |
+| Explicit start offset N with magic at N | Signature parsed at N; members listed; no forward scan performed |
+| Forced `format=SEVEN_Z`, `MZ` stub, magic at N within `SFX_MAX` | Scan finds magic; open succeeds |
+| Forced `format=SEVEN_Z`, no magic within `SFX_MAX` | `CorruptionError` (not a silent empty archive) |
+| Packed streams after an SFX signature | Pack/header seeks use signature origin; members readable |
+| Either path, magic at N | `info.payload_offset == N`, measured from the start of `source` |

--- a/openspec/changes/archive-origin-reporting/specs/format-rar/spec.md
+++ b/openspec/changes/archive-origin-reporting/specs/format-rar/spec.md
@@ -1,0 +1,44 @@
+## ADDED Requirements
+
+### Requirement: Accept a non-zero archive start offset (SFX)
+
+The RAR reader SHALL accept an archive whose marker (`Rar!\x1a\x07\x00` for RAR4 or
+`Rar!\x1a\x07\x01\x00` for RAR5) begins at a non-zero byte offset — whether supplied as an
+explicit start offset from detection (`payload_offset`) or discovered by a bounded forward
+scan when the marker is absent at the open position (forced `format=RAR` on an SFX stub).
+
+This is the same contract `format-7z` states for its signature header, and SHALL be
+implemented through the same shared resolver in `internal/sfx.py`: a fast-path read at the
+open position, a bounded forward scan on a miss, and `CorruptionError` past the bound. The
+scan bound SHALL be the shared `SFX_MAX` constant.
+
+Resolution SHALL yield the RAR **version** alongside the offset, from whichever marker
+matched, so version determination is not a second search. Scanning for both markers rather
+than their shared `Rar!\x1a\x07` prefix is what makes this exact: a stub containing the
+bare prefix without a valid version byte SHALL NOT be accepted as the payload.
+
+Member and header offsets SHALL be relative to the resolved origin. The system SHALL read
+in place and SHALL NOT copy the archive to a temporary file solely to strip a stub; a
+backend that hands the source to an external tool MAY pass the original path where that
+tool locates the payload itself.
+
+A non-zero start offset SHALL NOT be combined with a multi-volume set: the offset describes
+one file and the volumes are separate ones. The reader SHALL raise
+`UnsupportedFeatureError` rather than applying the offset to a volume it does not describe.
+
+The reader SHALL report the resolved origin as `ArchiveInfo.prefix_kind` /
+`ArchiveInfo.payload_offset` (`archive-data-model`), on both the detected and the
+forced-format path.
+
+#### Scenario: RAR SFX / start-offset matrix
+
+| Case | Expected |
+| --- | --- |
+| Marker at open origin (offset 0) | Unchanged success path; version from the marker read |
+| Detection supplies `payload_offset == N` | Opens at N; no forward scan performed |
+| Forced `format=RAR`, RAR5 marker at N within `SFX_MAX` | Bounded scan finds N; version 5; members listed |
+| Forced `format=RAR`, RAR4 marker at N within `SFX_MAX` | Bounded scan finds N; version 4; members listed |
+| Stub contains bare `Rar!\x1a\x07` without a valid version byte, real marker later | Resolves to the real marker, not the decoy |
+| Forced `format=RAR`, no marker within `SFX_MAX` | `CorruptionError`, not an empty archive |
+| Non-zero start offset with a multi-volume set | `UnsupportedFeatureError` |
+| Either path, marker at N | `info.payload_offset == N` and `info.prefix_kind` is not `NONE` |

--- a/openspec/changes/archive-origin-reporting/specs/format-rar/spec.md
+++ b/openspec/changes/archive-origin-reporting/specs/format-rar/spec.md
@@ -22,9 +22,20 @@ in place and SHALL NOT copy the archive to a temporary file solely to strip a st
 backend that hands the source to an external tool MAY pass the original path where that
 tool locates the payload itself.
 
+**The resolved origin SHALL be the sum of the supplied start offset and the offset the
+resolver found within it**, as `format-7z` already computes it. Reporting either component
+alone makes the two doors disagree: on the auto-detect path the supplied offset carries the
+whole value and the resolver returns 0, while on the forced path the supplied offset is 0
+and the resolver returns the whole value. `ArchiveInfo.payload_offset` SHALL be that sum,
+measured from the start of `source` (`archive-data-model`).
+
 A non-zero start offset SHALL NOT be combined with a multi-volume set: the offset describes
 one file and the volumes are separate ones. The reader SHALL raise
 `UnsupportedFeatureError` rather than applying the offset to a volume it does not describe.
+**This check SHALL run after origin resolution**, against the resolved origin rather than
+the supplied start offset — otherwise a forced-format open of a self-extracting first
+volume passes the guard with a start offset of 0 and reaches the case the requirement
+exists to reject.
 
 The reader SHALL report the resolved origin as `ArchiveInfo.prefix_kind` /
 `ArchiveInfo.payload_offset` (`archive-data-model`), on both the detected and the
@@ -41,4 +52,5 @@ forced-format path.
 | Stub contains bare `Rar!\x1a\x07` without a valid version byte, real marker later | Resolves to the real marker, not the decoy |
 | Forced `format=RAR`, no marker within `SFX_MAX` | `CorruptionError`, not an empty archive |
 | Non-zero start offset with a multi-volume set | `UnsupportedFeatureError` |
-| Either path, marker at N | `info.payload_offset == N` and `info.prefix_kind` is not `NONE` |
+| Forced `format=RAR` on a self-extracting first volume of a multi-volume set | `UnsupportedFeatureError` — the guard sees the resolved origin, not the supplied `0` |
+| Either path, marker at N | `info.payload_offset == N`, measured from the start of `source` |

--- a/openspec/changes/archive-origin-reporting/specs/format-zip/spec.md
+++ b/openspec/changes/archive-origin-reporting/specs/format-zip/spec.md
@@ -31,6 +31,11 @@ report the origin as not established (`prefix_kind is None`, `payload_offset is 
 rather than `0`, unless an origin was supplied. It SHALL NOT scan or tail-probe to resolve
 that case: an unestablished origin is reported as unestablished, not searched for.
 
+Where the origin **is** established and non-zero, the reader SHALL classify the prefix from
+the source's leading bytes as `archive-reading` requires, so both open paths agree on
+`prefix_kind`. That bounded read is not a search for the origin and is not covered by the
+prohibition above.
+
 #### Scenario: ZIP payload origin matrix
 
 | Case | Expected |
@@ -41,7 +46,8 @@ that case: an unestablished origin is reported as unestablished, not searched fo
 | `zipapp` `.pyz` (member offsets written from byte 0), forced `format=ZIP` | `payload_offset` is the shebang length, **not** `0` |
 | JPEG + appended ZIP, forced `format=ZIP` | `payload_offset` is the JPEG length |
 | Empty ZIP behind a prefix, forced `format=ZIP` | `prefix_kind is None` and `payload_offset is None` — no member to measure from |
-| Forced `format=ZIP` on a **prefixed** ZIP | `prefix_kind is None`: the offset is known, the prefix was never inspected |
+| Forced `format=ZIP` on a `zipapp` `.pyz` | `prefix_kind is SCRIPT`, classified from the leading `#!` |
+| Forced `format=ZIP` on a JPEG + appended ZIP | `prefix_kind is UNKNOWN` — no cue matched |
 | Forced `format=ZIP` on a plain ZIP | `prefix_kind is NONE` — offset `0` means there is no prefix to classify |
-| Forced `format=ZIP` on any ZIP | No scan or tail probe is performed to fill the field |
+| Forced `format=ZIP` on any ZIP | No scan or tail probe is performed to fill the fields |
 | Stub carrying EOCD-shaped bytes, origin supplied | Slicing pins the answer to the supplied origin |

--- a/openspec/changes/archive-origin-reporting/specs/format-zip/spec.md
+++ b/openspec/changes/archive-origin-reporting/specs/format-zip/spec.md
@@ -3,32 +3,45 @@
 ### Requirement: Report the ZIP payload origin
 
 The ZIP reader SHALL report where the ZIP proper began inside the source, as
-`ArchiveInfo.prefix_kind` / `ArchiveInfo.payload_offset` (`archive-data-model`).
+`ArchiveInfo.prefix_kind` / `ArchiveInfo.payload_offset` (`archive-data-model`), on both
+the auto-detect and the forced-`format=` path.
 
 ZIP resolves its origin differently from 7z and RAR and SHALL NOT be forced onto the
-shared forward-scan resolver. A ZIP locates its central directory from the end of the
-file, so two distinct situations arise:
+shared forward-scan resolver — it needs no scan at all. `payload_offset` SHALL be the
+**position of the earliest local file header**, the same definition `format-detection`
+uses, and it SHALL be taken from the central directory the reader already parsed:
+`zipfile` applies its prefix adjustment to each entry's `header_offset` while reading the
+central directory, so the smallest such offset is the payload origin in source
+coordinates. Deriving it costs no additional read.
 
-- **The origin is supplied** (detection's `payload_offset`, or any other start offset).
-  The reader slices the source at that offset so the payload is the whole world, and SHALL
-  report that offset. Slicing rather than relying on the stdlib's own adjustment is
-  required for correctness independently of reporting: "adjust past whatever precedes the
-  EOCD" is not the same promise as "the archive starts here", and a stub carrying
-  EOCD-shaped bytes would otherwise move the answer.
-- **No origin is supplied** (forced `format=ZIP`). Stdlib `zipfile` locates the central
-  directory past any prefix on its own and the archive opens correctly, but archivey does
-  not learn where the payload began. The reader SHALL report `prefix_kind is UNKNOWN` and
-  `payload_offset is None`.
+The reader SHALL NOT use `zipfile`'s internal offset adjustment (`concat`) for this: it is
+`0` for a `zipapp`, a Spring Boot executable JAR, and any other prefixed ZIP whose member
+offsets were written relative to the file rather than to the payload, so it would report
+those as unprefixed. The earliest-local-header definition exists precisely to avoid that.
 
-The reader SHALL NOT perform a scan or a tail probe solely to populate these fields: an
-unestablished origin is reported as unestablished, not searched for at open time.
+Where an origin is **supplied** (detection's `payload_offset`, or any other start offset),
+the reader SHALL slice the source at that offset so the payload is the whole world, and
+report that offset. Slicing rather than relying on the stdlib's own adjustment is required
+for correctness independently of reporting: "adjust past whatever precedes the EOCD" is not
+the same promise as "the archive starts here", and a stub carrying EOCD-shaped bytes would
+otherwise move the answer.
+
+An archive with **no members** has no local file header to measure from. The reader SHALL
+report the origin as not established (`prefix_kind is None`, `payload_offset is None`)
+rather than `0`, unless an origin was supplied. It SHALL NOT scan or tail-probe to resolve
+that case: an unestablished origin is reported as unestablished, not searched for.
 
 #### Scenario: ZIP payload origin matrix
 
 | Case | Expected |
 | --- | --- |
-| Plain ZIP, either open path | `prefix_kind is NONE` and `payload_offset == 0` |
+| Plain ZIP, either path | `prefix_kind is NONE` and `payload_offset == 0` |
 | Prefixed ZIP at offset N, origin supplied | Source sliced at N; `payload_offset == N` |
-| Prefixed ZIP, forced `format=ZIP` | Members listed correctly; `prefix_kind is UNKNOWN` and `payload_offset is None` |
-| Forced `format=ZIP` on any ZIP | No additional scan or tail probe is performed to fill in the field |
+| Prefixed ZIP at offset N, forced `format=ZIP` | `payload_offset == N`, from the earliest local header; no extra read |
+| `zipapp` `.pyz` (member offsets written from byte 0), forced `format=ZIP` | `payload_offset` is the shebang length, **not** `0` |
+| JPEG + appended ZIP, forced `format=ZIP` | `payload_offset` is the JPEG length |
+| Empty ZIP behind a prefix, forced `format=ZIP` | `prefix_kind is None` and `payload_offset is None` — no member to measure from |
+| Forced `format=ZIP` on a **prefixed** ZIP | `prefix_kind is None`: the offset is known, the prefix was never inspected |
+| Forced `format=ZIP` on a plain ZIP | `prefix_kind is NONE` — offset `0` means there is no prefix to classify |
+| Forced `format=ZIP` on any ZIP | No scan or tail probe is performed to fill the field |
 | Stub carrying EOCD-shaped bytes, origin supplied | Slicing pins the answer to the supplied origin |

--- a/openspec/changes/archive-origin-reporting/specs/format-zip/spec.md
+++ b/openspec/changes/archive-origin-reporting/specs/format-zip/spec.md
@@ -1,0 +1,34 @@
+## ADDED Requirements
+
+### Requirement: Report the ZIP payload origin
+
+The ZIP reader SHALL report where the ZIP proper began inside the source, as
+`ArchiveInfo.prefix_kind` / `ArchiveInfo.payload_offset` (`archive-data-model`).
+
+ZIP resolves its origin differently from 7z and RAR and SHALL NOT be forced onto the
+shared forward-scan resolver. A ZIP locates its central directory from the end of the
+file, so two distinct situations arise:
+
+- **The origin is supplied** (detection's `payload_offset`, or any other start offset).
+  The reader slices the source at that offset so the payload is the whole world, and SHALL
+  report that offset. Slicing rather than relying on the stdlib's own adjustment is
+  required for correctness independently of reporting: "adjust past whatever precedes the
+  EOCD" is not the same promise as "the archive starts here", and a stub carrying
+  EOCD-shaped bytes would otherwise move the answer.
+- **No origin is supplied** (forced `format=ZIP`). Stdlib `zipfile` locates the central
+  directory past any prefix on its own and the archive opens correctly, but archivey does
+  not learn where the payload began. The reader SHALL report `prefix_kind is UNKNOWN` and
+  `payload_offset is None`.
+
+The reader SHALL NOT perform a scan or a tail probe solely to populate these fields: an
+unestablished origin is reported as unestablished, not searched for at open time.
+
+#### Scenario: ZIP payload origin matrix
+
+| Case | Expected |
+| --- | --- |
+| Plain ZIP, either open path | `prefix_kind is NONE` and `payload_offset == 0` |
+| Prefixed ZIP at offset N, origin supplied | Source sliced at N; `payload_offset == N` |
+| Prefixed ZIP, forced `format=ZIP` | Members listed correctly; `prefix_kind is UNKNOWN` and `payload_offset is None` |
+| Forced `format=ZIP` on any ZIP | No additional scan or tail probe is performed to fill in the field |
+| Stub carrying EOCD-shaped bytes, origin supplied | Slicing pins the answer to the supplied origin |

--- a/openspec/changes/archive-origin-reporting/tasks.md
+++ b/openspec/changes/archive-origin-reporting/tasks.md
@@ -17,10 +17,13 @@
 - [ ] 1.1 Characterisation test recording today's asymmetry: an SFX 7z / RAR / ZIP opened
       auto-detected and with `format=`, asserting what the caller can learn about the
       origin in each case (today: nothing, on either path)
-- [ ] 1.2 Failing test: the two open paths report the same `prefix_kind` and
-      `payload_offset` for the same SFX 7z and SFX RAR
-- [ ] 1.3 Failing test: forced `format=ZIP` on a prefixed ZIP reports `UNKNOWN` / `None`
-      — explicitly *not* `NONE` / `0`
+- [ ] 1.2 Failing test: the two open paths report the same `payload_offset` for the same
+      SFX 7z and SFX RAR. `prefix_kind` is classified on the detected path and `None` on the
+      forced one — assert that too, so the asymmetry is pinned deliberately rather than
+      discovered later
+- [ ] 1.3 Failing test: forced `format=ZIP` on a prefixed ZIP reports the real origin —
+      `zipapp` (`concat == 0`, so the naive derivation would say `0`), shebang, `MZ` and
+      JPEG prefixes. Plus an empty ZIP behind a prefix reporting `None` / `None`
 - [ ] 1.4 Failing test: the `(prefix_kind is NONE) == (payload_offset == 0)` invariant
       holds for every format in the declarative corpus, including the ones that cannot
       carry a prefix
@@ -43,37 +46,60 @@
 ## 3. Reporting the origin back
 
 - [ ] 3.1 Add the reader-side channel (`design.md` option A: a base-class attribute the
-      `ArchiveInfo` builder reads, defaulted so the four `reject_start_offset` backends are
-      unaffected)
+      `ArchiveInfo` builder reads, defaulted so backends that never receive a start offset
+      are unaffected). Derive that set from `reject_start_offset` **at implementation
+      time**, not from today's census — `prefixed-archive-detection` moves formats into the
+      prefix-capable set (see 3.6)
 - [ ] 3.2 7z reader reports its resolved origin on both paths
 - [ ] 3.3 RAR reader reports its resolved origin on both paths
-- [ ] 3.4 ZIP reader reports the slice origin when given one, `UNKNOWN` / `None` otherwise
-      — and performs no extra scan or tail probe to fill the field
+- [ ] 3.4 ZIP reader reports the slice origin when given one, and otherwise
+      `min(header_offset)` over the central directory it already parsed — **not** `concat`,
+      which is `0` for a `zipapp`. No extra scan or tail probe. `None` only when there are
+      no members to measure from
 - [ ] 3.5 Formats that cannot carry a prefix report `NONE` / `0` without per-backend code
+- [ ] 3.6 **Cover every format `prefixed-archive-detection` can hand a `start_offset`**, not
+      only ZIP / 7z / RAR. That change makes a makeself `.run` (`#!` + tar.gz) detect as
+      `TAR_GZ` with a non-zero `payload_offset`, so TAR and the single-file codecs stop
+      being start-offset-rejecting. Reporting `NONE` / `0` for those would recreate the
+      exact "detection knew, `ArchiveInfo` says byte zero" hole this change exists to
+      close. Add the makeself fixture alongside PAD's
 
 ## 4. The public fields
 
-- [ ] 4.1 `ArchiveInfo.prefix_kind: PrefixKind` and `ArchiveInfo.payload_offset:
+- [ ] 4.1 `ArchiveInfo.prefix_kind: PrefixKind | None` and `ArchiveInfo.payload_offset:
       int | None`, both defaulted so existing backend construction sites stay valid
-- [ ] 4.2 Assert the state pairing from the spec table as a real invariant (an `assert` or
-      `__post_init__` check), not a convention — `UNKNOWN` ⟺ `None` is the one a caller
-      will get wrong
-- [ ] 4.3 Extend the conformance sweep so every corpus archive is checked, rather than
+- [ ] 4.2 Assert the state table as a real invariant (an `assert` or `__post_init__`
+      check), not a convention: `prefix_kind is NONE` ⟺ `payload_offset == 0`, and
+      `payload_offset is None` ⟹ `prefix_kind is None`. The check MUST accept two values the
+      naive version would reject: `UNKNOWN` with a positive offset (an exhaustive-scan
+      prefix from `prefixed-archive-detection` — rejecting it would fail that change's own
+      fixtures), and `None` kind with a positive offset (a forced-format open)
+- [ ] 4.3 Guard against the tempting shortcut: nothing may infer `prefix_kind` from
+      `payload_offset > 0`. A red–green test that a forced-format open on a JPEG+ZIP reports
+      `None`, not `EXECUTABLE` or `OTHER_FORMAT`
+- [ ] 4.4 Extend the conformance sweep so every corpus archive is checked, rather than
       only the SFX fixtures
 
 ## 5. Second consumer
 
-- [ ] 5.1 `cli/info_cmd.py` reads the origin from `reader.info` and drops its second
-      `detect_format(archive)` call — the API gap `VISION.md` says the CLI exists to expose
-- [ ] 5.2 Confirm the CLI prints the origin on a forced-format open too, which it cannot
-      do today at all
+- [ ] 5.1 `cli/info_cmd.py` prints the origin from `reader.info` instead of from its own
+      `detect_format(archive)` result. **Keep that call** — it also supplies `format`,
+      `confidence` and `detected_by`, which have no reader-side home until
+      `detection-result-surface` lands. Removing it here would trade one gap for three
+- [ ] 5.2 Decide whether the printed key stays `sfx_offset` or follows the field names
+      (`payload_offset` / `prefix_kind`) — a CLI output change either way, so it is a
+      deliberate choice rather than a rename that falls out of the refactor
+- [ ] 5.3 Cover the forced-format path as a **library** test, not a CLI one: the CLI has no
+      `--format` flag, so `open_archive(..., format=...)` is the only way to reach that
+      door
 
 ## 6. Docs
 
 - [ ] 6.1 `docs/formats.md` self-extracting prose: what the two fields mean, and that
       `None` means not-established rather than zero
-- [ ] 6.2 Record the forced-ZIP tail-probe question in `dev-docs/IDEAS.md` if the
-      maintainer leaves it open (`design.md` §Open question)
+- [ ] 6.2 Nothing to record: the forced-ZIP origin question is resolved in `design.md`
+      (`min(header_offset)`, no tail probe). Drop this task if it is still open at
+      implementation time
 
 ## 7. Verify
 
@@ -85,6 +111,8 @@
 - [ ] 7.5 `openspec validate --strict archive-origin-reporting`
 - [ ] 7.6 Dry-run archive on a scratch tree and diff `openspec/specs/` — `--strict` does
       not check that a `MODIFIED` header names an existing requirement, and three of the
-      five deltas here are `MODIFIED`
+      five deltas here are `MODIFIED`. Diff **scenario rows**, not just requirement counts:
+      a `MODIFIED` requirement is replaced whole, so a row omitted from the delta is
+      silently deleted from the live spec and the totals line still reads `- 0`
 - [ ] 7.7 `openspec archive archive-origin-reporting --yes` and commit the
       `openspec/specs/` diff

--- a/openspec/changes/archive-origin-reporting/tasks.md
+++ b/openspec/changes/archive-origin-reporting/tasks.md
@@ -2,8 +2,12 @@
 
 - [ ] 0.0 **Implement after `prefixed-archive-detection`**, which defines `PrefixKind`.
       This change reuses that enum rather than adding a second, coarser spelling of the
-      same property on `ArchiveInfo`. `MagicHit` — the other dependency — landed with
-      `detection-prefix-workspace` (#273).
+      same property on `ArchiveInfo`, and assumes the member set that change is settling on:
+      `NONE` / `EXECUTABLE` / `SCRIPT` / `UNKNOWN`, with **`OTHER_FORMAT` merged into
+      `UNKNOWN`**. That merge is load-bearing here — it is what makes classification a pure
+      function of the leading bytes, cheap enough to run on the forced path. If
+      `OTHER_FORMAT` survives there, revisit tasks 3.2–3.4 and 4.3. `MagicHit` — the other
+      dependency — landed with `detection-prefix-workspace` (#273).
 
   **If the order inverts**, ship the resolver unification and `payload_offset: int | None`
   alone and add `prefix_kind` with the other change (`design.md` §Sequencing). That is a
@@ -17,10 +21,8 @@
 - [ ] 1.1 Characterisation test recording today's asymmetry: an SFX 7z / RAR / ZIP opened
       auto-detected and with `format=`, asserting what the caller can learn about the
       origin in each case (today: nothing, on either path)
-- [ ] 1.2 Failing test: the two open paths report the same `payload_offset` for the same
-      SFX 7z and SFX RAR. `prefix_kind` is classified on the detected path and `None` on the
-      forced one — assert that too, so the asymmetry is pinned deliberately rather than
-      discovered later
+- [ ] 1.2 Failing test: the two open paths report the same `payload_offset` **and** the same
+      `prefix_kind` for the same SFX 7z and SFX RAR. No door-dependent answer survives
 - [ ] 1.3 Failing test: forced `format=ZIP` on a prefixed ZIP reports the real origin —
       `zipapp` (`concat == 0`, so the naive derivation would say `0`), shebang, `MZ` and
       JPEG prefixes. Plus an empty ZIP behind a prefix reporting `None` / `None`
@@ -50,12 +52,16 @@
       are unaffected). Derive that set from `reject_start_offset` **at implementation
       time**, not from today's census — `prefixed-archive-detection` moves formats into the
       prefix-capable set (see 3.6)
-- [ ] 3.2 7z reader reports its resolved origin on both paths
-- [ ] 3.3 RAR reader reports its resolved origin on both paths
+- [ ] 3.2 7z reader reports its resolved origin **and** prefix kind on both paths
+- [ ] 3.3 RAR reader reports its resolved origin and prefix kind on both paths
 - [ ] 3.4 ZIP reader reports the slice origin when given one, and otherwise
       `min(header_offset)` over the central directory it already parsed — **not** `concat`,
       which is `0` for a `zipapp`. No extra scan or tail probe. `None` only when there are
       no members to measure from
+- [ ] 3.7 One shared prefix classifier, called by every prefix-capable backend once it has a
+      non-zero origin: `MZ`/ELF/Mach-O → `EXECUTABLE`, `#!` → `SCRIPT`, else `UNKNOWN`. It
+      must be the **same** function detection uses, not a second copy that can drift — a
+      door-dependent kind is the defect this change exists to close
 - [ ] 3.5 Formats that cannot carry a prefix report `NONE` / `0` without per-backend code
 - [ ] 3.6 **Cover every format `prefixed-archive-detection` can hand a `start_offset`**, not
       only ZIP / 7z / RAR. That change makes a makeself `.run` (`#!` + tar.gz) detect as
@@ -70,13 +76,13 @@
       int | None`, both defaulted so existing backend construction sites stay valid
 - [ ] 4.2 Assert the state table as a real invariant (an `assert` or `__post_init__`
       check), not a convention: `prefix_kind is NONE` ⟺ `payload_offset == 0`, and
-      `payload_offset is None` ⟹ `prefix_kind is None`. The check MUST accept two values the
-      naive version would reject: `UNKNOWN` with a positive offset (an exhaustive-scan
-      prefix from `prefixed-archive-detection` — rejecting it would fail that change's own
-      fixtures), and `None` kind with a positive offset (a forced-format open)
+      `prefix_kind is None` ⟺ `payload_offset is None`. The check MUST accept `UNKNOWN` with
+      a positive offset — a prefix that matched no cue is a legitimate value, and rejecting
+      it would fail `prefixed-archive-detection`'s own fixtures
 - [ ] 4.3 Guard against the tempting shortcut: nothing may infer `prefix_kind` from
       `payload_offset > 0`. A red–green test that a forced-format open on a JPEG+ZIP reports
-      `None`, not `EXECUTABLE` or `OTHER_FORMAT`
+      `UNKNOWN` (no cue matched), not `EXECUTABLE` — and that a `zipapp` reports `SCRIPT` on
+      both doors
 - [ ] 4.4 Extend the conformance sweep so every corpus archive is checked, rather than
       only the SFX fixtures
 

--- a/openspec/changes/archive-origin-reporting/tasks.md
+++ b/openspec/changes/archive-origin-reporting/tasks.md
@@ -1,0 +1,90 @@
+## 0. Order
+
+- [ ] 0.0 **Implement after `prefixed-archive-detection`**, which defines `PrefixKind`.
+      This change reuses that enum rather than adding a second, coarser spelling of the
+      same property on `ArchiveInfo`. `MagicHit` — the other dependency — landed with
+      `detection-prefix-workspace` (#273).
+
+  **If the order inverts**, ship the resolver unification and `payload_offset: int | None`
+  alone and add `prefix_kind` with the other change (`design.md` §Sequencing). That is a
+  fallback: it costs two public-shape changes where one would do.
+
+  **It blocks nothing.** `detection-result-surface` touches the reader's detection field,
+  not `ArchiveInfo`, and neither change reads the other's field.
+
+## 1. Pin the current behaviour, then change it
+
+- [ ] 1.1 Characterisation test recording today's asymmetry: an SFX 7z / RAR / ZIP opened
+      auto-detected and with `format=`, asserting what the caller can learn about the
+      origin in each case (today: nothing, on either path)
+- [ ] 1.2 Failing test: the two open paths report the same `prefix_kind` and
+      `payload_offset` for the same SFX 7z and SFX RAR
+- [ ] 1.3 Failing test: forced `format=ZIP` on a prefixed ZIP reports `UNKNOWN` / `None`
+      — explicitly *not* `NONE` / `0`
+- [ ] 1.4 Failing test: the `(prefix_kind is NONE) == (payload_offset == 0)` invariant
+      holds for every format in the declarative corpus, including the ones that cannot
+      carry a prefix
+
+## 2. The shared resolver
+
+- [ ] 2.1 `resolve_payload_origin(fp, needles, *, limit=SFX_MAX) -> MagicHit` in
+      `internal/sfx.py`: fast-path read at the open position, bounded forward scan on a
+      miss, `CorruptionError` past the bound, `fp` restored either way
+- [ ] 2.2 Port `sevenzip_parser.find_signature_offset` onto it; keep the exported name as
+      a thin wrapper only if callers outside the reader still need it
+- [ ] 2.3 Port `rar_parser._find_sfx_header` onto it, taking the version from
+      `hit.needle` rather than a second code path; delete the `tuple[int, int]` signature
+- [ ] 2.4 Verify the detected path still performs **no** scan (instrument
+      `scan_for_magic`; the fast path must hit when detection supplied the offset)
+- [ ] 2.5 Decide `find_signature_offset`'s fate on the evidence of what still imports it
+      (`tests/test_sfx.py`, the fuzz harness) — keep as a wrapper or delete with callers
+      updated, not left as an unexplained alias
+
+## 3. Reporting the origin back
+
+- [ ] 3.1 Add the reader-side channel (`design.md` option A: a base-class attribute the
+      `ArchiveInfo` builder reads, defaulted so the four `reject_start_offset` backends are
+      unaffected)
+- [ ] 3.2 7z reader reports its resolved origin on both paths
+- [ ] 3.3 RAR reader reports its resolved origin on both paths
+- [ ] 3.4 ZIP reader reports the slice origin when given one, `UNKNOWN` / `None` otherwise
+      — and performs no extra scan or tail probe to fill the field
+- [ ] 3.5 Formats that cannot carry a prefix report `NONE` / `0` without per-backend code
+
+## 4. The public fields
+
+- [ ] 4.1 `ArchiveInfo.prefix_kind: PrefixKind` and `ArchiveInfo.payload_offset:
+      int | None`, both defaulted so existing backend construction sites stay valid
+- [ ] 4.2 Assert the state pairing from the spec table as a real invariant (an `assert` or
+      `__post_init__` check), not a convention — `UNKNOWN` ⟺ `None` is the one a caller
+      will get wrong
+- [ ] 4.3 Extend the conformance sweep so every corpus archive is checked, rather than
+      only the SFX fixtures
+
+## 5. Second consumer
+
+- [ ] 5.1 `cli/info_cmd.py` reads the origin from `reader.info` and drops its second
+      `detect_format(archive)` call — the API gap `VISION.md` says the CLI exists to expose
+- [ ] 5.2 Confirm the CLI prints the origin on a forced-format open too, which it cannot
+      do today at all
+
+## 6. Docs
+
+- [ ] 6.1 `docs/formats.md` self-extracting prose: what the two fields mean, and that
+      `None` means not-established rather than zero
+- [ ] 6.2 Record the forced-ZIP tail-probe question in `dev-docs/IDEAS.md` if the
+      maintainer leaves it open (`design.md` §Open question)
+
+## 7. Verify
+
+- [ ] 7.1 `uv run --no-sync pytest tests/test_sfx.py tests/test_detection.py` plus the
+      backend suites for zip / 7z / rar
+- [ ] 7.2 Fuzz harness still imports what it needs from `sevenzip_parser` after task 2.5
+- [ ] 7.3 `./scripts/check.sh --fix`
+- [ ] 7.4 `./scripts/test.sh --all-configs`
+- [ ] 7.5 `openspec validate --strict archive-origin-reporting`
+- [ ] 7.6 Dry-run archive on a scratch tree and diff `openspec/specs/` — `--strict` does
+      not check that a `MODIFIED` header names an existing requirement, and three of the
+      five deltas here are `MODIFIED`
+- [ ] 7.7 `openspec archive archive-origin-reporting --yes` and commit the
+      `openspec/specs/` diff


### PR DESCRIPTION
## Summary

Proposal only — no code changes. Adds `openspec/changes/archive-origin-reporting/`.

Came out of a question on #273 about how SFX offsets flow from detection into the RAR and 7z parsers. Tracing it turned up two things worth a change, and one thing that turned out **not** to be a problem.

## What the trace found

Measured on `main` (`056c429`), 4 224-byte `MZ` stub, `scan_for_magic` instrumented:

| case | detection `payload_offset` | scans during `open_archive` |
| --- | --- | --- |
| 7z SFX, auto-detect | 4 224 | 0 |
| 7z SFX, `format=SEVEN_Z` | — | 1 |
| RAR SFX, auto-detect | 4 224 | 0 |
| RAR SFX, `format=RAR` | — | 1 |
| ZIP SFX, `format=ZIP` | — | 0 (stdlib self-adjusts) |

**Not a problem:** the detected path does not re-scan. Both parsers fast-path a 6/8-byte read at the open position and return offset 0 when the magic is already there, so a supplied `payload_offset` costs one short read. The scan is the forced-path fallback, not redundant work. The scanning is also already shared (`internal/sfx.scan_for_magic`, one `SFX_MAX`).

**Problem 1 — the origin is computed and discarded.** `ArchiveInfo` carries nothing about it, so `cli/info_cmd.py:57` calls `detect_format()` a second time purely to print `sfx_offset`.

**Problem 2 — the two open paths know different amounts.** With `format=` the parser finds the origin and throws it away, so the caller who already knew the format learns *less* than the one who did not. `archive-reading` currently states this as a rule ("an explicit `format=` retains each backend's own start-offset / SFX rules"), which was right while the offset was only an internal input and is a §2 parity hole once it is reportable metadata.

Underneath, origin resolution is done three ways — ZIP slices, 7z views + scans and rebases, RAR keeps a bare `_origin` and also resolves RAR4/RAR5 — so there is no single place that owns the answer. That is why it has nowhere to go.

## What the proposal does

- `ArchiveInfo.prefix_kind` + `ArchiveInfo.payload_offset`, populated identically on both open paths.
- One shared `resolve_payload_origin()` in `internal/sfx.py` replacing `sevenzip_parser.find_signature_offset` and `rar_parser._find_sfx_header`. It returns the `MagicHit` from #273, so RAR's version falls out of `hit.needle` instead of a second code path.
- `format-rar` gains the start-offset requirement it never had, stated as the contract `format-7z` already carries.
- CLI stops detecting twice.

Explicitly out of scope: when a scan runs, the cue set, the ZIP tail probe — those are `prefixed-archive-detection`. No detection tier moves and no detection answer changes.

## Enum, not a bool

Asked and answered in `design.md`. Three states exist, not two: starts at byte 0; starts later; opened correctly without establishing where (forced `format=ZIP`, where stdlib `zipfile` locates the central directory past the stub and archivey never learns the offset). So `payload_offset: int | None`, and `prefix_kind` reuses `PrefixKind` from `prefixed-archive-detection` rather than an `is_sfx` bool — a `.pyz`, a Spring Boot JAR and a JPEG with an appended ZIP are all "offset > 0" and none is self-extracting. Describing one property with a rich enum on `FormatInfo` and a coarse bool on `ArchiveInfo` is the cross-surface inconsistency §2 guards against.

Invariant, asserted in the spec:

```
prefix_kind is NONE     <=>  payload_offset == 0
prefix_kind is UNKNOWN  <=>  payload_offset is None
otherwise                    payload_offset > 0
```

## Sequencing

After `prefixed-archive-detection` (defines `PrefixKind`). `MagicHit` landed with `detection-prefix-workspace` in #273. Blocks nothing; `detection-result-surface` touches the reader's detection field, not `ArchiveInfo`, and neither reads the other's field. Fallback if the order inverts is in `design.md` §Sequencing.

## Open question for the maintainer

Whether a forced-format ZIP should run the (format-bounded, 65 557-byte) tail probe at open time so its origin becomes known too. Not done here: that is new I/O purely to fill a metadata field, on the path a caller chose to skip work, and `UNKNOWN` is an honest answer rather than a wrong one. `UNKNOWN` is the v1 behaviour either way, so deciding later costs nothing.

## Test plan

- [x] `openspec validate --strict archive-origin-reporting` → valid
- [x] Dry-run archive on a scratch worktree → `+ 2, ~ 3, - 0`; deltas apply in place, no duplicated requirement headers, no deletions (`--strict` does not check that a `MODIFIED` header names a real requirement, and 3 of the 5 deltas are `MODIFIED`)
- [x] `openspec list` → change registered, 0/29 tasks
- [ ] Implementation — not started; this PR is the proposal

The change's own trailing task (`openspec archive`) is deliberately unchecked: the proposal is not implemented, so the specs must not yet claim it ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K8NzcBHgS6gAwPtS1R2LyE

---
_Generated by [Claude Code](https://claude.ai/code/session_01K8NzcBHgS6gAwPtS1R2LyE)_