### PR TITLE
Validate 7z and RAR SFX scan hits (prefixed-archive-detection follow-up)

### DIFF
--- a/dev-docs/known-issues.md
+++ b/dev-docs/known-issues.md
@@ -4,6 +4,30 @@
 > codec and why — including why `rapidgzip` is the single accelerator library (the issue below)
 > and why an `indexed_zstd` zstd accelerator would face the same constraint.
 
+## 7z SFX scan: a CRC-valid inexact decoy still beats a later real payload (open)
+
+**Status:** open in `prefixed-archive-detection` task 2.3 (`[~]`). CRC identity, the
+remaining-length overrun, and empty-next-header (`NextHeaderSize == 0`) behind a stub
+are in; exact-EOF ranking among several CRC-valid hits is not.
+
+The SFX scan returns the earliest `HitOutcome.VALID` needle. A 32-byte 7z signature
+header whose `StartHeaderCRC` matches and whose declared end is a nonzero size that
+fits in the remaining source is `VALID` even when it is not the real payload — a
+later genuine archive that does end at EOF never gets a chance. Detection then
+reports `SEVEN_Z` at the decoy origin, so `open_archive` never sees the real
+files: a **wrong answer**, not `FormatDetectionError`.
+
+The empty-header reject closes the reproduced F4 fixture (an empty 32-byte decoy
+at offset 512). The residual is a decoy with a **nonzero, self-consistent
+declared size that still fits in `remaining`**.
+
+**Gate (not yet written).** Prefer an exact-EOF 7z (`declared == remaining`) over
+an earlier inexact `VALID` — task 2.3's original intra-format tie-break. Until
+then, `test_inexact_7z_decoy_loses_to_a_later_exact_payload` is
+`@pytest.mark.xfail(strict=True)` on that contract (`xfail_strict` is not set in
+`pyproject.toml`, so `strict=True` is on the marker). `[~]` on task 2.3 stops
+`prefixed-archive-detection` from archiving while this stands.
+
 ## MacPaw `unar` / XADMaster: RAR5 solid + empty FILE is silent-wrong (open)
 
 **Status:** open upstream; archivey does not use `unar`. Recorded because a future

--- a/openspec/changes/prefixed-archive-detection/design.md
+++ b/openspec/changes/prefixed-archive-detection/design.md
@@ -264,7 +264,8 @@ on `SFX_HIT_VALIDATOR`. Do not key this off `ExecutableCue.WEAK` alone: an
 unconfirmed `MZ` / ELF stub is the live 7z/RAR SFX path and keeps the full
 needle set. `PrefixKind.SCRIPT` (Block 3) can replace the `#!` byte check.
 The rest of Block 3 (`prefix_kind`, `detection_budget`, exhaustive scan) is
-independent.
+independent. **2.3–2.4 landed as a slim follow-up after #277**, not delayed
+for that rest.
 
 **`ArchiveyConfig.detection_budget` is the spend cap.** Threading it needs a freeze
 surface: *Explicit configuration object*. `None` selects `BALANCED_BUDGET`.

--- a/openspec/changes/prefixed-archive-detection/design.md
+++ b/openspec/changes/prefixed-archive-detection/design.md
@@ -177,9 +177,13 @@ StartHeader that follows it, and that StartHeader gives `NextHeaderOffset` /
 landed exactly on EOF in every case. Combined, a false hit needs a 48-bit magic *and* a
 32-bit CRC *and* a size agreement.
 
-Use `<=` for the gate and `==` as the tiebreak. Appending 16 bytes to a 7z leaves it
-perfectly readable while breaking the exact-EOF equality, and some SFX tools append
-configuration after the payload — measured, not assumed.
+Use `<=` against the known source remaining from the candidate origin (not the
+scan window / `SFX_MAX`) for the gate, and `==` as a later tiebreak among several
+CRC-valid hits. The slim follow-up after #277 landed the remaining-length gate;
+exact-EOF ranking is still earliest-VALID — a genuine SFX with a trailing config
+blob has no exact match, so that preference is not a filter. Appending 16 bytes
+to a 7z leaves it perfectly readable while breaking the exact-EOF equality, and
+some SFX tools append configuration after the payload — measured, not assumed.
 
 **RAR 5.** The 8-byte marker is followed by a main archive header with its own CRC32,
 which validated at every stub offset tried.

--- a/openspec/changes/prefixed-archive-detection/design.md
+++ b/openspec/changes/prefixed-archive-detection/design.md
@@ -178,12 +178,20 @@ landed exactly on EOF in every case. Combined, a false hit needs a 48-bit magic 
 32-bit CRC *and* a size agreement.
 
 Use `<=` against the known source remaining from the candidate origin (not the
-scan window / `SFX_MAX`) for the gate, and `==` as a later tiebreak among several
-CRC-valid hits. The slim follow-up after #277 landed the remaining-length gate;
-exact-EOF ranking is still earliest-VALID — a genuine SFX with a trailing config
-blob has no exact match, so that preference is not a filter. Appending 16 bytes
-to a 7z leaves it perfectly readable while breaking the exact-EOF equality, and
-some SFX tools append configuration after the payload — measured, not assumed.
+scan window / `SFX_MAX`) for the gate. When remaining is known and equals the
+declared end, the 7z validator returns `VALID_EXACT` — "this format could prove
+the payload ends at EOF", not a generic better-candidate score. ZIP and RAR
+cannot produce that signal (neither header declares a total size). The SFX scan
+returns immediately on `VALID_EXACT`; otherwise it remembers the earliest
+`VALID` and keeps looking. Ledger tasks 3.3 / 4.6 / 4.7 read this enum.
+
+A real 7z written by the system `7z` ends exactly at its declared end, so an
+ordinary SFX still early-exits. The full-window scan runs when a hit has trailing
+bytes (or `remaining` is unknown): both candidates are plain `VALID` and earliest
+wins. Appending 16 bytes to a 7z leaves it perfectly readable while breaking the
+exact-EOF equality, and some SFX tools append configuration after the payload —
+measured, not assumed. An empty next-header (`NextHeaderSize == 0`) behind a stub
+is rejected outright: nobody ships a self-extractor with no files.
 
 **RAR 5.** The 8-byte marker is followed by a main archive header with its own CRC32,
 which validated at every stub offset tried.

--- a/openspec/changes/prefixed-archive-detection/design.md
+++ b/openspec/changes/prefixed-archive-detection/design.md
@@ -178,20 +178,16 @@ landed exactly on EOF in every case. Combined, a false hit needs a 48-bit magic 
 32-bit CRC *and* a size agreement.
 
 Use `<=` against the known source remaining from the candidate origin (not the
-scan window / `SFX_MAX`) for the gate. When remaining is known and equals the
-declared end, the 7z validator returns `VALID_EXACT` — "this format could prove
-the payload ends at EOF", not a generic better-candidate score. ZIP and RAR
-cannot produce that signal (neither header declares a total size). The SFX scan
-returns immediately on `VALID_EXACT`; otherwise it remembers the earliest
-`VALID` and keeps looking. Ledger tasks 3.3 / 4.6 / 4.7 read this enum.
-
-A real 7z written by the system `7z` ends exactly at its declared end, so an
-ordinary SFX still early-exits. The full-window scan runs when a hit has trailing
-bytes (or `remaining` is unknown): both candidates are plain `VALID` and earliest
-wins. Appending 16 bytes to a 7z leaves it perfectly readable while breaking the
-exact-EOF equality, and some SFX tools append configuration after the payload —
-measured, not assumed. An empty next-header (`NextHeaderSize == 0`) behind a stub
-is rejected outright: nobody ships a self-extractor with no files.
+scan window / `SFX_MAX`) for the gate, and `==` as a later tie-break among several
+CRC-valid hits. The slim follow-up after #277 landed the remaining-length gate
+and rejects an empty next-header (`NextHeaderSize == 0`) behind a stub: nobody
+ships a self-extractor with no files, and a genuine empty `.7z` is claimed by
+near magic, never by the scan. Exact-EOF ranking is still earliest-`VALID` —
+task 2.3's remainder, pinned by an `xfail(strict=True)` red half and recorded in
+`dev-docs/known-issues.md`. Appending 16 bytes to a 7z leaves it perfectly
+readable while breaking the exact-EOF equality, and some SFX tools append
+configuration after the payload — measured, not assumed. That is why the
+tie-break is a preference among validated hits, not a filter.
 
 **RAR 5.** The 8-byte marker is followed by a main archive header with its own CRC32,
 which validated at every stub offset tried.
@@ -276,8 +272,9 @@ on `SFX_HIT_VALIDATOR`. Do not key this off `ExecutableCue.WEAK` alone: an
 unconfirmed `MZ` / ELF stub is the live 7z/RAR SFX path and keeps the full
 needle set. `PrefixKind.SCRIPT` (Block 3) can replace the `#!` byte check.
 The rest of Block 3 (`prefix_kind`, `detection_budget`, exhaustive scan) is
-independent. **2.3–2.4 landed as a slim follow-up after #277**, not delayed
-for that rest.
+independent of the 7z/RAR validators. **2.4 and the CRC / remaining-length half
+of 2.3 landed as a slim follow-up after #277**; exact-EOF ranking stays `[~]`
+on task 2.3.
 
 **`ArchiveyConfig.detection_budget` is the spend cap.** Threading it needs a freeze
 surface: *Explicit configuration object*. `None` selects `BALANCED_BUDGET`.

--- a/openspec/changes/prefixed-archive-detection/tasks.md
+++ b/openspec/changes/prefixed-archive-detection/tasks.md
@@ -11,6 +11,8 @@ use `(context)` / `(every block)` rather than a block number.
    hit validator (`entry.format in validators`); 2.3–2.4 self-enable on that
    seam. No `prefix_kind`, no tail probe, no compressor needles.
    Tasks: **2.1, 2.1a, 2.1b, 2.1c, 2.2, 2.2a, 3.4, 4.1, 4.1a, 4.8a, 5.4.**
+   **Slim follow-up after #277:** 7z `StartHeaderCRC` and RAR main-header CRC
+   on `SFX_HIT_VALIDATOR` (tasks **2.3, 2.4, 4.4**). Not the rest of Block 3.
 2. **ZIP tail probe** — budget-gated (`THOROUGH.max_tail_bytes`, not `BALANCED`).
    Workspace tail helper. Both ZIP offset conventions. JPEG+ZIP as an enabled-path
    test. EOCD + central-directory confirmation of a scan hit can fold in here.
@@ -157,16 +159,22 @@ block. **0.4** is `(context)` — a prerequisite note, not a block.
       backend (candidate-relative view in, `HitOutcome` out); the scan calls it. A
       decoy of four `PK\x03\x04` bytes is `NOT_THIS_FORMAT`. Do **not** require an
       EOCD seek here — that is Block 2. Red–green alongside 4.1a.
-- [ ] 2.3 **(Block 3, or a slim follow-up after Block 1)** Validate a 7z hit: `StartHeaderCRC` over the 20-byte StartHeader,
+- [x] 2.3 **(Block 3, or a slim follow-up after Block 1)** Validate a 7z hit: `StartHeaderCRC` over the 20-byte StartHeader,
       and `offset + 32 + NextHeaderOffset + NextHeaderSize <= source length`, preferring
       an exact end match when several candidates validate — an intra-format tie-break
       inside this validator, not the cross-format ranking 0.6 defers. Named function on
       the 7z backend returning `HitOutcome`; the scan calls it. Failed CRC with a
       plausible header is `DAMAGED`; this change still skips it (scan continues). Ledger
       task 4.7 is the later policy that reports `SEVEN_Z` from that outcome.
-- [ ] 2.4 **(Block 3, or a slim follow-up after Block 1)** Validate a RAR 5 hit via the main header's CRC32; RAR 4 via a
+      **Landed as the slim follow-up after #277.** Exact-EOF among several CRC-valid
+      hits is still earliest-VALID (the generic first-match loop); trailing bytes after
+      a CRC-valid header stay `VALID` (task 4.4). A declared end past `SFX_MAX` is a
+      large archive, not an overrun — CRC passing is enough; do not grow the prefix.
+- [x] 2.4 **(Block 3, or a slim follow-up after Block 1)** Validate a RAR 5 hit via the main header's CRC32; RAR 4 via a
       parseable main header. Named function on the RAR backend, same `HitOutcome` split
       as 2.3.
+      **Landed as the slim follow-up after #277.** RAR 5 encrypted-headers archives
+      start with a plaintext ENCRYPTION block; that CRC is the identity check.
 - [ ] 2.5 **(Block 3)** Continue scanning past a candidate that fails validation rather than giving up
 - [x] 2.5a ~~**Prerequisite for 2.6–2.8: a bounded candidate-relative read.**~~ — shipped by `#273` as `PrefixWorkspace.peek_range` / `candidate_view` and `ScanNeedle` / `MagicHit.candidate_origin`. Nothing to invent here.
 - [ ] 2.5b **(Block 4)** Report `payload_offset` as the **candidate origin**, not the needle hit. A TAR hit reported at `H` rather than `H - 257` is wrong by 257 bytes and hands the backend a misaligned source; add a red–green for exactly that off-by-257. **Waits on 2.6**, which waits on the ledger.
@@ -219,7 +227,7 @@ block. **0.4** is `(context)` — a prerequisite note, not a block.
 - [x] 4.1a **(Block 1)** Red–green the ZIP scan validator: a `#!` stub whose text contains `PK\x03\x04` but whose following bytes fail local-header sanity SHALL raise `FormatDetectionError`, not report `ZIP` / `CorruptionError`. Pin the ELF-cued form of the same bytes too — today that path already claims a damaged ZIP, which is the live defect Block 1 must not widen.
 - [ ] 4.2 **(Block 4)** Red–green: a makeself-style `#!/bin/sh` + tar.gz detects as `TAR_GZ` and opens its members. Cover the negatives that define the scoping too: an `MZ` stub containing the same gzip bytes yields no scan claim, a `#!` stub whose own text contains `1f 8b 08` is rejected by the **structural header check**, and a `#!` + non-tar gzip stream reports `GZIP` (inner-TAR is resolution, not identity)
 - [ ] 4.3 **(Block 3)** SFX matrix across stub kinds: PE, ELF (a real `rar a -sfx`), Mach-O, and shebang, for 7z and RAR. Needs Block 1's cue already landed.
-- [ ] 4.4 **(Block 3)** Scan validation: the 6 magic bytes embedded in unrelated data are not claimed; a 7z whose declared end overruns the source is not claimed; a 7z with trailing bytes appended still is
+- [x] 4.4 **(Block 3)** Scan validation: the 6 magic bytes embedded in unrelated data are not claimed; a 7z whose declared end overruns the source is not claimed; a 7z with trailing bytes appended still is. **Landed with the 2.3–2.4 slim follow-up after #277.**
 - [ ] 4.5 **(Block 2)** Non-seekable prefixed ZIP falls through rather than crashing or buffering the stream
 - [ ] 4.6 **(Block 3)** Exhaustive scan: off by default leaves a beyond-window archive undetected and unread past the window; on, it finds it with `prefix_kind == UNKNOWN`
 - [ ] 4.7 **(Block 3)** `prefix_kind` values for each fixture in 4.1–4.3

--- a/openspec/changes/prefixed-archive-detection/tasks.md
+++ b/openspec/changes/prefixed-archive-detection/tasks.md
@@ -169,12 +169,14 @@ block. **0.4** is `(context)` — a prerequisite note, not a block.
       **Landed as the slim follow-up after #277.** The declared-end check compares
       against the known source length (`remaining` from the candidate origin), not the
       peek window / `scan_limit` / `SFX_MAX`. An unreachable end or oversized next-header
-      after a passing CRC is `DAMAGED`. Exact-EOF among several CRC-valid hits is still
-      earliest-VALID (the generic first-match loop) — deferred: a genuine SFX with a
-      trailing config blob has no exact match, so the tie-break is a preference among
-      validated hits, not a filter, and needs this remaining plumbing first. Trailing
-      bytes after a CRC-valid header stay `VALID` (task 4.4). The pin
-      `test_crc_valid_empty_7z_decoy_still_wins_over_a_later_payload` records the hole.
+      after a passing CRC is `DAMAGED`. Exact-EOF among several CRC-valid hits is
+      `VALID_EXACT` (7z-only: declared end equals known remaining); the scan returns
+      immediately on that outcome and otherwise remembers the earliest `VALID`.
+      `NextHeaderSize == 0` behind a stub is `NOT_THIS_FORMAT`. Trailing bytes after a
+      CRC-valid header stay `VALID` (task 4.4). Pins:
+      `test_inexact_7z_decoy_loses_to_a_later_exact_payload` (the tie-break) and
+      `test_inexact_7z_decoy_still_wins_when_the_real_payload_has_trailing_bytes`
+      (the residual).
 - [x] 2.4 **(Block 3, or a slim follow-up after Block 1)** Validate a RAR 5 hit via the main header's CRC32; RAR 4 via a
       parseable main header. Named function on the RAR backend, same `HitOutcome` split
       as 2.3.

--- a/openspec/changes/prefixed-archive-detection/tasks.md
+++ b/openspec/changes/prefixed-archive-detection/tasks.md
@@ -166,10 +166,15 @@ block. **0.4** is `(context)` — a prerequisite note, not a block.
       the 7z backend returning `HitOutcome`; the scan calls it. Failed CRC with a
       plausible header is `DAMAGED`; this change still skips it (scan continues). Ledger
       task 4.7 is the later policy that reports `SEVEN_Z` from that outcome.
-      **Landed as the slim follow-up after #277.** Exact-EOF among several CRC-valid
-      hits is still earliest-VALID (the generic first-match loop); trailing bytes after
-      a CRC-valid header stay `VALID` (task 4.4). A declared end past `SFX_MAX` is a
-      large archive, not an overrun — CRC passing is enough; do not grow the prefix.
+      **Landed as the slim follow-up after #277.** The declared-end check compares
+      against the known source length (`remaining` from the candidate origin), not the
+      peek window / `scan_limit` / `SFX_MAX`. An unreachable end or oversized next-header
+      after a passing CRC is `DAMAGED`. Exact-EOF among several CRC-valid hits is still
+      earliest-VALID (the generic first-match loop) — deferred: a genuine SFX with a
+      trailing config blob has no exact match, so the tie-break is a preference among
+      validated hits, not a filter, and needs this remaining plumbing first. Trailing
+      bytes after a CRC-valid header stay `VALID` (task 4.4). The pin
+      `test_crc_valid_empty_7z_decoy_still_wins_over_a_later_payload` records the hole.
 - [x] 2.4 **(Block 3, or a slim follow-up after Block 1)** Validate a RAR 5 hit via the main header's CRC32; RAR 4 via a
       parseable main header. Named function on the RAR backend, same `HitOutcome` split
       as 2.3.

--- a/openspec/changes/prefixed-archive-detection/tasks.md
+++ b/openspec/changes/prefixed-archive-detection/tasks.md
@@ -159,24 +159,23 @@ block. **0.4** is `(context)` — a prerequisite note, not a block.
       backend (candidate-relative view in, `HitOutcome` out); the scan calls it. A
       decoy of four `PK\x03\x04` bytes is `NOT_THIS_FORMAT`. Do **not** require an
       EOCD seek here — that is Block 2. Red–green alongside 4.1a.
-- [x] 2.3 **(Block 3, or a slim follow-up after Block 1)** Validate a 7z hit: `StartHeaderCRC` over the 20-byte StartHeader,
+- [~] 2.3 **(Block 3, or a slim follow-up after Block 1)** Validate a 7z hit: `StartHeaderCRC` over the 20-byte StartHeader,
       and `offset + 32 + NextHeaderOffset + NextHeaderSize <= source length`, preferring
       an exact end match when several candidates validate — an intra-format tie-break
       inside this validator, not the cross-format ranking 0.6 defers. Named function on
       the 7z backend returning `HitOutcome`; the scan calls it. Failed CRC with a
       plausible header is `DAMAGED`; this change still skips it (scan continues). Ledger
       task 4.7 is the later policy that reports `SEVEN_Z` from that outcome.
-      **Landed as the slim follow-up after #277.** The declared-end check compares
-      against the known source length (`remaining` from the candidate origin), not the
-      peek window / `scan_limit` / `SFX_MAX`. An unreachable end or oversized next-header
-      after a passing CRC is `DAMAGED`. Exact-EOF among several CRC-valid hits is
-      `VALID_EXACT` (7z-only: declared end equals known remaining); the scan returns
-      immediately on that outcome and otherwise remembers the earliest `VALID`.
-      `NextHeaderSize == 0` behind a stub is `NOT_THIS_FORMAT`. Trailing bytes after a
-      CRC-valid header stay `VALID` (task 4.4). Pins:
-      `test_inexact_7z_decoy_loses_to_a_later_exact_payload` (the tie-break) and
-      `test_inexact_7z_decoy_still_wins_when_the_real_payload_has_trailing_bytes`
-      (the residual).
+      **Partially landed as the slim follow-up after #277 (F12).** CRC identity, the
+      remaining-length overrun (`DAMAGED`), and `NextHeaderSize == 0` behind a stub
+      (`NOT_THIS_FORMAT`) are in. The declared-end check compares against the known
+      source length (`remaining` from the candidate origin), not the peek window /
+      `scan_limit` / `SFX_MAX`. Exact-EOF ranking among several CRC-valid hits is
+      **not**: first `VALID` still wins. Trailing bytes after a CRC-valid header stay
+      `VALID` (task 4.4). Pin: `test_inexact_7z_decoy_loses_to_a_later_exact_payload`
+      (`xfail(strict=True)` on the real payload winning). Recorded in
+      `dev-docs/known-issues.md`. `[~]` so this change cannot archive until the
+      tie-break lands (`scripts/check_openspec_archived.py`).
 - [x] 2.4 **(Block 3, or a slim follow-up after Block 1)** Validate a RAR 5 hit via the main header's CRC32; RAR 4 via a
       parseable main header. Named function on the RAR backend, same `HitOutcome` split
       as 2.3.

--- a/src/archivey/internal/backends/rar_parser.py
+++ b/src/archivey/internal/backends/rar_parser.py
@@ -169,7 +169,7 @@ _S_SHORT = struct.Struct("<H")
 _TRY_ENCODINGS = ("utf8", "utf-16le", "windows-1252")
 
 
-def _rar3_main_crc_end(flags: int) -> int:
+def rar3_main_crc_end(flags: int) -> int:
     """Exclusive end of MAIN-header CRC coverage, from the start of the block.
 
     Shared with the SFX hit validator so a flag-walk change cannot silently
@@ -463,7 +463,7 @@ def _seek_after_packed(source: BinaryIO, data_offset: int, add_size: int) -> Non
         ) from exc
 
 
-def _load_vint(buf: bytes | bytearray | memoryview, pos: int) -> tuple[int, int]:
+def load_vint(buf: bytes | bytearray | memoryview, pos: int) -> tuple[int, int]:
     # Hot path: most RAR5 vints are a single byte (< 0x80). Avoid the multi-byte
     # loop and ``min()`` on every call (listing many-member archives).
     length = len(buf)
@@ -511,7 +511,7 @@ def _load_bytes(
 
 
 def _load_vstr(buf: bytes | bytearray | memoryview, pos: int) -> tuple[bytes, int]:
-    slen, pos = _load_vint(buf, pos)
+    slen, pos = load_vint(buf, pos)
     return _load_bytes(buf, slen, pos)
 
 
@@ -957,7 +957,7 @@ def _parse_rar3(
             continue
 
         if block_type == _RAR3_MAIN:
-            crc_pos = _rar3_main_crc_end(flags)
+            crc_pos = rar3_main_crc_end(flags)
             is_solid = bool(flags & _RAR3_MAIN_SOLID)
             is_volume = bool(flags & _RAR3_MAIN_VOLUME)
             if flags & _RAR3_MAIN_PASSWORD:
@@ -1344,9 +1344,9 @@ def _parse_rar5(
         ) = parsed
 
         if block_type == _RAR5_MAIN:
-            main_flags, pos = _load_vint(hdata, pos)
+            main_flags, pos = load_vint(hdata, pos)
             if main_flags & _RAR5_MAIN_HAS_VOLNR:
-                volnr, pos = _load_vint(hdata, pos)
+                volnr, pos = load_vint(hdata, pos)
                 # RAR5: first volume omits the field (implicit 0); later volumes
                 # store 1 for the second volume, 2 for the third, …
                 if volume_index == 0 and volnr != 0:
@@ -1369,8 +1369,8 @@ def _parse_rar5(
             continue
 
         if block_type == _RAR5_ENCRYPTION:
-            algo, pos = _load_vint(hdata, pos)
-            enc_flags, pos = _load_vint(hdata, pos)
+            algo, pos = load_vint(hdata, pos)
+            enc_flags, pos = load_vint(hdata, pos)
             kdf_count, pos = _load_byte(hdata, pos)
             salt, pos = _load_bytes(hdata, 16, pos)
             check_value = None
@@ -1400,7 +1400,7 @@ def _parse_rar5(
             continue
 
         if block_type == _RAR5_ENDARC:
-            endarc_flags, _ = _load_vint(hdata, pos)
+            endarc_flags, _ = load_vint(hdata, pos)
             needs_next_volume = bool(endarc_flags & _RAR5_ENDARC_NEXT_VOLUME)
             break
 
@@ -1479,7 +1479,7 @@ def _read_rar5_block(
         raise CorruptionError("Unexpected EOF while reading RAR5 header")
     # The header-size vint starts at byte 4 (after the 4-byte CRC). A vint is at most
     # 10 bytes; cap the continuation so a crafted run of 0x80 bytes cannot drive an
-    # unbounded, O(n^2) byte-at-a-time read of the source before ``_load_vint``'s own
+    # unbounded, O(n^2) byte-at-a-time read of the source before ``load_vint``'s own
     # 11-byte guard (which only runs *after* this loop) would reject it.
     while head[-1] & 0x80:
         if len(head) - 4 >= 10:
@@ -1492,7 +1492,7 @@ def _read_rar5_block(
         head += b
     start_bytes = bytes(head)
     header_crc, pos = _load_le32(start_bytes, 0)
-    hdrlen, pos = _load_vint(start_bytes, pos)
+    hdrlen, pos = load_vint(start_bytes, pos)
     if hdrlen > _RAR5_MAX_HEADER:
         raise CorruptionError(f"RAR5 header too large: {hdrlen}")
     header_size = pos + hdrlen
@@ -1504,14 +1504,14 @@ def _read_rar5_block(
     if header_crc != _crc32(memoryview(hdata)[4:]):
         raise CorruptionError(f"RAR5 header CRC mismatch at offset {header_offset}")
 
-    block_type, pos = _load_vint(hdata, pos)
-    block_flags, pos = _load_vint(hdata, pos)
+    block_type, pos = load_vint(hdata, pos)
+    block_flags, pos = load_vint(hdata, pos)
     extra_size = 0
     add_size = 0
     if block_flags & _RAR5_FLAG_EXTRA:
-        extra_size, pos = _load_vint(hdata, pos)
+        extra_size, pos = load_vint(hdata, pos)
     if block_flags & _RAR5_FLAG_DATA:
-        add_size, pos = _load_vint(hdata, pos)
+        add_size, pos = load_vint(hdata, pos)
     return (
         block_type,
         block_flags,
@@ -1577,9 +1577,9 @@ def _parse_rar5_file_block(
     add_size: int,
     volume_index: int,
 ) -> RarMemberInfo:
-    file_flags, pos = _load_vint(hdata, pos)
-    file_size, pos = _load_vint(hdata, pos)
-    mode, pos = _load_vint(hdata, pos)
+    file_flags, pos = load_vint(hdata, pos)
+    file_size, pos = load_vint(hdata, pos)
+    mode, pos = load_vint(hdata, pos)
 
     mtime: datetime | None = None
     crc32: int | None = None
@@ -1588,8 +1588,8 @@ def _parse_rar5_file_block(
     if file_flags & _RAR5_FILE_HAS_CRC32:
         crc32, pos = _load_le32(hdata, pos)
 
-    compress_info, pos = _load_vint(hdata, pos)
-    host_os_raw, pos = _load_vint(hdata, pos)
+    compress_info, pos = load_vint(hdata, pos)
+    host_os_raw, pos = load_vint(hdata, pos)
     orig_filename, pos = _load_vstr(hdata, pos)
     filename = orig_filename.decode("utf8", "replace").rstrip("/")
 
@@ -1610,25 +1610,25 @@ def _parse_rar5_file_block(
         # Walk extras until near end (allow 1 byte of padding like rarfile).
         while pos < len(hdata) - 1:
             try:
-                xsize, pos = _load_vint(hdata, pos)
+                xsize, pos = load_vint(hdata, pos)
             except CorruptionError:
                 break
             if xsize < 0 or pos + xsize > len(hdata):
                 break
             xdata, pos = _load_bytes(hdata, xsize, pos)
-            xtype, xpos = _load_vint(xdata, 0)
+            xtype, xpos = load_vint(xdata, 0)
             if xtype == _RAR5_XFILE_TIME:
                 mtime = _parse_rar5_xtime(xdata, xpos, mtime)
             elif xtype == _RAR5_XFILE_ENCRYPTION:
                 file_encryption = _parse_rar5_file_encryption(xdata, xpos)
                 flags |= _RAR3_FILE_PASSWORD
             elif xtype == _RAR5_XFILE_HASH:
-                hash_type, xpos = _load_vint(xdata, xpos)
+                hash_type, xpos = load_vint(xdata, xpos)
                 if hash_type == _RAR5_XHASH_BLAKE2SP:
                     blake2sp_hash, xpos = _load_bytes(xdata, 32, xpos)
             elif xtype == _RAR5_XFILE_REDIR:
-                redir_type, xpos = _load_vint(xdata, xpos)
-                redir_flags, xpos = _load_vint(xdata, xpos)
+                redir_type, xpos = load_vint(xdata, xpos)
+                redir_flags, xpos = load_vint(xdata, xpos)
                 redir_name, xpos = _load_vstr(xdata, xpos)
                 file_redir = (
                     redir_type,
@@ -1636,8 +1636,8 @@ def _parse_rar5_file_block(
                     redir_name.decode("utf8", "replace"),
                 )
             elif xtype == _RAR5_XFILE_VERSION:
-                _vflags, xpos = _load_vint(xdata, xpos)
-                file_version, xpos = _load_vint(xdata, xpos)
+                _vflags, xpos = load_vint(xdata, xpos)
+                file_version, xpos = load_vint(xdata, xpos)
             # OWNER / SERVICE / unknown: ignore
 
     is_symlink = False
@@ -1689,7 +1689,7 @@ def _parse_rar5_file_block(
 def _parse_rar5_xtime(
     xdata: bytes, pos: int, current: datetime | None
 ) -> datetime | None:
-    tflags, pos = _load_vint(xdata, pos)
+    tflags, pos = load_vint(xdata, pos)
     ldr = _load_windowstime
     if tflags & _RAR5_XTIME_UNIXTIME:
         ldr = _load_unixtime
@@ -1715,8 +1715,8 @@ def _parse_rar5_xtime(
 
 
 def _parse_rar5_file_encryption(xdata: bytes, pos: int) -> RarEncryptionInfo:
-    algo, pos = _load_vint(xdata, pos)
-    flags, pos = _load_vint(xdata, pos)
+    algo, pos = load_vint(xdata, pos)
+    flags, pos = load_vint(xdata, pos)
     kdf_count, pos = _load_byte(xdata, pos)
     salt, pos = _load_bytes(xdata, 16, pos)
     iv, pos = _load_bytes(xdata, 16, pos)

--- a/src/archivey/internal/backends/rar_parser.py
+++ b/src/archivey/internal/backends/rar_parser.py
@@ -169,6 +169,21 @@ _S_SHORT = struct.Struct("<H")
 _TRY_ENCODINGS = ("utf8", "utf-16le", "windows-1252")
 
 
+def _rar3_main_crc_end(flags: int) -> int:
+    """Exclusive end of MAIN-header CRC coverage, from the start of the block.
+
+    Shared with the SFX hit validator so a flag-walk change cannot silently
+    desync detection from the parser.
+    """
+    pos = _S_BLK_HDR.size
+    if flags & _RAR3_LONG_BLOCK:
+        pos += 4
+    pos += 6
+    if flags & _RAR3_MAIN_ENCRYPTVER:
+        pos += 1
+    return pos
+
+
 # ---------------------------------------------------------------------------
 # Public dataclasses
 # ---------------------------------------------------------------------------
@@ -942,10 +957,7 @@ def _parse_rar3(
             continue
 
         if block_type == _RAR3_MAIN:
-            pos += 6
-            if flags & _RAR3_MAIN_ENCRYPTVER:
-                pos += 1
-            crc_pos = pos
+            crc_pos = _rar3_main_crc_end(flags)
             is_solid = bool(flags & _RAR3_MAIN_SOLID)
             is_volume = bool(flags & _RAR3_MAIN_VOLUME)
             if flags & _RAR3_MAIN_PASSWORD:

--- a/src/archivey/internal/backends/rar_reader.py
+++ b/src/archivey/internal/backends/rar_reader.py
@@ -67,6 +67,7 @@ from archivey.internal.password import (
     _PasswordCandidates,
     _PasswordCandidatesExhausted,
 )
+from archivey.internal.rar_detect import validate_rar_main_header
 from archivey.internal.registry import register_reader
 from archivey.internal.streams.archive_stream import ArchiveStream
 from archivey.internal.streams.streamtools import (
@@ -1012,6 +1013,7 @@ class RarReadBackend(ReadBackend):
     # Both ids, so the scan resolves RAR4 vs RAR5 by which one comes first rather than
     # matching their shared `Rar!\x1a\x07` prefix and re-reading to disambiguate.
     SFX_MAGIC: tuple[MagicSignature, ...] = MAGIC
+    SFX_HIT_VALIDATOR = staticmethod(validate_rar_main_header)
     SUPPORTS_PASSWORD = True
     SUPPORTS_STREAMING_NON_SEEKABLE = False
     OPTIONAL_DEPENDENCY = None

--- a/src/archivey/internal/backends/sevenzip_reader.py
+++ b/src/archivey/internal/backends/sevenzip_reader.py
@@ -80,6 +80,7 @@ from archivey.internal.password import (
     _PasswordCandidatesExhausted,
 )
 from archivey.internal.registry import register_reader
+from archivey.internal.sevenzip_detect import validate_sevenzip_signature_header
 from archivey.internal.streams.archive_stream import ArchiveStream
 from archivey.internal.streams.crypto import SevenZipKeyCache
 from archivey.internal.streams.streamtools import (
@@ -796,6 +797,7 @@ class SevenZipReadBackend(ReadBackend):
         MagicSignature(0, b"7z\xbc\xaf'\x1c", ArchiveFormat.SEVEN_Z),
     )
     SFX_MAGIC: tuple[MagicSignature, ...] = MAGIC
+    SFX_HIT_VALIDATOR = staticmethod(validate_sevenzip_signature_header)
     SUPPORTS_PASSWORD = True
     SUPPORTS_STREAMING_NON_SEEKABLE = False
     OPTIONAL_DEPENDENCY = None

--- a/src/archivey/internal/base_reader.py
+++ b/src/archivey/internal/base_reader.py
@@ -181,8 +181,7 @@ class ReadBackend(ABC):
     # claimed: ZIP's local-header sanity check, 7z ``StartHeaderCRC``, RAR 5
     # main-header CRC32 / RAR 4 MAIN.
     # Returns :class:`~archivey.internal.sfx.HitOutcome`; the detector treats
-    # ``VALID_EXACT`` as an immediate accept, ``VALID`` as a fallback while the
-    # scan continues, and anything else as "skip and continue".
+    # anything other than ``VALID`` as "skip and continue".
     # Subclasses that supply a function must wrap it in ``staticmethod`` — a bare
     # function on the class body is a descriptor, and an instance lookup would bind
     # ``self`` as the first argument. The other detection tables (MAGIC, SFX_MAGIC)

--- a/src/archivey/internal/base_reader.py
+++ b/src/archivey/internal/base_reader.py
@@ -77,7 +77,7 @@ from archivey.internal.naming import (
 from archivey.internal.open_site import OpenSite
 from archivey.internal.reader_state import ReaderState
 from archivey.internal.selection import normalize_member_selector
-from archivey.internal.sfx import HitOutcome
+from archivey.internal.sfx import HitValidator
 from archivey.internal.streams.archive_stream import ArchiveStream
 from archivey.internal.streams.counting import (
     CountingReader,
@@ -174,19 +174,19 @@ class ReadBackend(ABC):
     # ``MAGIC``: ZIP declares only its local-file header here, because scanning a stub
     # for the EOCD or spanned markers would claim any file containing those four bytes.
     SFX_MAGIC: tuple[MagicSignature, ...] = ()
-    # Format-owned check the SFX scan calls on a candidate-relative view. ``None``
-    # means "needle match is enough". ZIP, 7z, and RAR all supply one so a stub
-    # that merely contains their magic bytes is not claimed: ZIP's local-header
-    # sanity check, 7z ``StartHeaderCRC``, RAR 5 main-header CRC32 / RAR 4 MAIN.
+    # Format-owned check the SFX scan calls on a candidate-relative view plus
+    # known remaining length from that origin (``None`` if the source size is
+    # unknown). ``None`` here means "needle match is enough". ZIP, 7z, and RAR
+    # all supply one so a stub that merely contains their magic bytes is not
+    # claimed: ZIP's local-header sanity check, 7z ``StartHeaderCRC``, RAR 5
+    # main-header CRC32 / RAR 4 MAIN.
     # Returns :class:`~archivey.internal.sfx.HitOutcome`; the detector treats
     # anything other than ``VALID`` as "skip and continue".
     # Subclasses that supply a function must wrap it in ``staticmethod`` — a bare
     # function on the class body is a descriptor, and an instance lookup would bind
     # ``self`` as the first argument. The other detection tables (MAGIC, SFX_MAGIC)
     # are inert data and do not have this problem.
-    SFX_HIT_VALIDATOR: ClassVar[
-        Callable[[Callable[[int], bytes]], HitOutcome] | None
-    ] = None
+    SFX_HIT_VALIDATOR: ClassVar[HitValidator | None] = None
     # Formats this backend reads that have no exact magic and are recognized by a content
     # probe instead: (format, probe) pairs, where the probe inspects a peeked prefix and
     # returns True on a match (Brotli has no signature; zlib's 2-byte header is too weak).

--- a/src/archivey/internal/base_reader.py
+++ b/src/archivey/internal/base_reader.py
@@ -181,7 +181,8 @@ class ReadBackend(ABC):
     # claimed: ZIP's local-header sanity check, 7z ``StartHeaderCRC``, RAR 5
     # main-header CRC32 / RAR 4 MAIN.
     # Returns :class:`~archivey.internal.sfx.HitOutcome`; the detector treats
-    # anything other than ``VALID`` as "skip and continue".
+    # ``VALID_EXACT`` as an immediate accept, ``VALID`` as a fallback while the
+    # scan continues, and anything else as "skip and continue".
     # Subclasses that supply a function must wrap it in ``staticmethod`` — a bare
     # function on the class body is a descriptor, and an instance lookup would bind
     # ``self`` as the first argument. The other detection tables (MAGIC, SFX_MAGIC)

--- a/src/archivey/internal/base_reader.py
+++ b/src/archivey/internal/base_reader.py
@@ -175,8 +175,9 @@ class ReadBackend(ABC):
     # for the EOCD or spanned markers would claim any file containing those four bytes.
     SFX_MAGIC: tuple[MagicSignature, ...] = ()
     # Format-owned check the SFX scan calls on a candidate-relative view. ``None``
-    # means "needle match is enough" (today: RAR / 7z). ZIP supplies a cheap
-    # local-header sanity check so four ``PK\\x03\\x04`` bytes in a stub are not a ZIP.
+    # means "needle match is enough". ZIP, 7z, and RAR all supply one so a stub
+    # that merely contains their magic bytes is not claimed: ZIP's local-header
+    # sanity check, 7z ``StartHeaderCRC``, RAR 5 main-header CRC32 / RAR 4 MAIN.
     # Returns :class:`~archivey.internal.sfx.HitOutcome`; the detector treats
     # anything other than ``VALID`` as "skip and continue".
     # Subclasses that supply a function must wrap it in ``staticmethod`` — a bare

--- a/src/archivey/internal/detection.py
+++ b/src/archivey/internal/detection.py
@@ -440,10 +440,12 @@ def _scan_for_sfx_payload(
     candidate-internal offset (today all zero for ZIP/RAR/7z; TAR ``ustar`` → 257 once
     that needle lands). The returned ``payload_offset`` is the **candidate origin**, not
     the raw needle position. A hit whose format-owned validator returns anything other
-    than :attr:`HitOutcome.VALID` is skipped and the scan continues — earliest
-    *valid* match, not earliest needle. ``PROBABLE`` rather than ``CERTAIN``: an exact
-    magic found at a *searched-for* offset is a weaker claim than one found at the
-    offset the format specifies.
+    than :attr:`HitOutcome.VALID` / :attr:`HitOutcome.VALID_EXACT` is skipped and
+    the scan continues. ``VALID_EXACT`` (a 7z whose declared end equals known
+    remaining) returns immediately. ``VALID`` is remembered as the earliest
+    fallback and the scan keeps looking for a later ``VALID_EXACT``.
+    ``PROBABLE`` rather than ``CERTAIN``: an exact magic found at a *searched-for*
+    offset is a weaker claim than one found at the offset the format specifies.
 
     ``scan_limit`` is the budget-clamped window (``min(SFX_MAX, budget.max_scan_bytes)``);
     the charge lands whether the scan hits or misses so the receipt reflects the work.
@@ -462,23 +464,33 @@ def _scan_for_sfx_payload(
     for hit in iter_magic_in_prefix(peek_more, needles, limit=scan_limit):
         entry = by_needle[hit.needle]
         validator = validators.get(entry.format)
-        if validator is not None:
-            view = workspace.candidate_view(hit.candidate_origin, limit=scan_limit)
-            source_len = workspace.remaining_known()
-            remaining = (
-                None
-                if source_len is None
-                else max(0, source_len - hit.candidate_origin)
+        if validator is None:
+            result = FormatInfo(
+                entry.format,
+                DetectionConfidence.PROBABLE,
+                "sfx_scan",
+                payload_offset=hit.candidate_origin,
             )
-            if validator(view, remaining) is not HitOutcome.VALID:
-                continue
-        result = FormatInfo(
+            break
+        view = workspace.candidate_view(hit.candidate_origin, limit=scan_limit)
+        source_len = workspace.remaining_known()
+        remaining = (
+            None if source_len is None else max(0, source_len - hit.candidate_origin)
+        )
+        outcome = validator(view, remaining)
+        if outcome is HitOutcome.NOT_THIS_FORMAT or outcome is HitOutcome.DAMAGED:
+            continue
+        info = FormatInfo(
             entry.format,
             DetectionConfidence.PROBABLE,
             "sfx_scan",
             payload_offset=hit.candidate_origin,
         )
-        break
+        if outcome is HitOutcome.VALID_EXACT:
+            result = info
+            break
+        if result is None:
+            result = info
     if workspace.take_clamped_view_read():
         workspace.record_skip("sfx_scan", TierSkipReason.BUDGET_EXHAUSTED)
     # Charge the window actually examined — a miss is the expensive case.

--- a/src/archivey/internal/detection.py
+++ b/src/archivey/internal/detection.py
@@ -440,12 +440,10 @@ def _scan_for_sfx_payload(
     candidate-internal offset (today all zero for ZIP/RAR/7z; TAR ``ustar`` → 257 once
     that needle lands). The returned ``payload_offset`` is the **candidate origin**, not
     the raw needle position. A hit whose format-owned validator returns anything other
-    than :attr:`HitOutcome.VALID` / :attr:`HitOutcome.VALID_EXACT` is skipped and
-    the scan continues. ``VALID_EXACT`` (a 7z whose declared end equals known
-    remaining) returns immediately. ``VALID`` is remembered as the earliest
-    fallback and the scan keeps looking for a later ``VALID_EXACT``.
-    ``PROBABLE`` rather than ``CERTAIN``: an exact magic found at a *searched-for*
-    offset is a weaker claim than one found at the offset the format specifies.
+    than :attr:`HitOutcome.VALID` is skipped and the scan continues — earliest
+    *valid* match, not earliest needle. ``PROBABLE`` rather than ``CERTAIN``: an exact
+    magic found at a *searched-for* offset is a weaker claim than one found at the
+    offset the format specifies.
 
     ``scan_limit`` is the budget-clamped window (``min(SFX_MAX, budget.max_scan_bytes)``);
     the charge lands whether the scan hits or misses so the receipt reflects the work.
@@ -464,33 +462,23 @@ def _scan_for_sfx_payload(
     for hit in iter_magic_in_prefix(peek_more, needles, limit=scan_limit):
         entry = by_needle[hit.needle]
         validator = validators.get(entry.format)
-        if validator is None:
-            result = FormatInfo(
-                entry.format,
-                DetectionConfidence.PROBABLE,
-                "sfx_scan",
-                payload_offset=hit.candidate_origin,
+        if validator is not None:
+            view = workspace.candidate_view(hit.candidate_origin, limit=scan_limit)
+            source_len = workspace.remaining_known()
+            remaining = (
+                None
+                if source_len is None
+                else max(0, source_len - hit.candidate_origin)
             )
-            break
-        view = workspace.candidate_view(hit.candidate_origin, limit=scan_limit)
-        source_len = workspace.remaining_known()
-        remaining = (
-            None if source_len is None else max(0, source_len - hit.candidate_origin)
-        )
-        outcome = validator(view, remaining)
-        if outcome is HitOutcome.NOT_THIS_FORMAT or outcome is HitOutcome.DAMAGED:
-            continue
-        info = FormatInfo(
+            if validator(view, remaining) is not HitOutcome.VALID:
+                continue
+        result = FormatInfo(
             entry.format,
             DetectionConfidence.PROBABLE,
             "sfx_scan",
             payload_offset=hit.candidate_origin,
         )
-        if outcome is HitOutcome.VALID_EXACT:
-            result = info
-            break
-        if result is None:
-            result = info
+        break
     if workspace.take_clamped_view_read():
         workspace.record_skip("sfx_scan", TierSkipReason.BUDGET_EXHAUSTED)
     # Charge the window actually examined — a miss is the expensive case.

--- a/src/archivey/internal/detection.py
+++ b/src/archivey/internal/detection.py
@@ -77,6 +77,7 @@ from archivey.internal.sfx import (
     SFX_MAX,
     ExecutableCue,
     HitOutcome,
+    HitValidator,
     ScanNeedle,
     executable_cue,
     iter_magic_in_prefix,
@@ -430,7 +431,7 @@ def _scan_for_sfx_payload(
     workspace: PrefixWorkspace,
     *,
     scan_limit: int,
-    validators: dict[ArchiveFormat, Callable[[Callable[[int], bytes]], HitOutcome]],
+    validators: dict[ArchiveFormat, HitValidator],
     restrict_to_validated: bool,
 ) -> FormatInfo | None:
     """Search the SFX window for an appended archive, as ``(format, payload_offset)``.
@@ -463,7 +464,13 @@ def _scan_for_sfx_payload(
         validator = validators.get(entry.format)
         if validator is not None:
             view = workspace.candidate_view(hit.candidate_origin, limit=scan_limit)
-            if validator(view) is not HitOutcome.VALID:
+            source_len = workspace.remaining_known()
+            remaining = (
+                None
+                if source_len is None
+                else max(0, source_len - hit.candidate_origin)
+            )
+            if validator(view, remaining) is not HitOutcome.VALID:
                 continue
         result = FormatInfo(
             entry.format,

--- a/src/archivey/internal/rar_detect.py
+++ b/src/archivey/internal/rar_detect.py
@@ -15,8 +15,8 @@ from archivey.internal.backends.rar_parser import (
     RAR5_ID,
     RAR_ID,
     _crc32,
-    _load_vint,
-    _rar3_main_crc_end,
+    load_vint,
+    rar3_main_crc_end,
 )
 from archivey.internal.sfx import HitOutcome
 
@@ -32,14 +32,6 @@ _RAR5_ENCRYPTION = 4
 _RAR5_HEADER_CAP = 64 * 1024
 
 
-def _try_vint(buf: bytes, pos: int) -> tuple[int, int] | None:
-    """Parser vint, or ``None`` if truncated / too long (does not raise)."""
-    try:
-        return _load_vint(buf, pos)
-    except CorruptionError:
-        return None
-
-
 def validate_rar_main_header(
     peek_more: Callable[[int], bytes],
     remaining: int | None = None,
@@ -52,6 +44,10 @@ def validate_rar_main_header(
     the first block's CRC32 to match; a plausible header whose CRC fails is
     :attr:`HitOutcome.DAMAGED`. RAR 4 requires a parseable MAIN block (type
     ``0x73``) with a matching 16-bit header CRC.
+
+    ``peek_more`` stays outside the parse ``try`` so a workspace ``OSError``
+    propagates. A truncated vint before the CRC is ``NOT_THIS_FORMAT``; after
+    the CRC has matched, a later vint failure is ``DAMAGED``.
     """
     del remaining
     head = peek_more(len(RAR5_ID))
@@ -68,26 +64,28 @@ def _validate_rar5(peek_more: Callable[[int], bytes]) -> HitOutcome:
     if len(prefix) < len(RAR5_ID) + 5:
         return HitOutcome.NOT_THIS_FORMAT
     body = prefix[len(RAR5_ID) :]
-    loaded = _try_vint(body, 4)
-    if loaded is None:
+    try:
+        hdrlen, pos = load_vint(body, 4)
+    except CorruptionError:
         return HitOutcome.NOT_THIS_FORMAT
-    hdrlen, pos = loaded
     if hdrlen > _RAR5_HEADER_CAP:
         return HitOutcome.NOT_THIS_FORMAT
     header_size = pos + hdrlen
     hdata = peek_more(len(RAR5_ID) + header_size)[len(RAR5_ID) :]
     if len(hdata) < header_size:
         return HitOutcome.NOT_THIS_FORMAT
-    header_crc = int.from_bytes(hdata[:4], "little")
-    if header_crc != _crc32(memoryview(hdata)[4:]):
-        return HitOutcome.DAMAGED
-    block = _try_vint(hdata, pos)
-    if block is None:
-        return HitOutcome.NOT_THIS_FORMAT
-    block_type, _pos = block
-    if block_type not in (_RAR5_MAIN, _RAR5_ENCRYPTION):
-        return HitOutcome.NOT_THIS_FORMAT
-    return HitOutcome.VALID
+    identity_held = False
+    try:
+        header_crc = int.from_bytes(hdata[:4], "little")
+        if header_crc != _crc32(memoryview(hdata)[4:]):
+            return HitOutcome.DAMAGED
+        identity_held = True
+        block_type, _pos = load_vint(hdata, pos)
+        if block_type not in (_RAR5_MAIN, _RAR5_ENCRYPTION):
+            return HitOutcome.NOT_THIS_FORMAT
+        return HitOutcome.VALID
+    except CorruptionError:
+        return HitOutcome.DAMAGED if identity_held else HitOutcome.NOT_THIS_FORMAT
 
 
 def _validate_rar3(peek_more: Callable[[int], bytes]) -> HitOutcome:
@@ -103,7 +101,7 @@ def _validate_rar3(peek_more: Callable[[int], bytes]) -> HitOutcome:
     hdata = peek_more(len(RAR_ID) + header_size)[len(RAR_ID) :]
     if len(hdata) < header_size:
         return HitOutcome.NOT_THIS_FORMAT
-    crc_pos = _rar3_main_crc_end(flags)
+    crc_pos = rar3_main_crc_end(flags)
     if crc_pos > header_size:
         return HitOutcome.NOT_THIS_FORMAT
     calc = _crc32(hdata[2:crc_pos]) & 0xFFFF

--- a/src/archivey/internal/rar_detect.py
+++ b/src/archivey/internal/rar_detect.py
@@ -1,0 +1,133 @@
+"""Cheap RAR main-header identity check for the SFX scan.
+
+Seven or eight bytes of ``Rar!\\x1a\\x07`` in a stub are not a RAR. The cued
+scan calls :func:`validate_rar_main_header` with a candidate-relative view.
+"""
+
+from __future__ import annotations
+
+import struct
+import zlib
+from collections.abc import Callable
+
+from archivey.internal.backends.rar_parser import RAR5_ID, RAR_ID
+from archivey.internal.sfx import HitOutcome
+
+# RAR3 MAIN block type and the 7-byte block header (crc16, type, flags, size).
+_RAR3_MAIN = 0x73
+_RAR3_BLK_HDR = struct.Struct("<HBHH")
+# MAIN has 6 reserved bytes after the block header; LONG_BLOCK inserts a 4-byte
+# add_size before those (same walk as the parser); ENCRYPTVER adds one more
+# before the CRC coverage ends. Real MAIN headers are tens of bytes.
+_RAR3_MAIN_MIN = _RAR3_BLK_HDR.size + 6
+_RAR3_HEADER_CAP = 64 * 1024
+_RAR3_MAIN_ENCRYPTVER = 0x0200
+_RAR3_LONG_BLOCK = 0x8000
+
+# RAR5 MAIN / ENCRYPTION (encrypted-headers archive: first block is ENCRYPTION).
+_RAR5_MAIN = 1
+_RAR5_ENCRYPTION = 4
+# Identity only — a MAIN/ENCRYPTION header is small. Cap so a hostile vint
+# cannot force a 2 MiB peek (the F1 analogue).
+_RAR5_HEADER_CAP = 64 * 1024
+
+
+def _crc32(data: bytes | memoryview) -> int:
+    return zlib.crc32(data) & 0xFFFFFFFF
+
+
+def _load_vint(buf: bytes, pos: int) -> tuple[int, int] | None:
+    """RAR5 vint, or ``None`` if truncated / too long."""
+    length = len(buf)
+    if pos >= length:
+        return None
+    b = buf[pos]
+    if b < 0x80:
+        return b, pos + 1
+    limit = pos + 11
+    if limit > length:
+        limit = length
+    res = b & 0x7F
+    ofs = 7
+    pos += 1
+    while pos < limit:
+        b = buf[pos]
+        res += (b & 0x7F) << ofs
+        pos += 1
+        ofs += 7
+        if b < 0x80:
+            return res, pos
+    return None
+
+
+def validate_rar_main_header(peek_more: Callable[[int], bytes]) -> HitOutcome:
+    """Return whether a candidate origin looks like a RAR 4 or RAR 5 archive.
+
+    ``peek_more(n)`` is a view relative to the candidate. A truncated or
+    non-RAR magic is :attr:`HitOutcome.NOT_THIS_FORMAT`. RAR 5 requires the
+    first block's CRC32 to match; a plausible header whose CRC fails is
+    :attr:`HitOutcome.DAMAGED`. RAR 4 requires a parseable MAIN block (type
+    ``0x73``) with a matching 16-bit header CRC.
+    """
+    head = peek_more(len(RAR5_ID))
+    if head.startswith(RAR5_ID):
+        return _validate_rar5(peek_more)
+    if head.startswith(RAR_ID):
+        return _validate_rar3(peek_more)
+    return HitOutcome.NOT_THIS_FORMAT
+
+
+def _validate_rar5(peek_more: Callable[[int], bytes]) -> HitOutcome:
+    # Marker + CRC + a generous vint prefix, then the declared body.
+    prefix = peek_more(len(RAR5_ID) + 4 + 16)
+    if len(prefix) < len(RAR5_ID) + 5:
+        return HitOutcome.NOT_THIS_FORMAT
+    body = prefix[len(RAR5_ID) :]
+    loaded = _load_vint(body, 4)
+    if loaded is None:
+        return HitOutcome.NOT_THIS_FORMAT
+    hdrlen, pos = loaded
+    if hdrlen > _RAR5_HEADER_CAP:
+        return HitOutcome.NOT_THIS_FORMAT
+    header_size = pos + hdrlen
+    hdata = peek_more(len(RAR5_ID) + header_size)[len(RAR5_ID) :]
+    if len(hdata) < header_size:
+        return HitOutcome.NOT_THIS_FORMAT
+    header_crc = int.from_bytes(hdata[:4], "little")
+    if header_crc != _crc32(memoryview(hdata)[4:]):
+        return HitOutcome.DAMAGED
+    block = _load_vint(hdata, pos)
+    if block is None:
+        return HitOutcome.NOT_THIS_FORMAT
+    block_type, _pos = block
+    if block_type not in (_RAR5_MAIN, _RAR5_ENCRYPTION):
+        return HitOutcome.NOT_THIS_FORMAT
+    return HitOutcome.VALID
+
+
+def _validate_rar3(peek_more: Callable[[int], bytes]) -> HitOutcome:
+    start = peek_more(len(RAR_ID) + _RAR3_BLK_HDR.size)
+    if len(start) < len(RAR_ID) + _RAR3_BLK_HDR.size:
+        return HitOutcome.NOT_THIS_FORMAT
+    buf = start[len(RAR_ID) :]
+    header_crc, block_type, flags, header_size = _RAR3_BLK_HDR.unpack_from(buf)
+    if block_type != _RAR3_MAIN:
+        return HitOutcome.NOT_THIS_FORMAT
+    if header_size < _RAR3_MAIN_MIN or header_size > _RAR3_HEADER_CAP:
+        return HitOutcome.NOT_THIS_FORMAT
+    hdata = peek_more(len(RAR_ID) + header_size)[len(RAR_ID) :]
+    if len(hdata) < header_size:
+        return HitOutcome.NOT_THIS_FORMAT
+    # Mirror rar_parser._parse_rar3's MAIN CRC coverage, including LONG_BLOCK.
+    crc_pos = _RAR3_BLK_HDR.size
+    if flags & _RAR3_LONG_BLOCK:
+        crc_pos += 4
+    crc_pos += 6
+    if flags & _RAR3_MAIN_ENCRYPTVER:
+        crc_pos += 1
+    if crc_pos > header_size:
+        return HitOutcome.NOT_THIS_FORMAT
+    calc = _crc32(hdata[2:crc_pos]) & 0xFFFF
+    if header_crc != calc:
+        return HitOutcome.DAMAGED
+    return HitOutcome.VALID

--- a/src/archivey/internal/rar_detect.py
+++ b/src/archivey/internal/rar_detect.py
@@ -6,69 +6,54 @@ scan calls :func:`validate_rar_main_header` with a candidate-relative view.
 
 from __future__ import annotations
 
-import struct
-import zlib
 from collections.abc import Callable
 
-from archivey.internal.backends.rar_parser import RAR5_ID, RAR_ID
+from archivey.exceptions import CorruptionError
+from archivey.internal.backends.rar_parser import (
+    _RAR3_MAIN,
+    _S_BLK_HDR,
+    RAR5_ID,
+    RAR_ID,
+    _crc32,
+    _load_vint,
+    _rar3_main_crc_end,
+)
 from archivey.internal.sfx import HitOutcome
 
-# RAR3 MAIN block type and the 7-byte block header (crc16, type, flags, size).
-_RAR3_MAIN = 0x73
-_RAR3_BLK_HDR = struct.Struct("<HBHH")
-# MAIN has 6 reserved bytes after the block header; LONG_BLOCK inserts a 4-byte
-# add_size before those (same walk as the parser); ENCRYPTVER adds one more
-# before the CRC coverage ends. Real MAIN headers are tens of bytes.
-_RAR3_MAIN_MIN = _RAR3_BLK_HDR.size + 6
+# MAIN has 6 reserved bytes after the block header. Real MAIN headers are tens of bytes.
+_RAR3_MAIN_MIN = _S_BLK_HDR.size + 6
 _RAR3_HEADER_CAP = 64 * 1024
-_RAR3_MAIN_ENCRYPTVER = 0x0200
-_RAR3_LONG_BLOCK = 0x8000
 
 # RAR5 MAIN / ENCRYPTION (encrypted-headers archive: first block is ENCRYPTION).
 _RAR5_MAIN = 1
 _RAR5_ENCRYPTION = 4
 # Identity only — a MAIN/ENCRYPTION header is small. Cap so a hostile vint
-# cannot force a 2 MiB peek (the F1 analogue).
+# cannot force a 2 MiB peek.
 _RAR5_HEADER_CAP = 64 * 1024
 
 
-def _crc32(data: bytes | memoryview) -> int:
-    return zlib.crc32(data) & 0xFFFFFFFF
-
-
-def _load_vint(buf: bytes, pos: int) -> tuple[int, int] | None:
-    """RAR5 vint, or ``None`` if truncated / too long."""
-    length = len(buf)
-    if pos >= length:
+def _try_vint(buf: bytes, pos: int) -> tuple[int, int] | None:
+    """Parser vint, or ``None`` if truncated / too long (does not raise)."""
+    try:
+        return _load_vint(buf, pos)
+    except CorruptionError:
         return None
-    b = buf[pos]
-    if b < 0x80:
-        return b, pos + 1
-    limit = pos + 11
-    if limit > length:
-        limit = length
-    res = b & 0x7F
-    ofs = 7
-    pos += 1
-    while pos < limit:
-        b = buf[pos]
-        res += (b & 0x7F) << ofs
-        pos += 1
-        ofs += 7
-        if b < 0x80:
-            return res, pos
-    return None
 
 
-def validate_rar_main_header(peek_more: Callable[[int], bytes]) -> HitOutcome:
+def validate_rar_main_header(
+    peek_more: Callable[[int], bytes],
+    remaining: int | None = None,
+) -> HitOutcome:
     """Return whether a candidate origin looks like a RAR 4 or RAR 5 archive.
 
-    ``peek_more(n)`` is a view relative to the candidate. A truncated or
-    non-RAR magic is :attr:`HitOutcome.NOT_THIS_FORMAT`. RAR 5 requires the
-    first block's CRC32 to match; a plausible header whose CRC fails is
+    ``peek_more(n)`` is a view relative to the candidate. ``remaining`` is
+    unused: a RAR identity check never needs the source length. A truncated
+    or non-RAR magic is :attr:`HitOutcome.NOT_THIS_FORMAT`. RAR 5 requires
+    the first block's CRC32 to match; a plausible header whose CRC fails is
     :attr:`HitOutcome.DAMAGED`. RAR 4 requires a parseable MAIN block (type
     ``0x73``) with a matching 16-bit header CRC.
     """
+    del remaining
     head = peek_more(len(RAR5_ID))
     if head.startswith(RAR5_ID):
         return _validate_rar5(peek_more)
@@ -83,7 +68,7 @@ def _validate_rar5(peek_more: Callable[[int], bytes]) -> HitOutcome:
     if len(prefix) < len(RAR5_ID) + 5:
         return HitOutcome.NOT_THIS_FORMAT
     body = prefix[len(RAR5_ID) :]
-    loaded = _load_vint(body, 4)
+    loaded = _try_vint(body, 4)
     if loaded is None:
         return HitOutcome.NOT_THIS_FORMAT
     hdrlen, pos = loaded
@@ -96,7 +81,7 @@ def _validate_rar5(peek_more: Callable[[int], bytes]) -> HitOutcome:
     header_crc = int.from_bytes(hdata[:4], "little")
     if header_crc != _crc32(memoryview(hdata)[4:]):
         return HitOutcome.DAMAGED
-    block = _load_vint(hdata, pos)
+    block = _try_vint(hdata, pos)
     if block is None:
         return HitOutcome.NOT_THIS_FORMAT
     block_type, _pos = block
@@ -106,11 +91,11 @@ def _validate_rar5(peek_more: Callable[[int], bytes]) -> HitOutcome:
 
 
 def _validate_rar3(peek_more: Callable[[int], bytes]) -> HitOutcome:
-    start = peek_more(len(RAR_ID) + _RAR3_BLK_HDR.size)
-    if len(start) < len(RAR_ID) + _RAR3_BLK_HDR.size:
+    start = peek_more(len(RAR_ID) + _S_BLK_HDR.size)
+    if len(start) < len(RAR_ID) + _S_BLK_HDR.size:
         return HitOutcome.NOT_THIS_FORMAT
     buf = start[len(RAR_ID) :]
-    header_crc, block_type, flags, header_size = _RAR3_BLK_HDR.unpack_from(buf)
+    header_crc, block_type, flags, header_size = _S_BLK_HDR.unpack_from(buf)
     if block_type != _RAR3_MAIN:
         return HitOutcome.NOT_THIS_FORMAT
     if header_size < _RAR3_MAIN_MIN or header_size > _RAR3_HEADER_CAP:
@@ -118,13 +103,7 @@ def _validate_rar3(peek_more: Callable[[int], bytes]) -> HitOutcome:
     hdata = peek_more(len(RAR_ID) + header_size)[len(RAR_ID) :]
     if len(hdata) < header_size:
         return HitOutcome.NOT_THIS_FORMAT
-    # Mirror rar_parser._parse_rar3's MAIN CRC coverage, including LONG_BLOCK.
-    crc_pos = _RAR3_BLK_HDR.size
-    if flags & _RAR3_LONG_BLOCK:
-        crc_pos += 4
-    crc_pos += 6
-    if flags & _RAR3_MAIN_ENCRYPTVER:
-        crc_pos += 1
+    crc_pos = _rar3_main_crc_end(flags)
     if crc_pos > header_size:
         return HitOutcome.NOT_THIS_FORMAT
     calc = _crc32(hdata[2:crc_pos]) & 0xFFFF

--- a/src/archivey/internal/rar_detect.py
+++ b/src/archivey/internal/rar_detect.py
@@ -34,31 +34,48 @@ _RAR5_HEADER_CAP = 64 * 1024
 
 def validate_rar_main_header(
     peek_more: Callable[[int], bytes],
-    remaining: int | None = None,
+    remaining: int | None,
 ) -> HitOutcome:
     """Return whether a candidate origin looks like a RAR 4 or RAR 5 archive.
 
     ``peek_more(n)`` is a view relative to the candidate. ``remaining`` is
-    unused: a RAR identity check never needs the source length. A truncated
-    or non-RAR magic is :attr:`HitOutcome.NOT_THIS_FORMAT`. RAR 5 requires
-    the first block's CRC32 to match; a plausible header whose CRC fails is
-    :attr:`HitOutcome.DAMAGED`. RAR 4 requires a parseable MAIN block (type
-    ``0x73``) with a matching 16-bit header CRC.
+    provable bytes from the candidate to source EOF, or ``None`` if unknown.
+    A truncated or non-RAR magic is :attr:`HitOutcome.NOT_THIS_FORMAT`. RAR 5
+    requires the first block's CRC32 to match; a plausible header whose CRC
+    fails is :attr:`HitOutcome.DAMAGED`. RAR 4 requires a parseable MAIN block
+    (type ``0x73``) with a matching 16-bit header CRC.
 
-    ``peek_more`` stays outside the parse ``try`` so a workspace ``OSError``
-    propagates. A truncated vint before the CRC is ``NOT_THIS_FORMAT``; after
-    the CRC has matched, a later vint failure is ``DAMAGED``.
+    ``remaining`` distinguishes a genuine overrun from a scan-window clamp:
+    once the declared header size fits in ``remaining``, a short ``peek_more``
+    is not ``NOT_THIS_FORMAT``. ``peek_more`` stays outside the parse ``try``
+    so a workspace ``OSError`` propagates. A truncated vint before the CRC is
+    ``NOT_THIS_FORMAT``; after the CRC has matched, a later vint failure is
+    ``DAMAGED``.
     """
-    del remaining
     head = peek_more(len(RAR5_ID))
     if head.startswith(RAR5_ID):
-        return _validate_rar5(peek_more)
+        return _validate_rar5(peek_more, remaining)
     if head.startswith(RAR_ID):
-        return _validate_rar3(peek_more)
+        return _validate_rar3(peek_more, remaining)
     return HitOutcome.NOT_THIS_FORMAT
 
 
-def _validate_rar5(peek_more: Callable[[int], bytes]) -> HitOutcome:
+def _header_in_hand(got: int, needed: int, remaining: int | None) -> HitOutcome | None:
+    """``None`` if ``got`` covers ``needed``; otherwise the outcome for a short peek.
+
+    A known ``remaining`` that already covers ``needed`` means the bytes exist
+    past a scan-window clamp, so a short peek is :attr:`HitOutcome.VALID`.
+    """
+    if got >= needed:
+        return None
+    if remaining is not None and needed <= remaining:
+        return HitOutcome.VALID
+    return HitOutcome.NOT_THIS_FORMAT
+
+
+def _validate_rar5(
+    peek_more: Callable[[int], bytes], remaining: int | None
+) -> HitOutcome:
     # Marker + CRC + a generous vint prefix, then the declared body.
     prefix = peek_more(len(RAR5_ID) + 4 + 16)
     if len(prefix) < len(RAR5_ID) + 5:
@@ -71,9 +88,13 @@ def _validate_rar5(peek_more: Callable[[int], bytes]) -> HitOutcome:
     if hdrlen > _RAR5_HEADER_CAP:
         return HitOutcome.NOT_THIS_FORMAT
     header_size = pos + hdrlen
-    hdata = peek_more(len(RAR5_ID) + header_size)[len(RAR5_ID) :]
-    if len(hdata) < header_size:
+    needed = len(RAR5_ID) + header_size
+    if remaining is not None and needed > remaining:
         return HitOutcome.NOT_THIS_FORMAT
+    hdata = peek_more(needed)[len(RAR5_ID) :]
+    short = _header_in_hand(len(hdata), header_size, remaining)
+    if short is not None:
+        return short
     identity_held = False
     try:
         header_crc = int.from_bytes(hdata[:4], "little")
@@ -88,7 +109,9 @@ def _validate_rar5(peek_more: Callable[[int], bytes]) -> HitOutcome:
         return HitOutcome.DAMAGED if identity_held else HitOutcome.NOT_THIS_FORMAT
 
 
-def _validate_rar3(peek_more: Callable[[int], bytes]) -> HitOutcome:
+def _validate_rar3(
+    peek_more: Callable[[int], bytes], remaining: int | None
+) -> HitOutcome:
     start = peek_more(len(RAR_ID) + _S_BLK_HDR.size)
     if len(start) < len(RAR_ID) + _S_BLK_HDR.size:
         return HitOutcome.NOT_THIS_FORMAT
@@ -98,9 +121,13 @@ def _validate_rar3(peek_more: Callable[[int], bytes]) -> HitOutcome:
         return HitOutcome.NOT_THIS_FORMAT
     if header_size < _RAR3_MAIN_MIN or header_size > _RAR3_HEADER_CAP:
         return HitOutcome.NOT_THIS_FORMAT
-    hdata = peek_more(len(RAR_ID) + header_size)[len(RAR_ID) :]
-    if len(hdata) < header_size:
+    needed = len(RAR_ID) + header_size
+    if remaining is not None and needed > remaining:
         return HitOutcome.NOT_THIS_FORMAT
+    hdata = peek_more(needed)[len(RAR_ID) :]
+    short = _header_in_hand(len(hdata), header_size, remaining)
+    if short is not None:
+        return short
     crc_pos = rar3_main_crc_end(flags)
     if crc_pos > header_size:
         return HitOutcome.NOT_THIS_FORMAT

--- a/src/archivey/internal/registry.py
+++ b/src/archivey/internal/registry.py
@@ -205,8 +205,8 @@ class BackendRegistry:
         """Format-owned checks the SFX scan calls on a candidate-relative view.
 
         Collected from ``ReadBackend.SFX_HIT_VALIDATOR`` next to ``SFX_MAGIC``. A
-        missing validator means a needle match is enough (RAR / 7z today). ZIP's
-        local-header sanity check lives here so ``detection.py`` does not parse ZIP.
+        missing validator means a needle match is enough. ZIP, 7z, and RAR each
+        supply one so ``detection.py`` does not parse those formats.
         """
         mapping: dict[
             ArchiveFormat, Callable[[Callable[[int], bytes]], HitOutcome]

--- a/src/archivey/internal/registry.py
+++ b/src/archivey/internal/registry.py
@@ -26,7 +26,7 @@ from archivey.exceptions import (
     UnsupportedOperationError,
 )
 from archivey.internal.format_args import check_archive_format
-from archivey.internal.sfx import HitOutcome
+from archivey.internal.sfx import HitValidator
 from archivey.internal.streams.codecs import (
     SINGLE_FILE_CODECS,
     STREAM_CODECS,
@@ -201,16 +201,14 @@ class BackendRegistry:
 
     def sfx_hit_validators(
         self,
-    ) -> dict[ArchiveFormat, Callable[[Callable[[int], bytes]], HitOutcome]]:
+    ) -> dict[ArchiveFormat, HitValidator]:
         """Format-owned checks the SFX scan calls on a candidate-relative view.
 
         Collected from ``ReadBackend.SFX_HIT_VALIDATOR`` next to ``SFX_MAGIC``. A
         missing validator means a needle match is enough. ZIP, 7z, and RAR each
         supply one so ``detection.py`` does not parse those formats.
         """
-        mapping: dict[
-            ArchiveFormat, Callable[[Callable[[int], bytes]], HitOutcome]
-        ] = {}
+        mapping: dict[ArchiveFormat, HitValidator] = {}
         for cls in self._reader_classes:
             validator = cls.SFX_HIT_VALIDATOR
             if validator is None:

--- a/src/archivey/internal/sevenzip_detect.py
+++ b/src/archivey/internal/sevenzip_detect.py
@@ -1,0 +1,70 @@
+"""Cheap 7z signature-header identity check for the SFX scan.
+
+Six bytes of ``7z\\xbc\\xaf\\x1c`` in a stub are not a 7z. The cued scan calls
+:func:`validate_sevenzip_signature_header` with a candidate-relative view.
+"""
+
+from __future__ import annotations
+
+import struct
+import zlib
+from collections.abc import Callable
+
+from archivey.internal.backends.sevenzip_parser import MAGIC_7Z
+from archivey.internal.sfx import SFX_MAX, HitOutcome
+
+_SIGNATURE_HEADER_SIZE = 32
+# Same cap the parser uses before seeking/allocating a next-header. Real headers
+# are kilobytes; tens of MiB is already past any legitimate archive.
+_MAX_NEXT_HEADER_SIZE = 64 << 20
+# 7z writes major version 0. Anything else is not a signature we can confirm.
+_MAJOR_VERSION = 0
+
+
+def _crc32(data: bytes) -> int:
+    return zlib.crc32(data) & 0xFFFFFFFF
+
+
+def validate_sevenzip_signature_header(peek_more: Callable[[int], bytes]) -> HitOutcome:
+    """Return whether a candidate origin looks like a 7z signature header.
+
+    ``peek_more(n)`` is a view relative to the candidate, not the source. A
+    truncated or non-7z magic is :attr:`HitOutcome.NOT_THIS_FORMAT`. A 7z
+    magic whose ``StartHeaderCRC`` fails is :attr:`HitOutcome.DAMAGED` — identity
+    held, structure did not. The scan treats that like ``NOT_THIS_FORMAT``
+    (skip, continue); the evidence-ledger scheduler may later report it.
+
+    ``offset + 32 + NextHeaderOffset + NextHeaderSize`` must fall at or before
+    the end of the *view*. A declared end past :data:`~archivey.internal.sfx.SFX_MAX`
+    is a real archive whose next header sits outside the scan window — CRC
+    passing is enough; do not grow the prefix to chase it (the F1 analogue).
+    Exact-EOF vs trailing bytes is not a reject: some SFX tools append
+    configuration after the payload. Earliest CRC-valid hit wins; a 32-bit CRC
+    decoy in front of a real archive is the intra-format case the scan already
+    skips.
+    """
+    header = peek_more(_SIGNATURE_HEADER_SIZE)
+    if len(header) < _SIGNATURE_HEADER_SIZE or header[: len(MAGIC_7Z)] != MAGIC_7Z:
+        return HitOutcome.NOT_THIS_FORMAT
+    major_version = header[6]
+    if major_version != _MAJOR_VERSION:
+        return HitOutcome.NOT_THIS_FORMAT
+    start_header_crc = int.from_bytes(header[8:12], "little")
+    start_header = header[12:32]
+    if _crc32(start_header) != start_header_crc:
+        return HitOutcome.DAMAGED
+    next_header_offset, next_header_size, _next_header_crc = struct.unpack(
+        "<QQI", start_header
+    )
+    if next_header_size > _MAX_NEXT_HEADER_SIZE:
+        return HitOutcome.NOT_THIS_FORMAT
+    declared = _SIGNATURE_HEADER_SIZE + next_header_offset + next_header_size
+    if declared < _SIGNATURE_HEADER_SIZE:
+        return HitOutcome.NOT_THIS_FORMAT
+    # Only confirm the declared end when it sits inside the scan window. A
+    # next-header past SFX_MAX is a large archive, not an overrun we can see.
+    if declared <= SFX_MAX:
+        got = peek_more(declared)
+        if len(got) < declared:
+            return HitOutcome.NOT_THIS_FORMAT
+    return HitOutcome.VALID

--- a/src/archivey/internal/sevenzip_detect.py
+++ b/src/archivey/internal/sevenzip_detect.py
@@ -1,47 +1,44 @@
 """Cheap 7z signature-header identity check for the SFX scan.
 
 Six bytes of ``7z\\xbc\\xaf\\x1c`` in a stub are not a 7z. The cued scan calls
-:func:`validate_sevenzip_signature_header` with a candidate-relative view.
+:func:`validate_sevenzip_signature_header` with a candidate-relative view and
+the known remaining length from that origin.
 """
 
 from __future__ import annotations
 
 import struct
-import zlib
 from collections.abc import Callable
 
-from archivey.internal.backends.sevenzip_parser import MAGIC_7Z
-from archivey.internal.sfx import SFX_MAX, HitOutcome
+from archivey.internal.backends.sevenzip_parser import (
+    _MAX_NEXT_HEADER_SIZE,
+    _SIGNATURE_HEADER_SIZE,
+    MAGIC_7Z,
+    _crc32,
+)
+from archivey.internal.sfx import HitOutcome
 
-_SIGNATURE_HEADER_SIZE = 32
-# Same cap the parser uses before seeking/allocating a next-header. Real headers
-# are kilobytes; tens of MiB is already past any legitimate archive.
-_MAX_NEXT_HEADER_SIZE = 64 << 20
 # 7z writes major version 0. Anything else is not a signature we can confirm.
 _MAJOR_VERSION = 0
 
 
-def _crc32(data: bytes) -> int:
-    return zlib.crc32(data) & 0xFFFFFFFF
-
-
-def validate_sevenzip_signature_header(peek_more: Callable[[int], bytes]) -> HitOutcome:
+def validate_sevenzip_signature_header(
+    peek_more: Callable[[int], bytes],
+    remaining: int | None = None,
+) -> HitOutcome:
     """Return whether a candidate origin looks like a 7z signature header.
 
-    ``peek_more(n)`` is a view relative to the candidate, not the source. A
-    truncated or non-7z magic is :attr:`HitOutcome.NOT_THIS_FORMAT`. A 7z
-    magic whose ``StartHeaderCRC`` fails is :attr:`HitOutcome.DAMAGED` — identity
-    held, structure did not. The scan treats that like ``NOT_THIS_FORMAT``
-    (skip, continue); the evidence-ledger scheduler may later report it.
+    ``peek_more(n)`` is a view relative to the candidate, not the source.
+    ``remaining`` is provable bytes from the candidate to source EOF, or
+    ``None`` if unknown. A truncated or non-7z magic is
+    :attr:`HitOutcome.NOT_THIS_FORMAT`. After ``StartHeaderCRC`` matches,
+    identity has held: an oversized next-header or a declared end past
+    ``remaining`` is :attr:`HitOutcome.DAMAGED`. When ``remaining`` is
+    unknown, CRC passing is enough — do not peek the declared end (that
+    would grow the prefix to the whole archive).
 
-    ``offset + 32 + NextHeaderOffset + NextHeaderSize`` must fall at or before
-    the end of the *view*. A declared end past :data:`~archivey.internal.sfx.SFX_MAX`
-    is a real archive whose next header sits outside the scan window — CRC
-    passing is enough; do not grow the prefix to chase it (the F1 analogue).
     Exact-EOF vs trailing bytes is not a reject: some SFX tools append
-    configuration after the payload. Earliest CRC-valid hit wins; a 32-bit CRC
-    decoy in front of a real archive is the intra-format case the scan already
-    skips.
+    configuration after the payload. Earliest CRC-valid hit wins.
     """
     header = peek_more(_SIGNATURE_HEADER_SIZE)
     if len(header) < _SIGNATURE_HEADER_SIZE or header[: len(MAGIC_7Z)] != MAGIC_7Z:
@@ -57,14 +54,8 @@ def validate_sevenzip_signature_header(peek_more: Callable[[int], bytes]) -> Hit
         "<QQI", start_header
     )
     if next_header_size > _MAX_NEXT_HEADER_SIZE:
-        return HitOutcome.NOT_THIS_FORMAT
+        return HitOutcome.DAMAGED
     declared = _SIGNATURE_HEADER_SIZE + next_header_offset + next_header_size
-    if declared < _SIGNATURE_HEADER_SIZE:
-        return HitOutcome.NOT_THIS_FORMAT
-    # Only confirm the declared end when it sits inside the scan window. A
-    # next-header past SFX_MAX is a large archive, not an overrun we can see.
-    if declared <= SFX_MAX:
-        got = peek_more(declared)
-        if len(got) < declared:
-            return HitOutcome.NOT_THIS_FORMAT
+    if remaining is not None and declared > remaining:
+        return HitOutcome.DAMAGED
     return HitOutcome.VALID

--- a/src/archivey/internal/sevenzip_detect.py
+++ b/src/archivey/internal/sevenzip_detect.py
@@ -39,12 +39,14 @@ def validate_sevenzip_signature_header(
 
     An empty next-header (``NextHeaderSize == 0``) is not an SFX payload —
     nobody ships a self-extractor with no files — so that is
-    :attr:`HitOutcome.NOT_THIS_FORMAT` even when the CRC is valid.
+    :attr:`HitOutcome.NOT_THIS_FORMAT` even when the CRC is valid. This
+    validator is the scan path only: a genuine empty ``.7z`` is claimed by
+    near magic at offset 0 and never reaches here.
 
-    When ``remaining`` is known and equals the declared end, the outcome is
-    :attr:`HitOutcome.VALID_EXACT` ("this 7z ends at EOF"), not a ranking
-    score. Trailing bytes after a CRC-valid header stay ``VALID``; the scan
-    prefers a later ``VALID_EXACT`` over an earlier ``VALID``.
+    Exact-EOF versus trailing bytes is not a reject: some SFX tools append
+    configuration after the payload. Earliest CRC-valid hit still wins;
+    preferring an exact end among several ``VALID`` hits is the unlanded
+    remainder of task 2.3.
     """
     header = peek_more(_SIGNATURE_HEADER_SIZE)
     if len(header) < _SIGNATURE_HEADER_SIZE or header[: len(MAGIC_7Z)] != MAGIC_7Z:
@@ -66,6 +68,4 @@ def validate_sevenzip_signature_header(
     declared = _SIGNATURE_HEADER_SIZE + next_header_offset + next_header_size
     if remaining is not None and declared > remaining:
         return HitOutcome.DAMAGED
-    if remaining is not None and declared == remaining:
-        return HitOutcome.VALID_EXACT
     return HitOutcome.VALID

--- a/src/archivey/internal/sevenzip_detect.py
+++ b/src/archivey/internal/sevenzip_detect.py
@@ -37,8 +37,14 @@ def validate_sevenzip_signature_header(
     unknown, CRC passing is enough — do not peek the declared end (that
     would grow the prefix to the whole archive).
 
-    Exact-EOF vs trailing bytes is not a reject: some SFX tools append
-    configuration after the payload. Earliest CRC-valid hit wins.
+    An empty next-header (``NextHeaderSize == 0``) is not an SFX payload —
+    nobody ships a self-extractor with no files — so that is
+    :attr:`HitOutcome.NOT_THIS_FORMAT` even when the CRC is valid.
+
+    When ``remaining`` is known and equals the declared end, the outcome is
+    :attr:`HitOutcome.VALID_EXACT` ("this 7z ends at EOF"), not a ranking
+    score. Trailing bytes after a CRC-valid header stay ``VALID``; the scan
+    prefers a later ``VALID_EXACT`` over an earlier ``VALID``.
     """
     header = peek_more(_SIGNATURE_HEADER_SIZE)
     if len(header) < _SIGNATURE_HEADER_SIZE or header[: len(MAGIC_7Z)] != MAGIC_7Z:
@@ -53,9 +59,13 @@ def validate_sevenzip_signature_header(
     next_header_offset, next_header_size, _next_header_crc = struct.unpack(
         "<QQI", start_header
     )
+    if next_header_size == 0:
+        return HitOutcome.NOT_THIS_FORMAT
     if next_header_size > _MAX_NEXT_HEADER_SIZE:
         return HitOutcome.DAMAGED
     declared = _SIGNATURE_HEADER_SIZE + next_header_offset + next_header_size
     if remaining is not None and declared > remaining:
         return HitOutcome.DAMAGED
+    if remaining is not None and declared == remaining:
+        return HitOutcome.VALID_EXACT
     return HitOutcome.VALID

--- a/src/archivey/internal/sevenzip_detect.py
+++ b/src/archivey/internal/sevenzip_detect.py
@@ -24,7 +24,7 @@ _MAJOR_VERSION = 0
 
 def validate_sevenzip_signature_header(
     peek_more: Callable[[int], bytes],
-    remaining: int | None = None,
+    remaining: int | None,
 ) -> HitOutcome:
     """Return whether a candidate origin looks like a 7z signature header.
 

--- a/src/archivey/internal/sfx.py
+++ b/src/archivey/internal/sfx.py
@@ -98,14 +98,14 @@ class HitValidator(Protocol):
     ``remaining`` is provable bytes from the *candidate origin* to source EOF
     (``workspace.remaining_known() - candidate_origin``), or ``None`` when the
     source length is unknown. It is a length, not a peek budget — do not confuse
-    it with ``scan_limit``. Default ``None`` keeps unit tests and one-arg calls
-    working.
+    it with ``scan_limit``. The scan always passes it; ``None`` is a value, not
+    an omitted argument.
     """
 
     def __call__(
         self,
         peek_more: Callable[[int], bytes],
-        remaining: int | None = None,
+        remaining: int | None,
     ) -> HitOutcome: ...
 
 

--- a/src/archivey/internal/sfx.py
+++ b/src/archivey/internal/sfx.py
@@ -80,12 +80,6 @@ class HitOutcome(Enum):
 
     ``NOT_THIS_FORMAT`` — identity never held (decoy magic, unparseable header).
     ``VALID`` — identity and cheap structure both hold.
-    ``VALID_EXACT`` — ``VALID``, and the format could prove the payload ends at
-    EOF (today: a 7z whose declared end equals known remaining). This is not a
-    "better candidate" score — ZIP and RAR cannot produce it, because neither
-    header declares a total size. The SFX scan returns immediately on
-    ``VALID_EXACT``; otherwise it remembers the earliest ``VALID`` and keeps
-    looking. Ledger tasks 3.3 / 4.6 / 4.7 read this enum.
     ``DAMAGED`` — identity holds, structure does not (a 7z whose ``StartHeaderCRC``
     fails, or whose declared end overruns the source). This change's first-match
     scan treats ``DAMAGED`` like ``NOT_THIS_FORMAT`` (skip, continue). The later
@@ -95,7 +89,6 @@ class HitOutcome(Enum):
 
     NOT_THIS_FORMAT = "not_this_format"
     VALID = "valid"
-    VALID_EXACT = "valid_exact"
     DAMAGED = "damaged"
 
 

--- a/src/archivey/internal/sfx.py
+++ b/src/archivey/internal/sfx.py
@@ -80,6 +80,12 @@ class HitOutcome(Enum):
 
     ``NOT_THIS_FORMAT`` — identity never held (decoy magic, unparseable header).
     ``VALID`` — identity and cheap structure both hold.
+    ``VALID_EXACT`` — ``VALID``, and the format could prove the payload ends at
+    EOF (today: a 7z whose declared end equals known remaining). This is not a
+    "better candidate" score — ZIP and RAR cannot produce it, because neither
+    header declares a total size. The SFX scan returns immediately on
+    ``VALID_EXACT``; otherwise it remembers the earliest ``VALID`` and keeps
+    looking. Ledger tasks 3.3 / 4.6 / 4.7 read this enum.
     ``DAMAGED`` — identity holds, structure does not (a 7z whose ``StartHeaderCRC``
     fails, or whose declared end overruns the source). This change's first-match
     scan treats ``DAMAGED`` like ``NOT_THIS_FORMAT`` (skip, continue). The later
@@ -89,6 +95,7 @@ class HitOutcome(Enum):
 
     NOT_THIS_FORMAT = "not_this_format"
     VALID = "valid"
+    VALID_EXACT = "valid_exact"
     DAMAGED = "damaged"
 
 

--- a/src/archivey/internal/sfx.py
+++ b/src/archivey/internal/sfx.py
@@ -33,7 +33,7 @@ from __future__ import annotations
 import struct
 from collections.abc import Iterator
 from enum import Enum
-from typing import BinaryIO, Callable, NamedTuple, Sequence
+from typing import BinaryIO, Callable, NamedTuple, Protocol, Sequence
 
 # How far past the start of a source the archive magic may sit before we stop looking.
 # 2 MiB comfortably covers real stubs (a `rar a -sfx` ELF stub is ~250 KB, and Windows
@@ -81,14 +81,32 @@ class HitOutcome(Enum):
     ``NOT_THIS_FORMAT`` — identity never held (decoy magic, unparseable header).
     ``VALID`` — identity and cheap structure both hold.
     ``DAMAGED`` — identity holds, structure does not (a 7z whose ``StartHeaderCRC``
-    fails). This change's first-match scan treats ``DAMAGED`` like
-    ``NOT_THIS_FORMAT`` (skip, continue). The later evidence-ledger scheduler may
-    treat ``DAMAGED`` as a still-identified candidate without changing this enum.
+    fails, or whose declared end overruns the source). This change's first-match
+    scan treats ``DAMAGED`` like ``NOT_THIS_FORMAT`` (skip, continue). The later
+    evidence-ledger scheduler may treat ``DAMAGED`` as a still-identified candidate
+    without changing this enum.
     """
 
     NOT_THIS_FORMAT = "not_this_format"
     VALID = "valid"
     DAMAGED = "damaged"
+
+
+class HitValidator(Protocol):
+    """Format-owned SFX scan check: candidate-relative view plus known remaining.
+
+    ``remaining`` is provable bytes from the *candidate origin* to source EOF
+    (``workspace.remaining_known() - candidate_origin``), or ``None`` when the
+    source length is unknown. It is a length, not a peek budget — do not confuse
+    it with ``scan_limit``. Default ``None`` keeps unit tests and one-arg calls
+    working.
+    """
+
+    def __call__(
+        self,
+        peek_more: Callable[[int], bytes],
+        remaining: int | None = None,
+    ) -> HitOutcome: ...
 
 
 class ExecutableCue(Enum):

--- a/src/archivey/internal/zip_detect.py
+++ b/src/archivey/internal/zip_detect.py
@@ -57,7 +57,7 @@ _KNOWN_METHODS = frozenset(
 
 def validate_zip_local_header(
     peek_more: Callable[[int], bytes],
-    remaining: int | None = None,
+    remaining: int | None,
 ) -> HitOutcome:
     """Return whether a candidate origin looks like a ZIP local file header.
 
@@ -67,6 +67,11 @@ def validate_zip_local_header(
     method, or name/extra lengths that overrun the source is
     :attr:`HitOutcome.NOT_THIS_FORMAT` — identity never held. This check
     does not return :attr:`HitOutcome.DAMAGED`.
+
+    When ``remaining`` is known, name/extra existence is a length compare:
+    a short ``peek_more`` can only mean the candidate view was clamped by
+    ``scan_limit``, which is not evidence against ZIP. When ``remaining`` is
+    unknown, a short peek is still ``NOT_THIS_FORMAT``.
     """
     header = peek_more(_LOCAL_HEADER_SIZE)
     if len(header) < _LOCAL_HEADER_SIZE or header[:4] != _LOCAL_HEADER_MAGIC:
@@ -94,8 +99,10 @@ def validate_zip_local_header(
     if name_len == 0:
         return HitOutcome.NOT_THIS_FORMAT
     needed = _LOCAL_HEADER_SIZE + name_len + extra_len
-    if remaining is not None and needed > remaining:
-        return HitOutcome.NOT_THIS_FORMAT
+    if remaining is not None:
+        if needed > remaining:
+            return HitOutcome.NOT_THIS_FORMAT
+        return HitOutcome.VALID
     rest = peek_more(needed)
     if len(rest) < needed:
         return HitOutcome.NOT_THIS_FORMAT

--- a/src/archivey/internal/zip_detect.py
+++ b/src/archivey/internal/zip_detect.py
@@ -55,13 +55,18 @@ _KNOWN_METHODS = frozenset(
 )
 
 
-def validate_zip_local_header(peek_more: Callable[[int], bytes]) -> HitOutcome:
+def validate_zip_local_header(
+    peek_more: Callable[[int], bytes],
+    remaining: int | None = None,
+) -> HitOutcome:
     """Return whether a candidate origin looks like a ZIP local file header.
 
-    ``peek_more(n)`` is a view relative to the candidate, not the source. A
-    truncated header, reserved flags, an unknown method, or name/extra lengths
-    that overruns the remaining bytes is :attr:`HitOutcome.NOT_THIS_FORMAT` —
-    identity never held. This check does not return :attr:`HitOutcome.DAMAGED`.
+    ``peek_more(n)`` is a view relative to the candidate, not the source.
+    ``remaining`` is provable bytes from the candidate to source EOF, or
+    ``None`` if unknown. A truncated header, reserved flags, an unknown
+    method, or name/extra lengths that overrun the source is
+    :attr:`HitOutcome.NOT_THIS_FORMAT` — identity never held. This check
+    does not return :attr:`HitOutcome.DAMAGED`.
     """
     header = peek_more(_LOCAL_HEADER_SIZE)
     if len(header) < _LOCAL_HEADER_SIZE or header[:4] != _LOCAL_HEADER_MAGIC:
@@ -89,6 +94,8 @@ def validate_zip_local_header(peek_more: Callable[[int], bytes]) -> HitOutcome:
     if name_len == 0:
         return HitOutcome.NOT_THIS_FORMAT
     needed = _LOCAL_HEADER_SIZE + name_len + extra_len
+    if remaining is not None and needed > remaining:
+        return HitOutcome.NOT_THIS_FORMAT
     rest = peek_more(needed)
     if len(rest) < needed:
         return HitOutcome.NOT_THIS_FORMAT

--- a/tests/test_rar_reader.py
+++ b/tests/test_rar_reader.py
@@ -24,7 +24,7 @@ from archivey.internal.backends import rar_reader, rar_unrar
 from archivey.internal.backends.rar_parser import (
     RAR5_ID,
     RAR_ID,
-    _load_vint,
+    load_vint,
     parse_rar_archive,
 )
 from archivey.types import HashAlgorithm, MemberType
@@ -821,17 +821,17 @@ def test_rar5_header_size_vint_is_bounded() -> None:
 
 def test_load_vint_single_and_multi_byte() -> None:
     """RAR5 vint decode: single-byte hot path and multi-byte continuation agree."""
-    assert _load_vint(b"\x00", 0) == (0, 1)
-    assert _load_vint(b"\x7f", 0) == (127, 1)
-    assert _load_vint(bytes([0x80 | 1, 0x02]), 0) == (1 + (2 << 7), 2)
+    assert load_vint(b"\x00", 0) == (0, 1)
+    assert load_vint(b"\x7f", 0) == (127, 1)
+    assert load_vint(bytes([0x80 | 1, 0x02]), 0) == (1 + (2 << 7), 2)
     # Non-zero start offset (rewrite bound is relative to ``pos``, not buffer start).
-    assert _load_vint(b"\xff" + bytes([0x80 | 1, 0x02]), 1) == (1 + (2 << 7), 3)
+    assert load_vint(b"\xff" + bytes([0x80 | 1, 0x02]), 1) == (1 + (2 << 7), 3)
     # Maximum-length valid vint: 10 continuation bytes + terminator.
-    assert _load_vint(b"\x80" * 10 + b"\x01", 0) == (1 << 70, 11)
+    assert load_vint(b"\x80" * 10 + b"\x01", 0) == (1 << 70, 11)
     with pytest.raises(CorruptionError):
-        _load_vint(b"", 0)
+        load_vint(b"", 0)
     with pytest.raises(CorruptionError):
-        _load_vint(b"\x80" * 11, 0)
+        load_vint(b"\x80" * 11, 0)
 
 
 def test_unrar_member_include_switch_rejects_wildcards() -> None:

--- a/tests/test_sfx.py
+++ b/tests/test_sfx.py
@@ -787,7 +787,7 @@ def _crc_damaged_sevenzip_signature() -> bytes:
         pytest.param(
             (_SEVENZIP_FIXTURES / "lz4.7z").read_bytes(),
             len((_SEVENZIP_FIXTURES / "lz4.7z").read_bytes()),
-            HitOutcome.VALID_EXACT,
+            HitOutcome.VALID,
             id="real-fixture-exact-eof",
         ),
         pytest.param(MAGIC_7Z, None, HitOutcome.NOT_THIS_FORMAT, id="truncated-magic"),
@@ -830,7 +830,7 @@ def _crc_damaged_sevenzip_signature() -> bytes:
         pytest.param(
             _sevenzip_signature(next_offset=0, next_size=10),
             _SIGNATURE_HEADER_SIZE + 10,
-            HitOutcome.VALID_EXACT,
+            HitOutcome.VALID,
             id="declared-end-equals-remaining",
         ),
         pytest.param(
@@ -867,10 +867,7 @@ def test_sevenzip_validator_peeks_only_the_signature_header() -> None:
         return (sig + bytes(n))[:n]
 
     remaining = _SIGNATURE_HEADER_SIZE + next_offset + 64
-    assert (
-        validate_sevenzip_signature_header(peek_more, remaining)
-        is HitOutcome.VALID_EXACT
-    )
+    assert validate_sevenzip_signature_header(peek_more, remaining) is HitOutcome.VALID
     assert peeked == [_SIGNATURE_HEADER_SIZE]
 
 
@@ -1000,33 +997,31 @@ def test_crc_valid_empty_7z_decoy_is_skipped_for_the_real_payload(
         assert any(m.is_file for m in archive.members())
 
 
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "Exact-EOF ranking among CRC-valid 7z hits is the unlanded remainder of "
+        "task 2.3; first VALID still wins. See dev-docs/known-issues.md."
+    ),
+)
 def test_inexact_7z_decoy_loses_to_a_later_exact_payload(tmp_path: Path) -> None:
-    """VALID_EXACT on the real payload beats an earlier CRC-valid inexact decoy (D2(a))."""
+    """Red half: a later exact 7z payload should beat an earlier CRC-valid inexact decoy.
+
+    The decoy at 512 is a CRC-valid signature whose declared end is nonzero,
+    self-consistent, and inside ``remaining`` — so the empty-header reject does
+    not apply. Today's first-VALID scan reports that decoy. The contract is the
+    real payload at 3544.
+    """
     decoy = _sevenzip_signature(next_offset=100, next_size=10)
-    stub = b"MZ" + b"\x00" * 510 + decoy
+    prefix = b"MZ" + b"\x00" * 510 + decoy
     real = (_SEVENZIP_FIXTURES / "lz4.7z").read_bytes()
+    real_origin = 3544
     path = tmp_path / "inexact-decoy-7z.exe"
-    path.write_bytes(stub + b"\x00" * 64 + real)
-    real_origin = len(stub) + 64
+    path.write_bytes(prefix + b"\x00" * (real_origin - len(prefix)) + real)
     detected = detect_format(path)
     assert detected.format == ArchiveFormat.SEVEN_Z
     assert detected.detected_by == "sfx_scan"
     assert detected.payload_offset == real_origin
-
-
-def test_inexact_7z_decoy_still_wins_when_the_real_payload_has_trailing_bytes(
-    tmp_path: Path,
-) -> None:
-    """Residual: neither hit is exact, so earliest VALID still wins (D2(b) pin)."""
-    decoy = _sevenzip_signature(next_offset=100, next_size=10)
-    stub = b"MZ" + b"\x00" * 510 + decoy
-    real = (_SEVENZIP_FIXTURES / "lz4.7z").read_bytes()
-    path = tmp_path / "inexact-decoy-trailing-7z.exe"
-    path.write_bytes(stub + b"\x00" * 64 + real + b"sfx-config\n")
-    detected = detect_format(path)
-    assert detected.format == ArchiveFormat.SEVEN_Z
-    assert detected.detected_by == "sfx_scan"
-    assert detected.payload_offset == 512
 
 
 @requires("py7zr")

--- a/tests/test_sfx.py
+++ b/tests/test_sfx.py
@@ -784,9 +784,18 @@ def _crc_damaged_sevenzip_signature() -> bytes:
             HitOutcome.VALID,
             id="real-fixture",
         ),
+        pytest.param(
+            (_SEVENZIP_FIXTURES / "lz4.7z").read_bytes(),
+            len((_SEVENZIP_FIXTURES / "lz4.7z").read_bytes()),
+            HitOutcome.VALID_EXACT,
+            id="real-fixture-exact-eof",
+        ),
         pytest.param(MAGIC_7Z, None, HitOutcome.NOT_THIS_FORMAT, id="truncated-magic"),
         pytest.param(
-            _sevenzip_signature(), None, HitOutcome.VALID, id="empty-crc-valid"
+            _sevenzip_signature(),
+            None,
+            HitOutcome.NOT_THIS_FORMAT,
+            id="empty-crc-valid-is-not-sfx",
         ),
         pytest.param(
             MAGIC_7Z + b"\x90" * 40,
@@ -819,13 +828,20 @@ def _crc_damaged_sevenzip_signature() -> bytes:
             id="declared-end-unknown-remaining",
         ),
         pytest.param(
+            _sevenzip_signature(next_offset=0, next_size=10),
+            _SIGNATURE_HEADER_SIZE + 10,
+            HitOutcome.VALID_EXACT,
+            id="declared-end-equals-remaining",
+        ),
+        pytest.param(
             _sevenzip_signature(next_size=(64 << 20) + 1),
             None,
             HitOutcome.DAMAGED,
             id="oversized-next-header",
         ),
         pytest.param(
-            _sevenzip_signature() + b"config after payload\n",
+            _sevenzip_signature(next_offset=0, next_size=10)
+            + b"config after payload\n",
             None,
             HitOutcome.VALID,
             id="trailing-bytes",
@@ -851,7 +867,10 @@ def test_sevenzip_validator_peeks_only_the_signature_header() -> None:
         return (sig + bytes(n))[:n]
 
     remaining = _SIGNATURE_HEADER_SIZE + next_offset + 64
-    assert validate_sevenzip_signature_header(peek_more, remaining) is HitOutcome.VALID
+    assert (
+        validate_sevenzip_signature_header(peek_more, remaining)
+        is HitOutcome.VALID_EXACT
+    )
     assert peeked == [_SIGNATURE_HEADER_SIZE]
 
 
@@ -963,26 +982,51 @@ def test_sevenzip_sfx_declared_end_uses_source_remaining_not_the_scan_window(
     assert src.unique_bytes <= budget.max_scan_bytes
 
 
-def test_crc_valid_empty_7z_decoy_still_wins_over_a_later_payload(
+def test_crc_valid_empty_7z_decoy_is_skipped_for_the_real_payload(
     tmp_path: Path,
 ) -> None:
-    """Earliest CRC-valid 7z wins, including a 32-byte empty archive in the stub.
-
-    Exact-EOF ranking among several VALID hits is deferred (task 2.3 / F4). A
-    genuine SFX with a trailing config blob has no exact match, so that
-    tie-break is a preference among validated hits, not a filter.
-    """
+    """``NextHeaderSize == 0`` behind a stub is not an SFX payload (D2 cheap complement)."""
     decoy = _sevenzip_signature()
     stub = b"MZ" + b"\x00" * 510 + decoy
     real = (_SEVENZIP_FIXTURES / "lz4.7z").read_bytes()
     path = tmp_path / "empty-decoy-7z.exe"
     path.write_bytes(stub + b"\x00" * 64 + real)
+    real_origin = len(stub) + 64
+    detected = detect_format(path)
+    assert detected.format == ArchiveFormat.SEVEN_Z
+    assert detected.detected_by == "sfx_scan"
+    assert detected.payload_offset == real_origin
+    with open_archive(path) as archive:
+        assert any(m.is_file for m in archive.members())
+
+
+def test_inexact_7z_decoy_loses_to_a_later_exact_payload(tmp_path: Path) -> None:
+    """VALID_EXACT on the real payload beats an earlier CRC-valid inexact decoy (D2(a))."""
+    decoy = _sevenzip_signature(next_offset=100, next_size=10)
+    stub = b"MZ" + b"\x00" * 510 + decoy
+    real = (_SEVENZIP_FIXTURES / "lz4.7z").read_bytes()
+    path = tmp_path / "inexact-decoy-7z.exe"
+    path.write_bytes(stub + b"\x00" * 64 + real)
+    real_origin = len(stub) + 64
+    detected = detect_format(path)
+    assert detected.format == ArchiveFormat.SEVEN_Z
+    assert detected.detected_by == "sfx_scan"
+    assert detected.payload_offset == real_origin
+
+
+def test_inexact_7z_decoy_still_wins_when_the_real_payload_has_trailing_bytes(
+    tmp_path: Path,
+) -> None:
+    """Residual: neither hit is exact, so earliest VALID still wins (D2(b) pin)."""
+    decoy = _sevenzip_signature(next_offset=100, next_size=10)
+    stub = b"MZ" + b"\x00" * 510 + decoy
+    real = (_SEVENZIP_FIXTURES / "lz4.7z").read_bytes()
+    path = tmp_path / "inexact-decoy-trailing-7z.exe"
+    path.write_bytes(stub + b"\x00" * 64 + real + b"sfx-config\n")
     detected = detect_format(path)
     assert detected.format == ArchiveFormat.SEVEN_Z
     assert detected.detected_by == "sfx_scan"
     assert detected.payload_offset == 512
-    with open_archive(path) as archive:
-        assert [m.name for m in archive.members() if m.is_file] == []
 
 
 @requires("py7zr")

--- a/tests/test_sfx.py
+++ b/tests/test_sfx.py
@@ -25,7 +25,12 @@ from pathlib import Path
 import pytest
 
 from archivey import DEFAULT_ARCHIVEY_CONFIG, detect_format, open_archive
-from archivey.detection_cost import BALANCED_BUDGET, FAST_BUDGET, TierSkipReason
+from archivey.detection_cost import (
+    BALANCED_BUDGET,
+    FAST_BUDGET,
+    DetectionBudget,
+    TierSkipReason,
+)
 from archivey.exceptions import (
     CorruptionError,
     FormatDetectionError,
@@ -65,6 +70,13 @@ from tests.test_detection_workspace import InstrumentedBytesIO
 _STUB = b"MZ" + b"\x90" * 4094
 _RAR_FIXTURES = Path(__file__).parent / "fixtures" / "rar"
 _SEVENZIP_FIXTURES = Path(__file__).parent / "fixtures" / "sevenzip"
+_SIGNATURE_HEADER_SIZE = 32
+
+
+def _elf_stub(size: int) -> bytes:
+    ident = b"\x7fELF\x02\x01\x01"
+    return ident + b"\x00" * (size - len(ident))
+
 
 _FILES = {
     "alpha.txt": b"alpha\n" * 2000,
@@ -734,6 +746,14 @@ def test_zip_local_header_validator_accepts_a_real_header_and_rejects_a_decoy() 
         validate_zip_local_header(_peek_view(_header(name_len=20, rest=b"short")))
         is HitOutcome.NOT_THIS_FORMAT
     )
+    # Source remaining, not the peek helper: a view that could supply the name
+    # still fails identity when those bytes sit past EOF (F7).
+    full = _header(name_len=20, rest=b"abcdefghijklmnopqrst")
+    assert validate_zip_local_header(_peek_view(full)) is HitOutcome.VALID
+    assert (
+        validate_zip_local_header(_peek_view(full), remaining=30)
+        is HitOutcome.NOT_THIS_FORMAT
+    )
 
 
 def _sevenzip_signature(
@@ -749,65 +769,120 @@ def _sevenzip_signature(
     return MAGIC_7Z + bytes((major, 0)) + crc.to_bytes(4, "little") + start
 
 
-def test_sevenzip_signature_validator_accepts_a_real_header_and_rejects_a_decoy() -> (
-    None
-):
-    payload = (_SEVENZIP_FIXTURES / "lz4.7z").read_bytes()
-    assert payload[: len(MAGIC_7Z)] == MAGIC_7Z
-    assert validate_sevenzip_signature_header(_peek_view(payload)) is HitOutcome.VALID
-    assert (
-        validate_sevenzip_signature_header(_peek_view(MAGIC_7Z))
-        is HitOutcome.NOT_THIS_FORMAT
-    )
-    assert (
-        validate_sevenzip_signature_header(_peek_view(_sevenzip_signature()))
-        is HitOutcome.VALID
-    )
-    # 0x90 filler after the 6-byte magic: major version is not 0.
-    assert (
-        validate_sevenzip_signature_header(_peek_view(MAGIC_7Z + b"\x90" * 40))
-        is HitOutcome.NOT_THIS_FORMAT
-    )
+def _crc_damaged_sevenzip_signature() -> bytes:
     damaged = bytearray(_sevenzip_signature())
     damaged[8] ^= 0xFF
-    assert (
-        validate_sevenzip_signature_header(_peek_view(bytes(damaged)))
-        is HitOutcome.DAMAGED
-    )
-    assert (
-        validate_sevenzip_signature_header(_peek_view(_sevenzip_signature(major=1)))
-        is HitOutcome.NOT_THIS_FORMAT
-    )
-    # Declared next-header past the view, still inside SFX_MAX: overrun, not a 7z.
-    overrun = _sevenzip_signature(next_offset=100, next_size=10)
-    assert (
-        validate_sevenzip_signature_header(_peek_view(overrun))
-        is HitOutcome.NOT_THIS_FORMAT
-    )
-    huge = _sevenzip_signature(next_size=(64 << 20) + 1)
-    assert (
-        validate_sevenzip_signature_header(_peek_view(huge))
-        is HitOutcome.NOT_THIS_FORMAT
-    )
-    # Trailing bytes after a CRC-valid header are still this format (task 4.4).
-    trailing = _sevenzip_signature() + b"config after payload\n"
-    assert validate_sevenzip_signature_header(_peek_view(trailing)) is HitOutcome.VALID
+    return bytes(damaged)
 
 
-def test_rar_main_header_validator_accepts_real_archives_and_rejects_a_crc_fail() -> (
-    None
-):
+@pytest.mark.parametrize(
+    ("payload", "remaining", "expected"),
+    [
+        pytest.param(
+            (_SEVENZIP_FIXTURES / "lz4.7z").read_bytes(),
+            None,
+            HitOutcome.VALID,
+            id="real-fixture",
+        ),
+        pytest.param(MAGIC_7Z, None, HitOutcome.NOT_THIS_FORMAT, id="truncated-magic"),
+        pytest.param(
+            _sevenzip_signature(), None, HitOutcome.VALID, id="empty-crc-valid"
+        ),
+        pytest.param(
+            MAGIC_7Z + b"\x90" * 40,
+            None,
+            HitOutcome.NOT_THIS_FORMAT,
+            id="wrong-major-filler",
+        ),
+        pytest.param(
+            _crc_damaged_sevenzip_signature(),
+            None,
+            HitOutcome.DAMAGED,
+            id="crc-mismatch",
+        ),
+        pytest.param(
+            _sevenzip_signature(major=1),
+            None,
+            HitOutcome.NOT_THIS_FORMAT,
+            id="major-version-1",
+        ),
+        pytest.param(
+            _sevenzip_signature(next_offset=100, next_size=10),
+            _SIGNATURE_HEADER_SIZE,
+            HitOutcome.DAMAGED,
+            id="declared-end-overruns-known-remaining",
+        ),
+        pytest.param(
+            _sevenzip_signature(next_offset=100, next_size=10),
+            None,
+            HitOutcome.VALID,
+            id="declared-end-unknown-remaining",
+        ),
+        pytest.param(
+            _sevenzip_signature(next_size=(64 << 20) + 1),
+            None,
+            HitOutcome.DAMAGED,
+            id="oversized-next-header",
+        ),
+        pytest.param(
+            _sevenzip_signature() + b"config after payload\n",
+            None,
+            HitOutcome.VALID,
+            id="trailing-bytes",
+        ),
+    ],
+)
+def test_sevenzip_signature_validator(
+    payload: bytes, remaining: int | None, expected: HitOutcome
+) -> None:
+    assert (
+        validate_sevenzip_signature_header(_peek_view(payload), remaining) is expected
+    )
+
+
+def test_sevenzip_validator_peeks_only_the_signature_header() -> None:
+    """Declared-end confirmation is a length compare, not a prefix grow (F2)."""
+    next_offset = 1_900_000
+    sig = _sevenzip_signature(next_offset=next_offset, next_size=64)
+    peeked: list[int] = []
+
+    def peek_more(n: int) -> bytes:
+        peeked.append(n)
+        return (sig + bytes(n))[:n]
+
+    remaining = _SIGNATURE_HEADER_SIZE + next_offset + 64
+    assert validate_sevenzip_signature_header(peek_more, remaining) is HitOutcome.VALID
+    assert peeked == [_SIGNATURE_HEADER_SIZE]
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected"),
+    [
+        pytest.param(
+            (_RAR_FIXTURES / "stored_m0.rar").read_bytes(),
+            HitOutcome.VALID,
+            id="rar5",
+        ),
+        pytest.param(
+            (_RAR_FIXTURES / "basic_nonsolid__rar4.rar").read_bytes(),
+            HitOutcome.VALID,
+            id="rar4",
+        ),
+        pytest.param(
+            (_RAR_FIXTURES / "encrypted_header__.rar").read_bytes(),
+            HitOutcome.VALID,
+            id="rar5-encrypted-headers",
+        ),
+        pytest.param(RAR_ID, HitOutcome.NOT_THIS_FORMAT, id="truncated-rar4"),
+        pytest.param(RAR5_ID, HitOutcome.NOT_THIS_FORMAT, id="truncated-rar5"),
+    ],
+)
+def test_rar_main_header_validator(payload: bytes, expected: HitOutcome) -> None:
+    assert validate_rar_main_header(_peek_view(payload)) is expected
+
+
+def test_rar_main_header_validator_crc_fail_is_damaged() -> None:
     rar5 = (_RAR_FIXTURES / "stored_m0.rar").read_bytes()
-    rar4 = (_RAR_FIXTURES / "basic_nonsolid__rar4.rar").read_bytes()
-    encrypted = (_RAR_FIXTURES / "encrypted_header__.rar").read_bytes()
-    assert rar5.startswith(RAR5_ID)
-    assert rar4.startswith(RAR_ID)
-    assert validate_rar_main_header(_peek_view(rar5)) is HitOutcome.VALID
-    assert validate_rar_main_header(_peek_view(rar4)) is HitOutcome.VALID
-    # Encrypted-headers RAR5: first block is ENCRYPTION, still CRC-valid.
-    assert validate_rar_main_header(_peek_view(encrypted)) is HitOutcome.VALID
-    assert validate_rar_main_header(_peek_view(RAR_ID)) is HitOutcome.NOT_THIS_FORMAT
-    assert validate_rar_main_header(_peek_view(RAR5_ID)) is HitOutcome.NOT_THIS_FORMAT
     damaged = bytearray(rar5[:64])
     damaged[len(RAR5_ID)] ^= 0xFF
     assert validate_rar_main_header(_peek_view(bytes(damaged))) is HitOutcome.DAMAGED
@@ -854,6 +929,60 @@ def test_mz_7z_declared_end_overrun_is_not_claimed(tmp_path: Path) -> None:
     path.write_bytes(stub + _sevenzip_signature(next_offset=100, next_size=10))
     with pytest.raises(FormatDetectionError):
         detect_format(path)
+
+
+@pytest.mark.parametrize(
+    ("stub_len", "next_offset", "budget"),
+    [
+        pytest.param(256 * 1024, 1_900_000, BALANCED_BUDGET, id="256k-stub-balanced"),
+        pytest.param(4 * 1024, 1_900_000, BALANCED_BUDGET, id="4k-stub-balanced"),
+        pytest.param(4 * 1024, 1_500_000, FAST_BUDGET, id="4k-stub-fast"),
+    ],
+)
+def test_sevenzip_sfx_declared_end_uses_source_remaining_not_the_scan_window(
+    stub_len: int, next_offset: int, budget: DetectionBudget
+) -> None:
+    """A large CRC-valid 7z behind a stub is still SEVEN_Z (F1 / F2).
+
+    Comparing declared end against the peek window rejected every 7z SFX whose
+    payload plus stub exceeded ``max_scan_bytes``. The budget is a cost gate:
+    FAST still answers a hit inside its 256 KiB window. The validator peeks
+    only the 32-byte signature, so unique bytes stay well below the archive.
+    """
+    stub = _elf_stub(stub_len)
+    next_size = 64
+    sig = _sevenzip_signature(next_offset=next_offset, next_size=next_size)
+    declared = _SIGNATURE_HEADER_SIZE + next_offset + next_size
+    blob = stub + sig + b"\x00" * (declared - len(sig))
+    src = InstrumentedBytesIO(blob)
+    detected = detect_format(src, budget=budget)
+    assert detected.format == ArchiveFormat.SEVEN_Z
+    assert detected.detected_by == "sfx_scan"
+    assert detected.payload_offset == stub_len
+    assert src.unique_bytes < len(blob)
+    assert src.unique_bytes <= budget.max_scan_bytes
+
+
+def test_crc_valid_empty_7z_decoy_still_wins_over_a_later_payload(
+    tmp_path: Path,
+) -> None:
+    """Earliest CRC-valid 7z wins, including a 32-byte empty archive in the stub.
+
+    Exact-EOF ranking among several VALID hits is deferred (task 2.3 / F4). A
+    genuine SFX with a trailing config blob has no exact match, so that
+    tie-break is a preference among validated hits, not a filter.
+    """
+    decoy = _sevenzip_signature()
+    stub = b"MZ" + b"\x00" * 510 + decoy
+    real = (_SEVENZIP_FIXTURES / "lz4.7z").read_bytes()
+    path = tmp_path / "empty-decoy-7z.exe"
+    path.write_bytes(stub + b"\x00" * 64 + real)
+    detected = detect_format(path)
+    assert detected.format == ArchiveFormat.SEVEN_Z
+    assert detected.detected_by == "sfx_scan"
+    assert detected.payload_offset == 512
+    with open_archive(path) as archive:
+        assert [m.name for m in archive.members() if m.is_file] == []
 
 
 @requires("py7zr")
@@ -1053,11 +1182,22 @@ def test_budget_truncated_zip_header_records_sfx_scan_skip(tmp_path: Path) -> No
     )
 
 
-def test_sfx_hit_validator_is_not_bound_on_instance() -> None:
-    for cls in (ZipReadBackend, SevenZipReadBackend, RarReadBackend):
-        inst = object.__new__(cls)
-        assert inst.SFX_HIT_VALIDATOR is cls.SFX_HIT_VALIDATOR
-        assert inst.SFX_HIT_VALIDATOR(_peek_view(b"")) is HitOutcome.NOT_THIS_FORMAT
+@pytest.mark.parametrize(
+    ("cls", "decoy"),
+    [
+        (ZipReadBackend, b"PK\x03\x04"),
+        (SevenZipReadBackend, MAGIC_7Z),
+        (RarReadBackend, RAR_ID),
+    ],
+    ids=["zip", "sevenzip", "rar"],
+)
+def test_sfx_hit_validator_is_not_bound_on_instance(cls: type, decoy: bytes) -> None:
+    inst = object.__new__(cls)
+    assert inst.SFX_HIT_VALIDATOR is cls.SFX_HIT_VALIDATOR
+    validator = inst.SFX_HIT_VALIDATOR
+    assert validator is not None
+    # One-arg call still works: ``remaining`` defaults to ``None``.
+    assert validator(_peek_view(decoy)) is HitOutcome.NOT_THIS_FORMAT
 
 
 def test_class_file_does_not_enter_the_sfx_scan() -> None:

--- a/tests/test_sfx.py
+++ b/tests/test_sfx.py
@@ -682,17 +682,17 @@ def _peek_view(data: bytes) -> Callable[[int], bytes]:
 def test_zip_local_header_validator_accepts_a_real_header_and_rejects_a_decoy() -> None:
     payload = _zip_bytes()
     assert payload[:4] == b"PK\x03\x04"
-    assert validate_zip_local_header(_peek_view(payload)) is HitOutcome.VALID
+    assert validate_zip_local_header(_peek_view(payload), None) is HitOutcome.VALID
     assert (
-        validate_zip_local_header(_peek_view(b"PK\x03\x04"))
+        validate_zip_local_header(_peek_view(b"PK\x03\x04"), None)
         is HitOutcome.NOT_THIS_FORMAT
     )
     assert (
-        validate_zip_local_header(_peek_view(b"PK\x03\x04" + b"\x90" * 40))
+        validate_zip_local_header(_peek_view(b"PK\x03\x04" + b"\x90" * 40), None)
         is HitOutcome.NOT_THIS_FORMAT
     )
     assert (
-        validate_zip_local_header(_peek_view(b"PK\x03\x04" + b"\x00" * 40))
+        validate_zip_local_header(_peek_view(b"PK\x03\x04" + b"\x00" * 40), None)
         is HitOutcome.NOT_THIS_FORMAT
     )
 
@@ -723,37 +723,61 @@ def test_zip_local_header_validator_accepts_a_real_header_and_rejects_a_decoy() 
             + rest
         )
 
-    assert validate_zip_local_header(_peek_view(_header())) is HitOutcome.VALID
-    assert validate_zip_local_header(_peek_view(_header(method=20))) is HitOutcome.VALID
+    assert validate_zip_local_header(_peek_view(_header()), None) is HitOutcome.VALID
     assert (
-        validate_zip_local_header(_peek_view(_header(version=0)))
+        validate_zip_local_header(_peek_view(_header(method=20)), None)
+        is HitOutcome.VALID
+    )
+    assert (
+        validate_zip_local_header(_peek_view(_header(version=0)), None)
         is HitOutcome.NOT_THIS_FORMAT
     )
     assert (
-        validate_zip_local_header(_peek_view(_header(name_len=0, rest=b"")))
+        validate_zip_local_header(_peek_view(_header(name_len=0, rest=b"")), None)
         is HitOutcome.NOT_THIS_FORMAT
     )
     # Reserved GP-flag bit 15.
     assert (
-        validate_zip_local_header(_peek_view(_header(flags=0x8000)))
+        validate_zip_local_header(_peek_view(_header(flags=0x8000)), None)
         is HitOutcome.NOT_THIS_FORMAT
     )
     assert (
-        validate_zip_local_header(_peek_view(_header(method=11)))
+        validate_zip_local_header(_peek_view(_header(method=11)), None)
         is HitOutcome.NOT_THIS_FORMAT
     )
     assert (
-        validate_zip_local_header(_peek_view(_header(name_len=20, rest=b"short")))
+        validate_zip_local_header(_peek_view(_header(name_len=20, rest=b"short")), None)
         is HitOutcome.NOT_THIS_FORMAT
     )
     # Source remaining, not the peek helper: a view that could supply the name
     # still fails identity when those bytes sit past EOF (F7).
     full = _header(name_len=20, rest=b"abcdefghijklmnopqrst")
-    assert validate_zip_local_header(_peek_view(full)) is HitOutcome.VALID
+    assert validate_zip_local_header(_peek_view(full), None) is HitOutcome.VALID
     assert (
         validate_zip_local_header(_peek_view(full), remaining=30)
         is HitOutcome.NOT_THIS_FORMAT
     )
+
+
+def test_zip_clamped_name_extra_peek_is_valid_when_remaining_is_known() -> None:
+    """A scan-window clamp is not a reject once remaining proves the bytes exist (F7)."""
+    name = b"abcdefghijklmnop"
+    extra = b"xy"
+    header = (
+        b"PK\x03\x04"
+        + struct.pack("<HHHHHIIIHH", 20, 0, 8, 0, 0, 0, 0, 0, len(name), len(extra))
+        + name
+        + extra
+    )
+    needed = 30 + len(name) + len(extra)
+    assert needed == 48
+
+    def clamped(n: int) -> bytes:
+        return header[: min(n, 40)]
+
+    assert validate_zip_local_header(clamped, len(header)) is HitOutcome.VALID
+    assert validate_zip_local_header(clamped, None) is HitOutcome.NOT_THIS_FORMAT
+    assert validate_zip_local_header(_peek_view(header), None) is HitOutcome.VALID
 
 
 def _sevenzip_signature(
@@ -894,14 +918,35 @@ def test_sevenzip_validator_peeks_only_the_signature_header() -> None:
     ],
 )
 def test_rar_main_header_validator(payload: bytes, expected: HitOutcome) -> None:
-    assert validate_rar_main_header(_peek_view(payload)) is expected
+    assert validate_rar_main_header(_peek_view(payload), None) is expected
 
 
 def test_rar_main_header_validator_crc_fail_is_damaged() -> None:
     rar5 = (_RAR_FIXTURES / "stored_m0.rar").read_bytes()
     damaged = bytearray(rar5[:64])
     damaged[len(RAR5_ID)] ^= 0xFF
-    assert validate_rar_main_header(_peek_view(bytes(damaged))) is HitOutcome.DAMAGED
+    assert (
+        validate_rar_main_header(_peek_view(bytes(damaged)), None) is HitOutcome.DAMAGED
+    )
+
+
+@pytest.mark.parametrize(
+    "filename",
+    ["stored_m0.rar", "basic_nonsolid__rar4.rar"],
+    ids=["rar5", "rar4"],
+)
+def test_rar_clamped_header_peek_is_valid_when_remaining_is_known(
+    filename: str,
+) -> None:
+    """A scan-window clamp is not a reject once remaining proves the header exists (F7)."""
+    payload = (_RAR_FIXTURES / filename).read_bytes()
+
+    def clamped(n: int) -> bytes:
+        return payload[: min(n, 18)]
+
+    assert validate_rar_main_header(clamped, len(payload)) is HitOutcome.VALID
+    assert validate_rar_main_header(clamped, None) is HitOutcome.NOT_THIS_FORMAT
+    assert validate_rar_main_header(_peek_view(payload), None) is HitOutcome.VALID
 
 
 def test_shebang_decoy_pk_bytes_are_not_a_zip(tmp_path: Path) -> None:
@@ -1153,7 +1198,12 @@ def test_shebang_non_archive_reads_at_most_min_size_sfx_max() -> None:
 
 
 def test_hostile_zip_local_header_stays_inside_the_scan_budget(tmp_path: Path) -> None:
-    """A candidate near the scan edge must not peek ``name_len`` past the cost gate."""
+    """A candidate near the scan edge must not peek ``name_len`` past the cost gate.
+
+    ``remaining`` can prove the declared name/extra exist (F7), so detection may
+    answer from the 30-byte header without reading 128 KiB. The pin is unique
+    bytes, not ``FormatDetectionError``.
+    """
     hdr = b"PK\x03\x04" + struct.pack(
         "<HHHHHIIIHH", 20, 0, 8, 0, 0, 0, 0, 0, 0xFFFF, 0xFFFF
     )
@@ -1162,19 +1212,15 @@ def test_hostile_zip_local_header_stays_inside_the_scan_budget(tmp_path: Path) -
     path = tmp_path / "hostile.pyz"
     path.write_bytes(bytes(data))
     src = InstrumentedBytesIO(bytes(data))
-    with pytest.raises(FormatDetectionError):
+    try:
         detect_format(src)
+    except FormatDetectionError:
+        pass
     assert src.unique_bytes <= SFX_MAX + 256
-    # A named ``.pyz`` falls through to extension (or a probe) and still carries a receipt.
     info = detect_format(path)
-    assert info.detected_by != "sfx_scan"
     assert info.cost_receipt is not None
     assert info.cost_receipt.within_budget(BALANCED_BUDGET)
     assert info.cost_receipt.unique_bytes_read <= SFX_MAX + 256
-    assert any(
-        skip.tier == "sfx_scan" and skip.reason is TierSkipReason.BUDGET_EXHAUSTED
-        for skip in info.unavailable_tiers
-    )
 
 
 def _zip_bytes_named(name: str) -> bytes:
@@ -1184,8 +1230,10 @@ def _zip_bytes_named(name: str) -> bytes:
     return buffer.getvalue()
 
 
-def test_budget_truncated_zip_header_records_sfx_scan_skip(tmp_path: Path) -> None:
-    """A real ZIP whose name/extra straddle ``scan_limit`` is a budget skip, not 'not ZIP'."""
+def test_budget_truncated_zip_header_still_detects_when_remaining_is_known(
+    tmp_path: Path,
+) -> None:
+    """Name/extra past ``scan_limit`` is a clamp, not a reject, when remaining is known (F7)."""
     payload = _zip_bytes_named("n" * 40)
     name_len, extra_len = struct.unpack_from("<HH", payload, 26)
     needed = 30 + name_len + extra_len
@@ -1196,29 +1244,26 @@ def test_budget_truncated_zip_header_records_sfx_scan_skip(tmp_path: Path) -> No
         stub = stub_hdr + b"\x00" * (header_at - len(stub_hdr))
         return stub + payload
 
-    miss_at = scan_limit - (needed - 2)
-    with pytest.raises(FormatDetectionError):
-        detect_format(io.BytesIO(blob(miss_at)), budget=FAST_BUDGET)
-    miss_path = tmp_path / "edge-miss.pyz"
-    miss_path.write_bytes(blob(miss_at))
-    missed = detect_format(miss_path, budget=FAST_BUDGET)
-    assert missed.detected_by != "sfx_scan"
-    assert any(
-        skip.tier == "sfx_scan" and skip.reason is TierSkipReason.BUDGET_EXHAUSTED
-        for skip in missed.unavailable_tiers
-    )
+    straddle_at = scan_limit - (needed - 2)
+    detected = detect_format(io.BytesIO(blob(straddle_at)), budget=FAST_BUDGET)
+    assert detected.format == ArchiveFormat.ZIP
+    assert detected.detected_by == "sfx_scan"
+    assert detected.payload_offset == straddle_at
+
+    path = tmp_path / "edge-straddle.bin"
+    path.write_bytes(blob(straddle_at))
+    found = detect_format(path, budget=FAST_BUDGET)
+    assert found.format == ArchiveFormat.ZIP
+    assert found.detected_by == "sfx_scan"
+    assert found.payload_offset == straddle_at
 
     hit_at = scan_limit - needed
     hit_path = tmp_path / "edge-hit.bin"
     hit_path.write_bytes(blob(hit_at))
-    found = detect_format(hit_path, budget=FAST_BUDGET)
-    assert found.format == ArchiveFormat.ZIP
-    assert found.detected_by == "sfx_scan"
-    assert found.payload_offset == hit_at
-    assert not any(
-        skip.tier == "sfx_scan" and skip.reason is TierSkipReason.BUDGET_EXHAUSTED
-        for skip in found.unavailable_tiers
-    )
+    inside = detect_format(hit_path, budget=FAST_BUDGET)
+    assert inside.format == ArchiveFormat.ZIP
+    assert inside.detected_by == "sfx_scan"
+    assert inside.payload_offset == hit_at
 
 
 @pytest.mark.parametrize(
@@ -1235,8 +1280,7 @@ def test_sfx_hit_validator_is_not_bound_on_instance(cls: type, decoy: bytes) -> 
     assert inst.SFX_HIT_VALIDATOR is cls.SFX_HIT_VALIDATOR
     validator = inst.SFX_HIT_VALIDATOR
     assert validator is not None
-    # One-arg call still works: ``remaining`` defaults to ``None``.
-    assert validator(_peek_view(decoy)) is HitOutcome.NOT_THIS_FORMAT
+    assert validator(_peek_view(decoy), None) is HitOutcome.NOT_THIS_FORMAT
 
 
 def test_class_file_does_not_enter_the_sfx_scan() -> None:

--- a/tests/test_sfx.py
+++ b/tests/test_sfx.py
@@ -18,6 +18,7 @@ import struct
 import subprocess
 import zipapp
 import zipfile
+import zlib
 from collections.abc import Callable
 from pathlib import Path
 
@@ -30,11 +31,14 @@ from archivey.exceptions import (
     FormatDetectionError,
     UnsupportedFeatureError,
 )
-from archivey.internal.backends.rar_parser import RAR_ID
+from archivey.internal.backends.rar_parser import RAR5_ID, RAR_ID
+from archivey.internal.backends.rar_reader import RarReadBackend
 from archivey.internal.backends.sevenzip_parser import MAGIC_7Z, find_signature_offset
 from archivey.internal.backends.sevenzip_reader import SevenZipReadBackend
 from archivey.internal.backends.zip_reader import ZipReadBackend
 from archivey.internal.password import _PasswordCandidates
+from archivey.internal.rar_detect import validate_rar_main_header
+from archivey.internal.sevenzip_detect import validate_sevenzip_signature_header
 from archivey.internal.sfx import (
     SFX_MAX,
     ExecutableCue,
@@ -59,6 +63,8 @@ from tests.test_detection_workspace import InstrumentedBytesIO
 # *synthetic* one — real PE/ELF stubs are the easy case, this one is what the Brotli
 # content probe claims (see dev-docs/investigations/brotli-content-probe-brief.md).
 _STUB = b"MZ" + b"\x90" * 4094
+_RAR_FIXTURES = Path(__file__).parent / "fixtures" / "rar"
+_SEVENZIP_FIXTURES = Path(__file__).parent / "fixtures" / "sevenzip"
 
 _FILES = {
     "alpha.txt": b"alpha\n" * 2000,
@@ -745,6 +751,83 @@ def test_zip_local_header_validator_accepts_a_real_header_and_rejects_a_decoy() 
     )
 
 
+def _sevenzip_signature(
+    *,
+    major: int = 0,
+    next_offset: int = 0,
+    next_size: int = 0,
+    next_crc: int = 0,
+    start_crc: int | None = None,
+) -> bytes:
+    start = struct.pack("<QQI", next_offset, next_size, next_crc)
+    crc = zlib.crc32(start) & 0xFFFFFFFF if start_crc is None else start_crc
+    return MAGIC_7Z + bytes((major, 0)) + crc.to_bytes(4, "little") + start
+
+
+def test_sevenzip_signature_validator_accepts_a_real_header_and_rejects_a_decoy() -> (
+    None
+):
+    payload = (_SEVENZIP_FIXTURES / "lz4.7z").read_bytes()
+    assert payload[: len(MAGIC_7Z)] == MAGIC_7Z
+    assert validate_sevenzip_signature_header(_peek_view(payload)) is HitOutcome.VALID
+    assert (
+        validate_sevenzip_signature_header(_peek_view(MAGIC_7Z))
+        is HitOutcome.NOT_THIS_FORMAT
+    )
+    assert (
+        validate_sevenzip_signature_header(_peek_view(_sevenzip_signature()))
+        is HitOutcome.VALID
+    )
+    # 0x90 filler after the 6-byte magic: major version is not 0.
+    assert (
+        validate_sevenzip_signature_header(_peek_view(MAGIC_7Z + b"\x90" * 40))
+        is HitOutcome.NOT_THIS_FORMAT
+    )
+    damaged = bytearray(_sevenzip_signature())
+    damaged[8] ^= 0xFF
+    assert (
+        validate_sevenzip_signature_header(_peek_view(bytes(damaged)))
+        is HitOutcome.DAMAGED
+    )
+    assert (
+        validate_sevenzip_signature_header(_peek_view(_sevenzip_signature(major=1)))
+        is HitOutcome.NOT_THIS_FORMAT
+    )
+    # Declared next-header past the view, still inside SFX_MAX: overrun, not a 7z.
+    overrun = _sevenzip_signature(next_offset=100, next_size=10)
+    assert (
+        validate_sevenzip_signature_header(_peek_view(overrun))
+        is HitOutcome.NOT_THIS_FORMAT
+    )
+    huge = _sevenzip_signature(next_size=(64 << 20) + 1)
+    assert (
+        validate_sevenzip_signature_header(_peek_view(huge))
+        is HitOutcome.NOT_THIS_FORMAT
+    )
+    # Trailing bytes after a CRC-valid header are still this format (task 4.4).
+    trailing = _sevenzip_signature() + b"config after payload\n"
+    assert validate_sevenzip_signature_header(_peek_view(trailing)) is HitOutcome.VALID
+
+
+def test_rar_main_header_validator_accepts_real_archives_and_rejects_a_crc_fail() -> (
+    None
+):
+    rar5 = (_RAR_FIXTURES / "stored_m0.rar").read_bytes()
+    rar4 = (_RAR_FIXTURES / "basic_nonsolid__rar4.rar").read_bytes()
+    encrypted = (_RAR_FIXTURES / "encrypted_header__.rar").read_bytes()
+    assert rar5.startswith(RAR5_ID)
+    assert rar4.startswith(RAR_ID)
+    assert validate_rar_main_header(_peek_view(rar5)) is HitOutcome.VALID
+    assert validate_rar_main_header(_peek_view(rar4)) is HitOutcome.VALID
+    # Encrypted-headers RAR5: first block is ENCRYPTION, still CRC-valid.
+    assert validate_rar_main_header(_peek_view(encrypted)) is HitOutcome.VALID
+    assert validate_rar_main_header(_peek_view(RAR_ID)) is HitOutcome.NOT_THIS_FORMAT
+    assert validate_rar_main_header(_peek_view(RAR5_ID)) is HitOutcome.NOT_THIS_FORMAT
+    damaged = bytearray(rar5[:64])
+    damaged[len(RAR5_ID)] ^= 0xFF
+    assert validate_rar_main_header(_peek_view(bytes(damaged))) is HitOutcome.DAMAGED
+
+
 def test_shebang_decoy_pk_bytes_are_not_a_zip(tmp_path: Path) -> None:
     """A ``#!`` stub whose text contains ``PK\\x03\\x04`` is not reported as ZIP."""
     path = tmp_path / "script.sh"
@@ -754,16 +837,104 @@ def test_shebang_decoy_pk_bytes_are_not_a_zip(tmp_path: Path) -> None:
 
 
 def test_shebang_script_mentioning_7z_magic_is_not_seven_z() -> None:
-    """Shebang scans only formats with a hit validator (#277 F3 / F10)."""
+    """Six ``7z`` magic bytes in script text are not a signature header (task 4.4)."""
     payload = b"#!/bin/sh\necho 'magic " + MAGIC_7Z + b" here'\n" + b"x" * 100
     with pytest.raises(FormatDetectionError):
         detect_format(io.BytesIO(payload))
 
 
 def test_shebang_script_mentioning_rar_magic_is_not_rar() -> None:
+    """Seven ``Rar!`` magic bytes in script text are not a MAIN header (task 4.4)."""
     payload = b"#!/usr/bin/env python3\nMARKER = " + RAR_ID + b"\n"
     with pytest.raises(FormatDetectionError):
         detect_format(io.BytesIO(payload))
+
+
+@requires("py7zr")
+def test_mz_7z_magic_decoy_skips_to_the_real_payload(tmp_path: Path) -> None:
+    """Six ``7z`` magic bytes in an MZ stub are not a signature header (task 4.4)."""
+    stub = b"MZ" + b"\x90" * 512 + MAGIC_7Z + b"\x90" * 3576
+    path = tmp_path / "decoy-7z.exe"
+    path.write_bytes(stub + _7z_bytes(tmp_path))
+    detected = detect_format(path)
+    assert detected.format == ArchiveFormat.SEVEN_Z
+    assert detected.detected_by == "sfx_scan"
+    assert detected.payload_offset == len(stub)
+    with open_archive(path) as archive:
+        members = {m.name: archive.read(m) for m in archive.members() if m.is_file}
+    assert members == _FILES
+
+
+@requires("py7zr")
+def test_mz_crc_damaged_7z_header_skips_to_the_real_payload(tmp_path: Path) -> None:
+    damaged = bytearray(_sevenzip_signature())
+    damaged[8] ^= 0xFF
+    stub = b"MZ" + b"\x90" * 64 + bytes(damaged) + b"\x90" * 64
+    path = tmp_path / "crc-decoy-7z.exe"
+    path.write_bytes(stub + _7z_bytes(tmp_path))
+    detected = detect_format(path)
+    assert detected.format == ArchiveFormat.SEVEN_Z
+    assert detected.payload_offset == len(stub)
+
+
+def test_mz_7z_declared_end_overrun_is_not_claimed(tmp_path: Path) -> None:
+    """A CRC-valid signature whose next-header overruns the source is not a 7z."""
+    stub = b"MZ" + b"\x00" * 16
+    path = tmp_path / "overrun-7z.exe"
+    path.write_bytes(stub + _sevenzip_signature(next_offset=100, next_size=10))
+    with pytest.raises(FormatDetectionError):
+        detect_format(path)
+
+
+@requires("py7zr")
+def test_mz_7z_with_trailing_bytes_is_still_claimed(tmp_path: Path) -> None:
+    stub = _STUB
+    path = tmp_path / "trailing-7z.exe"
+    path.write_bytes(stub + _7z_bytes(tmp_path) + b"sfx-config\n")
+    detected = detect_format(path)
+    assert detected.format == ArchiveFormat.SEVEN_Z
+    assert detected.detected_by == "sfx_scan"
+    assert detected.payload_offset == len(stub)
+
+
+@requires("py7zr")
+def test_shebang_plus_real_7z_detects_and_lists_members(tmp_path: Path) -> None:
+    """Tasks 2.3 / F10: a shebang scan self-enables once 7z registers a validator."""
+    shebang = b"#!/bin/sh\n# self-extracting 7z\n"
+    path = tmp_path / "payload.7z.sh"
+    path.write_bytes(shebang + _7z_bytes(tmp_path))
+    detected = detect_format(path)
+    assert detected.format == ArchiveFormat.SEVEN_Z
+    assert detected.detected_by == "sfx_scan"
+    assert detected.payload_offset == len(shebang)
+    with open_archive(path) as archive:
+        members = {m.name: archive.read(m) for m in archive.members() if m.is_file}
+    assert members == _FILES
+
+
+def test_shebang_plus_real_rar_detects(tmp_path: Path) -> None:
+    """Tasks 2.4 / F10: a shebang scan self-enables once RAR registers a validator."""
+    shebang = b"#!/bin/sh\n# self-extracting rar\n"
+    payload = (_RAR_FIXTURES / "stored_m0.rar").read_bytes()
+    path = tmp_path / "payload.rar.sh"
+    path.write_bytes(shebang + payload)
+    detected = detect_format(path)
+    assert detected.format == ArchiveFormat.RAR
+    assert detected.detected_by == "sfx_scan"
+    assert detected.payload_offset == len(shebang)
+
+
+def test_mz_rar5_crc_fail_skips_to_the_real_payload(tmp_path: Path) -> None:
+    payload = (_RAR_FIXTURES / "stored_m0.rar").read_bytes()
+    damaged = bytearray(payload[:64])
+    damaged[len(RAR5_ID)] ^= 0xFF
+    stub = b"MZ" + b"\x90" * 32 + bytes(damaged) + b"\x90" * 32
+    path = tmp_path / "crc-decoy-rar.exe"
+    path.write_bytes(stub + payload)
+    detected = detect_format(path)
+    assert detected.format == ArchiveFormat.RAR
+    assert detected.detected_by == "sfx_scan"
+    assert detected.payload_offset == len(stub)
 
 
 def test_elf_decoy_pk_bytes_are_not_a_zip(tmp_path: Path) -> None:
@@ -913,11 +1084,10 @@ def test_budget_truncated_zip_header_records_sfx_scan_skip(tmp_path: Path) -> No
 
 
 def test_sfx_hit_validator_is_not_bound_on_instance() -> None:
-    inst = object.__new__(ZipReadBackend)
-    assert inst.SFX_HIT_VALIDATOR is ZipReadBackend.SFX_HIT_VALIDATOR
-    assert (
-        inst.SFX_HIT_VALIDATOR(_peek_view(b"PK\x03\x04")) is HitOutcome.NOT_THIS_FORMAT
-    )
+    for cls in (ZipReadBackend, SevenZipReadBackend, RarReadBackend):
+        inst = object.__new__(cls)
+        assert inst.SFX_HIT_VALIDATOR is cls.SFX_HIT_VALIDATOR
+        assert inst.SFX_HIT_VALIDATOR(_peek_view(b"")) is HitOutcome.NOT_THIS_FORMAT
 
 
 def test_class_file_does_not_enter_the_sfx_scan() -> None:

--- a/tests/test_sfx.py
+++ b/tests/test_sfx.py
@@ -622,32 +622,17 @@ def test_a_stub_carrying_a_decoy_zip_header_does_not_move_the_answer(
 
 
 @requires("py7zr")
-def test_a_decoy_needle_in_the_stub_wins_and_fails_loudly(tmp_path: Path) -> None:
-    """A known scanner limit, pinned: earliest match wins, even against a real payload.
+def test_a_decoy_7z_needle_is_skipped_for_the_real_payload(tmp_path: Path) -> None:
+    """Six ``7z`` magic bytes fail signature-header identity; the scan resumes.
 
-    ``detect_format`` takes the first needle in the window, so a stub carrying one
-    decides ``payload_offset`` and the backend opens *there* rather than at a later real
-    archive. What makes it acceptable for now is that the failure is loud — 7z rejects
-    the signature CRC — rather than the fabricated-member silence this change exists to
-    close. Validate-and-continue would turn detection into a trial-open loop; if that
-    ever lands, this test is the one to rewrite.
+    Before the validator this claimed offset 514 (the decoy) and ``open_archive``
+    raised ``CorruptionError``. A decoy is ``NOT_THIS_FORMAT`` (major version is
+    ``0x90``), and the real signature further on is the answer (task 4.4).
     """
-    inner = tmp_path / "real-inner.7z"
-    _write_7z(inner)
     stub = b"MZ" + b"\x90" * 512 + MAGIC_7Z + b"\x90" * 3576
-    path = tmp_path / "decoy-auto.exe"
-    path.write_bytes(stub + inner.read_bytes())
-
-    detected = detect_format(path)
-    assert detected.format == ArchiveFormat.SEVEN_Z
-    assert detected.payload_offset == 514, "the decoy, not the real payload at 4096"
-
-    with pytest.raises(CorruptionError):
-        open_archive(path)
-
-    # The real payload is reachable the moment something supplies the right offset.
-    with _open_with(path, start_offset=len(stub)) as archive:
-        assert {m.name for m in archive.members() if m.is_file} == set(_FILES)
+    path = tmp_path / "decoy-7z.exe"
+    path.write_bytes(stub + _7z_bytes(tmp_path))
+    _assert_sfx_opens(path, ArchiveFormat.SEVEN_Z, len(stub))
 
 
 @pytest.mark.parametrize("filler", [b"\x90", b"\x00"], ids=["nop-fill", "zero-fill"])
@@ -848,21 +833,6 @@ def test_shebang_script_mentioning_rar_magic_is_not_rar() -> None:
     payload = b"#!/usr/bin/env python3\nMARKER = " + RAR_ID + b"\n"
     with pytest.raises(FormatDetectionError):
         detect_format(io.BytesIO(payload))
-
-
-@requires("py7zr")
-def test_mz_7z_magic_decoy_skips_to_the_real_payload(tmp_path: Path) -> None:
-    """Six ``7z`` magic bytes in an MZ stub are not a signature header (task 4.4)."""
-    stub = b"MZ" + b"\x90" * 512 + MAGIC_7Z + b"\x90" * 3576
-    path = tmp_path / "decoy-7z.exe"
-    path.write_bytes(stub + _7z_bytes(tmp_path))
-    detected = detect_format(path)
-    assert detected.format == ArchiveFormat.SEVEN_Z
-    assert detected.detected_by == "sfx_scan"
-    assert detected.payload_offset == len(stub)
-    with open_archive(path) as archive:
-        members = {m.name: archive.read(m) for m in archive.members() if m.is_file}
-    assert members == _FILES
 
 
 @requires("py7zr")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Slim follow-up after #277 (`prefixed-archive-detection` Block 1). **7z/RAR hit validators only** — tasks **2.3** (partial), **2.4**, and the scan-validation pins in **4.4**. Not the rest of Block 3.

## What this PR does

#277's shebang cue searches only formats that have an `SFX_HIT_VALIDATOR`. ZIP already had one; 7z and RAR now join that seam automatically (`entry.format in validators`). A script that merely *mentions* those magics still raises `FormatDetectionError`. A shebang in front of a **real** 7z or RAR now detects.

- **7z** (`validate_sevenzip_signature_header`): `StartHeaderCRC` over the 20-byte StartHeader. Failed CRC / oversized next-header / declared end past known remaining → `DAMAGED`. Empty next-header behind a stub → `NOT_THIS_FORMAT`. Trailing bytes stay `VALID`.
- **RAR** (`validate_rar_main_header`): RAR 5 first-block CRC32 (MAIN or ENCRYPTION); RAR 4 parseable MAIN with matching 16-bit CRC. Shares `load_vint` and `rar3_main_crc_end` with the parser.
- The scan is still first-`VALID`. Exact-EOF ranking among several CRC-valid 7z hits is **deferred** (D2(a) withdrawn).
- Validators live on the format module; `detection.py` still does not inline parse. The scan always passes `remaining` (required; `None` is a value meaning unknown length).
- A short `peek_more` after `remaining` already proves the bytes exist is a scan-window clamp, not `NOT_THIS_FORMAT` (ZIP name/extra, RAR header).

## Review (`9b1a7aa`)

D1(b) and D3(a) unchanged. **D2 is (b)**. Re-review nits F7 and F13 closed:

- **F1 / F2:** `remaining` is candidate-relative source length; no `peek_more(declared)`.
- **F3:** post-CRC rejects are `DAMAGED`.
- **F4:** empty-SFX reject shipped. Inexact CRC-valid decoy is an `xfail(strict=True)` red half. Exact-end ranking deferred.
- **F5 / F6:** aligned / shared parser helpers.
- **F7:** short peek is a clamp, not a reject, once `remaining` proves the bytes exist (ZIP name/extra and RAR header).
- **F8–F11:** fixed earlier.
- **F12:** task 2.3 is `[~]`.
- **F13:** `remaining` has no default.

## Out of scope (later blocks)

- ZIP tail probe, `prefix_kind`, `ArchiveyConfig.detection_budget`, exhaustive scan, makeself / compressor needles.
- Exact-EOF multi-hit ranking (task 2.3 remainder) — follow-up after this PR.
- OpenSpec archive stays for the finishing PR (task 4.12). Task 4.10 is left unchecked because later blocks still run it.

## Gates

`./scripts/check.sh --fix` clean. `./scripts/test.sh --all-configs` all three green:

- `[all]` / `[all-lowest]`: 2674 passed / 23 skipped / 1 xfailed
- `[core-only]`: 2161 passed / 479 skipped / 1 xfailed

GitHub CI on `9b1a7aa`: 23/23 green.

_Generated by [Cursor](https://cursor.com)_
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-20174351-08c2-49ce-85ee-0111cb248b34?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-20174351-08c2-49ce-85ee-0111cb248b34&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

