### PR TITLE
ci: build macOS unrar from source after Homebrew disabled the rar cask

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,16 +208,26 @@ jobs:
       - name: Install unrar (Linux)
         if: (matrix.install == 'all' || matrix.install == 'all-lowest') && runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y unrar
+      # Homebrew disabled the `rar` cask on 2026-09-01 (official binaries fail
+      # Gatekeeper notarization). Compile RARLAB UnRAR from the published source
+      # instead: that is the same unrar Debian/conda-forge ship, it does not
+      # install the trialware `rar` writer, and a GHA cache of the binary means
+      # jobs after the first do not fetch from rarlab. `unar` is not a substitute
+      # — archivey's finder requires the RARLAB banner.
+      - name: Cache compiled RARLAB unrar (macOS)
+        if: (matrix.install == 'all' || matrix.install == 'all-lowest') && runner.os == 'macOS'
+        uses: actions/cache@v4
+        with:
+          path: ${{ runner.temp }}/rarlab-unrar
+          key: rarlab-unrar-${{ hashFiles('scripts/install-rarlab-unrar.sh') }}-${{ runner.os }}-${{ runner.arch }}
+          save-always: true
       - name: Install unrar (macOS)
         if: (matrix.install == 'all' || matrix.install == 'all-lowest') && runner.os == 'macOS'
         run: |
-          brew install --cask rar
-          # Cask ships both rar + unrar; drop the writer. Nothing in the suite needs
-          # it — corpus RAR archives are committed (see the Linux step above) — and
-          # removing it keeps the "no trialware on CI" property explicit rather than
-          # incidental.
-          rm -f "$(brew --prefix)/bin/rar"
-          command -v unrar
+          DEST="${RUNNER_TEMP}/rarlab-unrar"
+          ./scripts/install-rarlab-unrar.sh --dest "$DEST" --cache-dir "$DEST"
+          echo "$DEST" >> "$GITHUB_PATH"
+          test -x "$DEST/unrar"
           command -v rar && exit 1 || true
       - name: Install unrar (Windows)
         if: (matrix.install == 'all' || matrix.install == 'all-lowest') && runner.os == 'Windows'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,11 +209,11 @@ jobs:
         if: (matrix.install == 'all' || matrix.install == 'all-lowest') && runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y unrar
       # Homebrew disabled the `rar` cask on 2026-09-01 (official binaries fail
-      # Gatekeeper notarization). Compile RARLAB UnRAR from a pinned GitHub
-      # mirror of the published source (not rarlab): same unrar Debian/conda-forge
-      # ship, no trialware `rar` writer, and a GHA cache of the binary so later
-      # jobs skip the download. `unar` is not a substitute — archivey's finder
-      # requires the RARLAB banner.
+      # Gatekeeper notarization). Compile RARLAB UnRAR from a pinned git commit
+      # of the pmachapman/unrar GitHub mirror (not rarlab, not GitHub's generated
+      # archive tarball). The GHA cache stores the *built binary*; the commit pin
+      # is checked when the script actually builds, not on a cache hit. `unar` is
+      # not a substitute — archivey's finder requires the RARLAB banner.
       - name: Cache compiled RARLAB unrar (macOS)
         if: (matrix.install == 'all' || matrix.install == 'all-lowest') && runner.os == 'macOS'
         uses: actions/cache@v4
@@ -225,7 +225,7 @@ jobs:
         if: (matrix.install == 'all' || matrix.install == 'all-lowest') && runner.os == 'macOS'
         run: |
           DEST="${RUNNER_TEMP}/rarlab-unrar"
-          ./scripts/install-rarlab-unrar.sh --dest "$DEST" --cache-dir "$DEST"
+          ./scripts/install-rarlab-unrar.sh --dest "$DEST"
           echo "$DEST" >> "$GITHUB_PATH"
           test -x "$DEST/unrar"
           command -v rar && exit 1 || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,11 +209,11 @@ jobs:
         if: (matrix.install == 'all' || matrix.install == 'all-lowest') && runner.os == 'Linux'
         run: sudo apt-get update && sudo apt-get install -y unrar
       # Homebrew disabled the `rar` cask on 2026-09-01 (official binaries fail
-      # Gatekeeper notarization). Compile RARLAB UnRAR from the published source
-      # instead: that is the same unrar Debian/conda-forge ship, it does not
-      # install the trialware `rar` writer, and a GHA cache of the binary means
-      # jobs after the first do not fetch from rarlab. `unar` is not a substitute
-      # — archivey's finder requires the RARLAB banner.
+      # Gatekeeper notarization). Compile RARLAB UnRAR from a pinned GitHub
+      # mirror of the published source (not rarlab): same unrar Debian/conda-forge
+      # ship, no trialware `rar` writer, and a GHA cache of the binary so later
+      # jobs skip the download. `unar` is not a substitute — archivey's finder
+      # requires the RARLAB banner.
       - name: Cache compiled RARLAB unrar (macOS)
         if: (matrix.install == 'all' || matrix.install == 'all-lowest') && runner.os == 'macOS'
         uses: actions/cache@v4

--- a/dev-docs/IDEAS.md
+++ b/dev-docs/IDEAS.md
@@ -625,3 +625,7 @@
   `tests/fixtures/rar/README.md`. Linux `setup-dev-env.sh` still apt-installs
   `rar`, so these are not dark on a provisioned Linux laptop — only on CI /
   macOS.
+- **Pin and checksum the Windows UnRAR download.** The Windows CI leg still
+  `Invoke-WebRequest`s `https://www.rarlab.com/rar/unrarw64.exe` with no version
+  pin and no SHA-256, then runs the SFX. The macOS leg now fetches a pinned git
+  commit instead. Same pattern would close the gap; not blocking.

--- a/dev-docs/IDEAS.md
+++ b/dev-docs/IDEAS.md
@@ -614,3 +614,14 @@
 - **CLI earlier, as dev tool + demo** — ~~`archivey list/test/extract` was
   invaluable…~~ **Done in `cli-v1` (PR #120).** Remaining CLI backlog lives under
   **CLI (post-`cli-v1` follow-ups)** above.
+
+## Testing
+
+- **Commit the leftover live-`rar a` fixtures.** ADR 0016 committed the corpus RAR
+  column and `tests/fixtures/rar/`, so CI installs unrar only. Four tests still
+  shell out to the trialware writer at runtime (SFX stub, real `rar a -sfx`, live
+  multi-volume roundtrip) and skip on every CI leg. Same move as 0016: generate
+  once, commit, drop the live `rar a`. Inventory in
+  `tests/fixtures/rar/README.md`. Linux `setup-dev-env.sh` still apt-installs
+  `rar`, so these are not dark on a provisioned Linux laptop — only on CI /
+  macOS.

--- a/dev-docs/decisions/0016-committed-rar-corpus-fixtures.md
+++ b/dev-docs/decisions/0016-committed-rar-corpus-fixtures.md
@@ -87,3 +87,13 @@ introduces a native RAR reader. 192 KB once is the cheaper side of that trade.
 - **The precedent is bounded.** `COMMITTED_FIXTURE_KEYS` makes "which formats are
   exceptions" a one-line answer rather than a convention, so a future format cannot
   drift into being committed without an explicit edit here.
+
+## Follow-up: live `rar a` tests are still dark on CI
+
+The corpus and `tests/fixtures/rar/` are the committed set. Four tests still
+shell out to the writer at runtime (`rar a`, `rar a -sfx`, `rar a -v`) and skip
+on every CI leg, which never installs `rar`. That is the same skip-quietly shape
+this ADR closed for the sweep, just a smaller residue. Inventory:
+`tests/fixtures/rar/README.md` §"Tests that still need the `rar` writer". Closing
+it is the same move again — generate once, commit, drop the live `rar a`. Parked
+in `dev-docs/IDEAS.md`.

--- a/scripts/install-rarlab-unrar.sh
+++ b/scripts/install-rarlab-unrar.sh
@@ -1,12 +1,16 @@
 #!/usr/bin/env bash
 # Build RARLAB UnRAR (the freeware decompressor, not the trialware writer) from
-# the published source tarball and install the `unrar` binary.
+# a pinned GitHub mirror of the published source, and install the `unrar` binary.
 #
 # Why this exists: Homebrew disabled the `rar` cask on 2026-09-01 because the
 # official macOS binaries fail Gatekeeper notarization. Compiling from source
-# produces a local binary CI will actually run, and the tarball is cached so
-# jobs after the first do not fetch from rarlab. archivey's finder requires
-# the RARLAB banner — `unar` / `unrar-free` / `7z` are not substitutes.
+# produces a local binary CI will actually run. The tarball is fetched from
+# GitHub (not rarlab) and cached so later jobs do not re-download. archivey's
+# finder requires the RARLAB banner — `unar` / `unrar-free` / `7z` are not
+# substitutes.
+#
+# Source: https://github.com/pmachapman/unrar (mirror of rarlab UnRAR source).
+# Pin both the commit and the archive sha256; bump both together.
 #
 # Usage:
 #   scripts/install-rarlab-unrar.sh --dest DIR [--cache-dir DIR]
@@ -14,15 +18,17 @@
 # Writes DIR/unrar. No-ops if that path is already executable.
 set -euo pipefail
 
+# Mirror commit "Updated to 7.2.7" — same tree as rarlab unrarsrc-7.2.7.
 UNRAR_VERSION="7.2.7"
-UNRAR_SHA256="01d903a7dcf413cb2925696d7796e48e38d471f79bfe7ef3ad2aebf6c12dbefd"
-UNRAR_URL="https://www.rarlab.com/rar/unrarsrc-${UNRAR_VERSION}.tar.gz"
+UNRAR_COMMIT="d8612461815f7feffcf7f1bf9c5942125b25c1b4"
+UNRAR_SHA256="3d385eb009bbd657981ef317fc6625be9b627e699095019349ffec48da7fcf04"
+UNRAR_URL="https://github.com/pmachapman/unrar/archive/${UNRAR_COMMIT}.tar.gz"
 
 DEST=""
 CACHE_DIR="${XDG_CACHE_HOME:-${HOME}/.cache}/archivey/unrarsrc"
 
 usage() {
-  sed -n '2,16p' "$0" | sed 's/^# \?//'
+  sed -n '2,19p' "$0" | sed 's/^# \?//'
 }
 
 while [ $# -gt 0 ]; do
@@ -68,7 +74,7 @@ if ! command -v curl >/dev/null 2>&1; then
 fi
 
 mkdir -p "$CACHE_DIR"
-tarball="${CACHE_DIR}/unrarsrc-${UNRAR_VERSION}.tar.gz"
+tarball="${CACHE_DIR}/unrar-${UNRAR_COMMIT}.tar.gz"
 
 verify_sha256() {
   local file="$1"
@@ -105,14 +111,15 @@ cleanup() { rm -rf "$workdir"; }
 trap cleanup EXIT
 
 tar -xf "$tarball" -C "$workdir"
-src="${workdir}/unrar"
+# GitHub archive/<sha>.tar.gz extracts to unrar-<sha>/ (files at repo root).
+src="${workdir}/unrar-${UNRAR_COMMIT}"
 if [ ! -f "${src}/makefile" ]; then
-  echo "install-rarlab-unrar: tarball did not contain unrar/makefile" >&2
+  echo "install-rarlab-unrar: expected makefile at ${src}/makefile" >&2
   exit 1
 fi
 
 jobs="$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 2)"
-echo "install-rarlab-unrar: compiling UnRAR ${UNRAR_VERSION} with ${jobs} jobs"
+echo "install-rarlab-unrar: compiling UnRAR ${UNRAR_VERSION} (${UNRAR_COMMIT:0:12}) with ${jobs} jobs"
 make -C "$src" -j"$jobs"
 
 # macOS install(1) has no GNU -D; copy the binary ourselves.

--- a/scripts/install-rarlab-unrar.sh
+++ b/scripts/install-rarlab-unrar.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Build RARLAB UnRAR (the freeware decompressor, not the trialware writer) from
+# the published source tarball and install the `unrar` binary.
+#
+# Why this exists: Homebrew disabled the `rar` cask on 2026-09-01 because the
+# official macOS binaries fail Gatekeeper notarization. Compiling from source
+# produces a local binary CI will actually run, and the tarball is cached so
+# jobs after the first do not fetch from rarlab. archivey's finder requires
+# the RARLAB banner — `unar` / `unrar-free` / `7z` are not substitutes.
+#
+# Usage:
+#   scripts/install-rarlab-unrar.sh --dest DIR [--cache-dir DIR]
+#
+# Writes DIR/unrar. No-ops if that path is already executable.
+set -euo pipefail
+
+UNRAR_VERSION="7.2.7"
+UNRAR_SHA256="01d903a7dcf413cb2925696d7796e48e38d471f79bfe7ef3ad2aebf6c12dbefd"
+UNRAR_URL="https://www.rarlab.com/rar/unrarsrc-${UNRAR_VERSION}.tar.gz"
+
+DEST=""
+CACHE_DIR="${XDG_CACHE_HOME:-${HOME}/.cache}/archivey/unrarsrc"
+
+usage() {
+  sed -n '2,16p' "$0" | sed 's/^# \?//'
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dest)
+      DEST="${2:-}"
+      shift 2
+      ;;
+    --cache-dir)
+      CACHE_DIR="${2:-}"
+      shift 2
+      ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "install-rarlab-unrar: unknown argument: $1 (try --help)" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [ -z "$DEST" ]; then
+  echo "install-rarlab-unrar: --dest DIR is required" >&2
+  exit 2
+fi
+
+mkdir -p "$DEST"
+if [ -x "${DEST}/unrar" ]; then
+  echo "install-rarlab-unrar: already present at ${DEST}/unrar"
+  exit 0
+fi
+
+if ! command -v c++ >/dev/null 2>&1; then
+  echo "install-rarlab-unrar: need a C++ compiler (macOS: Xcode CLI tools)" >&2
+  exit 1
+fi
+
+if ! command -v curl >/dev/null 2>&1; then
+  echo "install-rarlab-unrar: curl is required to fetch ${UNRAR_URL}" >&2
+  exit 1
+fi
+
+mkdir -p "$CACHE_DIR"
+tarball="${CACHE_DIR}/unrarsrc-${UNRAR_VERSION}.tar.gz"
+
+verify_sha256() {
+  local file="$1"
+  local got
+  if command -v sha256sum >/dev/null 2>&1; then
+    got="$(sha256sum "$file" | awk '{ print $1 }')"
+  elif command -v shasum >/dev/null 2>&1; then
+    got="$(shasum -a 256 "$file" | awk '{ print $1 }')"
+  else
+    echo "install-rarlab-unrar: need sha256sum or shasum" >&2
+    return 1
+  fi
+  if [ "$got" != "$UNRAR_SHA256" ]; then
+    echo "install-rarlab-unrar: sha256 mismatch for $file" >&2
+    echo "  got  $got" >&2
+    echo "  want $UNRAR_SHA256" >&2
+    return 1
+  fi
+}
+
+if [ -f "$tarball" ] && verify_sha256 "$tarball"; then
+  echo "install-rarlab-unrar: using cached tarball $tarball"
+else
+  echo "install-rarlab-unrar: fetching $UNRAR_URL"
+  curl -fsSL "$UNRAR_URL" -o "$tarball"
+  if ! verify_sha256 "$tarball"; then
+    rm -f "$tarball"
+    exit 1
+  fi
+fi
+
+workdir="$(mktemp -d "${TMPDIR:-/tmp}/unrarsrc.XXXXXX")"
+cleanup() { rm -rf "$workdir"; }
+trap cleanup EXIT
+
+tar -xf "$tarball" -C "$workdir"
+src="${workdir}/unrar"
+if [ ! -f "${src}/makefile" ]; then
+  echo "install-rarlab-unrar: tarball did not contain unrar/makefile" >&2
+  exit 1
+fi
+
+jobs="$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 2)"
+echo "install-rarlab-unrar: compiling UnRAR ${UNRAR_VERSION} with ${jobs} jobs"
+make -C "$src" -j"$jobs"
+
+# macOS install(1) has no GNU -D; copy the binary ourselves.
+cp "${src}/unrar" "${DEST}/unrar"
+chmod +x "${DEST}/unrar"
+echo "install-rarlab-unrar: installed ${DEST}/unrar"

--- a/scripts/install-rarlab-unrar.sh
+++ b/scripts/install-rarlab-unrar.sh
@@ -4,13 +4,12 @@
 #
 # Why this exists: Homebrew disabled the `rar` cask on 2026-09-01 because the
 # official macOS binaries fail Gatekeeper notarization. Compiling from source
-# produces a local binary CI will actually run. The tarball is fetched from
-# GitHub (not rarlab) and cached so later jobs do not re-download. archivey's
-# finder requires the RARLAB banner — `unar` / `unrar-free` / `7z` are not
-# substitutes.
+# produces a local binary CI will actually run. archivey's finder requires the
+# RARLAB banner — `unar` / `unrar-free` / `7z` are not substitutes.
 #
-# Source: https://github.com/pmachapman/unrar (mirror of rarlab UnRAR source).
-# Pin both the commit and the archive sha256; bump both together.
+# Source: https://github.com/pmachapman/unrar (one-person mirror of rarlab
+# UnRAR source). We fetch a pinned commit with git so the SHA is
+# content-addressed; GitHub's generated archive tarballs are not used.
 #
 # Usage:
 #   scripts/install-rarlab-unrar.sh --dest DIR [--cache-dir DIR]
@@ -18,17 +17,24 @@
 # Writes DIR/unrar. No-ops if that path is already executable.
 set -euo pipefail
 
-# Mirror commit "Updated to 7.2.7" — same tree as rarlab unrarsrc-7.2.7.
+# rarlab unrarsrc tarball name; the binary banner reads "UNRAR 7.23"
+# (version.hpp RARVER_MAJOR 7 / RARVER_MINOR 23).
 UNRAR_VERSION="7.2.7"
 UNRAR_COMMIT="d8612461815f7feffcf7f1bf9c5942125b25c1b4"
-UNRAR_SHA256="3d385eb009bbd657981ef317fc6625be9b627e699095019349ffec48da7fcf04"
-UNRAR_URL="https://github.com/pmachapman/unrar/archive/${UNRAR_COMMIT}.tar.gz"
+UNRAR_REPO="https://github.com/pmachapman/unrar.git"
 
 DEST=""
 CACHE_DIR="${XDG_CACHE_HOME:-${HOME}/.cache}/archivey/unrarsrc"
 
 usage() {
-  sed -n '2,19p' "$0" | sed 's/^# \?//'
+  cat <<'EOF'
+Build RARLAB UnRAR from a pinned GitHub mirror and install the unrar binary.
+
+Usage:
+  scripts/install-rarlab-unrar.sh --dest DIR [--cache-dir DIR]
+
+Writes DIR/unrar. No-ops if that path is already executable.
+EOF
 }
 
 while [ $# -gt 0 ]; do
@@ -63,63 +69,42 @@ if [ -x "${DEST}/unrar" ]; then
   exit 0
 fi
 
-if ! command -v c++ >/dev/null 2>&1; then
-  echo "install-rarlab-unrar: need a C++ compiler (macOS: Xcode CLI tools)" >&2
-  exit 1
-fi
-
-if ! command -v curl >/dev/null 2>&1; then
-  echo "install-rarlab-unrar: curl is required to fetch ${UNRAR_URL}" >&2
-  exit 1
-fi
-
-mkdir -p "$CACHE_DIR"
-tarball="${CACHE_DIR}/unrar-${UNRAR_COMMIT}.tar.gz"
-
-verify_sha256() {
-  local file="$1"
-  local got
-  if command -v sha256sum >/dev/null 2>&1; then
-    got="$(sha256sum "$file" | awk '{ print $1 }')"
-  elif command -v shasum >/dev/null 2>&1; then
-    got="$(shasum -a 256 "$file" | awk '{ print $1 }')"
-  else
-    echo "install-rarlab-unrar: need sha256sum or shasum" >&2
-    return 1
-  fi
-  if [ "$got" != "$UNRAR_SHA256" ]; then
-    echo "install-rarlab-unrar: sha256 mismatch for $file" >&2
-    echo "  got  $got" >&2
-    echo "  want $UNRAR_SHA256" >&2
-    return 1
-  fi
-}
-
-if [ -f "$tarball" ] && verify_sha256 "$tarball"; then
-  echo "install-rarlab-unrar: using cached tarball $tarball"
-else
-  echo "install-rarlab-unrar: fetching $UNRAR_URL"
-  curl -fsSL "$UNRAR_URL" -o "$tarball"
-  if ! verify_sha256 "$tarball"; then
-    rm -f "$tarball"
+need() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "install-rarlab-unrar: need $1 on PATH" >&2
     exit 1
   fi
+}
+need git
+need c++
+need make
+
+mkdir -p "$CACHE_DIR"
+src="${CACHE_DIR}/unrar-${UNRAR_COMMIT}"
+# Content-addressed fetch of the pin — not GitHub's generated archive tarball.
+# init + fetch --depth 1 <sha> skips cloning the default branch. GitHub serves
+# reachable SHAs of public repos this way.
+if [ "$(git -C "$src" rev-parse HEAD 2>/dev/null || true)" != "$UNRAR_COMMIT" ]; then
+  echo "install-rarlab-unrar: fetching ${UNRAR_REPO} @ ${UNRAR_COMMIT:0:12}"
+  rm -rf "$src"
+  mkdir -p "$src"
+  git -C "$src" init --quiet
+  git -C "$src" remote add origin "$UNRAR_REPO"
+  GIT_TERMINAL_PROMPT=0 git -C "$src" fetch --depth 1 origin "$UNRAR_COMMIT"
+  git -C "$src" -c advice.detachedHead=false checkout --detach FETCH_HEAD
 fi
-
-workdir="$(mktemp -d "${TMPDIR:-/tmp}/unrarsrc.XXXXXX")"
-cleanup() { rm -rf "$workdir"; }
-trap cleanup EXIT
-
-tar -xf "$tarball" -C "$workdir"
-# GitHub archive/<sha>.tar.gz extracts to unrar-<sha>/ (files at repo root).
-src="${workdir}/unrar-${UNRAR_COMMIT}"
+got="$(git -C "$src" rev-parse HEAD)"
+if [ "$got" != "$UNRAR_COMMIT" ]; then
+  echo "install-rarlab-unrar: expected commit ${UNRAR_COMMIT}, got ${got}" >&2
+  exit 1
+fi
 if [ ! -f "${src}/makefile" ]; then
   echo "install-rarlab-unrar: expected makefile at ${src}/makefile" >&2
   exit 1
 fi
 
 jobs="$(getconf _NPROCESSORS_ONLN 2>/dev/null || echo 2)"
-echo "install-rarlab-unrar: compiling UnRAR ${UNRAR_VERSION} (${UNRAR_COMMIT:0:12}) with ${jobs} jobs"
+echo "install-rarlab-unrar: compiling UnRAR ${UNRAR_VERSION} (banner 7.23, ${UNRAR_COMMIT:0:12}) with ${jobs} jobs"
 make -C "$src" -j"$jobs"
 
 # macOS install(1) has no GNU -D; copy the binary ourselves.

--- a/scripts/setup-dev-env.sh
+++ b/scripts/setup-dev-env.sh
@@ -58,9 +58,9 @@ install_linux_packages() {
 
 install_macos_packages() {
   # Homebrew disabled the `rar` cask on 2026-09-01 (Gatekeeper). Build RARLAB
-  # UnRAR from source instead — same binary the macOS CI job installs, and
-  # archivey's finder requires the RARLAB banner (unar / 7z do not satisfy it).
-  # This does not need Homebrew; p7zip below still does.
+  # UnRAR from a pinned GitHub mirror of the source — same binary the macOS CI
+  # job installs. archivey's finder requires the RARLAB banner (unar / 7z do
+  # not satisfy it). This does not need Homebrew; p7zip below still does.
   if ! command -v unrar >/dev/null 2>&1; then
     mkdir -p "${HOME}/.local/bin"
     "${REPO_ROOT}/scripts/install-rarlab-unrar.sh" --dest "${HOME}/.local/bin"

--- a/scripts/setup-dev-env.sh
+++ b/scripts/setup-dev-env.sh
@@ -18,6 +18,11 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "${REPO_ROOT}"
 
 # Official uv installer lands here; keep it first for non-login shells.
+# Snapshot the incoming PATH first so verification can tell "this process
+# can see unrar" from "a new login shell will see it" (macOS does not put
+# ~/.local/bin on PATH by default).
+ARCHIVEY_LOGIN_PATH="${PATH}"
+export ARCHIVEY_LOGIN_PATH
 export PATH="${HOME}/.local/bin:${PATH}"
 
 log() { printf '\n=== %s\n' "$1"; }
@@ -65,11 +70,17 @@ install_macos_packages() {
   # normal login shell can see `unrar` (macOS zsh does not put ~/.local/bin
   # on PATH). p7zip below still needs Homebrew.
   if ! command -v unrar >/dev/null 2>&1; then
+    # `command -v brew` succeeding does not mean `brew --prefix` succeeds.
+    # An empty substitution would make dest=/bin, and this function runs
+    # under `|| system_packages_ok=0` so set -e does not catch it.
+    prefix=""
     if command -v brew >/dev/null 2>&1; then
-      dest="$(brew --prefix)/bin"
+      prefix="$(brew --prefix 2>/dev/null || true)"
+    fi
+    if [ -n "$prefix" ]; then
+      dest="${prefix}/bin"
     else
       dest="${HOME}/.local/bin"
-      mkdir -p "$dest"
       echo "! unrar will be installed to ${dest}; add that directory to your login PATH or RAR data tests will skip" >&2
     fi
     mkdir -p "$dest"
@@ -128,14 +139,40 @@ log "git hooks"
 # Report rather than assume: a missing binary here is the difference between
 # "tests passed" and "tests silently skipped", and it is worth seeing at boot.
 log "verification"
-uv run --no-sync python - <<'PY'
+ARCHIVEY_LOGIN_PATH="${ARCHIVEY_LOGIN_PATH}" uv run --no-sync python - <<'PY'
+import os
 import shutil
+from pathlib import Path
 
 from benchmarks.harness import missing_baseline_requirements
 
+login_dirs = {
+    os.path.normcase(os.path.realpath(entry))
+    for entry in os.environ.get("ARCHIVEY_LOGIN_PATH", os.environ.get("PATH", "")).split(
+        os.pathsep
+    )
+    if entry
+}
+
+
+def _on_login_path(found: str) -> bool:
+    parent = os.path.normcase(os.path.realpath(str(Path(found).parent)))
+    return parent in login_dirs
+
+
 for tool in ("unrar", "7z"):
     found = shutil.which(tool)
-    print(f"{'ok  ' if found else 'MISSING'} {tool}{f': {found}' if found else ''}")
+    if not found:
+        print(f"MISSING {tool}")
+        continue
+    if _on_login_path(found):
+        print(f"ok   {tool}: {found}")
+    else:
+        print(
+            f"HIDDEN {tool}: {found}  "
+            "(not on login PATH — a new shell will skip RAR data tests "
+            "unless that directory is added)"
+        )
 
 missing = missing_baseline_requirements()
 if missing:

--- a/scripts/setup-dev-env.sh
+++ b/scripts/setup-dev-env.sh
@@ -57,13 +57,18 @@ install_linux_packages() {
 }
 
 install_macos_packages() {
+  # Homebrew disabled the `rar` cask on 2026-09-01 (Gatekeeper). Build RARLAB
+  # UnRAR from source instead — same binary the macOS CI job installs, and
+  # archivey's finder requires the RARLAB banner (unar / 7z do not satisfy it).
+  # This does not need Homebrew; p7zip below still does.
+  if ! command -v unrar >/dev/null 2>&1; then
+    mkdir -p "${HOME}/.local/bin"
+    "${REPO_ROOT}/scripts/install-rarlab-unrar.sh" --dest "${HOME}/.local/bin"
+  fi
   if ! command -v brew >/dev/null 2>&1; then
-    echo "! Homebrew not found; install unrar and p7zip manually" >&2
+    echo "! Homebrew not found; install p7zip manually" >&2
     return 0
   fi
-  # The rar formula ships both `rar` and `unrar`. archivey's finder requires the
-  # RARLAB build specifically — unar / 7z do not satisfy it.
-  command -v unrar >/dev/null 2>&1 || brew install rar
   command -v 7z >/dev/null 2>&1 || brew install p7zip
 }
 

--- a/scripts/setup-dev-env.sh
+++ b/scripts/setup-dev-env.sh
@@ -49,9 +49,10 @@ install_linux_packages() {
     -o Acquire::Check-Valid-Until=false \
     update || echo "! apt-get update reported errors; continuing with cached indexes" >&2
   # unrar: RAR member-data tests (multiverse component).
-  # rar: the WRITER, which the declarative corpus needs to build its 41 RAR cases.
-  #   Without it they skip quietly and the RAR column of the conformance sweep is
-  #   unexercised (F16 / O6; see dev-docs/investigations/rar-corpus-sweep-diagnosis.md).
+  # rar: the WRITER, needed only to regenerate committed RAR fixtures (ADR 0016)
+  #   and to run the leftover live `rar a` tests listed in
+  #   tests/fixtures/rar/README.md. The corpus RAR column itself does not skip
+  #   without it. macOS / CI install unrar only.
   # p7zip-full: encrypted ZIP fixtures built by shelling out to `7z`.
   ${SUDO} apt-get install -y unrar rar p7zip-full
 }

--- a/scripts/setup-dev-env.sh
+++ b/scripts/setup-dev-env.sh
@@ -61,10 +61,19 @@ install_macos_packages() {
   # Homebrew disabled the `rar` cask on 2026-09-01 (Gatekeeper). Build RARLAB
   # UnRAR from a pinned GitHub mirror of the source — same binary the macOS CI
   # job installs. archivey's finder requires the RARLAB banner (unar / 7z do
-  # not satisfy it). This does not need Homebrew; p7zip below still does.
+  # not satisfy it). Install into brew's prefix when brew is present so a
+  # normal login shell can see `unrar` (macOS zsh does not put ~/.local/bin
+  # on PATH). p7zip below still needs Homebrew.
   if ! command -v unrar >/dev/null 2>&1; then
-    mkdir -p "${HOME}/.local/bin"
-    "${REPO_ROOT}/scripts/install-rarlab-unrar.sh" --dest "${HOME}/.local/bin"
+    if command -v brew >/dev/null 2>&1; then
+      dest="$(brew --prefix)/bin"
+    else
+      dest="${HOME}/.local/bin"
+      mkdir -p "$dest"
+      echo "! unrar will be installed to ${dest}; add that directory to your login PATH or RAR data tests will skip" >&2
+    fi
+    mkdir -p "$dest"
+    "${REPO_ROOT}/scripts/install-rarlab-unrar.sh" --dest "$dest"
   fi
   if ! command -v brew >/dev/null 2>&1; then
     echo "! Homebrew not found; install p7zip manually" >&2

--- a/tests/fixtures/rar/README.md
+++ b/tests/fixtures/rar/README.md
@@ -34,8 +34,31 @@ Encrypted / hash fixtures of note:
 | `encryption_blake2sp.rar` | RAR5 `-m0 -htb -ppassword`; HASHMAC tweaked BLAKE2sp |
 | `blake2sp.rar` | RAR5 `-m0 -htb`; plaintext BLAKE2sp (no encryption) |
 
-Many-member listing fixtures (structural benchmark gate; CI has `unrar` but not
-`rar`, so these are committed rather than built on demand):
+## Tests that still need the `rar` writer at runtime
+
+CI and macOS `setup-dev-env.sh` install **unrar only** — the writer is trialware
+(ADR [0016](../../../dev-docs/decisions/0016-committed-rar-corpus-fixtures.md)).
+The corpus RAR column and the fixtures in this directory already run without it.
+
+These tests still shell out to `rar a` and **skip** when the writer is absent.
+They are the leftover of that decision, not a new gap from dropping the Homebrew
+cask. Linux `setup-dev-env.sh` still `apt-get install`s `rar`, so they run on a
+provisioned Linux laptop; they do not run on CI.
+
+| Test | Why it still writes |
+| --- | --- |
+| `test_sfx.py::test_sfx_rar_behind_a_low_entropy_stub_is_not_brotli` | `rar a` for a payload matching `_FILES` |
+| `test_sfx.py::test_a_real_sfx_archive_auto_opens` | `rar a -sfx` — a real ~250 KB stub, not a hand-rolled `MZ` |
+| `test_sfx.py::test_auto_open_matches_an_explicitly_sliced_stream[rar]` | same payload as the stub test |
+| `test_volumes.py::test_multi_volume_rar_real_roundtrip` | live `rar a -v400b`; listing/read of committed volumes is already covered by `tinyvol*` above |
+
+Committing a small SFX payload (and a real `-sfx` stub) the way this directory
+already does for volumes would close the gap. Tracked in `dev-docs/IDEAS.md`.
+
+## Many-member listing fixtures
+
+Structural benchmark gate; CI has `unrar` but not `rar`, so these are committed
+rather than built on demand:
 
 | Files | Notes |
 | --- | --- |

--- a/tests/test_rar_oracle.py
+++ b/tests/test_rar_oracle.py
@@ -89,7 +89,6 @@ def test_native_rar_matches_rarfile_metadata_and_bytes(
 
 @requires("rarfile")
 @requires_binary("unrar")
-@requires_binary("rar")
 @pytest.mark.parametrize(
     "entry",
     [
@@ -99,6 +98,7 @@ def test_native_rar_matches_rarfile_metadata_and_bytes(
     ],
 )
 def test_corpus_rar_matches_rarfile(entry: CorpusEntry, tmp_path: Path) -> None:
+    """Native reader vs rarfile on committed corpus RAR fixtures (no ``rar`` writer)."""
     rarfile = _rarfile()
     archive = corpus_archive_path(entry, "rar", tmp_path)
     password = entry.passwords[0] if entry.passwords else None

--- a/tests/test_rar_reader.py
+++ b/tests/test_rar_reader.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import dataclasses
 import io
+import shutil
 import struct
 import time
 import zlib
@@ -689,6 +690,20 @@ def test_non_rarlab_unrar_rejected(
     monkeypatch.setattr(rar_unrar, "_cached_unrar", None)
     with pytest.raises(PackageNotInstalledError, match="RARLAB"):
         rar_unrar.find_rarlab_unrar()
+
+
+def test_unrar_on_path_is_the_rarlab_build() -> None:
+    """Environment guard: an ``unrar`` the finder rejects makes RAR data tests fail confusingly.
+
+    On CI this duplicates the ``Verify RARLAB unrar on PATH`` step. Unique value is
+    developer machines: one named failure instead of a wall of
+    ``PackageNotInstalledError``. Finder unit behaviour is
+    ``test_non_rarlab_unrar_rejected``. This does not cover a binary installed
+    off PATH (that is the macOS ``~/.local/bin`` trap).
+    """
+    if shutil.which("unrar") is None:
+        pytest.skip("no unrar on PATH — RAR data tests skip, the documented state")
+    rar_unrar.find_rarlab_unrar()
 
 
 def test_missing_unrar_raises(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:

--- a/tests/test_review_simplicity_consistency.py
+++ b/tests/test_review_simplicity_consistency.py
@@ -38,9 +38,7 @@ from archivey import (
     ArchiveFormat,
     ArchiveyConfig,
     ArchiveyUsageError,
-    FormatSupport,
     StreamNotSeekableError,
-    format_availability,
     open_archive,
     open_stream,
 )
@@ -517,23 +515,19 @@ def test_streaming_mode_is_uniform_across_formats(key: str, tmp_path: Path) -> N
                 pass
 
 
-def test_rar_column_is_unmeasured_without_the_rar_writer() -> None:
-    """RAR readability does not imply a live ``rar`` writer.
+def test_unrar_on_path_is_rarlab() -> None:
+    """If ``unrar`` is on PATH, archivey's finder must accept it as RARLAB.
 
-    ``unrar`` is enough to *read* RAR. The corpus RAR column is committed
-    (ADR 0016) and runs without the writer. What still skips on an unrar-only box
-    is the handful of tests that shell out to ``rar a`` at runtime — listed in
-    ``tests/fixtures/rar/README.md``.
-
-    This test skips where the writer *is* present (Linux ``setup-dev-env.sh``).
-    On CI / macOS it pins that the backend still registers as readable without it.
+    Format availability is FULL without any binary (listing is native). Member-data
+    tests skip when ``find_rarlab_unrar`` fails. This pins the compile path: a
+    freshly built macOS ``unrar`` must pass the banner check, not just exist.
     """
-    rar_is_readable = format_availability(ArchiveFormat.RAR).support is not (
-        FormatSupport.NONE
-    )
-    if shutil.which("rar") is not None:
-        pytest.skip("rar writer present — the RAR corpus column is measurable here")
-    assert rar_is_readable, "unrar present: RAR reads fine, yet no RAR fixture is built"
+    if shutil.which("unrar") is None:
+        pytest.skip("unrar not on PATH")
+    from archivey.internal.backends.rar_unrar import find_rarlab_unrar
+
+    path = find_rarlab_unrar()
+    assert Path(path).is_file()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_review_simplicity_consistency.py
+++ b/tests/test_review_simplicity_consistency.py
@@ -518,23 +518,15 @@ def test_streaming_mode_is_uniform_across_formats(key: str, tmp_path: Path) -> N
 
 
 def test_rar_column_is_unmeasured_without_the_rar_writer() -> None:
-    """The coupling: RAR readability does not imply RAR *measurability*.
+    """RAR readability does not imply a live ``rar`` writer.
 
-    ``unrar`` (the decompressor) is enough to *read* RAR, but the corpus builds its RAR
-    fixtures with the RARLAB ``rar`` writer, so a green suite on an unrar-only box says
-    nothing about the RAR column of the conformance sweep.
+    ``unrar`` is enough to *read* RAR. The corpus RAR column is committed
+    (ADR 0016) and runs without the writer. What still skips on an unrar-only box
+    is the handful of tests that shell out to ``rar a`` at runtime — listed in
+    ``tests/fixtures/rar/README.md``.
 
-    The writer is now installed on Linux (`scripts/setup-dev-env.sh`, and the Linux
-    `[all]` CI leg), so this test skips there. It still runs on macOS and Windows, where
-    the writer is deliberately absent — the RAR column is claimed on Linux only, because
-    nothing in the diagnosis was plausibly platform-specific but that is an expectation
-    rather than a measurement.
-
-    The old justification for withholding the writer everywhere — "the RAR fixtures'
-    digest expectations are Linux-fixture-oriented" — did not survive being measured:
-    the corpus makes no platform-dependent assertion about a RAR member, and the sweep
-    was failing on two wrong assertions in the test itself. F16 / Q11 / O6; full
-    evidence in `dev-docs/investigations/rar-corpus-sweep-diagnosis.md`.
+    This test skips where the writer *is* present (Linux ``setup-dev-env.sh``).
+    On CI / macOS it pins that the backend still registers as readable without it.
     """
     rar_is_readable = format_availability(ArchiveFormat.RAR).support is not (
         FormatSupport.NONE

--- a/tests/test_review_simplicity_consistency.py
+++ b/tests/test_review_simplicity_consistency.py
@@ -29,7 +29,6 @@ were moved here from `review/simplicity-consistency/tests/` (pre-archive path), 
 from __future__ import annotations
 
 import io
-import shutil
 from pathlib import Path
 
 import pytest
@@ -513,21 +512,6 @@ def test_streaming_mode_is_uniform_across_formats(key: str, tmp_path: Path) -> N
         with pytest.raises(UnsupportedOperationError):
             for _ in reader:
                 pass
-
-
-def test_unrar_on_path_is_rarlab() -> None:
-    """If ``unrar`` is on PATH, archivey's finder must accept it as RARLAB.
-
-    Format availability is FULL without any binary (listing is native). Member-data
-    tests skip when ``find_rarlab_unrar`` fails. This pins the compile path: a
-    freshly built macOS ``unrar`` must pass the banner check, not just exist.
-    """
-    if shutil.which("unrar") is None:
-        pytest.skip("unrar not on PATH")
-    from archivey.internal.backends.rar_unrar import find_rarlab_unrar
-
-    path = find_rarlab_unrar()
-    assert Path(path).is_file()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_sfx.py
+++ b/tests/test_sfx.py
@@ -382,6 +382,7 @@ def test_sfx_zip_behind_a_low_entropy_stub_is_not_brotli(tmp_path: Path) -> None
     _assert_sfx_opens(path, ArchiveFormat.ZIP, len(_STUB))
 
 
+# Live ``rar a`` — skips on CI (unrar only). See tests/fixtures/rar/README.md.
 @requires_binary("rar")
 def test_sfx_rar_behind_a_low_entropy_stub_is_not_brotli(tmp_path: Path) -> None:
     path = tmp_path / "installer.exe"
@@ -389,6 +390,7 @@ def test_sfx_rar_behind_a_low_entropy_stub_is_not_brotli(tmp_path: Path) -> None
     _assert_sfx_opens(path, ArchiveFormat.RAR, len(_STUB))
 
 
+# Live ``rar a -sfx`` — skips on CI (unrar only). See tests/fixtures/rar/README.md.
 @requires_binary("rar")
 def test_a_real_sfx_archive_auto_opens(tmp_path: Path) -> None:
     """`rar a -sfx` output: a real ~250 KB stub, not a hand-rolled one.
@@ -508,7 +510,7 @@ def test_detection_leaves_a_non_seekable_stream_replayable(tmp_path: Path) -> No
             _rar_bytes,
             ArchiveFormat.RAR,
             id="rar",
-            marks=requires_binary("rar"),
+            marks=requires_binary("rar"),  # live rar a; see fixtures/rar/README.md
         ),
     ],
 )

--- a/tests/test_volumes.py
+++ b/tests/test_volumes.py
@@ -97,6 +97,7 @@ def test_multi_volume_rar_opens_volume_set_or_rejects_stub(tmp_path: Path) -> No
         pass
 
 
+# Live ``rar a`` — skips on CI (unrar only). See tests/fixtures/rar/README.md.
 @requires_binary("rar")
 @requires_binary("unrar")
 def test_multi_volume_rar_real_roundtrip(tmp_path: Path) -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Homebrew disabled the `rar` cask on 2026-09-01 because the official macOS binaries fail Gatekeeper notarization. That was how this repo installed RARLAB `unrar` on the macOS CI legs.

## Approach

Compile the published **UnRAR source** (freeware decompressor, not the trialware `rar` writer) from a **pinned git commit** of a GitHub mirror, then cache the built binary:

- `scripts/install-rarlab-unrar.sh` does `git init` + `fetch --depth 1` of [`pmachapman/unrar@d861246`](https://github.com/pmachapman/unrar/commit/d8612461815f7feffcf7f1bf9c5942125b25c1b4) (`Updated to 7.2.7`; binary banner **UNRAR 7.23**), then runs the upstream unix makefile. The commit SHA is the pin — GitHub's generated archive tarballs are not used.
- GitHub Actions caches `${RUNNER_TEMP}/rarlab-unrar` keyed on the script + OS + arch. The cache stores the *built binary*; the commit pin is checked when the script actually builds, not on a cache hit.
- `setup-dev-env.sh` uses the same script on Darwin, installing into `$(brew --prefix)/bin` when Homebrew is present (macOS zsh does not put `~/.local/bin` on PATH).

CI macOS does not download from rarlab. The Windows leg still does (`unrarw64.exe`, unpinned) — tracked in `dev-docs/IDEAS.md`.

## Did dropping the writer skip tests?

No new CI skips. macOS CI already deleted `rar` after the cask install; Linux/Windows never had the writer. The corpus RAR column and `tests/fixtures/rar/` are already committed (ADR 0016).

Four tests still shell out to `rar a` at runtime and skip on every CI leg. Inventory: `tests/fixtures/rar/README.md`, ADR 0016 follow-up, `dev-docs/IDEAS.md`. Closing that is the same move as 0016 — generate once, commit, drop the live `rar a`.

Also dropped a mistaken `@requires_binary("rar")` on the corpus rarfile oracle; those rows use committed fixtures and run with unrar alone.

## Alternatives considered

| Option | Why not |
|---|---|
| Homebrew `rar` cask | Disabled 2026-09-01 (fails Gatekeeper) |
| Download from rarlab every job | Hits rarlab; same unnotarized binary Homebrew dropped |
| `brew install carlocab/personal/unrar` | Personal tap; bottles stop at Sequoia while `macos-latest` is Tahoe |
| conda-forge `libunrar` via micromamba | Adds a second package manager to a uv workflow |
| `unar` | archivey rejects it (`find_rarlab_unrar`) |
| GitHub `/archive/{sha}.tar.gz` | Generated on demand; gzip bytes can change without the tree changing |
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3e6f5aae-2f67-43b3-80e6-3144384ca93e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3e6f5aae-2f67-43b3-80e6-3144384ca93e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

