### PR TITLE
docs: drop the handbook page skeleton, mark the structure TBD

### DIFF
--- a/.claude/skills/grill-with-handbook/SKILL.md
+++ b/.claude/skills/grill-with-handbook/SKILL.md
@@ -48,7 +48,7 @@ archivey’s source of truth is organised handbook pages, not an append-only ADR
 
 | Kind | Write to |
 | --- | --- |
-| Format behaviour / consequences | `dev-docs/formats/<format>.md` — create with the skeleton in pair-workflow §Living handbook if missing |
+| Format behaviour / consequences | `dev-docs/formats/<format>.md` — create if missing; page structure is TBD until `zip.md` settles it (pair-workflow §Living handbook) |
 | Cross-cutting behaviour | `dev-docs/topics/<topic>.md` — same; **link** `threat-model.md` `O*` rows, never restate that register |
 | Glossary / overloaded term | Short **Terms** subsection on the relevant format/topic page |
 | Heavy evidence | New or updated file under `dev-docs/investigations/`; link from the handbook page |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -318,9 +318,10 @@ Five questions, in order. The first `yes` wins.
 2. **Is it current maintainer truth about a format or cross-cutting topic?** → a
    living handbook page `dev-docs/formats/<format>.md` or `dev-docs/topics/<topic>.md`
    (rewrite in place; light decision bullets, not a new ADR). **Create the file in the
-   same PR that needs it** — do not add empty `formats/` / `topics/` trees. Page skeleton:
-   [`dev-docs/pair-workflow.md`](dev-docs/pair-workflow.md) §Living handbook. Everyday
-   loop: same doc.
+   same PR that needs it** — do not add empty `formats/` / `topics/` trees. Page
+   structure is **TBD** until the first page (`dev-docs/formats/zip.md`) settles it —
+   see [`dev-docs/pair-workflow.md`](dev-docs/pair-workflow.md) §Living handbook, and
+   fill that in from the page you write. Everyday loop: same doc.
 3. **Is it rare repo-wide policy that will not fit a handbook page?** → a new ADR in
    `dev-docs/decisions/`, ADR-shaped (Context / Decision / Consequences, tens of
    lines). If it needs an `## Open questions` section, it is not an ADR yet — grill

--- a/dev-docs/pair-workflow.md
+++ b/dev-docs/pair-workflow.md
@@ -60,14 +60,16 @@ Organised, **no-fluff**, rewritten in place — not an append-only log.
 
 **Until the first format/topic page exists:** point briefs at `code-map`, threat model,
 and the best ADR/investigation. When a change needs a living page, create
-`dev-docs/formats/<format>.md` or `dev-docs/topics/<topic>.md` **in that same PR**, with:
+`dev-docs/formats/<format>.md` or `dev-docs/topics/<topic>.md` **in that same PR**.
 
-1. Role here — support / refusals  
-2. How it works in this repo — entrypoints (link code-map), solid/seek, codecs  
-3. Consequences — perf, memory, crypto, bomb edges  
-4. Decisions (light) — choice → why → rejected alternative  
-5. Open pitfalls  
-6. Verify — tests/commands that pin claims  
+**Page structure: TBD.** An earlier six-section skeleton was written here before any page
+existed. It has been removed on purpose: `dev-docs/formats/zip.md` is being written first
+precisely to find out what shape a real page wants, and a skeleton sitting in this file
+anchors every agent that reads it — including the ones we ask to propose a structure
+independently. "Read this doc but skip §Living handbook" is not an instruction an agent
+follows reliably, so the skeleton is gone rather than fenced off. Fill this in from what
+ZIP actually needs, **in the same PR as that page**, so this file and the tree never
+disagree about the shape.
 
 Optional `formats/README.md` / `topics/README.md` indexes may appear alongside the first
 page; do not add empty stubs ahead of content.


### PR DESCRIPTION
Docs only. No code change.

`pair-workflow.md` §Living handbook carried a six-section page skeleton written before any format page existed. `dev-docs/formats/zip.md` is about to be written specifically to find out what shape a real page wants, and a skeleton sitting in that file anchors any agent that reads the doc — including one we ask to propose a structure independently.

Fencing it off does not work: *"read this document but skip §Living handbook"* is not an instruction an agent follows reliably. So the skeleton is removed rather than marked do-not-read.

## What changed

| File | Change |
| --- | --- |
| `dev-docs/pair-workflow.md` | The numbered six-section skeleton → a **Page structure: TBD** note saying why it is absent and that ZIP fills it back in |
| `CONTRIBUTING.md` | §"where does this go" said *"Page skeleton: … §Living handbook"*; now points at the TBD |
| `.claude/skills/grill-with-handbook/SKILL.md` | Write-to table said *"create with the skeleton in pair-workflow §Living handbook"*; same fix |

## What deliberately stayed

Only the numbered skeleton goes. The section keeps its heading and three parts that have nothing to do with page structure:

- the **path/role table** (where `formats/`, `topics/`, `code-map`, `threat-model`, `investigations/`, `decisions/`, `openspec/specs/` each live),
- the **docs-with-code** rule (a PR that makes a handbook claim false updates that page in the same PR),
- the **specs-to-handbook migration** direction.

Four documents reference this section — `CONTRIBUTING.md`, the grill skill, `pair-workflow.md`'s own intro, and `dev-docs/decisions/index.md`. Keeping the heading means none of them dangle, and only the two that pointed *specifically* at the skeleton needed editing.

## Follow-up this obliges

The TBD is a debt with a named payer: whoever writes `dev-docs/formats/zip.md` fills the structure back in **in that same PR**, so this file and the tree never disagree about the shape. That is stated in the note itself rather than left implicit.

## Gates

`./scripts/check.sh` — all checks passed (ruff, pyrefly, ty, openspec, docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aqe6NF4ebNJravf4UwZ7c5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aqe6NF4ebNJravf4UwZ7c5)_