### PR TITLE
Stop proposing a streaming=True retry the format will refuse

### DIFF
--- a/docs/access-and-cost.md
+++ b/docs/access-and-cost.md
@@ -140,10 +140,13 @@ Same-stream access still needs caller synchronization. Reader-wide passes
 
 `streaming=False` (default) **fails fast** if the format needs seek and the source is a
 pipe. Archivey will not silently buffer the whole archive into memory or a temp file.
-Use `streaming=True` for pipes/sockets.
+Use `streaming=True` for pipes and sockets — it works for TAR (including compressed
+tar) and the single-file compressors.
 
-ZIP (stdlib) and ISO always need seek today — even `streaming=True` cannot open them
-from a pure pipe.
+ZIP, ISO, 7z and RAR keep their index at the end of the archive or address it by
+offset, so they need seek in **either** mode; `streaming=True` cannot open them from a
+pipe. The error says so directly rather than proposing a retry that would be refused,
+and the fix is to buffer the source to a file or a `BytesIO` first.
 
 ## Streaming mode is one pass
 

--- a/docs/access-and-cost.md
+++ b/docs/access-and-cost.md
@@ -187,5 +187,5 @@ exception. Details:
 | Solid archive, many named opens | Reorder to archive order, or one streaming pass |
 | Need `seek()` on a member | `seekable_members=True` (+ `[seekable]` for gz/bz2/zlib/deflate) |
 | Thread pool of member readers | `concurrent_members=True` after `members()` |
-| stdin / socket | `streaming=True` |
+| stdin / socket | `streaming=True` for TAR and the single-file compressors; buffer ZIP / ISO / 7z / RAR to a file or `BytesIO` first ([above](#non-seekable-sources)) |
 | “Just unzip it safely” | `archivey.extract(src, dest)` |

--- a/docs/errors-and-diagnostics.md
+++ b/docs/errors-and-diagnostics.md
@@ -22,7 +22,7 @@ React to specific cases with the subtypes:
 
 | Exception | Raised when |
 | --- | --- |
-| `OpenError` | the source can't be opened — `FormatDetectionError` (unknown format), `UnsupportedFormatError`, `StreamNotSeekableError` (random-access open on a pipe) |
+| `OpenError` | the source can't be opened — `FormatDetectionError` (unknown format), `UnsupportedFormatError`, `StreamNotSeekableError` (a pipe, where the format or the access mode needs seek) |
 | `EncryptionError` | a password is required, missing, or wrong |
 | `CorruptionError` / `TruncatedError` | the archive is malformed or cut short |
 | `PackageNotInstalledError` | an optional package or tool is absent (e.g. the RARLAB `unrar` binary for RAR data; see [Install](install.md#getting-rarlab-unrar)) |

--- a/docs/index.md
+++ b/docs/index.md
@@ -34,7 +34,8 @@ with archivey.open_archive("big.tar.gz") as reader:
             for chunk in iter(lambda: stream.read(1 << 20), b""):
                 ...
 
-# Read from a pipe: forward-only, single pass.  -> Access costs
+# Read from a pipe: forward-only, single pass. TAR and the single-file compressors only
+# — ZIP, ISO, 7z and RAR need a seekable source.  -> Access costs
 with archivey.open_archive(sys.stdin.buffer, streaming=True) as reader:
     for member, stream in reader.stream_members():
         ...
@@ -55,8 +56,10 @@ with archivey.open_archive(sys.stdin.buffer, streaming=True) as reader:
   member *data* still uses the system `unrar`).
 - **Safe by default** — extraction blocks path traversal, symlink escapes, and archive
   bombs unless you opt out. See [Safe extraction](extracting.md).
-- **Streaming-friendly** — read straight from a pipe in a single forward pass, with
-  explicit, predictable [access costs](access-and-cost.md) for solid archives and seeking.
+- **Streaming-friendly** — read TAR and the single-file compressors straight from a pipe
+  in a single forward pass (formats that keep their index at the end need a seekable
+  source), with explicit, predictable [access costs](access-and-cost.md) for solid
+  archives and seeking.
 - **Consistent handling** of symlinks, timestamps, permissions, passwords, and a single
   [exception hierarchy](errors-and-diagnostics.md).
 

--- a/docs/migrating.md
+++ b/docs/migrating.md
@@ -171,6 +171,7 @@ Worth reading before you migrate a production path:
    ([reading members](reading-members.md#read-a-member)).
 4. **Random access on a pipe fails loudly** instead of silently buffering the whole thing
    into memory — an unbounded allocation you did not ask for is worse than an error.
-   Pass `streaming=True` for a forward-only pass.
+   Pass `streaming=True` for a forward-only pass where the format has one; ZIP, ISO, 7z
+   and RAR need seek in either mode, and the error says so instead of proposing a retry.
 5. **Salvage is not implemented yet.** Reading a badly damaged archive gives you the
    recoverable prefix plus an honest error, not a best-effort resync past the damage.

--- a/docs/philosophy.md
+++ b/docs/philosophy.md
@@ -48,7 +48,7 @@ When you need more, you **declare** it. Escape hatches are explicit, not ambient
 
 | Need | How |
 | --- | --- |
-| Pipes / sockets | `open_archive(..., streaming=True)` |
+| Pipes / sockets | `open_archive(..., streaming=True)` — TAR and the single-file compressors; ZIP, ISO, 7z and RAR need a seekable source in either mode |
 | Seek inside a member | `seekable_members=True` |
 | Many open members / workers | `concurrent_members=True` |
 | Trusted / unlimited extract | `ExtractionPolicy.TRUSTED`, `ExtractionLimits.UNLIMITED` |

--- a/openspec/changes/archive/2026-09-03-fix-non-seekable-refusal-advice/.openspec.yaml
+++ b/openspec/changes/archive/2026-09-03-fix-non-seekable-refusal-advice/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: minimalist
+created: 2026-09-03

--- a/openspec/changes/archive/2026-09-03-fix-non-seekable-refusal-advice/specs/access-mode-and-cost/spec.md
+++ b/openspec/changes/archive/2026-09-03-fix-non-seekable-refusal-advice/specs/access-mode-and-cost/spec.md
@@ -1,0 +1,37 @@
+## MODIFIED Requirements
+
+### Requirement: Declaring access mode at open_archive()
+
+`open_archive(..., streaming: bool = False)` SHALL accept exactly two modes:
+
+| Mode | Meaning |
+| --- | --- |
+| `streaming=False` (default) | **Random access.** Load indexes when available. Fail fast at open if the source is non-seekable and the format cannot adapt — never silently degrade to forward-only. Seek points for single-stream formats are built **lazily** on first `seek()`. |
+| `streaming=True` | **Forward-only, single pass.** Disable index loading where possible; works on non-seekable sources. Random-access / full-materialization APIs disabled **uniformly** (independent of any loaded index). `members_report_if_available()` stays callable (never scans). |
+
+Non-seekable sources are never given random access: with `streaming=False` the
+library fails fast at open when the format needs seek (it does not buffer the
+source into memory or a temp file). `streaming=True` is the fix for pipes and
+sockets **only where the backend reads front to back** (TAR, the single-file
+compressors). A format that needs seek in either mode (ZIP, ISO, 7z, RAR) SHALL be
+refused with one message naming a seekable source as the fix, in both modes, rather
+than proposing a `streaming=True` retry the same call would then refuse.
+Eager seek-point building is not exposed.
+
+A **seekable** stream source is wrapped in a fixed-size read buffer at the source
+boundary so `read(n)` returns the full count (`ensure_full_count_reads`) — a raw
+`read(n)` may legally return short, and header parsers, archivey's and the stdlib's
+alike, read a short return as EOF. That is bounded readahead over a source the caller
+already made seekable, not the materialization forbidden above: it never converts a
+non-seekable source, and never copies the archive into memory or a temp file. A path
+source has always paid the same cost through `open()`'s `BufferedReader`.
+
+#### Scenario: open mode matrix
+
+| Case | Expected |
+| --- | --- |
+| `streaming=False` on indexed ZIP | Central directory loaded; random access available |
+| `streaming=True` on `.tar.gz` | No full-archive index scan; members as stream is read |
+| `streaming=False` on non-seekable source, backend reads front to back | Error at open (before member data) naming `streaming=True` — library does not buffer |
+| Either mode on non-seekable source, backend needs seek | Same error and same message in both modes, naming a seekable source (buffer to disk or a `BytesIO`) — library does not buffer |
+| Seekable stream source, either mode | Buffered at the source boundary for full-count `read(n)`; bounded readahead only — never materialized to memory or disk |

--- a/openspec/changes/archive/2026-09-03-fix-non-seekable-refusal-advice/tasks.md
+++ b/openspec/changes/archive/2026-09-03-fix-non-seekable-refusal-advice/tasks.md
@@ -1,0 +1,10 @@
+## 1. Implement
+
+- [x] 1.1 Consult `SUPPORTS_STREAMING_NON_SEEKABLE` before the mode in `open_archive`'s non-seekable branch, so a seek-only format gets the "needs a seekable source" message in both modes instead of a `streaming=True` retry it would refuse
+- [x] 1.2 `tests/test_non_seekable_refusal.py`: both sides of the split (seek-only formats never name `streaming=True`; forward-only formats still do), plus the two modes agreeing
+
+## 2. Verify
+
+- [x] 2.1 `docs/access-and-cost.md` names all four seek-only formats and the fix that works
+- [x] 2.2 `openspec validate --strict fix-non-seekable-refusal-advice`
+- [x] 2.3 Archive this change in the finishing PR (`openspec archive fix-non-seekable-refusal-advice --yes`)

--- a/openspec/specs/access-mode-and-cost/spec.md
+++ b/openspec/specs/access-mode-and-cost/spec.md
@@ -15,7 +15,9 @@ block count). This spec is the **canonical** access-mode × method table;
 | `reader-concurrency` | `MemberStreams.CONCURRENT` within random-access mode |
 | `diagnostics` | Runtime rewind / seek-index events (not frozen into `CostReceipt`) |
 | `safe-extraction` | `extract_all` as a forward-pass entry point |
+
 ## Requirements
+
 ### Requirement: Declaring access mode at open_archive()
 
 `open_archive(..., streaming: bool = False)` SHALL accept exactly two modes:
@@ -27,7 +29,11 @@ block count). This spec is the **canonical** access-mode × method table;
 
 Non-seekable sources are never given random access: with `streaming=False` the
 library fails fast at open when the format needs seek (it does not buffer the
-source into memory or a temp file). Use `streaming=True` for pipes/sockets.
+source into memory or a temp file). `streaming=True` is the fix for pipes and
+sockets **only where the backend reads front to back** (TAR, the single-file
+compressors). A format that needs seek in either mode (ZIP, ISO, 7z, RAR) SHALL be
+refused with one message naming a seekable source as the fix, in both modes, rather
+than proposing a `streaming=True` retry the same call would then refuse.
 Eager seek-point building is not exposed.
 
 A **seekable** stream source is wrapped in a fixed-size read buffer at the source
@@ -44,7 +50,8 @@ source has always paid the same cost through `open()`'s `BufferedReader`.
 | --- | --- |
 | `streaming=False` on indexed ZIP | Central directory loaded; random access available |
 | `streaming=True` on `.tar.gz` | No full-archive index scan; members as stream is read |
-| `streaming=False` on non-seekable source that needs seek | Error at open (before member data); caller must use `streaming=True` (or supply a seekable source) — library does not buffer |
+| `streaming=False` on non-seekable source, backend reads front to back | Error at open (before member data) naming `streaming=True` — library does not buffer |
+| Either mode on non-seekable source, backend needs seek | Same error and same message in both modes, naming a seekable source (buffer to disk or a `BytesIO`) — library does not buffer |
 | Seekable stream source, either mode | Buffered at the source boundary for full-count `read(n)`; bounded readahead only — never materialized to memory or disk |
 
 ### Requirement: Access-mode enforcement — streaming is forward-only
@@ -313,4 +320,3 @@ kinds of work counted — so a caller reading both sees one cost model rather th
 | `open_archive` on a path, detection read 32 774 bytes | `ar.cost` unchanged by those bytes; the detection receipt carries them |
 | Standalone `detect_format` | A detection receipt exists; no `CostReceipt` does, because no archive was opened |
 | A caller comparing the two | Capability and work-kind names match; the totals are of different things and are not summed |
-

--- a/openspec/specs/access-mode-and-cost/spec.md
+++ b/openspec/specs/access-mode-and-cost/spec.md
@@ -25,7 +25,7 @@ block count). This spec is the **canonical** access-mode × method table;
 | Mode | Meaning |
 | --- | --- |
 | `streaming=False` (default) | **Random access.** Load indexes when available. Fail fast at open if the source is non-seekable and the format cannot adapt — never silently degrade to forward-only. Seek points for single-stream formats are built **lazily** on first `seek()`. |
-| `streaming=True` | **Forward-only, single pass.** Disable index loading where possible; works on non-seekable sources. Random-access / full-materialization APIs disabled **uniformly** (independent of any loaded index). `members_report_if_available()` stays callable (never scans). |
+| `streaming=True` | **Forward-only, single pass.** Disable index loading where possible; works on non-seekable sources **where the backend reads front to back** (see below). Random-access / full-materialization APIs disabled **uniformly** (independent of any loaded index). `members_report_if_available()` stays callable (never scans). |
 
 Non-seekable sources are never given random access: with `streaming=False` the
 library fails fast at open when the format needs seek (it does not buffer the

--- a/src/archivey/core.py
+++ b/src/archivey/core.py
@@ -330,20 +330,24 @@ def open_archive(
     # streaming=True still needs a front-to-back format (TAR, raw codecs); trailing
     # indexes (ZIP CD, ISO) cannot.
     if is_stream(reader_source) and not is_seekable(reader_source):
+        # Capability first, mode second: for a format that needs seek in *either* mode
+        # the requested mode is not what went wrong, so both modes get the one message
+        # naming the only fix. Proposing streaming=True here would send the caller into
+        # a second refusal explaining the retry could never have worked.
+        if not backend_cls.SUPPORTS_STREAMING_NON_SEEKABLE:
+            raise StreamNotSeekableError(
+                f"Format {resolved_format!r} cannot be read from a non-seekable source "
+                f"in either access mode (its index/metadata is not at the front of "
+                f"the stream). Buffer it to disk or a BytesIO and reopen.",
+                source_format=resolved_format,
+                archive_name=archive_name,
+            )
         if not streaming:
             raise StreamNotSeekableError(
                 f"Random access (streaming=False) requires a seekable source. Open with "
                 f"streaming=True for a single forward pass over this "
                 f"{resolved_format!r} stream, "
                 f"or buffer it to disk or a BytesIO and reopen.",
-                source_format=resolved_format,
-                archive_name=archive_name,
-            )
-        if not backend_cls.SUPPORTS_STREAMING_NON_SEEKABLE:
-            raise StreamNotSeekableError(
-                f"Format {resolved_format!r} cannot be read from a non-seekable source "
-                f"even in streaming mode (its index/metadata is not at the front of "
-                f"the stream). Buffer it to disk or a BytesIO and reopen.",
                 source_format=resolved_format,
                 archive_name=archive_name,
             )

--- a/tests/test_non_seekable_refusal.py
+++ b/tests/test_non_seekable_refusal.py
@@ -32,8 +32,22 @@ _NEEDS_SEEK = (
     ArchiveFormat.RAR,
 )
 
-# Read front to back, so a pipe is fine once the caller asks for streaming.
-_READS_FORWARD = (ArchiveFormat.TAR, ArchiveFormat.GZ)
+# Read front to back, so a pipe is fine once the caller asks for streaming. The
+# single-file compressors share one backend and one SUPPORTS_STREAMING_NON_SEEKABLE, so
+# sampling only GZ would miss a per-codec regression; the ones whose package is absent
+# skip through _skip_unless_registered rather than being left out of the list.
+_READS_FORWARD = (
+    ArchiveFormat.TAR,
+    ArchiveFormat.TAR_GZ,
+    ArchiveFormat.GZ,
+    ArchiveFormat.BZ2,
+    ArchiveFormat.XZ,
+    ArchiveFormat.ZST,
+    ArchiveFormat.LZ4,
+    ArchiveFormat.LZIP,
+    ArchiveFormat.ZLIB,
+    ArchiveFormat.BROTLI,
+)
 
 
 def _skip_unless_registered(fmt: ArchiveFormat) -> None:

--- a/tests/test_non_seekable_refusal.py
+++ b/tests/test_non_seekable_refusal.py
@@ -1,0 +1,84 @@
+"""What ``open_archive`` tells a caller who hands it a pipe.
+
+The refusal is one typed error (``StreamNotSeekableError``) for every format, but the
+*next step* it names depends on the backend rather than on the mode that was asked for.
+TAR and the single-file compressors read forward-only, so ``streaming=True`` really is
+the fix; ZIP, ISO, 7z and RAR need seek in either mode, so for those the only fix is a
+seekable source. Suggesting ``streaming=True`` there sent callers into a second refusal
+that explained the retry could never have worked, which is what these tests pin shut.
+
+Every case names ``format=`` explicitly, so the refusal is reached before a byte is
+read and no fixture archive is needed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from archivey import (
+    ArchiveFormat,
+    FormatSupport,
+    StreamNotSeekableError,
+    format_availability,
+    open_archive,
+)
+from tests.streams_util import NonSeekableBytesIO
+
+# Trailing index or offset-addressed: no forward-only pass exists for these.
+_NEEDS_SEEK = (
+    ArchiveFormat.ZIP,
+    ArchiveFormat.ISO,
+    ArchiveFormat.SEVEN_Z,
+    ArchiveFormat.RAR,
+)
+
+# Read front to back, so a pipe is fine once the caller asks for streaming.
+_READS_FORWARD = (ArchiveFormat.TAR, ArchiveFormat.GZ)
+
+
+def _skip_unless_registered(fmt: ArchiveFormat) -> None:
+    # ISO needs pycdlib; without it the open fails as UnsupportedFormatError long
+    # before the seekability check this module is about.
+    availability = format_availability(fmt)
+    if availability.support is FormatSupport.NONE:
+        pytest.skip(f"{fmt.display_name} has no usable backend here")
+
+
+@pytest.mark.parametrize("fmt", _NEEDS_SEEK, ids=lambda f: f.display_name)
+@pytest.mark.parametrize("streaming", [False, True], ids=["random", "streaming"])
+def test_seek_only_format_never_proposes_streaming(
+    fmt: ArchiveFormat, streaming: bool
+) -> None:
+    _skip_unless_registered(fmt)
+    with pytest.raises(StreamNotSeekableError) as excinfo:
+        open_archive(NonSeekableBytesIO(b""), format=fmt, streaming=streaming)
+
+    message = str(excinfo.value)
+    assert "streaming=True" not in message, (
+        f"{fmt.display_name} refuses streaming=True as well, so proposing it is a "
+        f"dead end: {message}"
+    )
+    assert "BytesIO" in message  # the step that does work
+    assert excinfo.value.source_format is fmt
+
+
+@pytest.mark.parametrize("fmt", _NEEDS_SEEK, ids=lambda f: f.display_name)
+def test_seek_only_format_refuses_both_modes_alike(fmt: ArchiveFormat) -> None:
+    """Same source, either mode, same answer — the mode was never the problem."""
+    _skip_unless_registered(fmt)
+    messages = set()
+    for streaming in (False, True):
+        with pytest.raises(StreamNotSeekableError) as excinfo:
+            open_archive(NonSeekableBytesIO(b""), format=fmt, streaming=streaming)
+        messages.add(str(excinfo.value))
+    assert len(messages) == 1, messages
+
+
+@pytest.mark.parametrize("fmt", _READS_FORWARD, ids=lambda f: f.display_name)
+def test_forward_only_format_still_proposes_streaming(fmt: ArchiveFormat) -> None:
+    _skip_unless_registered(fmt)
+    with pytest.raises(StreamNotSeekableError) as excinfo:
+        open_archive(NonSeekableBytesIO(b""), format=fmt, streaming=False)
+
+    assert "streaming=True" in str(excinfo.value)
+    assert excinfo.value.source_format is fmt

--- a/tests/test_zip.py
+++ b/tests/test_zip.py
@@ -395,9 +395,16 @@ def test_non_seekable_zip_fails_fast(simple_zip: Path) -> None:
 def test_non_seekable_zip_fails_fast_via_detection(simple_zip: Path) -> None:
     # Even without an explicit format, a non-seekable ZIP is rejected at open time (the
     # opener wraps it in a PeekableStream for detection, then enforces the seekable-source rule).
+    # The message is asserted here as well as in tests/test_non_seekable_refusal.py, which
+    # reaches the same branch with an explicit format= and no archive bytes: if a refactor
+    # ever moved the check after detection I/O, the two entry points could diverge and a
+    # type-only assertion would not notice.
     data = simple_zip.read_bytes()
-    with pytest.raises(StreamNotSeekableError):
+    with pytest.raises(StreamNotSeekableError) as excinfo:
         open_archive(NonSeekableBytesIO(data))
+    message = str(excinfo.value)
+    assert "streaming=True" not in message, message
+    assert "BytesIO" in message
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## The bug

Opening a non-seekable source with the default `streaming=False` told the caller to retry with `streaming=True`. For four of the seven formats that retry is a dead end:

```
open_archive(pipe)                  -> "Random access (streaming=False) requires a seekable
                                        source. Open with streaming=True for a single forward
                                        pass over this ArchiveFormat.ZIP stream, or buffer it
                                        to disk or a BytesIO and reopen."

open_archive(pipe, streaming=True)  -> "Format ArchiveFormat.ZIP cannot be read from a
                                        non-seekable source even in streaming mode (its
                                        index/metadata is not at the front of the stream).
                                        Buffer it to disk or a BytesIO and reopen."
```

The second message explains that the first message's primary suggestion never could have worked. `SUPPORTS_STREAMING_NON_SEEKABLE` is `False` for ZIP, ISO, 7z and RAR and `True` for TAR and the single-file compressors, so this is a shared-message bug across four formats, not a ZIP bug.

## The fix

`src/archivey/core.py`: the capability was already in scope at the first raise site — it simply was not consulted. Check it **before** the mode. A backend that cannot read a pipe in either mode now gets one message naming the fix it actually has (buffer to disk or a `BytesIO`); TAR and the single-file compressors keep the `streaming=True` suggestion, which works for them. Same `StreamNotSeekableError` type, same `source_format` / `archive_name`, both messages still name a concrete next step.

`directory` is also `False` but unreachable here (a directory source is not a stream), so no case was added for it.

## On review finding A4

`review/archive/2026-08-15-simplicity-consistency/SUMMARY.md` A4 records as a *good* property that every trailing-index format "refuses a pipe with one `StreamNotSeekableError` and one message shape".

**This change strengthens that property rather than splitting it.** Before, ZIP/ISO/7z/RAR had *two* message shapes — one per mode. Now they have one, in both modes, and it is the honest one. The line the split falls on (needs-seek vs reads-forward) is the same line A4 itself draws when it contrasts those four with "TAR and every single-file codec accept one". One error type throughout, unchanged. The guardrail that pins A4 — `tests/test_review_simplicity_consistency.py::test_trailing_index_formats_refuse_a_pipe_loudly` — asserts the type, not the text, and still passes.

`tests/test_non_seekable_refusal.py::test_seek_only_format_refuses_both_modes_alike` pins the newly-uniform half so it cannot drift back.

## Spec

No scenario pinned the message text, but `openspec/specs/access-mode-and-cost/spec.md` carried the same wrong remedy in prose ("Use `streaming=True` for pipes/sockets") and in the open-mode matrix ("caller must use `streaming=True`"). Corrected through `openspec/changes/archive/2026-09-03-fix-non-seekable-refusal-advice/` (schema `minimalist`), archived in this PR as its last task. Per CONTRIBUTING §"Thin as you go" the existing row was rewritten rather than a scenario added; the row count goes from four to five only because the one row was covering two genuinely different outcomes.

The four format specs (`format-zip`, `format-iso`, `format-7z`, `format-rar`) describe the *outcome* ("still rejected", "open fails") and needed no change.

## Docs

- `docs/access-and-cost.md` — the "ZIP (stdlib) and ISO always need seek today" line named two of the four formats; now names all four and points at the fix that works.
- `docs/errors-and-diagnostics.md` — `StreamNotSeekableError` was described as "random-access open on a pipe", which was already incomplete (it also fires on `streaming=True` for these formats).
- `docs/opening-and-listing.md` was already correct and precise; left alone.
- **`dev-docs/formats/zip.md` §5 could not be checked or edited here** — it lives on `claude/zip-knowledge-inventory-yixwjs` (#284), not on `main`. If it repeats the "open with `streaming=True`" advice for ZIP, it needs the same correction; worth a look when that branch lands.

## Not stacked

#284/#285/#286 touch `core.py` around line 250; this is at ~332 and independent. Based on `main` (532ae21).

## Gates

```
./scripts/check.sh --fix        # all green
./scripts/test.sh               # 2688 passed, 23 skipped
./scripts/test.sh --all-configs # [all] 2688, [all-lowest] 2688, [core-only] 2172 — all green
```

Red–green: the 8 new cases over the four seek-only formats failed on `main` and pass with the fix; the forward-only cases passed both before and after, which is the point.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014o1iwDmwTBR52DWFtGRmVE

---
_Generated by [Claude Code](https://claude.ai/code/session_014o1iwDmwTBR52DWFtGRmVE)_