### PR TITLE
docs: add a Verify section to topics/prefixed-archives.md

### DIFF
--- a/dev-docs/topics/prefixed-archives.md
+++ b/dev-docs/topics/prefixed-archives.md
@@ -190,7 +190,46 @@ produced a confidently wrong one.
 | Opening an embedded archive is the right default | A caller who opens a file has a reason to think it is an archive; a sweep can filter on the prefix instead | Refusing anything that is not an archive end to end |
 | Report what was found, do not classify the stub | The same tier finds an installer, a program and a polyglot; intent is not in the bytes | Deciding whether a file "is" self-extracting |
 
-## 8. References
+## 8. Verify
+
+```bash
+./scripts/test.sh tests/test_sfx.py tests/test_detection.py tests/test_detection_workspace.py
+```
+
+Corpus counts in §3 and §4 are measurements, not assertions — their provenance is the
+investigation linked in §9, and the machine they were taken on is gone. Everything below is
+behaviour a test holds.
+
+| Claim | Pinned by |
+| --- | --- |
+| One shared `SFX_MAX` across the detector and both native parsers (§2, §7) | `tests/test_sfx.py::test_sfx_max_is_one_shared_bound`, `::test_the_scan_does_not_reach_past_the_shared_bound` |
+| The scan is bounded, and a magic counts only when wholly inside the window | `::test_scan_stops_at_the_limit`, `::test_scan_requires_the_whole_magic_inside_the_limit` |
+| The cue is graded rather than boolean, and `STRONG` means the header structurally parses | `::test_executable_cue_grades_the_evidence`, `::test_pe_cue_does_not_require_alignment_and_does_not_reject_a_large_e_lfanew`, `::test_a_real_elf_binary_is_a_strong_cue` |
+| Mach-O parses or raises no cue at all, so a `.class` file is never scanned | `::test_mach_o_cue_requires_a_parsing_header`, `::test_class_file_does_not_enter_the_sfx_scan` |
+| A `STRONG` cue suppresses the content probes; a `WEAK` one does not, and a real Brotli stream still answers | `::test_executable_prefix_with_a_pe_header_never_becomes_a_stream_codec`, `::test_a_weak_cue_still_lets_a_content_probe_answer`, `::test_a_real_brotli_stream_is_unaffected` |
+| The Mach-O defect in §6 is closed: a stub of each kind opens its real 7z members | `::test_thin_macho_stub_plus_7z_opens_real_members`, `::test_fat_macho_stub_plus_7z_opens_real_members`, `::test_sfx_7z_behind_a_low_entropy_stub_is_not_brotli` and its ZIP/RAR siblings |
+| A shebang non-archive costs at most the window, and detection leaves a non-seekable stream replayable | `::test_shebang_non_archive_reads_at_most_min_size_sfx_max`, `::test_detection_leaves_a_non_seekable_stream_replayable` |
+| Each format's validator rejects its own decoy under every cue (§4) | ZIP: `::test_zip_local_header_validator_accepts_a_real_header_and_rejects_a_decoy`, `::test_shebang_decoy_pk_bytes_are_not_a_zip`, `::test_elf_decoy_pk_bytes_are_not_a_zip` · 7z: `::test_sevenzip_signature_validator` · RAR: `::test_rar_main_header_validator`, `::test_rar_main_header_validator_crc_fail_is_damaged` |
+| Magic bytes quoted in script *text* are not a hit | `::test_shebang_script_mentioning_7z_magic_is_not_seven_z`, `::test_shebang_script_mentioning_rar_magic_is_not_rar` |
+| The scan continues past a failed validation rather than giving up on the source | `::test_a_decoy_7z_needle_is_skipped_for_the_real_payload`, `::test_a_decoy_zip_needle_is_skipped_for_the_real_payload`, `::test_crc_valid_empty_7z_decoy_is_skipped_for_the_real_payload`, `::test_elf_zero_filled_zip_decoy_skips_to_the_real_payload` |
+| 7z's declared end is checked against the source length, not the peek window, and costs one 32-byte peek | `::test_sevenzip_sfx_declared_end_uses_source_remaining_not_the_scan_window`, `::test_sevenzip_validator_peeks_only_the_signature_header`, `::test_mz_7z_declared_end_overrun_is_not_claimed` |
+| A peek shortened by the budget is not evidence against the format | `::test_zip_clamped_name_extra_peek_is_valid_when_remaining_is_known`, `::test_rar_clamped_header_peek_is_valid_when_remaining_is_known`, `::test_budget_truncated_zip_header_still_detects_when_remaining_is_known` |
+| ZIP self-corrects from the tail, so a decoy hit does not move the answer (§5) | `::test_a_stub_carrying_a_decoy_zip_header_does_not_move_the_answer` |
+| 7z and RAR are opened *at* the offset, and a format with no stub story refuses one (§5) | `::test_forced_format_opens_a_7z_behind_a_stub`, `::test_forced_format_opens_packed_and_encoded_header_behind_a_stub`, `::test_start_offset_on_a_path_equals_an_offset_view_on_a_stream`, `::test_a_format_without_stubs_refuses_a_start_offset` |
+| The shapes in §1 detect end to end: `zipapp`, a shebang concatenation, a real SFX | `::test_zipapp_detects_as_zip_and_lists_members`, `::test_shebang_plus_concatenated_zip_detects_and_lists_members`, `::test_shebang_plus_real_7z_detects_and_lists_members`, `::test_shebang_plus_real_rar_detects`, `::test_a_real_sfx_archive_auto_opens` |
+| An uncued prefix (JPEG polyglot) is **not** detected — the §6 gap, pinned so it cannot close silently | `::test_jpeg_plus_appended_zip_stays_undetected_under_balanced` |
+| Exact-EOF ranking among CRC-valid 7z hits is still unlanded | `::test_inexact_7z_decoy_loses_to_a_later_exact_payload` — `xfail(strict=True)`, so it fails the suite the day the tie-break lands. Task 2.3 in `prefixed-archive-detection` is `[~]` for the same reason |
+
+**Building fixtures.** Most stubs here are synthetic — `MZ` plus filler, a seven-byte ELF
+ident, a hand-built Mach-O header — because the cue only reads the leading bytes and a real
+binary would add megabytes for nothing. Where the *payload* has to be real the tests build
+one with `py7zr` or read a committed RAR fixture. Real end-to-end SFX artifacts are
+generated rather than committed where the tool exists: `7z a -sfx7zCon.sfx` and
+`rar a -sfx` both produce one in a few seconds, and both are on CI. PE and Mach-O stubs
+cannot be produced on Linux, which is why those two are hand-built rather than generated —
+the full stub matrix is task 4.3 of `prefixed-archive-detection`.
+
+## 9. References
 
 - Specs: [`format-detection`](../../openspec/specs/format-detection/spec.md) ·
   [`detection-cost`](../../openspec/specs/detection-cost/spec.md)


### PR DESCRIPTION
Docs only. One file, one new section.

`formats/zip.md` §8 pins 30 claims to tests. `topics/prefixed-archives.md` pinned none — the one place the format shape and the topic shape diverged. Its testable claims were all already held by tests and simply not cited, so this is a citation table rather than new coverage.

## What it pins

47 pointers across 17 rows, grouped by the section each claim comes from — one shared `SFX_MAX`, the graded cue, Mach-O never grading weak, `STRONG` suppressing the content probes, each format's validator rejecting its own decoy under every cue, the scan continuing past a failed validation.

Three rows do more than cite:

- **The uncued JPEG polyglot is pinned as a gap**, so §6's known limitation cannot close silently without a test noticing.
- **The budget-clamped peek row** records that a read shortened by the budget is not evidence against a format — that was a real defect once, and it is the kind that comes back.
- **The exact-EOF row** points at `test_inexact_7z_decoy_loses_to_a_later_exact_payload`, `xfail(strict=True)`, which fails the suite the day the tie-break lands. That matches task 2.3's `[~]` in `prefixed-archive-detection`, so the test and the ledger say the same thing.

## What it deliberately does not pin

The `/usr` corpus counts in §3 and §4 (742 more files against 2 868 scanned; 3 320 binaries, six false `PK\x05\x06` matches). Those are measurements, not assertions — the machine they were taken on is gone. The section says so and leaves their provenance to the investigation linked in §9.

## Verify

```bash
./scripts/test.sh tests/test_sfx.py tests/test_detection.py tests/test_detection_workspace.py
```

187 passed, 1 xfailed — the xfail being the red half above. `./scripts/check.sh` passes. Checked mechanically, the same way I checked `zip.md`: all 47 test pointers resolve to a real `def test_`, all three named files exist, and every relative link resolves.

References renumbered §8 → §9. The only cross-reference to this page's sections anywhere in the repo is `zip.md` → §4, which is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aqe6NF4ebNJravf4UwZ7c5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Aqe6NF4ebNJravf4UwZ7c5)_