### PR TITLE
docs: make unslop the default voice toward the maintainer

### DIFF
--- a/.claude/skills/technical-writing/SKILL.md
+++ b/.claude/skills/technical-writing/SKILL.md
@@ -3,14 +3,18 @@ name: technical-writing
 description: |
   Diátaxis structure, plain developer sentences, and unslop (cut AI tells). Use when
   writing or reviewing docs/, handbook prose, PR descriptions, or commit messages; or
-  when the user invokes /technical-writing or asks to unslop prose.
+  when the user invokes /technical-writing or asks to unslop prose. Unslop alone is also
+  the standing voice for maintainer chat and decision packets (see AGENTS.md).
 ---
 
 # Technical writing (archivey)
 
-Condensed from poteto/pstack `technical-writing` + `unslop` (MIT). Apply to **published**
-`docs/` and to maintainer handbook prose that a human will read. Code comments still follow
-`CONTRIBUTING.md` (why, not what).
+Condensed from poteto/pstack `technical-writing` + `unslop` (MIT). Apply the full skill
+(Diátaxis + craft + unslop) to **published** `docs/` and to maintainer handbook prose
+that a human will read. **Unslop (§3) alone** is the default for maintainer-facing chat,
+decision packets, and PR comments — see
+[`AGENTS.md`](../../../AGENTS.md) §Communicating with the maintainer. Code comments
+still follow `CONTRIBUTING.md` (why, not what).
 
 Pair workflow: [`dev-docs/pair-workflow.md`](../../../dev-docs/pair-workflow.md).
 Doc placement: `CONTRIBUTING.md` §“Where does a new doc go?”.
@@ -36,6 +40,9 @@ reference; `docs/philosophy.md` is explanation.
 - No “simply” / “just” / “easy” in procedures.
 
 ## 3. Unslop
+
+**Always on** for maintainer-facing chat, decision packets, and PR comments
+([`AGENTS.md`](../../../AGENTS.md)). For docs/handbook pages, apply together with §§1–2.
 
 Rewrite until nothing reads like default LLM filler:
 

--- a/.claude/skills/technical-writing/SKILL.md
+++ b/.claude/skills/technical-writing/SKILL.md
@@ -1,20 +1,21 @@
 ---
 name: technical-writing
 description: |
-  Diátaxis structure, plain developer sentences, and unslop (cut AI tells). Use when
-  writing or reviewing docs/, handbook prose, PR descriptions, or commit messages; or
-  when the user invokes /technical-writing or asks to unslop prose. Unslop alone is also
-  the standing voice for maintainer chat and decision packets (see AGENTS.md).
+  Diátaxis structure and plain developer sentences for docs/ and handbook prose.
+  Use when writing or reviewing published docs, handbook pages, PR descriptions, or
+  commit messages; or when the user invokes /technical-writing. For strip-AI-tells
+  alone (chat, packets), use the unslop skill instead — do not load this skill for that.
 ---
 
 # Technical writing (archivey)
 
-Condensed from poteto/pstack `technical-writing` + `unslop` (MIT). Apply the full skill
-(Diátaxis + craft + unslop) to **published** `docs/` and to maintainer handbook prose
-that a human will read. **Unslop (§3) alone** is the default for maintainer-facing chat,
-decision packets, and PR comments — see
-[`AGENTS.md`](../../../AGENTS.md) §Communicating with the maintainer. Code comments
-still follow `CONTRIBUTING.md` (why, not what).
+Condensed from poteto/pstack `technical-writing` (MIT). Apply to **published** `docs/`
+and to maintainer handbook prose that a human will read. Code comments still follow
+`CONTRIBUTING.md` (why, not what).
+
+**Unslop is a separate skill** — [`../unslop/SKILL.md`](../unslop/SKILL.md). Apply it
+to the same prose (and always to maintainer chat / packets per `AGENTS.md`). Do not
+duplicate that checklist here so everyday sessions need not load this file.
 
 Pair workflow: [`dev-docs/pair-workflow.md`](../../../dev-docs/pair-workflow.md).
 Doc placement: `CONTRIBUTING.md` §“Where does a new doc go?”.
@@ -38,23 +39,9 @@ reference; `docs/philosophy.md` is explanation.
 - One thought per sentence; mix sentence length so it doesn’t sound machine-cut.
 - Conditions before instructions. Common case first.
 - No “simply” / “just” / “easy” in procedures.
+- Then apply [`unslop`](../unslop/SKILL.md).
 
-## 3. Unslop
-
-**Always on** for maintainer-facing chat, decision packets, and PR comments
-([`AGENTS.md`](../../../AGENTS.md)). For docs/handbook pages, apply together with §§1–2.
-
-Rewrite until nothing reads like default LLM filler:
-
-- Drop puffery (“robust”, “seamless”, “comprehensive”, “leverages”).
-- Drop throat-clearing (“It is important to note that”, “In order to”).
-- Avoid stacked em-dashes, decorative bold lead-ins, emoji ornaments, synonym cycling.
-- Prefer specific claims (“rename breaks the build”) over vague ones (“can cause issues”).
-- Have a point of view in Explanation mode; stay dry in Reference.
-
-Self-audit: “What still looks AI-generated?” Fix that next.
-
-## 4. Archivey checks
+## 3. Archivey checks
 
 - User-facing fact → `docs/` + `mkdocs.yml` nav in the same commit.
 - Maintainer current truth → `dev-docs/formats/<format>.md` or

--- a/.claude/skills/unslop/SKILL.md
+++ b/.claude/skills/unslop/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: unslop
+description: |
+  Cut AI tells from maintainer-facing prose (chat, decision packets, PR comments,
+  briefs). Standing default voice per AGENTS.md. Use when writing to the maintainer,
+  when the user invokes /unslop, or when asked to strip LLM filler. Prefer this over
+  loading technical-writing unless Diátaxis/docs craft is also needed.
+---
+
+# Unslop (archivey)
+
+Condensed from poteto/pstack `unslop` (MIT). Checklist only — no Diátaxis.
+
+Standing rule: [`AGENTS.md`](../../../AGENTS.md) §Communicating with the maintainer.  
+Docs/handbook structure + craft: [`../technical-writing/SKILL.md`](../technical-writing/SKILL.md).
+
+Rewrite until nothing reads like default LLM filler:
+
+- Drop puffery (“robust”, “seamless”, “comprehensive”, “leverages”).
+- Drop throat-clearing (“It is important to note that”, “In order to”).
+- Avoid stacked em-dashes, decorative bold lead-ins, emoji ornaments, synonym cycling.
+- Prefer specific claims (“rename breaks the build”) over vague ones (“can cause issues”).
+- Have a point of view when explaining trade-offs; stay dry in reference dumps.
+- Cut every word that does no work. Short everyday words (“use”, not “utilize”).
+
+Self-audit: “What still looks AI-generated?” Fix that next.

--- a/.cursor/commands/technical-writing.md
+++ b/.cursor/commands/technical-writing.md
@@ -2,8 +2,9 @@
 
 Follow `.claude/skills/technical-writing/SKILL.md`.
 
-Apply Diátaxis mode choice, plain sentences, and unslop to the prose in scope
-(`docs/`, handbook pages, PR body, or whatever the user named). Do not expand
-scope into unrelated refactors.
+Apply Diátaxis mode choice and plain sentences to the prose in scope
+(`docs/`, handbook pages, PR body, or whatever the user named). Also apply
+`.claude/skills/unslop/SKILL.md` to the same prose. Do not expand scope into
+unrelated refactors.
 
 Placement rules: `CONTRIBUTING.md` §“Where does a new doc go?”.

--- a/.cursor/commands/unslop.md
+++ b/.cursor/commands/unslop.md
@@ -1,0 +1,7 @@
+# Unslop
+
+Follow `.claude/skills/unslop/SKILL.md`.
+
+Strip AI tells from the maintainer-facing prose in scope (chat draft, decision
+packet, PR comment, or whatever the user named). Do not expand into a full
+Diátaxis rewrite unless asked — use `/technical-writing` for that.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,15 +66,15 @@ that one is the code map.
 
 ## Communicating with the maintainer (unslop)
 
-**Standing rule for every agent session:** apply the **Unslop** checklist in
-[`.claude/skills/technical-writing/SKILL.md`](.claude/skills/technical-writing/SKILL.md)
-§3 to **all maintainer-facing prose** — chat replies, decision packets, PR comments,
-and thin briefs — not only published `docs/` or handbook pages. Cut puffery,
-throat-clearing, stacked ornaments, and default LLM filler; prefer specific claims.
+**Standing rule for every agent session:** apply
+[`.claude/skills/unslop/SKILL.md`](.claude/skills/unslop/SKILL.md) to **all
+maintainer-facing prose** — chat replies, decision packets, PR comments, and thin
+briefs. Cut puffery, throat-clearing, stacked ornaments, and default LLM filler;
+prefer specific claims.
 
-Invoke `/technical-writing` (or ask for that skill by name) when you need the full
-Diátaxis + sentence-craft pass on a docs or handbook page. Unslop itself does not
-require a separate skill invoke — it is the default voice toward the maintainer.
+That skill is the checklist only. Do **not** load `/technical-writing` for everyday
+chat — use it when you need Diátaxis + sentence craft on a docs or handbook page
+(and still apply `unslop` to the same prose).
 
 ## Session setup (`unrar`, `7z`, `openspec`, deps)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,18 @@ that one is the code map.
 - `CONTRIBUTING.md` — coding/testing standards (type-checking, exception translation,
   behaviour-focused tests, red-green TDD, the pause-and-ask-on-discrepancies rule).
 
+## Communicating with the maintainer (unslop)
+
+**Standing rule for every agent session:** apply the **Unslop** checklist in
+[`.claude/skills/technical-writing/SKILL.md`](.claude/skills/technical-writing/SKILL.md)
+§3 to **all maintainer-facing prose** — chat replies, decision packets, PR comments,
+and thin briefs — not only published `docs/` or handbook pages. Cut puffery,
+throat-clearing, stacked ornaments, and default LLM filler; prefer specific claims.
+
+Invoke `/technical-writing` (or ask for that skill by name) when you need the full
+Diátaxis + sentence-craft pass on a docs or handbook page. Unslop itself does not
+require a separate skill invoke — it is the default voice toward the maintainer.
+
 ## Session setup (`unrar`, `7z`, `openspec`, deps)
 
 `scripts/setup-dev-env.sh` provisions everything: the `unrar` and `7z` system

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -313,7 +313,8 @@ Five questions, in order. The first `yes` wins.
 1. **Would someone who only *uses* the library need it?** → `docs/`, **and add it to
    `mkdocs.yml`'s nav in the same commit**. Curated "why we chose X" one-liners for
    curious users belong inline on the page that raises the question, not as a new
-   page per decision. Use `/technical-writing` (Diátaxis + unslop) for the prose.
+   page per decision. Use `/technical-writing` for structure/craft and `/unslop`
+   for strip-AI-tells on the prose.
 2. **Is it current maintainer truth about a format or cross-cutting topic?** → a
    living handbook page `dev-docs/formats/<format>.md` or `dev-docs/topics/<topic>.md`
    (rewrite in place; light decision bullets, not a new ADR). **Create the file in the

--- a/dev-docs/discussions/2026-09-pair-workflow-adoption.md
+++ b/dev-docs/discussions/2026-09-pair-workflow-adoption.md
@@ -36,8 +36,8 @@ skills** plus the handbook. Use upstream plugins only as optional desktop extras
 | Need | Source | In this repo | Why this shape |
 | --- | --- | --- | --- |
 | Sharpen plan + write decisions | Matt `grill-me` / `grill-with-docs` / `domain-modeling` | **Skill** [`grill-with-handbook`](../../.claude/skills/grill-with-handbook/SKILL.md) | Writes format/topic pages, not ADR spam |
-| Diátaxis + sentence craft | pstack `technical-writing` | **Skill** [`technical-writing`](../../.claude/skills/technical-writing/SKILL.md) | User `docs/` + PR/handbook prose |
-| Strip AI tells | pstack `unslop` | Folded into `technical-writing` | One invoke for published prose |
+| Diátaxis + sentence craft | pstack `technical-writing` | **Skill** [`technical-writing`](../../.claude/skills/technical-writing/SKILL.md) | User `docs/` + handbook prose |
+| Strip AI tells | pstack `unslop` | **Skill** [`unslop`](../../.claude/skills/unslop/SKILL.md) (standalone; AGENTS standing rule) | Chat / packets / PR comments without loading technical-writing |
 | Agent-facing doc craft | Matt `writing-for-agents` | Apply by hand when editing `AGENTS.md` / skills | Triggers in description; progressive body; checkable done criteria |
 | Deep-module vocabulary | Matt `codebase-design` | Optional later **doc** under `topics/` | Borrow terms; don’t import TS tooling |
 | Multi-model adversarial review | pstack `interrogate` | **Not default** | Manual other-model review is enough |

--- a/dev-docs/pair-workflow.md
+++ b/dev-docs/pair-workflow.md
@@ -116,9 +116,8 @@ review block 3.
 
 If an agent cannot fill these, it is not ready to ask — it should measure first.
 
-**Voice:** unslop the packet (and any chat around it) — same checklist as
-[`AGENTS.md`](../AGENTS.md) §Communicating with the maintainer and
-`.claude/skills/technical-writing/SKILL.md` §3.
+**Voice:** apply [`unslop`](../.claude/skills/unslop/SKILL.md) to the packet and any
+chat around it ([`AGENTS.md`](../AGENTS.md) §Communicating with the maintainer).
 
 Review quality does **not** drop: the implementor still gets the full finding list on the
 PR. The maintainer is not the audience for that list unless they ask.
@@ -146,8 +145,8 @@ means a decision was never recorded on the handbook page.
 | --- | --- |
 | Pair investigation + decisions on handbook | `/grill-with-handbook` |
 | Explore without implementing | `/openspec-explore` stance; don’t open a verbose change by default |
-| Unslop chat / packets / PR comments (default) | No invoke — standing rule in [`AGENTS.md`](../AGENTS.md) §Communicating with the maintainer |
-| User-facing or handbook prose craft | `/technical-writing` (Diátaxis + unslop) |
+| Unslop chat / packets / PR comments (default) | `/unslop` — standing rule in [`AGENTS.md`](../AGENTS.md); thin skill, not technical-writing |
+| User-facing or handbook prose craft | `/technical-writing` (then `/unslop` on the same prose) |
 | Review (other agent) | Cursor: `/code-review` (project command → archivey skill). Elsewhere: **`/code-review-skill`** — never bare `/code-review` (that is a host builtin). Full PR handoff; packets to maintainer |
 | Address review | Cursor: `/address-review`. Elsewhere: **`address-review-findings`** / ask for that skill by name |
 | PR babysitting | `steward` as today |

--- a/dev-docs/pair-workflow.md
+++ b/dev-docs/pair-workflow.md
@@ -116,6 +116,10 @@ review block 3.
 
 If an agent cannot fill these, it is not ready to ask — it should measure first.
 
+**Voice:** unslop the packet (and any chat around it) — same checklist as
+[`AGENTS.md`](../AGENTS.md) §Communicating with the maintainer and
+`.claude/skills/technical-writing/SKILL.md` §3.
+
 Review quality does **not** drop: the implementor still gets the full finding list on the
 PR. The maintainer is not the audience for that list unless they ask.
 
@@ -142,7 +146,8 @@ means a decision was never recorded on the handbook page.
 | --- | --- |
 | Pair investigation + decisions on handbook | `/grill-with-handbook` |
 | Explore without implementing | `/openspec-explore` stance; don’t open a verbose change by default |
-| User-facing or handbook prose craft | `/technical-writing` (includes unslop) |
+| Unslop chat / packets / PR comments (default) | No invoke — standing rule in [`AGENTS.md`](../AGENTS.md) §Communicating with the maintainer |
+| User-facing or handbook prose craft | `/technical-writing` (Diátaxis + unslop) |
 | Review (other agent) | Cursor: `/code-review` (project command → archivey skill). Elsewhere: **`/code-review-skill`** — never bare `/code-review` (that is a host builtin). Full PR handoff; packets to maintainer |
 | Address review | Cursor: `/address-review`. Elsewhere: **`address-review-findings`** / ask for that skill by name |
 | PR babysitting | `steward` as today |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Standing rule in `AGENTS.md` §Communicating with the maintainer: apply **`/unslop`** to chat, decision packets, and PR comments.

Unslop is a **separate thin skill** (`.claude/skills/unslop/`) so everyday sessions do not load the full `technical-writing` pack. `/technical-writing` stays for Diátaxis + craft on docs/handbook and still points at `unslop` for the strip-AI-tells pass.

## Also

- `.cursor/commands/unslop.md`
- `dev-docs/pair-workflow.md` entry points
- adoption crib table updated (no longer “folded into technical-writing”)
- `CONTRIBUTING.md` placement note

## Verify

`./scripts/check.sh` green (incl. internal md links).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-07f2d0c2-c431-45e7-a3da-32fef5519573?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-07f2d0c2-c431-45e7-a3da-32fef5519573&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

